### PR TITLE
Run MSTest acceptance assets under both reflection and source generation

### DIFF
--- a/NonWindowsTests.slnf
+++ b/NonWindowsTests.slnf
@@ -7,6 +7,7 @@
       "src\\Analyzers\\MSTest.Analyzers.CodeFixes\\MSTest.Analyzers.CodeFixes.csproj",
       "src\\Analyzers\\MSTest.Analyzers.Package\\MSTest.Analyzers.Package.csproj",
       "src\\Analyzers\\MSTest.Analyzers\\MSTest.Analyzers.csproj",
+      "src\\Analyzers\\MSTest.AotReflection.SourceGeneration\\MSTest.AotReflection.SourceGeneration.csproj",
       "src\\Analyzers\\MSTest.GlobalConfigsGenerator\\MSTest.GlobalConfigsGenerator.csproj",
       "src\\Analyzers\\MSTest.SourceGeneration\\MSTest.SourceGeneration.csproj",
       "src\\Package\\MSTest.Sdk\\MSTest.Sdk.csproj",

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 using Microsoft.Testing.Platform.Helpers;
@@ -22,23 +24,12 @@ public sealed class InconclusiveTests : AcceptanceTestBase<InconclusiveTests.Tes
         AssemblyCleanup,
     }
 
-    // Cross-products every inconclusive lifecycle step with the metadata modes under test
-    // (reflection and, unless globally disabled, the two source-generation paths) so the same
-    // expectations validate every metadata path.
-    public static IEnumerable<object[]> LifecycleAndMetadataModes()
-    {
-        foreach (Lifecycle lifecycle in Enum.GetValues<Lifecycle>())
-        {
-            foreach (MetadataMode mode in MetadataModesToRun)
-            {
-                yield return [lifecycle, mode];
-            }
-        }
-    }
-
+    // [CombinatorialData] cross-products every inconclusive lifecycle step (auto-expanded from the
+    // Lifecycle enum) with the metadata modes under test (reflection and, unless globally disabled,
+    // the two source-generation paths) so the same expectations validate every metadata path.
     [TestMethod]
-    [DynamicData(nameof(LifecycleAndMetadataModes))]
-    public async Task TestOutcomeShouldBeRespectedCorrectly(Lifecycle inconclusiveStep, MetadataMode metadataMode)
+    [CombinatorialData]
+    public async Task TestOutcomeShouldBeRespectedCorrectly(Lifecycle inconclusiveStep, [MetadataModeValues] MetadataMode metadataMode)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent, metadataMode: metadataMode);
         TestHostResult testHostResult = await testHost.ExecuteAsync(

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
@@ -23,12 +23,18 @@ public sealed class InconclusiveTests : AcceptanceTestBase<InconclusiveTests.Tes
     }
 
     // Cross-products every inconclusive lifecycle step with the metadata modes under test
-    // (reflection and, unless globally disabled, source generation) so the same expectations
-    // validate both metadata paths.
-    public static IEnumerable<object[]> LifecycleAndMetadataModes { get; }
-        = (from lifecycle in Enum.GetValues<Lifecycle>()
-           from mode in MetadataModesToRun
-           select new object[] { lifecycle, mode }).ToArray();
+    // (reflection and, unless globally disabled, the two source-generation paths) so the same
+    // expectations validate every metadata path.
+    public static IEnumerable<object[]> LifecycleAndMetadataModes()
+    {
+        foreach (Lifecycle lifecycle in Enum.GetValues<Lifecycle>())
+        {
+            foreach (MetadataMode mode in MetadataModesToRun)
+            {
+                yield return [lifecycle, mode];
+            }
+        }
+    }
 
     [TestMethod]
     [DynamicData(nameof(LifecycleAndMetadataModes))]
@@ -118,6 +124,9 @@ public sealed class InconclusiveTests : AcceptanceTestBase<InconclusiveTests.Tes
         public const string ProjectName = "TestInconclusive";
 
         public string ProjectPath => GetAssetPath(ProjectName);
+
+        protected override IReadOnlyList<MetadataMode> SourceGenMetadataModes { get; }
+            = [MetadataMode.SourceGeneration, MetadataMode.AotSourceGeneration];
 
         public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
                 SourceCode

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/InconclusiveTests.cs
@@ -22,18 +22,19 @@ public sealed class InconclusiveTests : AcceptanceTestBase<InconclusiveTests.Tes
         AssemblyCleanup,
     }
 
+    // Cross-products every inconclusive lifecycle step with the metadata modes under test
+    // (reflection and, unless globally disabled, source generation) so the same expectations
+    // validate both metadata paths.
+    public static IEnumerable<object[]> LifecycleAndMetadataModes { get; }
+        = (from lifecycle in Enum.GetValues<Lifecycle>()
+           from mode in MetadataModesToRun
+           select new object[] { lifecycle, mode }).ToArray();
+
     [TestMethod]
-    [DataRow(Lifecycle.Constructor)]
-    [DataRow(Lifecycle.AssemblyInitialize)]
-    [DataRow(Lifecycle.ClassInitialize)]
-    [DataRow(Lifecycle.TestInitialize)]
-    [DataRow(Lifecycle.TestMethod)]
-    [DataRow(Lifecycle.TestCleanup)]
-    [DataRow(Lifecycle.ClassCleanup)]
-    [DataRow(Lifecycle.AssemblyCleanup)]
-    public async Task TestOutcomeShouldBeRespectedCorrectly(Lifecycle inconclusiveStep)
+    [DynamicData(nameof(LifecycleAndMetadataModes))]
+    public async Task TestOutcomeShouldBeRespectedCorrectly(Lifecycle inconclusiveStep, MetadataMode metadataMode)
     {
-        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent, metadataMode: metadataMode);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
             "--settings my.runsettings",
             environmentVariables: new Dictionary<string, string?>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
@@ -10,10 +10,10 @@ namespace MSTest.Acceptance.IntegrationTests;
 public sealed class TestRunParametersTests : AcceptanceTestBase<TestRunParametersTests.TestAssetFixture>
 {
     [TestMethod]
-    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
-    public async Task TestRunParameters_WhenProvidingMultipleArgumentsToTheOption(string tfm)
+    [DynamicData(nameof(AllTfmsAndMetadataModes))]
+    public async Task TestRunParameters_WhenProvidingMultipleArgumentsToTheOption(string tfm, MetadataMode metadataMode)
     {
-        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm, metadataMode: metadataMode);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --test-parameter MyParameter2=MyValue2 MyParameter3=MyValue3", cancellationToken: TestContext.CancellationToken);
 
         // Assert
@@ -22,10 +22,10 @@ public sealed class TestRunParametersTests : AcceptanceTestBase<TestRunParameter
     }
 
     [TestMethod]
-    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
-    public async Task TestRunParameters_WhenProvidingMultipleMultipleTimesTheOptionAndArgument(string tfm)
+    [DynamicData(nameof(AllTfmsAndMetadataModes))]
+    public async Task TestRunParameters_WhenProvidingMultipleMultipleTimesTheOptionAndArgument(string tfm, MetadataMode metadataMode)
     {
-        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm);
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, tfm, metadataMode: metadataMode);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings --test-parameter MyParameter2=MyValue2 --test-parameter MyParameter3=MyValue3", cancellationToken: TestContext.CancellationToken);
 
         // Assert

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TestRunParametersTests.cs
@@ -39,6 +39,9 @@ public sealed class TestRunParametersTests : AcceptanceTestBase<TestRunParameter
 
         public string ProjectPath => GetAssetPath(ProjectName);
 
