### PR TITLE
Use Combinatorial.MSTest to simplify acceptance test matrices

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,6 +99,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.4" />
+    <!-- Third-party (community) package that brings xUnit.Combinatorial-style [CombinatorialData] support to
+         MSTest. Used by the acceptance tests to replace bespoke build-matrix DynamicData helpers. -->
+    <PackageVersion Include="Combinatorial.MSTest" Version="2.0.0" />
     <PackageVersion Include="Microsoft.TestPlatform" Version="$(MicrosoftNETTestSdkVersion)" />
     <!-- Previously pinned to 4.18.4 to avoid SponsorLink (4.20.0–4.20.x); resolved in 4.20.72 -->
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DotnetTestCliTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/DotnetTestCliTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
@@ -12,8 +14,8 @@ public class DotnetTestCliTests : AcceptanceTestBase<NopAssetFixture>
     private const string AssetName = "MSTestProject";
 
     [TestMethod]
-    [DynamicData(nameof(GetBuildMatrixTfmBuildConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
-    public async Task DotnetTest_Should_Execute_Tests(string tfm, BuildConfiguration buildConfiguration)
+    [CombinatorialData]
+    public async Task DotnetTest_Should_Execute_Tests([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
             AssetName,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="MSBuild.StructuredLogger" />
     <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RunnerTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 using Microsoft.Build.Logging.StructuredLogger;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
@@ -15,8 +17,8 @@ public class RunnerTests : AcceptanceTestBase<NopAssetFixture>
     private const string AssetName = "MSTestProject";
 
     [TestMethod]
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
-    public async SystemTask EnableMSTestRunner_True_Will_Run_Standalone(string tfm, BuildConfiguration buildConfiguration, Verb verb)
+    [CombinatorialData]
+    public async SystemTask EnableMSTestRunner_True_Will_Run_Standalone([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration, Verb verb)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
             AssetName,
@@ -42,8 +44,8 @@ public class RunnerTests : AcceptanceTestBase<NopAssetFixture>
     }
 
     [TestMethod]
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
-    public async SystemTask EnableMSTestRunner_True_WithCustomEntryPoint_Will_Run_Standalone(string tfm, BuildConfiguration buildConfiguration, Verb verb)
+    [CombinatorialData]
+    public async SystemTask EnableMSTestRunner_True_WithCustomEntryPoint_Will_Run_Standalone([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration, Verb verb)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
             AssetName,
@@ -76,8 +78,8 @@ return await app.RunAsync();
     }
 
     [TestMethod]
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
-    public async SystemTask EnableMSTestRunner_False_Will_Run_Empty_Program_EntryPoint_From_Tpv2_SDK(string tfm, BuildConfiguration buildConfiguration, Verb verb)
+    [CombinatorialData]
+    public async SystemTask EnableMSTestRunner_False_Will_Run_Empty_Program_EntryPoint_From_Tpv2_SDK([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration, Verb verb)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
             AssetName,
@@ -106,8 +108,8 @@ return await app.RunAsync();
     }
 
     [TestMethod]
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
-    public async SystemTask EnableMSTestRunner_False_Wont_Flow_TestingPlatformServer_Capability(string tfm, BuildConfiguration buildConfiguration, Verb verb)
+    [CombinatorialData]
+    public async SystemTask EnableMSTestRunner_False_Wont_Flow_TestingPlatformServer_Capability([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration, Verb verb)
     {
         using TestAsset generator = await TestAsset.GenerateAssetAsync(
             AssetName,

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 public abstract class AcceptanceTestBase
@@ -70,20 +72,6 @@ public abstract class AcceptanceTestBase
 
         string packageFullName = Path.GetFileName(matches[0]);
         return packageFullName.Substring(packagePrefixName.Length, packageFullName.Length - packagePrefixName.Length - NuGetPackageExtensionName.Length);
-    }
-
-    internal static IEnumerable<(string Tfm, BuildConfiguration BuildConfiguration, Verb Verb)> GetBuildMatrixTfmBuildVerbConfiguration()
-    {
-        foreach (string tfm in TargetFrameworks.All)
-        {
-            foreach (BuildConfiguration compilationMode in Enum.GetValues<BuildConfiguration>())
-            {
-                foreach (Verb verb in Enum.GetValues<Verb>())
-                {
-                    yield return new(tfm, compilationMode, verb);
-                }
-            }
-        }
     }
 
     internal static IEnumerable<(string Tfm, BuildConfiguration BuildConfiguration)> GetBuildMatrixTfmBuildConfiguration()
@@ -218,4 +206,16 @@ public class UnitTest1
     [SuppressMessage("Design", "CA1000:Do not declare static members on generic types", Justification = "Fine in this context")]
     public static void ClassCleanup()
         => AssetFixture.Dispose();
+}
+
+/// <summary>
+/// A <see cref="ICombinatorialValuesProvider"/> that yields every target framework in
+/// <see cref="TargetFrameworks.All"/> (the OS-dependent set, which includes .NET Framework on Windows).
+/// Apply it to a <see langword="string"/> parameter of a <c>[CombinatorialData]</c> test method to combine
+/// over all target frameworks without hand-writing a bespoke build-matrix data source.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class AllTargetFrameworksAttribute : Attribute, ICombinatorialValuesProvider
+{
+    public object?[] GetValues(ParameterInfo parameter) => [.. TargetFrameworks.All];
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -215,7 +215,8 @@ public class UnitTest1
 /// over all target frameworks without hand-writing a bespoke build-matrix data source.
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter)]
-public sealed class AllTargetFrameworksAttribute : Attribute, ICombinatorialValuesProvider
+internal sealed class AllTargetFrameworksAttribute : Attribute, ICombinatorialValuesProvider
 {
-    public object?[] GetValues(ParameterInfo parameter) => [.. TargetFrameworks.All];
+    // TargetFrameworks.All is never mutated, so it's safe to hand the same array back on every call.
+    public object?[] GetValues(ParameterInfo _) => TargetFrameworks.All;
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuild.KnownExtensionRegistration.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuild.KnownExtensionRegistration.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 using SL = Microsoft.Build.Logging.StructuredLogger;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -10,9 +12,9 @@ public class MSBuildTests_KnownExtensionRegistration : AcceptanceTestBase<NopAss
 {
     private const string AssetName = "MSBuildTests";
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task Microsoft_Testing_Platform_Extensions_ShouldBe_Correctly_Registered(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task Microsoft_Testing_Platform_Extensions_ShouldBe_Correctly_Registered([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
     {
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             nameof(Microsoft_Testing_Platform_Extensions_ShouldBe_Correctly_Registered),

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.ConfigurationFile.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.ConfigurationFile.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 [TestClass]
 public class MSBuildTests : AcceptanceTestBase<NopAssetFixture>
 {
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task ConfigFileGeneration_CorrectlyCreateAndCacheAndCleaned(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task ConfigFileGeneration_CorrectlyCreateAndCacheAndCleaned([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
     {
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             nameof(ConfigFileGeneration_CorrectlyCreateAndCacheAndCleaned),
@@ -63,9 +65,9 @@ public class MSBuildTests : AcceptanceTestBase<NopAssetFixture>
         }
     }
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task ConfigFileGeneration_NoConfigurationFile_TaskWontRun(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task ConfigFileGeneration_NoConfigurationFile_TaskWontRun([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
     {
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             nameof(ConfigFileGeneration_NoConfigurationFile_TaskWontRun),

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Combinatorial.MSTest;
+
 using SL = Microsoft.Build.Logging.StructuredLogger;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -10,9 +12,9 @@ public class MSBuildTests_EntryPoint : AcceptanceTestBase<NopAssetFixture>
 {
     private const string AssetName = "MSBuildTests";
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task When_GenerateTestingPlatformEntryPoint_IsFalse_NoEntryPointInjected(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task When_GenerateTestingPlatformEntryPoint_IsFalse_NoEntryPointInjected([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
     {
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             nameof(GenerateCSharpEntryPointAndVerifyTheCacheUsage),
@@ -42,9 +44,9 @@ public class MSBuildTests_EntryPoint : AcceptanceTestBase<NopAssetFixture>
         compilationResult.AssertExitCodeIsNot(0);
     }
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task GenerateCSharpEntryPointAndVerifyTheCacheUsage(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task GenerateCSharpEntryPointAndVerifyTheCacheUsage([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
         => await GenerateAndVerifyLanguageSpecificEntryPointAsync(nameof(GenerateCSharpEntryPointAndVerifyTheCacheUsage), CSharpSourceCode, "cs", tfm, compilationMode, verb,
             @"Entrypoint source:
 '//------------------------------------------------------------------------------
@@ -70,9 +72,9 @@ namespace MSBuildTests
     }
 }'", "Csc");
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task GenerateVBEntryPointAndVerifyTheCacheUsage(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task GenerateVBEntryPointAndVerifyTheCacheUsage([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
         => await GenerateAndVerifyLanguageSpecificEntryPointAsync(nameof(GenerateVBEntryPointAndVerifyTheCacheUsage), VBSourceCode, "vb", tfm, compilationMode, verb,
             @"Entrypoint source:
 ''------------------------------------------------------------------------------
@@ -98,9 +100,9 @@ Module MicrosoftTestingPlatformEntryPoint
 
 End Module'", "Vbc");
 
-    [DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    [CombinatorialData]
     [TestMethod]
-    public async Task GenerateFSharpEntryPointAndVerifyTheCacheUsage(string tfm, BuildConfiguration compilationMode, Verb verb)
+    public async Task GenerateFSharpEntryPointAndVerifyTheCacheUsage([AllTargetFrameworks] string tfm, BuildConfiguration compilationMode, Verb verb)
         => await GenerateAndVerifyLanguageSpecificEntryPointAsync(nameof(GenerateFSharpEntryPointAndVerifyTheCacheUsage), FSharpSourceCode, "fs", tfm, compilationMode, verb,
             @"Entrypoint source:
 '//------------------------------------------------------------------------------

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="MSBuild.StructuredLogger" />
     <!-- Transitive dependency of StreamJsonRpc, pinned to fix a security vulnerability -->
     <PackageReference Include="Nerdbank.MessagePack" />


### PR DESCRIPTION
## What

Introduces the community [`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest) package so acceptance tests can express their TFM × build-configuration × verb matrices with `[CombinatorialData]` instead of hand-written `DynamicData` "build matrix" helpers.

Today every cross-product needs a bespoke `GetBuildMatrix*` helper in `AcceptanceTestBase` plus a `[DynamicData(nameof(...), typeof(AcceptanceTestBase<NopAssetFixture>))]` reference on each test. With `[CombinatorialData]`, enum parameters (`BuildConfiguration`, `Verb`) auto-expand and only the OS-dependent TFM list needs a tiny provider.

### Before
```csharp
[TestMethod]
[DynamicData(nameof(GetBuildMatrixTfmBuildVerbConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
public async Task Foo(string tfm, BuildConfiguration buildConfiguration, Verb verb) { ... }
```

### After
```csharp
[TestMethod]
[CombinatorialData]
public async Task Foo([AllTargetFrameworks] string tfm, BuildConfiguration buildConfiguration, Verb verb) { ... }
```

## Changes

- Add `Combinatorial.MSTest` `2.0.0` to `Directory.Packages.props` (CPM) and reference it from both acceptance test projects.
- Add an `[AllTargetFrameworks]` `ICombinatorialValuesProvider` (in the shared `AcceptanceTestBase.cs`) that yields the OS-dependent `TargetFrameworks.All` set — evaluated per machine at discovery, so .NET Framework is still included on Windows only.
- Convert representative tests: `RunnerTests`, `DotnetTestCliTests`, `MSBuildTests.GenerateEntryPoint`, `MSBuildTests.ConfigurationFile`, `MSBuild.KnownExtensionRegistration`.
- Remove the now-unused `GetBuildMatrixTfmBuildVerbConfiguration` helper (the remaining folded/multi-TFM helpers are kept since they aren't plain combinatorials).

## Verification

- Both acceptance projects build with **0 warnings / 0 errors**.
- `--list-tests` confirms the generated combinations and display names are **identical** to the previous helpers, e.g.:
  - `DotnetTest_Should_Execute_Tests("net10.0",Debug)` … (TFM × config = 6 cases)
  - `EnableMSTestRunner_True_Will_Run_Standalone("net462",Release,publish)` … (TFM × config × verb = 12 cases, `net462` present on Windows)

## Notes

- `Combinatorial.MSTest` is a community package (not produced by the MSTest team); it requires `MSTest.TestFramework >= 4.0.1`, which the repo already satisfies (`4.3.0-preview`).
- This is intentionally a focused first adoption. If the team is happy with the direction, the remaining `DynamicData` matrices can be migrated incrementally and more helpers retired.

cc @Youssef1313