### PR TITLE
Add ExecutableConditionAttribute to conditionally run tests based on tool availability

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/ExecutableConditionAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/ExecutableConditionAttribute.cs
@@ -24,7 +24,8 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 ///     When <see cref="Arguments"/> are supplied, the condition runs <c>executable arguments</c> and is met only when
 ///     the process exits with code <c>0</c> within <see cref="TimeoutSeconds"/>. For example,
 ///     <c>[ExecutableCondition("docker", "version")]</c> verifies that the Docker CLI actually responds. The process
-///     output is redirected and discarded, and the process tree is terminated if it exceeds the timeout.
+///     output is redirected and discarded, and the process (together with its child process tree, where the runtime
+///     supports it) is terminated if it exceeds the timeout.
 ///     </description>
 ///   </item>
 /// </list>
@@ -119,7 +120,13 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
         : base(mode)
     {
         Executable = executable ?? throw new ArgumentNullException(nameof(executable));
-        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+
+        // Clone so a caller mutating the array they passed (params arrays are caller-owned) can't change this
+        // attribute's GroupName / cache key / IgnoreMessage after construction.
+        _arguments = arguments is null
+            ? throw new ArgumentNullException(nameof(arguments))
+            : (string[])arguments.Clone();
+        Arguments = Array.AsReadOnly(_arguments);
 
         string predicate = _arguments.Length == 0
             ? $"executable '{executable}' is available on PATH"
@@ -138,7 +145,7 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
     /// Gets the arguments passed to the executable. When empty, only the presence of the executable on <c>PATH</c> is
     /// checked; otherwise the executable is run with these arguments and must exit with code 0.
     /// </summary>
-    public IReadOnlyList<string> Arguments => _arguments;
+    public IReadOnlyList<string> Arguments { get; }
 
     /// <summary>
     /// Gets or sets the maximum number of seconds to wait for the executable to exit when <see cref="Arguments"/> are
@@ -148,16 +155,32 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
 
     /// <inheritdoc />
     public override bool IsConditionMet
-        => ResultCache.GetOrAdd(GroupName, _ => Evaluate());
+        => ResultCache.GetOrAdd(CacheKey, _ => Evaluate());
 
     /// <summary>
-    /// Gets the group name for this attribute. Each command forms its own group so that requiring several different
-    /// commands is combined with a logical AND.
+    /// Gets the group name for this attribute. Each command -- combined with <see cref="ConditionBaseAttribute.Mode"/>
+    /// -- forms its own group, so requiring several different commands is combined with a logical AND, while the same
+    /// command with opposite modes does not silently cancel out (mirroring <see cref="MemberConditionAttribute"/>).
     /// </summary>
+    /// <remarks>
+    /// The two evaluation modes are prefixed (<c>presence</c> vs <c>run</c>) and segments are separated with the null
+    /// character, which can't appear in an executable name or argument. This keeps the presence check for an executable
+    /// literally named <c>"foo bar"</c> distinct from running <c>foo</c> with argument <c>bar</c>.
+    /// <see cref="TimeoutSeconds"/> is intentionally excluded so the same command with different timeouts still groups
+    /// together (logical OR); it is instead part of <see cref="CacheKey"/> so a different timeout re-evaluates.
+    /// </remarks>
     public override string GroupName
         => _arguments.Length == 0
-            ? $"ExecutableCondition:{Executable}"
-            : $"ExecutableCondition:{Executable} {string.Join(" ", _arguments)}";
+            ? $"ExecutableCondition:presence\0{Executable}\0{Mode}"
+            : $"ExecutableCondition:run\0{Executable}\0{string.Join("\0", _arguments)}\0{Mode}";
+
+    // Key for the cached probe RESULT. Independent of Mode (whether the tool exists / the command succeeds doesn't
+    // depend on include vs exclude), but includes TimeoutSeconds because a stricter timeout can legitimately fail a
+    // command a looser one would pass. Uses '\0' as the separator so presence/run and arguments can never collide.
+    private string CacheKey
+        => _arguments.Length == 0
+            ? $"ExecutableCondition:presence\0{Executable}"
+            : $"ExecutableCondition:run\0{Executable}\0{string.Join("\0", _arguments)}\0{TimeoutSeconds}";
 
     private static bool IsWindows =>
 #if NET462
@@ -206,7 +229,9 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
 
-            int timeoutMilliseconds = TimeoutSeconds <= 0 ? Timeout.Infinite : TimeoutSeconds * 1000;
+            int timeoutMilliseconds = TimeoutSeconds <= 0
+                ? Timeout.Infinite
+                : (int)Math.Min((long)TimeoutSeconds * 1000, int.MaxValue);
             if (!process.WaitForExit(timeoutMilliseconds))
             {
                 try
@@ -216,10 +241,13 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
 #else
                     process.Kill();
 #endif
+
+                    // Best effort: give the kill a moment to take effect so the timed-out process doesn't linger.
+                    process.WaitForExit(5000);
                 }
-                catch
+                catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException)
                 {
-                    // Best effort: nothing more we can do if the process can't be terminated.
+                    // Nothing more we can do if the process can't be terminated (already exited, OS refused, etc.).
                 }
 
                 return false;