+        protected override IReadOnlyList<MetadataMode> SourceGenMetadataModes { get; }
+            = [MetadataMode.SourceGeneration, MetadataMode.AotSourceGeneration];
+
         public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
                 SourceCode
                 .PatchTargetFrameworks(TargetFrameworks.All)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -115,34 +115,49 @@ public abstract class AcceptanceTestBase
     }
 
     /// <summary>
-    /// Gets the metadata modes each acceptance assertion should run against. By default both the
-    /// runtime reflection path and the <c>MSTest.SourceGeneration</c> path are exercised; the
-    /// source-gen mode is dropped when globally disabled via the kill-switch.
+    /// Gets the metadata modes each acceptance assertion should run against. By default the runtime
+    /// reflection path and both source-generated paths (<c>MSTest.SourceGeneration</c> and
+    /// <c>MSTest.AotReflection.SourceGeneration</c>) are exercised; the source-gen modes are dropped
+    /// when globally disabled via the kill-switch.
     /// </summary>
     internal static MetadataMode[] MetadataModesToRun { get; }
         = AcceptanceSourceGen.IsGloballyDisabled
             ? [MetadataMode.Reflection]
-            : [MetadataMode.Reflection, MetadataMode.SourceGeneration];
+            : [MetadataMode.Reflection, MetadataMode.SourceGeneration, MetadataMode.AotSourceGeneration];
 
     /// <summary>
     /// DynamicData source: every <see cref="TargetFrameworks.All"/> TFM combined with every applicable
     /// <see cref="MetadataModesToRun"/> mode. Source generation is .NET-only, so .NET Framework TFMs
     /// (net4x) are paired with <see cref="MetadataMode.Reflection"/> only.
     /// </summary>
