### PR TITLE
Work around MSB4216 NET task host drive-casing failure in CodeQL build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,4 @@
-<Project>
+<Project InitialTargets="NormalizeNetCoreSdkRootCasing">
   <PropertyGroup Label="Version settings">
     <!-- MSTest version -->
     <VersionPrefix>4.3.0</VersionPrefix>
@@ -13,4 +13,286 @@
     <MSTestVersion>4.3.0-preview.26322.15</MSTestVersion>
     <MicrosoftTestingPlatformVersion>2.3.0-preview.26322.15</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
+
+  <!--
+    TEMPORARY WORKAROUND for https://github.com/dotnet/msbuild/issues/14026 (MSB4216).
+
+    On some hosted CI agents the .NET Framework MSBuild host and the .NET task host child derive the
+    SDK tools directory with different drive-letter casing ("D:" vs "d:"). Because the task host
+    handshake salt is a case-sensitive hash of that path, the salts differ and the .NET task host
+    handshake fails with MSB4216 (seen here in Arcade's InstallDotNetCore during the CodeQL build).
+
+    This rewrites ONLY the drive letter of $(NetCoreSdkRoot) to the casing the child will use,
+    learned by launching the SDK's dotnet host (dotnet.exe, same volume as the SDK) and reading
+    GetModuleFileNameW(NULL) - the API behind the child's Environment.ProcessPath. Casing-only and
+    safe on every agent. Knobs: NetCoreSdkRootDriveCasingOverride=lower|upper,
+    DisableNetCoreSdkRootDriveCasingWorkaround=true.
+
+    This is a temporary stopgap; remove it once the permanent fix (dotnet/arcade#17039, building on
+    dotnet/arcade#17002, and the child-side dotnet/msbuild#14027) flows into this repo's Arcade and SDK.
+  -->
+  <UsingTask TaskName="NormalizeSdkRootDriveCasing"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll"
+             Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != ''">
+    <ParameterGroup>
+      <SdkRoot ParameterType="System.String" Required="true" />
+      <Override ParameterType="System.String" />
+      <Result ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Class" Language="cs"><![CDATA[
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+public class NormalizeSdkRootDriveCasing : Task
+{
+    [Required]
+    public string SdkRoot { get; set; }
+
+    public string Override { get; set; }
+
+    [Output]
+    public string Result { get; set; }
+
+    private const string Marker = "__SDKDRIVEPROBE__=";
+
+    // Cache the registered drive letter per drive for the lifetime of the MSBuild process,
+    // so the (one-time) dotnet-host probe launch is not repeated for every project's InitialTargets.
+    private static readonly object s_lock = new object();
+    private static readonly Dictionary<char, char> s_driveCache = new Dictionary<char, char>();
+
+    public override bool Execute()
+    {
+        // Best-effort: never fail the build over a casing tweak. Default to a no-op.
+        Result = SdkRoot;
+
+        try
+        {
+            if (string.IsNullOrEmpty(SdkRoot) || SdkRoot.Length < 2 || SdkRoot[1] != ':')
+            {
+                return true;
+            }
+
+            // Deterministic escape hatch: the NetCoreSdkRootDriveCasingOverride property = "lower" or
+            // "upper" forces the drive-letter casing without probing the SDK, for emergencies or testing.
+            if (!string.IsNullOrEmpty(Override))
+            {
+                char forced = SdkRoot[0];
+                if (string.Equals(Override, "lower", StringComparison.OrdinalIgnoreCase))
+                {
+                    forced = char.ToLowerInvariant(SdkRoot[0]);
+                }
+                else if (string.Equals(Override, "upper", StringComparison.OrdinalIgnoreCase))
+                {
+                    forced = char.ToUpperInvariant(SdkRoot[0]);
+                }
+
+                if (forced != SdkRoot[0])
+                {
+                    Result = forced + SdkRoot.Substring(1);
+                    Log.LogMessage(MessageImportance.High,
+                        "Forced NetCoreSdkRoot drive casing '{0}' -> '{1}' via NetCoreSdkRootDriveCasingOverride='{2}' (#14026 workaround).",
+                        SdkRoot[0], forced, Override);
+                }
+
+                return true;
+            }
+
+            char registeredDrive = GetRegisteredSdkDrive(SdkRoot);
+            // Casing-only guard: only adopt the probed drive when it is the SAME letter as the SDK's
+            // (differing solely in case). This can never change the actual drive, only its casing.
+            if (registeredDrive != '\0' &&
+                registeredDrive != SdkRoot[0] &&
+                char.ToUpperInvariant(registeredDrive) == char.ToUpperInvariant(SdkRoot[0]))
+            {
+                Result = registeredDrive + SdkRoot.Substring(1);
+                Log.LogMessage(MessageImportance.High,
+                    "Normalized NetCoreSdkRoot drive casing '{0}' -> '{1}' to match the SDK task host (#14026 workaround).",
+                    SdkRoot[0], registeredDrive);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing skipped: {0}", ex.Message);
+        }
+
+        return true;
+    }
+
+    // Returns the volume-registered drive letter for the SDK, derived the same way the .NET task host
+    // child does: by launching the SDK's dotnet host and reading the drive-letter casing
+    // GetModuleFileNameW(NULL) - the API behind Environment.ProcessPath - resolves for that process.
+    // Returns '\0' if it cannot be determined.
+    private char GetRegisteredSdkDrive(string sdkRoot)
+    {
+        char driveKey = sdkRoot[0];
+        lock (s_lock)
+        {
+            if (s_driveCache.TryGetValue(driveKey, out char cached))
+            {
+                return cached;
+            }
+
+            char probed = ProbeSdkDrive(sdkRoot);
+            s_driveCache[driveKey] = probed;
+            return probed;
+        }
+    }
+
+    // Finds the dotnet host (dotnet.exe) ON THE SAME VOLUME as the SDK, so its drive-letter casing
+    // matches what the task host child will report. Prefers the dotnet root derived from the SDK
+    // directory (<dotnetRoot>\sdk\<ver>\ -> <dotnetRoot>\dotnet.exe), then DOTNET_HOST_PATH but only
+    // if it is on the same drive letter as the SDK. Returns null if none exists.
+    private static string LocateDotnetHost(string sdkRoot)
+    {
+        try
+        {
+            // sdkRoot = <dotnetRoot>\sdk\<version>\  ->  up two directories = <dotnetRoot>.
+            string sdkVersionDir = sdkRoot.TrimEnd('\\', '/');
+            string sdkDir = Path.GetDirectoryName(sdkVersionDir);
+            string dotnetRoot = Path.GetDirectoryName(sdkDir);
+            if (!string.IsNullOrEmpty(dotnetRoot))
+            {
+                string candidate = Path.Combine(dotnetRoot, "dotnet.exe");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+        catch
+        {
+            // fall through to DOTNET_HOST_PATH
+        }
+
+        string fromEnv = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        if (!string.IsNullOrEmpty(fromEnv) && fromEnv.Length >= 2 && fromEnv[1] == ':' &&
+            char.ToUpperInvariant(fromEnv[0]) == char.ToUpperInvariant(sdkRoot[0]) &&
+            File.Exists(fromEnv) &&
+            fromEnv.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            return fromEnv;
+        }
+
+        return null;
+    }
+
+    private char ProbeSdkDrive(string sdkRoot)
+    {
+        // Launch the dotnet host (NOT the SDK's MSBuild.exe apphost, which needs a matching runtime
+        // that may not be resolvable in this process's environment). dotnet.exe is the runtime host
+        // itself, lives on the same volume as the SDK, and always launches; its own process-path
+        // drive-letter casing (GetModuleFileNameW) therefore equals the casing the .NET task host
+        // child will report for the SDK directory.
+        string dotnetExe = LocateDotnetHost(sdkRoot);
+        if (dotnetExe == null)
+        {
+            Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing: dotnet host not found for SDK '{0}'.", sdkRoot);
+            return '\0';
+        }
+
+        string tasksDll = Path.Combine(sdkRoot, "Microsoft.Build.Tasks.Core.dll");
+        string tempDir = Path.Combine(Path.GetTempPath(), "sdkdrvprobe_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        string proj = Path.Combine(tempDir, "probe.proj");
+
+        // Bare <Project> (no Sdk attribute / no imports) so it does NOT re-import Arcade and cannot
+        // recurse into this workaround. The inline task P/Invokes GetModuleFileNameW(NULL) - the exact
+        // API behind the child task host's Environment.ProcessPath - so we read the same drive-letter
+        // casing the child will. No CDATA in the inner task code (it would close the outer CDATA).
+        var probe = new StringBuilder();
+        probe.Append("<Project>");
+        probe.Append("<UsingTask TaskName=\"PrintProcPath\" TaskFactory=\"RoslynCodeTaskFactory\" AssemblyFile=\"").Append(tasksDll).Append("\">");
+        probe.Append("<Task><Code Type=\"Class\" Language=\"cs\">\n");
+        probe.Append("using System;\n");
+        probe.Append("using System.Runtime.InteropServices;\n");
+        probe.Append("using System.Text;\n");
+        probe.Append("using Microsoft.Build.Framework;\n");
+        probe.Append("using Microsoft.Build.Utilities;\n");
+        probe.Append("public class PrintProcPath : Task {\n");
+        probe.Append("  [DllImport(\"kernel32.dll\", CharSet = CharSet.Unicode, SetLastError = true)]\n");
+        probe.Append("  static extern uint GetModuleFileNameW(IntPtr hModule, StringBuilder lpFilename, uint nSize);\n");
+        probe.Append("  public override bool Execute() {\n");
+        probe.Append("    var sb = new StringBuilder(1024);\n");
+        probe.Append("    GetModuleFileNameW(IntPtr.Zero, sb, 1024u);\n");
+        probe.Append("    Log.LogMessage(MessageImportance.High, \"").Append(Marker).Append("\" + sb.ToString());\n");
+        probe.Append("    return true;\n");
+        probe.Append("  }\n");
+        probe.Append("}\n");
+        probe.Append("</Code></Task></UsingTask>");
+        probe.Append("<Target Name=\"P\"><PrintProcPath /></Target>");
+        probe.Append("</Project>");
+        File.WriteAllText(proj, probe.ToString());
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = dotnetExe,
+                Arguments = "msbuild \"" + proj + "\" -nologo -nodeReuse:false -v:m -t:P",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = tempDir,
+            };
+
+            using (var p = Process.Start(psi))
+            {
+                string stdout = p.StandardOutput.ReadToEnd();
+                string stderr = p.StandardError.ReadToEnd();
+                if (!p.WaitForExit(120000))
+                {
+                    try { p.Kill(); } catch { }
+                    Log.LogMessage(MessageImportance.Low, "NormalizeSdkRootDriveCasing: probe timed out launching '{0}'.", dotnetExe);
+                    return '\0';
+                }
+
+                int idx = stdout.IndexOf(Marker, StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    string resolved = stdout.Substring(idx + Marker.Length).TrimStart();
+                    int nl = resolved.IndexOfAny(new[] { '\r', '\n' });
+                    if (nl >= 0)
+                    {
+                        resolved = resolved.Substring(0, nl);
+                    }
+
+                    if (resolved.Length >= 2 && resolved[1] == ':')
+                    {
+                        return resolved[0];
+                    }
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low,
+                        "NormalizeSdkRootDriveCasing: probe produced no result (exit {0}). stderr=[{1}]",
+                        p.ExitCode, stderr.Replace("\r", "").Replace("\n", " | "));
+                }
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+
+        return '\0';
+    }
+}
+]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="NormalizeNetCoreSdkRootCasing"
+          Condition="'$(MSBuildRuntimeType)' == 'Full' and '$(NetCoreSdkRoot)' != '' and '$(DisableNetCoreSdkRootDriveCasingWorkaround)' != 'true'">
+    <NormalizeSdkRootDriveCasing SdkRoot="$(NetCoreSdkRoot)" Override="$(NetCoreSdkRootDriveCasingOverride)">
+      <Output TaskParameter="Result" PropertyName="NetCoreSdkRoot" />
+    </NormalizeSdkRootDriveCasing>
+  </Target>
 </Project>


### PR DESCRIPTION
## Problem

The CodeQL pipeline (and other .NET Framework MSBuild host scenarios on certain hosted CI agents) fails with **MSB4216** when Arcade's `InstallDotNetCore` task launches the .NET task host:

```
error MSB4216: Could not run the "InstallDotNetCore" task because MSBuild could not
create or connect to a task host with runtime "NET" and architecture "x86".
```

Root cause (see dotnet/msbuild#14026): the task host handshake **salt** is a case-sensitive hash of the SDK tools directory. The .NET Framework host derives it from `$(NetCoreSdkRoot)` (drive-letter casing propagated verbatim from the environment, e.g. ADO's `D:\a\_work\1\s`), while the .NET task host child resolves its own path via `Environment.ProcessPath`, which on some agents reports the volume's canonical **lowercase** drive (`d:`). The salts then differ and the handshake fails. The failure is agent-specific, which is why it reproduces intermittently.

## Fix (temporary)

An `InitialTargets` target in `eng/Versions.props` rewrites **only the drive-letter casing** of `$(NetCoreSdkRoot)` to match the casing the child task host will use. It learns that casing by launching the SDK's own `dotnet` host (`dotnet.exe` — the runtime host, which always runs and lives on the same volume as the SDK) and reading `GetModuleFileNameW(NULL)`, the exact API behind the child's `Environment.ProcessPath`. The detected drive letter is adopted only when it is the **same letter** differing solely in case, so it can never change the actual drive — only its casing. Windows-only, cached, and a safe no-op on agents that already work.

Knobs:
- `DisableNetCoreSdkRootDriveCasingWorkaround=true` — skip entirely.
- `NetCoreSdkRootDriveCasingOverride=lower|upper` — force the casing without probing (emergency/testing).

## Validation

Reproduced and validated on the actual failing agent type via the `microsoft-testfx` CodeQL pipeline: the probe resolved `d:`, the target rewrote `NetCoreSdkRoot` `D:` → `d:`, and **MSB4216 was eliminated** (two independent runs that both landed on a "bad" agent went green; an `Override=lower` run also confirmed the salt reads the live, target-mutated property).

## Temporary / follow-up

This is a stopgap. The permanent fixes are:
- host-side: **dotnet/arcade#17039** (builds on @ViktorHofer's dotnet/arcade#17002) — once it flows into this repo's Arcade, this inline workaround can be removed;
- child-side: **dotnet/msbuild#14027** (handshake salt widening) flowing into the .NET SDK.

Remove this once both are in.