@@ -227,9 +255,9 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
 
             return process.ExitCode == 0;
         }
-        catch
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or InvalidOperationException or IOException or UnauthorizedAccessException or NotSupportedException or ObjectDisposedException)
         {
-            // A missing executable, permission issue, or any other failure means the condition isn't met.
+            // A missing executable, permission issue, or similar operational failure means the condition isn't met.
             return false;
         }
     }
@@ -286,17 +314,7 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
     }
 
     private static bool MatchesAnyExtension(string path, string[] extensions)
-    {
-        foreach (string extension in extensions)
-        {
-            if (File.Exists(path + extension))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => extensions.Any(extension => File.Exists(path + extension));
 
     private static string[] GetExecutableExtensions(string executable, bool isWindows)
     {
@@ -307,13 +325,13 @@ public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
         }
 
         string? pathExt = Environment.GetEnvironmentVariable("PATHEXT");
-        if (string.IsNullOrEmpty(pathExt))
+        if (pathExt is null || pathExt.Length == 0)
         {
             return [string.Empty, ".exe", ".cmd", ".bat", ".com"];
         }
 
         // PATHEXT entries already include the leading dot, for example ".COM;.EXE;.BAT".
-        string[] parts = pathExt!.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries);
+        string[] parts = pathExt.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries);
         string[] result = new string[parts.Length + 1];
 
         // Keep an empty extension first so an exact match (for example when a full file name was passed) still wins.

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/ExecutableConditionAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/ExecutableConditionAttribute.cs
@@ -1,0 +1,390 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// This attribute is used to conditionally control whether a test class or a test method will run or be ignored,
+/// based on whether a given executable (tool) is available.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a generic, tool-agnostic condition. There are two modes:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///     When no <see cref="Arguments"/> are supplied, the condition only checks that the executable is
+///     <em>discoverable</em> on the system <c>PATH</c> (and, on Windows, resolvable through <c>PATHEXT</c>). It does
+///     not run the executable. For example, it can verify that <c>docker</c> is installed.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///     When <see cref="Arguments"/> are supplied, the condition runs <c>executable arguments</c> and is met only when
+///     the process exits with code <c>0</c> within <see cref="TimeoutSeconds"/>. For example,
+///     <c>[ExecutableCondition("docker", "version")]</c> verifies that the Docker CLI actually responds. The process
+///     output is redirected and discarded, and the process tree is terminated if it exceeds the timeout.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Product-specific state (for example whether the Docker daemon is configured for Linux containers) is intentionally
+/// out of scope; layer such checks on top of this attribute or author your own <see cref="ConditionBaseAttribute"/>.
+/// </para>
+/// <para>
+/// Each distinct executable-and-arguments combination forms its own condition group (see <see cref="GroupName"/>).
+/// As a result, applying the attribute multiple times with different commands requires <em>all</em> of them to be
+/// satisfied (logical AND), while applying it multiple times with the same command requires only one to match
+/// (logical OR).
+/// </para>
+/// <para>
+/// This attribute isn't inherited. Applying it to a base class will not affect derived classes.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+public sealed class ExecutableConditionAttribute : ConditionBaseAttribute
+{
+    // The availability of a given command doesn't change during a test run, so the (potentially repeated) probe is
+    // cached. Keyed by the executable and arguments so distinct commands are resolved independently.
+    private static readonly ConcurrentDictionary<string, bool> ResultCache = new(StringComparer.Ordinal);
+
+#if !NET
+    private static readonly char[] QuoteOrWhitespace = [' ', '\t', '\n', '\v', '"'];
+#endif
+
+    private readonly string[] _arguments;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutableConditionAttribute"/> class that includes the test only
+    /// when the given executable is available on <c>PATH</c>.
+    /// </summary>
+    /// <param name="executable">
+    /// The executable to look for. This is typically a bare command name (for example <c>docker</c>), but a path
+    /// containing a directory separator is also supported, in which case it is checked directly instead of being
+    /// resolved against <c>PATH</c>.
+    /// </param>
+    public ExecutableConditionAttribute(string executable)
+        : this(ConditionMode.Include, executable, [])
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutableConditionAttribute"/> class that checks whether the given
+    /// executable is available on <c>PATH</c>.
+    /// </summary>
+    /// <param name="mode">Decides whether the test is included or excluded when the executable is available.</param>
+    /// <param name="executable">
+    /// The executable to look for. This is typically a bare command name (for example <c>docker</c>), but a path
+    /// containing a directory separator is also supported, in which case it is checked directly instead of being
+    /// resolved against <c>PATH</c>.
+    /// </param>
+    public ExecutableConditionAttribute(ConditionMode mode, string executable)
+        : this(mode, executable, [])
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutableConditionAttribute"/> class that includes the test only
+    /// when the given command is available.
+    /// </summary>
+    /// <param name="executable">
+    /// The executable to look for. This is typically a bare command name (for example <c>docker</c>), but a path
+    /// containing a directory separator is also supported, in which case it is checked directly instead of being
+    /// resolved against <c>PATH</c>.
+    /// </param>
+    /// <param name="arguments">
+    /// Optional arguments. When omitted, only the presence of <paramref name="executable"/> on <c>PATH</c> is checked.
+    /// When provided, <c>executable arguments</c> is executed and the condition is met only if it exits with code 0.
+    /// </param>
+    public ExecutableConditionAttribute(string executable, params string[] arguments)
+        : this(ConditionMode.Include, executable, arguments)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExecutableConditionAttribute"/> class.
+    /// </summary>
+    /// <param name="mode">Decides whether the test is included or excluded when the command is available.</param>
+    /// <param name="executable">
+    /// The executable to look for. This is typically a bare command name (for example <c>docker</c>), but a path
+    /// containing a directory separator is also supported, in which case it is checked directly instead of being
+    /// resolved against <c>PATH</c>.
+    /// </param>
+    /// <param name="arguments">
+    /// Optional arguments. When omitted, only the presence of <paramref name="executable"/> on <c>PATH</c> is checked.
+    /// When provided, <c>executable arguments</c> is executed and the condition is met only if it exits with code 0.
+    /// </param>
+    public ExecutableConditionAttribute(ConditionMode mode, string executable, params string[] arguments)
+        : base(mode)
+    {
+        Executable = executable ?? throw new ArgumentNullException(nameof(executable));
+        _arguments = arguments ?? throw new ArgumentNullException(nameof(arguments));
+
+        string predicate = _arguments.Length == 0
+            ? $"executable '{executable}' is available on PATH"
+            : $"command '{executable} {string.Join(" ", _arguments)}' succeeds";
+        IgnoreMessage = mode == ConditionMode.Include
+            ? $"Test is only supported when {predicate}"
+            : $"Test is not supported when {predicate}";
+    }
+
+    /// <summary>
+    /// Gets the executable that this condition looks for.
+    /// </summary>
+    public string Executable { get; }
+
+    /// <summary>
+    /// Gets the arguments passed to the executable. When empty, only the presence of the executable on <c>PATH</c> is
+    /// checked; otherwise the executable is run with these arguments and must exit with code 0.
+    /// </summary>
+    public IReadOnlyList<string> Arguments => _arguments;
+
+    /// <summary>
+    /// Gets or sets the maximum number of seconds to wait for the executable to exit when <see cref="Arguments"/> are
+    /// provided. A value less than or equal to 0 means no timeout. The default is 30 seconds.
+    /// </summary>
+    public int TimeoutSeconds { get; set; } = 30;
+
+    /// <inheritdoc />
+    public override bool IsConditionMet
+        => ResultCache.GetOrAdd(GroupName, _ => Evaluate());
+
+    /// <summary>
+    /// Gets the group name for this attribute. Each command forms its own group so that requiring several different
+    /// commands is combined with a logical AND.
+    /// </summary>
+    public override string GroupName
+        => _arguments.Length == 0
+            ? $"ExecutableCondition:{Executable}"
+            : $"ExecutableCondition:{Executable} {string.Join(" ", _arguments)}";
+
+    private static bool IsWindows =>
+#if NET462
+        // The net462 reference assemblies don't expose RuntimeInformation, and that target only runs on Windows.
+        true;
+#else
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+
+    private bool Evaluate()
+        => _arguments.Length == 0
+            ? ExecutableExistsOnPath(Executable)
+            : TryRunWithExitCodeZero();
+
+    private bool TryRunWithExitCodeZero()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo(Executable)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+#if NET
+            foreach (string argument in _arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+#else
+            // ProcessStartInfo.ArgumentList isn't available on these targets, so build a quoted argument string.
+            startInfo.Arguments = PasteArguments(_arguments);
+#endif
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            // Drain the redirected streams asynchronously so a chatty process can't fill the pipe buffer and deadlock.
+            process.OutputDataReceived += static (_, _) => { };
+            process.ErrorDataReceived += static (_, _) => { };
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            int timeoutMilliseconds = TimeoutSeconds <= 0 ? Timeout.Infinite : TimeoutSeconds * 1000;
+            if (!process.WaitForExit(timeoutMilliseconds))
+            {
+                try
+                {
+#if NET
+                    process.Kill(entireProcessTree: true);
+#else
+                    process.Kill();
+#endif
+                }
+                catch
+                {
+                    // Best effort: nothing more we can do if the process can't be terminated.
+                }
+
+                return false;
+            }
+
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            // A missing executable, permission issue, or any other failure means the condition isn't met.
+            return false;
+        }
+    }
+
+    private static bool ExecutableExistsOnPath(string executable)
+    {
+        if (executable.Length == 0)
+        {
+            return false;
+        }
+
+        bool isWindows = IsWindows;
+        string[] extensions = GetExecutableExtensions(executable, isWindows);
+
+        // A value that contains a directory component is treated as a path and checked directly rather than being
+        // resolved against PATH.
+        if (executable.IndexOf(Path.DirectorySeparatorChar) >= 0
+            || executable.IndexOf(Path.AltDirectorySeparatorChar) >= 0)
+        {
+            return MatchesAnyExtension(executable, extensions);
+        }
+
+        string? pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (pathVariable is null)
+        {
+            return false;
+        }
+
+        foreach (string directory in pathVariable.Split(Path.PathSeparator))
+        {
+            if (directory.Length == 0)
+            {
+                continue;
+            }
+
+            string candidate;
+            try
+            {
+                candidate = Path.Combine(directory, executable);
+            }
+            catch (ArgumentException)
+            {
+                // Skip malformed PATH entries that contain invalid path characters.
+                continue;
+            }
+
+            if (MatchesAnyExtension(candidate, extensions))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool MatchesAnyExtension(string path, string[] extensions)
+    {
+        foreach (string extension in extensions)
+        {
+            if (File.Exists(path + extension))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string[] GetExecutableExtensions(string executable, bool isWindows)
+    {
+        // On non-Windows platforms (or when the caller already specified an extension) only an exact match is relevant.
+        if (!isWindows || Path.HasExtension(executable))
+        {
+            return [string.Empty];
+        }
+
+        string? pathExt = Environment.GetEnvironmentVariable("PATHEXT");
+        if (string.IsNullOrEmpty(pathExt))
+        {
+            return [string.Empty, ".exe", ".cmd", ".bat", ".com"];
+        }
+
+        // PATHEXT entries already include the leading dot, for example ".COM;.EXE;.BAT".
+        string[] parts = pathExt!.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries);
+        string[] result = new string[parts.Length + 1];
+
+        // Keep an empty extension first so an exact match (for example when a full file name was passed) still wins.
+        result[0] = string.Empty;
+        Array.Copy(parts, 0, result, 1, parts.Length);
+        return result;
+    }
+
+#if !NET
+    // Mirrors the argument-quoting performed by ProcessStartInfo.ArgumentList on modern .NET (the well-known
+    // PasteArguments algorithm), used only on targets where ArgumentList isn't available.
+    private static string PasteArguments(string[] arguments)
+    {
+        var builder = new StringBuilder();
+        foreach (string argument in arguments)
+        {
+            if (builder.Length != 0)
+            {
+                builder.Append(' ');
+            }
+
+            if (argument.Length != 0 && argument.IndexOfAny(QuoteOrWhitespace) < 0)
+            {
+                builder.Append(argument);
+                continue;
+            }
+
+            builder.Append('"');
+            int index = 0;
+            while (index < argument.Length)
+            {
+                char c = argument[index++];
+                if (c == '\\')
+                {
+                    int backslashCount = 1;
+                    while (index < argument.Length && argument[index] == '\\')
+                    {
+                        backslashCount++;
+                        index++;
+                    }
+
+                    if (index == argument.Length)
+                    {
+                        builder.Append('\\', backslashCount * 2);
+                    }
+                    else if (argument[index] == '"')
+                    {
+                        builder.Append('\\', (backslashCount * 2) + 1);
+                        builder.Append('"');
+                        index++;
+                    }
+                    else
+                    {
+                        builder.Append('\\', backslashCount);
+                    }
+                }
+                else if (c == '"')
+                {
+                    builder.Append('\\');
+                    builder.Append('"');
+                }
+                else
+                {
+                    builder.Append(c);
+                }
+            }
+
+            builder.Append('"');
+        }
+
+        return builder.ToString();
+    }
+#endif
+}

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -16,6 +16,17 @@ Microsoft.VisualStudio.TestTools.UnitTesting.MemberConditionAttribute.ConditionM
 Microsoft.VisualStudio.TestTools.UnitTesting.MemberConditionAttribute.ConditionType.get -> System.Type!
 override Microsoft.VisualStudio.TestTools.UnitTesting.MemberConditionAttribute.GroupName.get -> string!
 override Microsoft.VisualStudio.TestTools.UnitTesting.MemberConditionAttribute.IsConditionMet.get -> bool
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.Arguments.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.ExecutableConditionAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.ConditionMode mode, string! executable) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.ExecutableConditionAttribute(Microsoft.VisualStudio.TestTools.UnitTesting.ConditionMode mode, string! executable, params string![]! arguments) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.ExecutableConditionAttribute(string! executable) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.ExecutableConditionAttribute(string! executable, params string![]! arguments) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.Executable.get -> string!
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.TimeoutSeconds.get -> int
+Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.TimeoutSeconds.set -> void
+override Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.GroupName.get -> string!
+override Microsoft.VisualStudio.TestTools.UnitTesting.ExecutableConditionAttribute.IsConditionMet.get -> bool
 Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder
 Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InAnyOrder = 1 -> Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder
 Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder.InOrder = 0 -> Microsoft.VisualStudio.TestTools.UnitTesting.SequenceOrder

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/ExecutableConditionAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/ExecutableConditionAttributeTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+using AwesomeAssertions;
+
+using TestFramework.ForTestingMSTest;
+
+namespace UnitTestFramework.Tests;
+
+/// <summary>
+/// Tests for class ExecutableConditionAttribute.
+/// </summary>
+public class ExecutableConditionAttributeTests : TestContainer
+{
+    public void Constructor_SetsCorrectMode()
+    {
+        var includeAttribute = new ExecutableConditionAttribute(ConditionMode.Include, "docker");
+        var excludeAttribute = new ExecutableConditionAttribute(ConditionMode.Exclude, "docker");
+
+        includeAttribute.Mode.Should().Be(ConditionMode.Include);
+        excludeAttribute.Mode.Should().Be(ConditionMode.Exclude);
+    }
+
+    public void Constructor_SingleArgument_DefaultsToIncludeMode()
+    {
+        var attribute = new ExecutableConditionAttribute("docker");
+
+        attribute.Mode.Should().Be(ConditionMode.Include);
+    }
+
+    public void Constructor_NullExecutable_Throws()
+    {
+        Action act = () => _ = new ExecutableConditionAttribute(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    public void Executable_ReturnsProvidedValue()
+        => new ExecutableConditionAttribute("docker").Executable.Should().Be("docker");
+
+    public void GroupName_IncludesExecutable()
+        => new ExecutableConditionAttribute("docker").GroupName.Should().Be("ExecutableCondition:docker");
+
+    public void GroupName_IncludesArguments()
+        => new ExecutableConditionAttribute("docker", "version").GroupName
+            .Should().Be("ExecutableCondition:docker version");
+
+    public void Arguments_DefaultsToEmpty()
+        => new ExecutableConditionAttribute("docker").Arguments.Should().BeEmpty();
+
+    public void Arguments_ReturnsProvidedValues()
+        => new ExecutableConditionAttribute("docker", "version", "--format", "json").Arguments
+            .Should().Equal("version", "--format", "json");
+
+    public void TimeoutSeconds_DefaultsTo30()
+        => new ExecutableConditionAttribute("docker", "version").TimeoutSeconds.Should().Be(30);
+
+    // A different GroupName per executable is what makes MSTest combine the conditions with a logical AND,
+    // so requiring two different tools requires both of them to be available.
+    public void GroupName_DiffersBetweenExecutables()
+        => new ExecutableConditionAttribute("docker").GroupName
+            .Should().NotBe(new ExecutableConditionAttribute("git").GroupName);
+
+    public void IgnoreMessage_IncludeMode_ReturnsCorrectMessage()
+        => new ExecutableConditionAttribute(ConditionMode.Include, "docker").IgnoreMessage
+            .Should().Be("Test is only supported when executable 'docker' is available on PATH");
+
+    public void IgnoreMessage_ExcludeMode_ReturnsCorrectMessage()
+        => new ExecutableConditionAttribute(ConditionMode.Exclude, "docker").IgnoreMessage
+            .Should().Be("Test is not supported when executable 'docker' is available on PATH");
+
+    public void IgnoreMessage_WithArguments_MentionsCommandSucceeds()
+        => new ExecutableConditionAttribute(ConditionMode.Include, "docker", "version").IgnoreMessage
+            .Should().Be("Test is only supported when command 'docker version' succeeds");
+
+    public void IsConditionMet_WhenExecutableMissing_ReturnsFalse()
+    {
+        // A randomized name that cannot exist on PATH (and is not cached from another test).
+        var attribute = new ExecutableConditionAttribute($"definitely-not-a-real-tool-{Guid.NewGuid():N}");
+
+        attribute.IsConditionMet.Should().BeFalse();
+    }
+
+    public void IsConditionMet_WhenExecutableOnPath_ReturnsTrue()
+    {
+        string directory = CreateTemporaryDirectory();
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // Use an extension that resolves on each platform: PATHEXT on Windows, a bare file elsewhere.
+        string commandName = $"fake-tool-{Guid.NewGuid():N}";
+        string fileName = isWindows ? $"{commandName}.cmd" : commandName;
+        File.WriteAllText(Path.Combine(directory, fileName), string.Empty);
+
+        string originalPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", directory + Path.PathSeparator + originalPath);
+
+            new ExecutableConditionAttribute(commandName).IsConditionMet.Should().BeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    public void IsConditionMet_WhenFullPathProvided_ReturnsTrue()
+    {
+        string directory = CreateTemporaryDirectory();
+        string fullPath = Path.Combine(directory, $"fake-tool-{Guid.NewGuid():N}");
+        File.WriteAllText(fullPath, string.Empty);
+
+        new ExecutableConditionAttribute(fullPath).IsConditionMet.Should().BeTrue();
+    }
+
+    public void IsConditionMet_IsCachedPerExecutable()
+    {
+        string directory = CreateTemporaryDirectory();
+        string commandName = $"cached-tool-{Guid.NewGuid():N}";
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        string fileName = isWindows ? $"{commandName}.cmd" : commandName;
+        string filePath = Path.Combine(directory, fileName);
+        File.WriteAllText(filePath, string.Empty);
+
+        string originalPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", directory + Path.PathSeparator + originalPath);
+
+            var attribute = new ExecutableConditionAttribute(commandName);
+            attribute.IsConditionMet.Should().BeTrue();
+
+            // Deleting the file should not change the result because the first probe is cached.
+            File.Delete(filePath);
+            attribute.IsConditionMet.Should().BeTrue();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+
+    public void IsConditionMet_WhenCommandExitsZero_ReturnsTrue()
+    {
+        (string executable, string[] arguments) = ExitCommand(0);
+
+        new ExecutableConditionAttribute(executable, arguments).IsConditionMet.Should().BeTrue();
+    }
+
+    public void IsConditionMet_WhenCommandExitsNonZero_ReturnsFalse()
+    {
+        (string executable, string[] arguments) = ExitCommand(1);
+
+        new ExecutableConditionAttribute(executable, arguments).IsConditionMet.Should().BeFalse();
+    }
+
+    public void IsConditionMet_WhenExecutableMissingButArgumentsProvided_ReturnsFalse()
+    {
+        var attribute = new ExecutableConditionAttribute($"definitely-not-a-real-tool-{Guid.NewGuid():N}", "version");
+
+        attribute.IsConditionMet.Should().BeFalse();
+    }
+
+    public void IsConditionMet_WhenCommandExceedsTimeout_ReturnsFalse()
+    {
+        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        // A command that sleeps well beyond the (very short) timeout, so the condition must give up and report false.
+        ExecutableConditionAttribute attribute = isWindows
+            ? new ExecutableConditionAttribute("cmd", "/c", "ping", "-n", "30", "127.0.0.1") { TimeoutSeconds = 1 }
+            : new ExecutableConditionAttribute("sh", "-c", "sleep 30") { TimeoutSeconds = 1 };
+
+        attribute.IsConditionMet.Should().BeFalse();
+    }
+
+    // Produces a per-OS command guaranteed to be on PATH that exits with the given code.
+    private static (string Executable, string[] Arguments) ExitCommand(int exitCode)
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? ("cmd", ["/c", "exit", exitCode.ToString(CultureInfo.InvariantCulture)])
+            : ("sh", ["-c", $"exit {exitCode}"]);
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/ExecutableConditionAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/ExecutableConditionAttributeTests.cs
@@ -41,11 +41,33 @@ public class ExecutableConditionAttributeTests : TestContainer
         => new ExecutableConditionAttribute("docker").Executable.Should().Be("docker");
 
     public void GroupName_IncludesExecutable()
-        => new ExecutableConditionAttribute("docker").GroupName.Should().Be("ExecutableCondition:docker");
+        => new ExecutableConditionAttribute("docker").GroupName.Should().Be("ExecutableCondition:presence\0docker\0Include");
 
     public void GroupName_IncludesArguments()
         => new ExecutableConditionAttribute("docker", "version").GroupName
-            .Should().Be("ExecutableCondition:docker version");
+            .Should().Be("ExecutableCondition:run\0docker\0version\0Include");
+
+    // A presence check for an executable literally named "foo bar" must not collide with running "foo" with the
+    // argument "bar"; the null-character separator keeps the two distinct.
+    public void GroupName_PresenceAndRunDoNotCollide()
+        => new ExecutableConditionAttribute("foo bar").GroupName
+            .Should().NotBe(new ExecutableConditionAttribute("foo", "bar").GroupName);
+
+    // Include and Exclude for the same command must NOT share a GroupName, otherwise the two would land in the same
+    // OR group and silently cancel each other out instead of being AND-ed.
+    public void GroupName_DiffersByMode()
+        => new ExecutableConditionAttribute(ConditionMode.Include, "docker").GroupName
+            .Should().NotBe(new ExecutableConditionAttribute(ConditionMode.Exclude, "docker").GroupName);
+
+    // The attribute must be immutable: mutating the array the caller passed must not change Arguments.
+    public void Arguments_AreCopiedFromConstructorArray()
+    {
+        string[] args = ["version", "--format"];
+        var attribute = new ExecutableConditionAttribute("docker", args);
+        args[0] = "mutated";
+
+        attribute.Arguments.Should().Equal("version", "--format");
+    }
 
     public void Arguments_DefaultsToEmpty()
         => new ExecutableConditionAttribute("docker").Arguments.Should().BeEmpty();
@@ -167,10 +189,11 @@ public class ExecutableConditionAttributeTests : TestContainer
     {
         bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-        // A command that sleeps well beyond the (very short) timeout, so the condition must give up and report false.
+        // Invoke ping/sleep directly (no shell wrapper) so killing the root process reliably stops the long-running
+        // command even on TFMs where only the root process can be killed (no entire-process-tree kill).
         ExecutableConditionAttribute attribute = isWindows
-            ? new ExecutableConditionAttribute("cmd", "/c", "ping", "-n", "30", "127.0.0.1") { TimeoutSeconds = 1 }
-            : new ExecutableConditionAttribute("sh", "-c", "sleep 30") { TimeoutSeconds = 1 };
+            ? new ExecutableConditionAttribute("ping", "-n", "30", "127.0.0.1") { TimeoutSeconds = 1 }
+            : new ExecutableConditionAttribute("sleep", "30") { TimeoutSeconds = 1 };
 
         attribute.IsConditionMet.Should().BeFalse();
     }


### PR DESCRIPTION
## What

Adds a new public ``ExecutableConditionAttribute`` (in ``Microsoft.VisualStudio.TestTools.UnitTesting``) that conditionally includes or excludes a test class or method based on whether a given executable/tool is available.

Two modes:
- **Presence check** — when no arguments are supplied, the condition only verifies that the executable is discoverable on ``PATH`` (and, on Windows, resolvable through ``PATHEXT``). It does not run the executable. E.g. ``[ExecutableCondition("docker")]``.
- **Run check** — when arguments are supplied, the condition runs ``executable arguments`` and is met only when the process exits with code ``0`` within ``TimeoutSeconds`` (default 30s). Output is redirected/discarded and the process tree is terminated on timeout. E.g. ``[ExecutableCondition("docker", "version")]``.

Each distinct executable+arguments combination forms its own condition group, so multiple attributes with different commands AND together, while repeats of the same command OR together.

## Details

- ``ConditionMode`` (Include/Exclude) overloads provided.
- Results are cached per command (availability doesn't change during a run).
- Cross-target: uses ``ProcessStartInfo.ArgumentList`` on modern .NET and the well-known PasteArguments quoting on ``netstandard``/``net462``.
- New public API recorded in ``PublicAPI.Unshipped.txt``; attribute is ``sealed`` and uses no ``init`` accessors.

## Tests

Adds ``ExecutableConditionAttributeTests`` (TestFramework.ForTestingMSTest). All 21 cases pass on net8.0; project builds clean (0 warnings/0 errors) across all TFMs.