-    public static IEnumerable<object[]> AllTfmsAndMetadataModes { get; }
-        = (from tfm in TargetFrameworks.All
-           from mode in MetadataModesToRun
-           where mode == MetadataMode.Reflection || TargetFrameworks.Net.Contains(tfm)
-           select new object[] { tfm, mode }).ToArray();
+    public static IEnumerable<object[]> AllTfmsAndMetadataModes()
+    {
+        foreach (string tfm in TargetFrameworks.All)
+        {
+            foreach (MetadataMode mode in MetadataModesToRun)
+            {
+                if (mode == MetadataMode.Reflection || TargetFrameworks.Net.Contains(tfm))
+                {
+                    yield return [tfm, mode];
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// DynamicData source: every .NET (non-.NET Framework) TFM combined with every
     /// <see cref="MetadataModesToRun"/> mode.
     /// </summary>
-    public static IEnumerable<object[]> NetTfmsAndMetadataModes { get; }
-        = (from tfm in TargetFrameworks.Net
-           from mode in MetadataModesToRun
-           select new object[] { tfm, mode }).ToArray();
+    public static IEnumerable<object[]> NetTfmsAndMetadataModes()
+    {
+        foreach (string tfm in TargetFrameworks.Net)
+        {
+            foreach (MetadataMode mode in MetadataModesToRun)
+            {
+                yield return [tfm, mode];
+            }
+        }
+    }
 
     /// <summary>
     /// DynamicData source: every <see cref="MetadataModesToRun"/> mode, for tests that are not

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -267,6 +267,9 @@ internal sealed class AllTargetFrameworksAttribute : Attribute, ICombinatorialVa
 [AttributeUsage(AttributeTargets.Parameter)]
 internal sealed class MetadataModeValuesAttribute : Attribute, ICombinatorialValuesProvider
 {
-    // MetadataModesToRun is a single immutable array, so it's safe to hand it back on every call.
-    public object?[] GetValues(ParameterInfo _) => AcceptanceTestBase.MetadataModesToRun.Cast<object?>().ToArray();
+    // MetadataModesToRun never changes during a run, so box it into an object?[] once and hand the
+    // same array back on every call to avoid repeated allocations during combinatorial expansion.
+    private static readonly object?[] BoxedValues = [.. AcceptanceTestBase.MetadataModesToRun.Cast<object?>()];
+
+    public object?[] GetValues(ParameterInfo _) => BoxedValues;
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -114,6 +114,43 @@ public abstract class AcceptanceTestBase
         }
     }
 
+    /// <summary>
+    /// Gets the metadata modes each acceptance assertion should run against. By default both the
+    /// runtime reflection path and the <c>MSTest.SourceGeneration</c> path are exercised; the
+    /// source-gen mode is dropped when globally disabled via the kill-switch.
+    /// </summary>
+    internal static MetadataMode[] MetadataModesToRun { get; }
+        = AcceptanceSourceGen.IsGloballyDisabled
+            ? [MetadataMode.Reflection]
+            : [MetadataMode.Reflection, MetadataMode.SourceGeneration];
+
+    /// <summary>
+    /// DynamicData source: every <see cref="TargetFrameworks.All"/> TFM combined with every applicable
+    /// <see cref="MetadataModesToRun"/> mode. Source generation is .NET-only, so .NET Framework TFMs
+    /// (net4x) are paired with <see cref="MetadataMode.Reflection"/> only.
+    /// </summary>
+    public static IEnumerable<object[]> AllTfmsAndMetadataModes { get; }
+        = (from tfm in TargetFrameworks.All
+           from mode in MetadataModesToRun
+           where mode == MetadataMode.Reflection || TargetFrameworks.Net.Contains(tfm)
+           select new object[] { tfm, mode }).ToArray();
+
+    /// <summary>
+    /// DynamicData source: every .NET (non-.NET Framework) TFM combined with every
+    /// <see cref="MetadataModesToRun"/> mode.
+    /// </summary>
+    public static IEnumerable<object[]> NetTfmsAndMetadataModes { get; }
+        = (from tfm in TargetFrameworks.Net
+           from mode in MetadataModesToRun
+           select new object[] { tfm, mode }).ToArray();
+
+    /// <summary>
+    /// DynamicData source: every <see cref="MetadataModesToRun"/> mode, for tests that are not
+    /// parameterized by TFM (they typically run against <see cref="TargetFrameworks.NetCurrent"/>).
+    /// </summary>
+    public static IEnumerable<object[]> MetadataModes { get; }
+        = MetadataModesToRun.Select(mode => new object[] { mode }).ToArray();
+
     // https://github.com/NuGet/NuGet.Client/blob/c5934bdcbc578eec1e2921f49e6a5d53481c5099/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs#L65-L94
     private protected static async Task<string> FindMsbuildWithVsWhereAsync(CancellationToken cancellationToken)
     {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -129,6 +129,13 @@ public abstract class AcceptanceTestBase
     /// DynamicData source: every <see cref="TargetFrameworks.All"/> TFM combined with every applicable
     /// <see cref="MetadataModesToRun"/> mode. Source generation is .NET-only, so .NET Framework TFMs
     /// (net4x) are paired with <see cref="MetadataMode.Reflection"/> only.
+    /// <para>
+    /// This cross-parameter filter (net4x → reflection only) cannot be expressed with independent
+    /// <c>[CombinatorialData]</c> parameter providers, so it stays a bespoke data source. Matrices
+    /// without such a dependency should instead use <c>[CombinatorialData]</c> with
+    /// <see cref="MetadataModeValuesAttribute"/> (and <see cref="AllTargetFrameworksAttribute"/> when
+    /// a TFM axis is needed).
+    /// </para>
     /// </summary>
     public static IEnumerable<object[]> AllTfmsAndMetadataModes()
     {
@@ -141,28 +148,6 @@ public abstract class AcceptanceTestBase
             }
         }
     }
-
-    /// <summary>
-    /// DynamicData source: every .NET (non-.NET Framework) TFM combined with every
-    /// <see cref="MetadataModesToRun"/> mode.
-    /// </summary>
-    public static IEnumerable<object[]> NetTfmsAndMetadataModes()
-    {
-        foreach (string tfm in TargetFrameworks.Net)
-        {
-            foreach (MetadataMode mode in MetadataModesToRun)
-            {
-                yield return [tfm, mode];
-            }
-        }
-    }
-
-    /// <summary>
-    /// DynamicData source: every <see cref="MetadataModesToRun"/> mode, for tests that are not
-    /// parameterized by TFM (they typically run against <see cref="TargetFrameworks.NetCurrent"/>).
-    /// </summary>
-    public static IEnumerable<object[]> MetadataModes { get; }
-        = MetadataModesToRun.Select(mode => new object[] { mode }).ToArray();
 
     // https://github.com/NuGet/NuGet.Client/blob/c5934bdcbc578eec1e2921f49e6a5d53481c5099/test/NuGet.Core.FuncTests/Msbuild.Integration.Test/MsbuildIntegrationTestFixture.cs#L65-L94
     private protected static async Task<string> FindMsbuildWithVsWhereAsync(CancellationToken cancellationToken)
@@ -269,4 +254,19 @@ internal sealed class AllTargetFrameworksAttribute : Attribute, ICombinatorialVa
 {
     // TargetFrameworks.All is never mutated, so it's safe to hand the same array back on every call.
     public object?[] GetValues(ParameterInfo _) => TargetFrameworks.All;
+}
+
+/// <summary>
+/// A <see cref="ICombinatorialValuesProvider"/> that yields every metadata mode under test
+/// (<see cref="AcceptanceTestBase.MetadataModesToRun"/>): the runtime reflection path and, unless
+/// disabled via the source-gen kill-switch, both source-generated paths. Apply it to a
+/// <see cref="MetadataMode"/> parameter of a <c>[CombinatorialData]</c> test method so the same
+/// assertions run against every metadata path. Prefer it over auto-expanding the enum, which would
+/// ignore the kill-switch and always emit all three values.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class MetadataModeValuesAttribute : Attribute, ICombinatorialValuesProvider
+{
+    // MetadataModesToRun is a single immutable array, so it's safe to hand it back on every call.
+    public object?[] GetValues(ParameterInfo _) => AcceptanceTestBase.MetadataModesToRun.Cast<object?>().ToArray();
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -134,12 +134,10 @@ public abstract class AcceptanceTestBase
     {
         foreach (string tfm in TargetFrameworks.All)
         {
-            foreach (MetadataMode mode in MetadataModesToRun)
+            // Source generation is .NET-only, so .NET Framework TFMs are paired with reflection only.
+            foreach (MetadataMode mode in MetadataModesToRun.Where(mode => mode == MetadataMode.Reflection || TargetFrameworks.Net.Contains(tfm)))
             {
-                if (mode == MetadataMode.Reflection || TargetFrameworks.Net.Contains(tfm))
-                {
-                    yield return [tfm, mode];
-                }
+                yield return [tfm, mode];
             }
         }
     }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.TestInfrastructure;
+
+/// <summary>
+/// Shared helpers for building the <see cref="MetadataMode.SourceGeneration"/> variant of an
+/// acceptance-test asset. The <c>MSTest.SourceGeneration</c> package is a plain Roslyn source
+/// generator: referencing it (together with <c>MSTest.TestAdapter</c>, which carries the runtime
+/// hook types) is all that is needed to switch an asset onto the source-generated metadata path.
+///
+/// <para>
+/// To avoid rewriting every generated <c>.csproj</c>, we inject the package reference through an
+/// MSBuild <c>CustomBeforeMicrosoftCommonProps</c> file that is only passed on the source-gen
+/// build command line. The normal (reflection) build never sees it. The two builds are sent to
+/// distinct output folders so both test hosts coexist on disk.
+/// </para>
+/// </summary>
+public static class AcceptanceSourceGen
+{
+    private const string SourceGenPropsFileName = "MSTest.AcceptanceSourceGen.props";
+
+    private const string NuGetPackageExtensionName = ".nupkg";
+
+    private const string SourceGenerationPackagePrefix = "MSTest.SourceGeneration.";
+
+    /// <summary>
+    /// The <c>BaseOutputPath</c>/<c>BaseIntermediateOutputPath</c> sub-folder used to keep the
+    /// source-gen build outputs separate from the reflection build (which uses the default
+    /// <c>bin</c>/<c>obj</c>).
+    /// </summary>
+    public const string OutputSubFolder = "SourceGen";
+
+    /// <summary>
+    /// Global kill-switch. When this environment variable is set to a truthy value, the source-gen
+    /// build variant is skipped everywhere (useful while ramping up or when debugging locally).
+    /// </summary>
+    public const string SkipEnvironmentVariable = "MSTEST_ACCEPTANCE_SKIP_SOURCEGEN";
+
+    private static readonly Lazy<string> LazyVersion = new(ResolveSourceGenerationVersion);
+
+    /// <summary>
+    /// Gets the version of the locally built <c>MSTest.SourceGeneration</c> shipping package.
+    /// </summary>
+    public static string Version => LazyVersion.Value;
+
+    /// <summary>
+    /// Gets a value indicating whether the source-gen build variant is globally disabled through
+    /// <see cref="SkipEnvironmentVariable"/>.
+    /// </summary>
+    public static bool IsGloballyDisabled
+    {
+        get
+        {
+            string? value = Environment.GetEnvironmentVariable(SkipEnvironmentVariable);
+            return value is not null
+                && (value == "1"
+                    || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    private static readonly string PropsContent =
+$$"""
+<Project>
+  <!--
+    Injected only for the MetadataMode.SourceGeneration build of an acceptance-test asset.
+    Referencing MSTest.SourceGeneration switches the asset onto the source-generated metadata path.
+  -->
+  <PropertyGroup>
+    <!--
+      This build redirects bin/obj to bin/SourceGen and obj/SourceGen (so it does not overwrite the
+      reflection build). That redirect drops the original obj/bin from DefaultItemExcludes, which would
+      let the reflection build's generated *.cs (AssemblyInfo, MicrosoftTestingPlatformEntryPoint,
+      SelfRegisteredExtensions) be double-compiled into this build. Re-exclude them here. This runs in
+      CustomBeforeMicrosoftCommonProps (before the SDK seeds DefaultItemExcludes), so the SDK appends
+      its own excludes after ours.
+    -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--
+      Source generation is .NET-only: the generated metadata references ModuleInitializerAttribute /
+      DynamicallyAccessedMembersAttribute / DynamicDependencyAttribute, which do not compile on .NET
+      Framework. Skip the generator on net4x legs of a multi-targeting asset; those legs build as plain
+      reflection and are simply not exercised in SourceGeneration mode by the test matrix. In the inner
+      build TargetFramework is already set as a global property, so the condition resolves per TFM (it is
+      empty for the outer cross-targeting build, which only dispatches and does not compile).
+    -->
+    <PackageReference Include="MSTest.SourceGeneration" Version="$(MSTestSourceGenerationVersion)"
+                      Condition=" !$(TargetFramework.StartsWith('net4')) " />
+  </ItemGroup>
+</Project>
+""";
+
+    /// <summary>
+    /// Writes the injection props file into the asset directory and returns the MSBuild command-line
+    /// arguments (without a leading space) needed to produce the source-gen build of that asset.
+    /// </summary>
+    /// <param name="assetDirectory">The directory containing the generated asset (project) files.</param>
+    /// <returns>The extra arguments to append to a <c>dotnet build</c> command.</returns>
+    public static async Task<string> PrepareBuildArgumentsAsync(string assetDirectory)
+    {
+        string propsPath = Path.Combine(assetDirectory, SourceGenPropsFileName);
+        await TempDirectory.WriteFileAsync(assetDirectory, SourceGenPropsFileName, PropsContent);
+
+        // - CustomBeforeMicrosoftCommonProps injects the MSTest.SourceGeneration PackageReference
+        //   early enough for restore to see it, without clobbering any Directory.Build.props.
+        // - BaseOutputPath/BaseIntermediateOutputPath redirect bin/obj so this build does not
+        //   overwrite the reflection build outputs. Forward slashes are used intentionally: a
+        //   trailing backslash immediately before the closing quote would escape the quote on
+        //   Windows and corrupt the argument. MSBuild accepts forward slashes on all platforms.
+        // - MSTestSourceGenerationVersion feeds the version into the injected props.
+        return $"-p:CustomBeforeMicrosoftCommonProps=\"{propsPath}\" "
+            + $"-p:BaseOutputPath=\"bin/{OutputSubFolder}/\" "
+            + $"-p:BaseIntermediateOutputPath=\"obj/{OutputSubFolder}/\" "
+            + $"-p:MSTestSourceGenerationVersion={Version}";
+    }
+
+    private static string ResolveSourceGenerationVersion()
+    {
+        string rootFolder = Constants.ArtifactsPackagesShipping;
+        string[] matches = Directory.Exists(rootFolder)
+            ? Directory.GetFiles(rootFolder, SourceGenerationPackagePrefix + "*" + NuGetPackageExtensionName, SearchOption.TopDirectoryOnly)
+            : [];
+
+        if (matches.Length > 1)
+        {
+            // The prefix can match neighboring packages; keep only those where a version digit
+            // follows the prefix (mirrors AcceptanceTestBase.ExtractVersionFromPackage).
+            matches = [.. matches
+                .Select(path => (path, fileName: Path.GetFileName(path)[SourceGenerationPackagePrefix.Length..]))
+                .Where(tuple => int.TryParse(tuple.fileName[0].ToString(), CultureInfo.InvariantCulture, out _))
+                .Select(tuple => tuple.path)];
+        }
+
+        if (matches.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Was expecting to find a single NuGet package named '{SourceGenerationPackagePrefix}' in '{rootFolder}', but found {matches.Length}: '{string.Join("', '", matches.Select(Path.GetFileName))}'. Did you run with -pack?");
+        }
+
+        string packageFullName = Path.GetFileName(matches[0]);
+        return packageFullName.Substring(
+            SourceGenerationPackagePrefix.Length,
+            packageFullName.Length - SourceGenerationPackagePrefix.Length - NuGetPackageExtensionName.Length);
+    }
+}

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
@@ -4,48 +4,45 @@
 namespace Microsoft.Testing.TestInfrastructure;
 
 /// <summary>
-/// Shared helpers for building the <see cref="MetadataMode.SourceGeneration"/> variant of an
-/// acceptance-test asset. The <c>MSTest.SourceGeneration</c> package is a plain Roslyn source
-/// generator: referencing it (together with <c>MSTest.TestAdapter</c>, which carries the runtime
-/// hook types) is all that is needed to switch an asset onto the source-generated metadata path.
+/// Shared helpers for building the source-generated variants of an acceptance-test asset. Two
+/// generators are exercised, each selected through a <see cref="MetadataMode"/>:
+/// <list type="bullet">
+///   <item><see cref="MetadataMode.SourceGeneration"/> injects the shipping <c>MSTest.SourceGeneration</c> package.</item>
+///   <item><see cref="MetadataMode.AotSourceGeneration"/> injects the experimental <c>MSTest.AotReflection.SourceGeneration</c> package.</item>
+/// </list>
+/// Both are plain Roslyn source generators: referencing one (together with <c>MSTest.TestAdapter</c>,
+/// which carries the runtime hook types) is all that is needed to switch an asset onto the matching
+/// source-generated metadata path.
 ///
 /// <para>
 /// To avoid rewriting every generated <c>.csproj</c>, we inject the package reference through an
 /// MSBuild <c>CustomBeforeMicrosoftCommonProps</c> file that is only passed on the source-gen
-/// build command line. The normal (reflection) build never sees it. The two builds are sent to
-/// distinct output folders so both test hosts coexist on disk.
+/// build command line. The normal (reflection) build never sees it. Each variant is sent to a
+/// distinct output folder so the hosts coexist on disk.
 /// </para>
 /// </summary>
 public static class AcceptanceSourceGen
 {
-    private const string SourceGenPropsFileName = "MSTest.AcceptanceSourceGen.props";
-
     private const string NuGetPackageExtensionName = ".nupkg";
 
-    private const string SourceGenerationPackagePrefix = "MSTest.SourceGeneration.";
+    private const string ShippingSourceGenerationPackagePrefix = "MSTest.SourceGeneration.";
 
-    /// <summary>
-    /// The <c>BaseOutputPath</c>/<c>BaseIntermediateOutputPath</c> sub-folder used to keep the
-    /// source-gen build outputs separate from the reflection build (which uses the default
-    /// <c>bin</c>/<c>obj</c>).
-    /// </summary>
-    public const string OutputSubFolder = "SourceGen";
+    private const string AotSourceGenerationPackagePrefix = "MSTest.AotReflection.SourceGeneration.";
 
     /// <summary>
     /// Global kill-switch. When this environment variable is set to a truthy value, the source-gen
-    /// build variant is skipped everywhere (useful while ramping up or when debugging locally).
+    /// build variants are skipped everywhere (useful while ramping up or when debugging locally).
     /// </summary>
     public const string SkipEnvironmentVariable = "MSTEST_ACCEPTANCE_SKIP_SOURCEGEN";
 
-    private static readonly Lazy<string> LazyVersion = new(ResolveSourceGenerationVersion);
+    private static readonly Lazy<string> LazyShippingVersion =
+        new(() => ResolveVersion(Constants.ArtifactsPackagesShipping, ShippingSourceGenerationPackagePrefix));
+
+    private static readonly Lazy<string> LazyAotVersion =
+        new(() => ResolveVersion(Constants.ArtifactsPackagesNonShipping, AotSourceGenerationPackagePrefix));
 
     /// <summary>
-    /// Gets the version of the locally built <c>MSTest.SourceGeneration</c> shipping package.
-    /// </summary>
-    public static string Version => LazyVersion.Value;
-
-    /// <summary>
-    /// Gets a value indicating whether the source-gen build variant is globally disabled through
+    /// Gets a value indicating whether the source-gen build variants are globally disabled through
     /// <see cref="SkipEnvironmentVariable"/>.
     /// </summary>
     public static bool IsGloballyDisabled
@@ -59,21 +56,72 @@ public static class AcceptanceSourceGen
         }
     }
 
-    private static readonly string PropsContent =
+    /// <summary>
+    /// Gets the <c>bin</c>/<c>obj</c> sub-folder used to keep a source-gen build's outputs separate
+    /// from the reflection build (which uses the default <c>bin</c>/<c>obj</c>) and from the other
+    /// source-gen build.
+    /// </summary>
+    /// <param name="metadataMode">The source-gen metadata mode.</param>
+    /// <returns>The output sub-folder name (for example <c>SourceGen</c>).</returns>
+    public static string GetOutputSubFolder(MetadataMode metadataMode)
+        => metadataMode switch
+        {
+            MetadataMode.SourceGeneration => "SourceGen",
+            MetadataMode.AotSourceGeneration => "AotSourceGen",
+            _ => throw new ArgumentOutOfRangeException(nameof(metadataMode), metadataMode, "Not a source-gen metadata mode."),
+        };
+
+    /// <summary>
+    /// Writes the injection props file into the asset directory and returns the MSBuild command-line
+    /// arguments (without a leading space) needed to produce the source-gen build of that asset for
+    /// the given <paramref name="metadataMode"/>.
+    /// </summary>
+    /// <param name="assetDirectory">The directory containing the generated asset (project) files.</param>
+    /// <param name="metadataMode">The source-gen metadata mode to build.</param>
+    /// <returns>The extra arguments to append to a <c>dotnet build</c> command.</returns>
+    public static async Task<string> PrepareBuildArgumentsAsync(string assetDirectory, MetadataMode metadataMode)
+    {
+        (string packageId, string version, string versionProperty) = metadataMode switch
+        {
+            MetadataMode.SourceGeneration => ("MSTest.SourceGeneration", LazyShippingVersion.Value, "MSTestSourceGenerationVersion"),
+            MetadataMode.AotSourceGeneration => ("MSTest.AotReflection.SourceGeneration", LazyAotVersion.Value, "MSTestAotReflectionSourceGenerationVersion"),
+            _ => throw new ArgumentOutOfRangeException(nameof(metadataMode), metadataMode, "Not a source-gen metadata mode."),
+        };
+
+        string outputSubFolder = GetOutputSubFolder(metadataMode);
+        string propsFileName = $"MSTest.AcceptanceSourceGen.{outputSubFolder}.props";
+        string propsPath = Path.Combine(assetDirectory, propsFileName);
+        await TempDirectory.WriteFileAsync(assetDirectory, propsFileName, BuildPropsContent(packageId, versionProperty));
+
+        // - CustomBeforeMicrosoftCommonProps injects the source-generator PackageReference early
+        //   enough for restore to see it, without clobbering any Directory.Build.props.
+        // - BaseOutputPath/BaseIntermediateOutputPath redirect bin/obj so this build does not
+        //   overwrite the reflection build (or the other source-gen build) outputs. Forward slashes
+        //   are used intentionally: a trailing backslash immediately before the closing quote would
+        //   escape the quote on Windows and corrupt the argument. MSBuild accepts forward slashes on
+        //   all platforms.
+        // - The version property feeds the resolved package version into the injected props.
+        return $"-p:CustomBeforeMicrosoftCommonProps=\"{propsPath}\" "
+            + $"-p:BaseOutputPath=\"bin/{outputSubFolder}/\" "
+            + $"-p:BaseIntermediateOutputPath=\"obj/{outputSubFolder}/\" "
+            + $"-p:{versionProperty}={version}";
+    }
+
+    private static string BuildPropsContent(string packageId, string versionProperty) =>
 $$"""
 <Project>
   <!--
-    Injected only for the MetadataMode.SourceGeneration build of an acceptance-test asset.
-    Referencing MSTest.SourceGeneration switches the asset onto the source-generated metadata path.
+    Injected only for a source-generation build of an acceptance-test asset.
+    Referencing {{packageId}} switches the asset onto the matching source-generated metadata path.
   -->
   <PropertyGroup>
     <!--
-      This build redirects bin/obj to bin/SourceGen and obj/SourceGen (so it does not overwrite the
-      reflection build). That redirect drops the original obj/bin from DefaultItemExcludes, which would
-      let the reflection build's generated *.cs (AssemblyInfo, MicrosoftTestingPlatformEntryPoint,
-      SelfRegisteredExtensions) be double-compiled into this build. Re-exclude them here. This runs in
-      CustomBeforeMicrosoftCommonProps (before the SDK seeds DefaultItemExcludes), so the SDK appends
-      its own excludes after ours.
+      This build redirects bin/obj to an isolated sub-folder (so it does not overwrite the reflection
+      build or the other source-gen build). That redirect drops the original obj/bin from
+      DefaultItemExcludes, which would let another build's generated *.cs (AssemblyInfo,
+      MicrosoftTestingPlatformEntryPoint, SelfRegisteredExtensions) be double-compiled into this build.
+      Re-exclude them here. This runs in CustomBeforeMicrosoftCommonProps (before the SDK seeds
+      DefaultItemExcludes), so the SDK appends its own excludes after ours.
     -->
     <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
   </PropertyGroup>
@@ -82,45 +130,20 @@ $$"""
       Source generation is .NET-only: the generated metadata references ModuleInitializerAttribute /
       DynamicallyAccessedMembersAttribute / DynamicDependencyAttribute, which do not compile on .NET
       Framework. Skip the generator on net4x legs of a multi-targeting asset; those legs build as plain
-      reflection and are simply not exercised in SourceGeneration mode by the test matrix. In the inner
-      build TargetFramework is already set as a global property, so the condition resolves per TFM (it is
+      reflection and are simply not exercised in source-gen mode by the test matrix. In the inner build
+      TargetFramework is already set as a global property, so the condition resolves per TFM (it is
       empty for the outer cross-targeting build, which only dispatches and does not compile).
     -->
-    <PackageReference Include="MSTest.SourceGeneration" Version="$(MSTestSourceGenerationVersion)"
+    <PackageReference Include="{{packageId}}" Version="$({{versionProperty}})"
                       Condition=" !$(TargetFramework.StartsWith('net4')) " />
   </ItemGroup>
 </Project>
 """;
 
-    /// <summary>
-    /// Writes the injection props file into the asset directory and returns the MSBuild command-line
-    /// arguments (without a leading space) needed to produce the source-gen build of that asset.
-    /// </summary>
-    /// <param name="assetDirectory">The directory containing the generated asset (project) files.</param>
-    /// <returns>The extra arguments to append to a <c>dotnet build</c> command.</returns>
-    public static async Task<string> PrepareBuildArgumentsAsync(string assetDirectory)
+    private static string ResolveVersion(string rootFolder, string packagePrefix)
     {
-        string propsPath = Path.Combine(assetDirectory, SourceGenPropsFileName);
-        await TempDirectory.WriteFileAsync(assetDirectory, SourceGenPropsFileName, PropsContent);
-
-        // - CustomBeforeMicrosoftCommonProps injects the MSTest.SourceGeneration PackageReference
-        //   early enough for restore to see it, without clobbering any Directory.Build.props.
-        // - BaseOutputPath/BaseIntermediateOutputPath redirect bin/obj so this build does not
-        //   overwrite the reflection build outputs. Forward slashes are used intentionally: a
-        //   trailing backslash immediately before the closing quote would escape the quote on
-        //   Windows and corrupt the argument. MSBuild accepts forward slashes on all platforms.
-        // - MSTestSourceGenerationVersion feeds the version into the injected props.
-        return $"-p:CustomBeforeMicrosoftCommonProps=\"{propsPath}\" "
-            + $"-p:BaseOutputPath=\"bin/{OutputSubFolder}/\" "
-            + $"-p:BaseIntermediateOutputPath=\"obj/{OutputSubFolder}/\" "
-            + $"-p:MSTestSourceGenerationVersion={Version}";
-    }
-
-    private static string ResolveSourceGenerationVersion()
-    {
-        string rootFolder = Constants.ArtifactsPackagesShipping;
         string[] matches = Directory.Exists(rootFolder)
-            ? Directory.GetFiles(rootFolder, SourceGenerationPackagePrefix + "*" + NuGetPackageExtensionName, SearchOption.TopDirectoryOnly)
+            ? Directory.GetFiles(rootFolder, packagePrefix + "*" + NuGetPackageExtensionName, SearchOption.TopDirectoryOnly)
             : [];
 
         if (matches.Length > 1)
@@ -128,7 +151,7 @@ $$"""
             // The prefix can match neighboring packages; keep only those where a version digit
             // follows the prefix (mirrors AcceptanceTestBase.ExtractVersionFromPackage).
             matches = [.. matches
-                .Select(path => (path, fileName: Path.GetFileName(path)[SourceGenerationPackagePrefix.Length..]))
+                .Select(path => (path, fileName: Path.GetFileName(path)[packagePrefix.Length..]))
                 .Where(tuple => int.TryParse(tuple.fileName[0].ToString(), CultureInfo.InvariantCulture, out _))
                 .Select(tuple => tuple.path)];
         }
@@ -136,12 +159,12 @@ $$"""
         if (matches.Length != 1)
         {
             throw new InvalidOperationException(
-                $"Was expecting to find a single NuGet package named '{SourceGenerationPackagePrefix}' in '{rootFolder}', but found {matches.Length}: '{string.Join("', '", matches.Select(Path.GetFileName))}'. Did you run with -pack?");
+                $"Was expecting to find a single NuGet package named '{packagePrefix}' in '{rootFolder}', but found {matches.Length}: '{string.Join("', '", matches.Select(Path.GetFileName))}'. Did you run with -pack?");
         }
 
         string packageFullName = Path.GetFileName(matches[0]);
         return packageFullName.Substring(
-            SourceGenerationPackagePrefix.Length,
-            packageFullName.Length - SourceGenerationPackagePrefix.Length - NuGetPackageExtensionName.Length);
+            packagePrefix.Length,
+            packageFullName.Length - packagePrefix.Length - NuGetPackageExtensionName.Length);
     }
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.TestInfrastructure;
+
+/// <summary>
+/// The mechanism a generated acceptance-test asset uses to obtain test metadata at runtime.
+/// Acceptance assets are built (and exercised) once per mode so the same behavioral assertions
+/// validate both the runtime reflection path and the <c>MSTest.SourceGeneration</c> path.
+/// </summary>
+public enum MetadataMode
+{
+    /// <summary>
+    /// The default build: metadata is discovered through runtime reflection.
+    /// Output lands under <c>bin/&lt;config&gt;/&lt;tfm&gt;</c>.
+    /// </summary>
+    Reflection,
+
+    /// <summary>
+    /// A second build with the <c>MSTest.SourceGeneration</c> package injected so the
+    /// source-generated <c>ReflectionMetadataHook</c> provides metadata.
+    /// Output lands under <c>bin/SourceGen/&lt;config&gt;/&lt;tfm&gt;</c>.
+    /// </summary>
+    SourceGeneration,
+}

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
@@ -25,9 +25,9 @@ public enum MetadataMode
 
     /// <summary>
     /// A build with the experimental <c>MSTest.AotReflection.SourceGeneration</c> package injected.
-    /// On top of the rooting the shipping generator performs, it also publishes materialized type-
-    /// and assembly-level attributes through <c>ReflectionMetadataHook</c> so the adapter serves them
-    /// without runtime reflection (the AOT-reflection path).
+    /// In addition to the type and test-method rooting the shipping generator performs, it also
+    /// publishes materialized type- and assembly-level attributes through <c>ReflectionMetadataHook</c>
+    /// so the adapter serves them without runtime reflection (the AOT-reflection path).
     /// Output lands under <c>bin/AotSourceGen/&lt;config&gt;/&lt;tfm&gt;</c>.
     /// </summary>
     AotSourceGeneration,

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/MetadataMode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Testing.TestInfrastructure;
 /// <summary>
 /// The mechanism a generated acceptance-test asset uses to obtain test metadata at runtime.
 /// Acceptance assets are built (and exercised) once per mode so the same behavioral assertions
-/// validate both the runtime reflection path and the <c>MSTest.SourceGeneration</c> path.
+/// validate the runtime reflection path and the two source-generated metadata paths.
 /// </summary>
 public enum MetadataMode
 {
@@ -17,9 +17,18 @@ public enum MetadataMode
     Reflection,
 
     /// <summary>
-    /// A second build with the <c>MSTest.SourceGeneration</c> package injected so the
+    /// A build with the shipping <c>MSTest.SourceGeneration</c> package injected so the
     /// source-generated <c>ReflectionMetadataHook</c> provides metadata.
     /// Output lands under <c>bin/SourceGen/&lt;config&gt;/&lt;tfm&gt;</c>.
     /// </summary>
     SourceGeneration,
+
+    /// <summary>
+    /// A build with the experimental <c>MSTest.AotReflection.SourceGeneration</c> package injected.
+    /// On top of the rooting the shipping generator performs, it also publishes materialized type-
+    /// and assembly-level attributes through <c>ReflectionMetadataHook</c> so the adapter serves them
+    /// without runtime reflection (the AOT-reflection path).
+    /// Output lands under <c>bin/AotSourceGen/&lt;config&gt;/&lt;tfm&gt;</c>.
+    /// </summary>
+    AotSourceGeneration,
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -24,25 +24,19 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     private bool _disposedValue;
 
     /// <summary>
-    /// Gets a value indicating whether the <see cref="MetadataMode.SourceGeneration"/> build variant
-    /// of the asset was produced. It is <see langword="false"/> when the fixture opts out via
-    /// <see cref="SkipSourceGenVariant"/> or when the variant is globally disabled.
+    /// Override to declare which source-gen metadata modes this fixture builds, in addition to the
+    /// always-built <see cref="MetadataMode.Reflection"/> build. This is opt-in: the default is empty
+    /// so an asset is only ever built under a source-gen mode once it has been validated to support
+    /// it. A mode returned here is expected to build successfully; a failed build throws with the
+    /// captured build output (see <see cref="InitializeAsync"/>).
+    /// <para>
+    /// Assets that cannot run under source generation (for example VSTest-host assets,
+    /// NativeAOT/Trim/Aspire/Playwright/ServerMode assets, or assets that rely on source-generator
+    /// gaps such as inherited <c>[TestClass]</c>, generic test methods, or cross-assembly reflection)
+    /// simply leave this empty and keep building reflection-only.
+    /// </para>
     /// </summary>
-    public bool SourceGenVariantBuilt { get; private set; }
-
-    /// <summary>
-    /// Gets the result of the <see cref="MetadataMode.SourceGeneration"/> build, or <see langword="null"/>
-    /// when the variant was not built. Useful for diagnostics when a source-gen build fails.
-    /// </summary>
-    public DotnetMuxerResult? SourceGenBuildResult { get; private set; }
-
-    /// <summary>
-    /// Override and return <see langword="true"/> to skip the <see cref="MetadataMode.SourceGeneration"/>
-    /// build variant for assets that cannot run under source generation (for example VSTest-host assets,
-    /// NativeAOT/Trim/Aspire/Playwright/ServerMode assets, or assets that rely on source-generator gaps
-    /// such as inherited <c>[TestClass]</c>, generic test methods, or cross-assembly reflection).
-    /// </summary>
-    protected virtual bool SkipSourceGenVariant => false;
+    protected virtual IReadOnlyList<MetadataMode> SourceGenMetadataModes => [];
 
     public string GetAssetPath(string assetID)
         => !_testAssets.TryGetValue(assetID, out TestAsset? testAsset)
@@ -57,18 +51,28 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         testAsset.DotnetResult = result;
         _testAssets.TryAdd(assetId, testAsset);
 
-        // Default-on: build a second variant with MSTest.SourceGeneration injected, into an isolated
-        // bin/SourceGen + obj/SourceGen output, so the same behavioral assertions also validate the
-        // source-generated metadata path. Only attempt it when the reflection build succeeded.
-        if (!SkipSourceGenVariant && !AcceptanceSourceGen.IsGloballyDisabled && result.ExitCode == 0)
+        // Opt-in: for each source-gen metadata mode the fixture declares, build a second variant with
+        // the matching generator injected, into an isolated bin/<sub> + obj/<sub> output, so the same
+        // behavioral assertions also validate the source-generated metadata path. The build is run
+        // with failIfReturnValueIsNotZero:false so we can surface the captured output if it fails
+        // (rather than the less actionable default exception from DotnetCli.RunAsync).
+        if (!AcceptanceSourceGen.IsGloballyDisabled)
         {
-            string sourceGenArgs = await AcceptanceSourceGen.PrepareBuildArgumentsAsync(testAsset.TargetAssetPath);
-            DotnetMuxerResult sourceGenResult = await DotnetCli.RunAsync(
-                $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
-                callerMemberName: $"{assetName}_SourceGen",
-                cancellationToken: cancellationToken);
-            SourceGenBuildResult = sourceGenResult;
-            SourceGenVariantBuilt = sourceGenResult.ExitCode == 0;
+            foreach (MetadataMode mode in SourceGenMetadataModes)
+            {
+                string sourceGenArgs = await AcceptanceSourceGen.PrepareBuildArgumentsAsync(testAsset.TargetAssetPath, mode);
+                DotnetMuxerResult sourceGenResult = await DotnetCli.RunAsync(
+                    $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
+                    failIfReturnValueIsNotZero: false,
+                    callerMemberName: $"{assetName}_{AcceptanceSourceGen.GetOutputSubFolder(mode)}",
+                    cancellationToken: cancellationToken);
+
+                if (sourceGenResult.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        $"The {mode} build of acceptance asset '{assetName}' failed with exit code {sourceGenResult.ExitCode}.{Environment.NewLine}{sourceGenResult}");
+                }
+            }
         }
     }
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -23,6 +23,27 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     private readonly TempDirectory _tempDirectory = new();
     private bool _disposedValue;
 
+    /// <summary>
+    /// Gets a value indicating whether the <see cref="MetadataMode.SourceGeneration"/> build variant
+    /// of the asset was produced. It is <see langword="false"/> when the fixture opts out via
+    /// <see cref="SkipSourceGenVariant"/> or when the variant is globally disabled.
+    /// </summary>
+    public bool SourceGenVariantBuilt { get; private set; }
+
+    /// <summary>
+    /// Gets the result of the <see cref="MetadataMode.SourceGeneration"/> build, or <see langword="null"/>
+    /// when the variant was not built. Useful for diagnostics when a source-gen build fails.
+    /// </summary>
+    public DotnetMuxerResult? SourceGenBuildResult { get; private set; }
+
+    /// <summary>
+    /// Override and return <see langword="true"/> to skip the <see cref="MetadataMode.SourceGeneration"/>
+    /// build variant for assets that cannot run under source generation (for example VSTest-host assets,
+    /// NativeAOT/Trim/Aspire/Playwright/ServerMode assets, or assets that rely on source-generator gaps
+    /// such as inherited <c>[TestClass]</c>, generic test methods, or cross-assembly reflection).
+    /// </summary>
+    protected virtual bool SkipSourceGenVariant => false;
+
     public string GetAssetPath(string assetID)
         => !_testAssets.TryGetValue(assetID, out TestAsset? testAsset)
             ? throw new ArgumentNullException(nameof(assetID), $"Cannot find target path for test asset '{assetID}'")
@@ -35,6 +56,20 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", callerMemberName: assetName, cancellationToken: cancellationToken);
         testAsset.DotnetResult = result;
         _testAssets.TryAdd(assetId, testAsset);
+
+        // Default-on: build a second variant with MSTest.SourceGeneration injected, into an isolated
+        // bin/SourceGen + obj/SourceGen output, so the same behavioral assertions also validate the
+        // source-generated metadata path. Only attempt it when the reflection build succeeded.
+        if (!SkipSourceGenVariant && !AcceptanceSourceGen.IsGloballyDisabled && result.ExitCode == 0)
+        {
+            string sourceGenArgs = await AcceptanceSourceGen.PrepareBuildArgumentsAsync(testAsset.TargetAssetPath);
+            DotnetMuxerResult sourceGenResult = await DotnetCli.RunAsync(
+                $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
+                callerMemberName: $"{assetName}_SourceGen",
+                cancellationToken: cancellationToken);
+            SourceGenBuildResult = sourceGenResult;
+            SourceGenVariantBuilt = sourceGenResult.ExitCode == 0;
+        }
     }
 
     /// <summary>

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
@@ -121,10 +121,16 @@ public sealed class TestHost
         string tfm,
         string rid = "",
         Verb verb = Verb.build,
-        BuildConfiguration buildConfiguration = BuildConfiguration.Release)
+        BuildConfiguration buildConfiguration = BuildConfiguration.Release,
+        MetadataMode metadataMode = MetadataMode.Reflection)
     {
         string moduleName = $"{testHostModuleNameWithoutExtension}{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty)}";
-        string expectedRootPath = Path.Combine(rootFolder, "bin", buildConfiguration.ToString(), tfm);
+
+        // The source-generation build variant is redirected to bin/SourceGen (see AcceptanceSourceGen),
+        // so it never overwrites the default reflection build under bin.
+        string expectedRootPath = metadataMode == MetadataMode.SourceGeneration
+            ? Path.Combine(rootFolder, "bin", AcceptanceSourceGen.OutputSubFolder, buildConfiguration.ToString(), tfm)
+            : Path.Combine(rootFolder, "bin", buildConfiguration.ToString(), tfm);
         string[] executables = Directory.GetFiles(expectedRootPath, moduleName, SearchOption.AllDirectories);
         string? expectedPath = executables.SingleOrDefault(p => p.Contains(rid) && p.Contains(verb == Verb.publish ? "publish" : string.Empty));
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestHost.cs
@@ -126,11 +126,23 @@ public sealed class TestHost
     {
         string moduleName = $"{testHostModuleNameWithoutExtension}{(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty)}";
 
-        // The source-generation build variant is redirected to bin/SourceGen (see AcceptanceSourceGen),
-        // so it never overwrites the default reflection build under bin.
-        string expectedRootPath = metadataMode == MetadataMode.SourceGeneration
-            ? Path.Combine(rootFolder, "bin", AcceptanceSourceGen.OutputSubFolder, buildConfiguration.ToString(), tfm)
-            : Path.Combine(rootFolder, "bin", buildConfiguration.ToString(), tfm);
+        // Each source-generation build variant is redirected to its own bin sub-folder (see
+        // AcceptanceSourceGen), so it never overwrites the default reflection build under bin.
+        string expectedRootPath = metadataMode == MetadataMode.Reflection
+            ? Path.Combine(rootFolder, "bin", buildConfiguration.ToString(), tfm)
+            : Path.Combine(rootFolder, "bin", AcceptanceSourceGen.GetOutputSubFolder(metadataMode), buildConfiguration.ToString(), tfm);
+
+        // Directory.GetFiles throws a non-actionable DirectoryNotFoundException when the expected
+        // output folder is missing (typically because the fixture did not build this metadata variant,
+        // for example a fixture that did not opt the mode into SourceGenMetadataModes). Surface a clear
+        // message instead.
+        if (!Directory.Exists(expectedRootPath))
+        {
+            throw new InvalidOperationException(
+                $"Expected build output folder for metadata mode '{metadataMode}' was not found: '{expectedRootPath}'. " +
+                $"Ensure the asset fixture builds the '{metadataMode}' variant (see TestAssetFixtureBase.SourceGenMetadataModes).");
+        }
+
         string[] executables = Directory.GetFiles(expectedRootPath, moduleName, SearchOption.AllDirectories);
         string? expectedPath = executables.SingleOrDefault(p => p.Contains(rid) && p.Contains(verb == Verb.publish ? "publish" : string.Empty));
 


### PR DESCRIPTION
## What

Adds shared test infrastructure so a generated MSTest acceptance-test asset can be **built and exercised under multiple metadata paths**, with the **same behavioral assertions** running against each:

- `Reflection` — the default runtime-reflection path.
- `SourceGeneration` — the shipping **`MSTest.SourceGeneration`** generator (source-generated `ReflectionMetadataHook`).
- `AotSourceGeneration` — the experimental **`MSTest.AotReflection.SourceGeneration`** generator (materializes type/assembly attributes through `ReflectionMetadataHook` for the AOT-reflection path).

This is the **foundation + two validated pilots**; the mechanical roll-out to the remaining acceptance classes will follow in batches.

## How (central shared-infra, minimal per-file churn)

- **`MetadataMode { Reflection, SourceGeneration, AotSourceGeneration }`** enum.
- **`AcceptanceSourceGen`** is mode-aware: for each source-gen mode it injects the matching generator via an MSBuild `CustomBeforeMicrosoftCommonProps` file (resolving the packed version from `Shipping`/`NonShipping`), into an **isolated `bin/<sub>` + `obj/<sub>`** output (`SourceGen` / `AotSourceGen`) so all hosts coexist. A global kill-switch env var (`MSTEST_ACCEPTANCE_SKIP_SOURCEGEN`) drops the source-gen modes everywhere.
- **`TestAssetFixtureBase`** is **opt-in**: `SourceGenMetadataModes` defaults to empty, so an asset only builds a source-gen variant once it has been validated to support it. An opted-in build runs with `failIfReturnValueIsNotZero: false` and **throws with the captured build output** if it fails.
- **`TestHost.LocateFrom`** is variant-aware and throws a clear, actionable error when the requested variant's output folder is missing.

## Test matrices (Combinatorial.MSTest)

Building on #9372, the unfiltered cross-product matrices use **`[CombinatorialData]`** instead of hand-written data sources:
- A **`[MetadataModeValues]`** `ICombinatorialValuesProvider` (next to `[AllTargetFrameworks]`) yields `MetadataModesToRun`, honoring the kill-switch rather than auto-expanding the enum.
- `InconclusiveTests` uses `[CombinatorialData]` over `(Lifecycle, [MetadataModeValues] MetadataMode)`.
- The TFM matrix (`AllTfmsAndMetadataModes`) stays a bespoke data source: its net4x → reflection-only rule is a **cross-parameter** filter that independent combinatorial providers can't express.

## Source generation is .NET-only

The generated metadata references `ModuleInitializerAttribute` / `DynamicallyAccessedMembersAttribute` / `DynamicDependencyAttribute`, which don't compile on .NET Framework. So:
- the matrix pairs the source-gen modes **only** with .NET TFMs (net4x → reflection only), and
- the injected `PackageReference` is conditioned `!$(TargetFramework.StartsWith('net4'))`, so a multi-targeting asset's net4x leg builds as plain reflection.

## Why opt-in (fixes the broken pipeline)

The previous default-on design built a source-gen variant for **every** fixture's `ClassInitialize`, which broke unrelated assets that source generation can't support (e.g. `FrameworkOnly` assets that don't reference the adapter carrying `ReflectionMetadataHook`). Opt-in confines source-gen builds to validated assets.

## Validation

After `build.cmd -pack`, both pilots pass under **all three modes** — **38/38** combined:
- `InconclusiveTests` — single-TFM (NetCurrent), `Lifecycle × MetadataMode` (24 cases).
- `TestRunParametersTests` — multi-TFM incl. net462 (14 cases; net462 reflection-only).
- `FrameworkOnlyTests` (the asset that broke CI) passes again — it no longer attempts a source-gen build.

## Follow-up

Mechanically opt the remaining ~80 acceptance classes into the source-gen modes in batches, surfacing source-gen gaps (inherited `[TestClass]`, generics, cross-assembly reflection, VSTest-host/NativeAOT/Aspire/Playwright/ServerMode assets) as fixtures are validated.

<sub>Co-authored-by: Copilot</sub>