### PR TITLE
[efficiency-improver] perf: single-pass PropertyBag collection in DotnetTestDataConsumer

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -66,7 +66,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                         {
                             testFileLocationProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestFileLocationProperty>();
                             testMethodIdentifierProperty = testNodeUpdateMessage.TestNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
-                            traits = testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>();
+                            traits = testNodeDetails.Traits;
                         }
 
                         DiscoveredTestMessages discoveredTestMessages = new(
@@ -150,7 +150,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                         break;
                 }
 
-                foreach (FileArtifactProperty artifact in testNodeUpdateMessage.TestNode.Properties.OfType<FileArtifactProperty>())
+                foreach (FileArtifactProperty artifact in testNodeDetails.Artifacts)
                 {
                     FileArtifactMessages testFileArtifactMessages = new(
                         _executionId,
@@ -219,10 +219,14 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
         }
 
         // Single pass over the property bag to collect all needed properties at once,
-        // instead of 3 separate linked-list walks for StandardOutput, StandardError, and TimingProperty.
+        // instead of 3 separate linked-list walks for StandardOutput, StandardError, and TimingProperty,
+        // plus 2 additional OfType<T>() walks in ConsumeAsync for FileArtifactProperty and TestMetadataProperty.
+        // This eliminates 4 O(N) PropertyBag traversals per test node update.
         TimingProperty? timingProperty = null;
         StandardOutputProperty? standardOutputProperty = null;
         StandardErrorProperty? standardErrorProperty = null;
+        List<FileArtifactProperty>? artifactsList = null;
+        List<TestMetadataProperty>? traitsList = null;
         PropertyBag.PropertyBagEnumerator enumerator = testNodeUpdateMessage.TestNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
@@ -237,8 +241,17 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                 case StandardErrorProperty errorProperty:
                     standardErrorProperty = GetSingleOrDefaultValue(standardErrorProperty, errorProperty);
                     break;
+                case FileArtifactProperty artifact:
+                    (artifactsList ??= []).Add(artifact);
+                    break;
+                case TestMetadataProperty trait:
+                    (traitsList ??= []).Add(trait);
+                    break;
             }
         }
+
+        FileArtifactProperty[] artifacts = artifactsList is null ? [] : [.. artifactsList];
+        TestMetadataProperty[] traits = traitsList is null ? [] : [.. traitsList];
 
         string? standardOutput = standardOutputProperty?.StandardOutput;
         string? standardError = standardErrorProperty?.StandardError;
@@ -295,7 +308,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                 break;
         }
 
-        return new TestNodeDetails(state, duration, reason, exceptions, standardOutput, standardError);
+        return new TestNodeDetails(state, duration, reason, exceptions, standardOutput, standardError, artifacts, traits);
 
         static TProperty GetSingleOrDefaultValue<TProperty>(TProperty? existingProperty, TProperty property)
             where TProperty : IProperty
@@ -322,7 +335,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
         }
     }
 
-    public sealed record TestNodeDetails(byte? State, long? Duration, string? Reason, ExceptionMessage[]? Exceptions, string? StandardOutput, string? StandardError);
+    public sealed record TestNodeDetails(byte? State, long? Duration, string? Reason, ExceptionMessage[]? Exceptions, string? StandardOutput, string? StandardError, FileArtifactProperty[] Artifacts, TestMetadataProperty[] Traits);
 
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -218,15 +218,21 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
             return null;
         }
 
-        // Single pass over the property bag to collect all needed properties at once,
-        // instead of 3 separate linked-list walks for StandardOutput, StandardError, and TimingProperty,
-        // plus 2 additional OfType<T>() walks in ConsumeAsync for FileArtifactProperty and TestMetadataProperty.
-        // This eliminates 4 O(N) PropertyBag traversals per test node update.
+        // This method already performs a single GetStructEnumerator() walk to collect the
+        // StandardOutput, StandardError, and TimingProperty values. Folding FileArtifactProperty
+        // and TestMetadataProperty collection into that same walk removes the two additional
+        // PropertyBag.OfType<T>() linked-list traversals that ConsumeAsync used to perform for
+        // every test node update.
         TimingProperty? timingProperty = null;
         StandardOutputProperty? standardOutputProperty = null;
         StandardErrorProperty? standardErrorProperty = null;
-        List<FileArtifactProperty>? artifactsList = null;
-        List<TestMetadataProperty>? traitsList = null;
+
+        // Mirror PropertyBag.OfType<T>()'s "first + overflow list" pattern so the common case of
+        // zero or one match doesn't allocate a List<T>.
+        FileArtifactProperty? firstArtifact = null;
+        List<FileArtifactProperty>? artifactsOverflow = null;
+        TestMetadataProperty? firstTrait = null;
+        List<TestMetadataProperty>? traitsOverflow = null;
         PropertyBag.PropertyBagEnumerator enumerator = testNodeUpdateMessage.TestNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
@@ -242,16 +248,36 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                     standardErrorProperty = GetSingleOrDefaultValue(standardErrorProperty, errorProperty);
                     break;
                 case FileArtifactProperty artifact:
-                    (artifactsList ??= []).Add(artifact);
+                    if (firstArtifact is null)
+                    {
+                        firstArtifact = artifact;
+                    }
+                    else
+                    {
+                        (artifactsOverflow ??= [firstArtifact]).Add(artifact);
+                    }
+
                     break;
                 case TestMetadataProperty trait:
-                    (traitsList ??= []).Add(trait);
+                    if (firstTrait is null)
+                    {
+                        firstTrait = trait;
+                    }
+                    else
+                    {
+                        (traitsOverflow ??= [firstTrait]).Add(trait);
+                    }
+
                     break;
             }
         }
 
-        FileArtifactProperty[] artifacts = artifactsList is null ? [] : [.. artifactsList];
-        TestMetadataProperty[] traits = traitsList is null ? [] : [.. traitsList];
+        FileArtifactProperty[] artifacts = firstArtifact is null
+            ? []
+            : artifactsOverflow is not null ? [.. artifactsOverflow] : [firstArtifact];
+        TestMetadataProperty[] traits = firstTrait is null
+            ? []
+            : traitsOverflow is not null ? [.. traitsOverflow] : [firstTrait];
 
         string? standardOutput = standardOutputProperty?.StandardOutput;
         string? standardError = standardErrorProperty?.StandardError;


### PR DESCRIPTION
## Goal and Rationale

Eliminate two redundant `OfType<T>()` PropertyBag linked-list walks in `DotnetTestDataConsumer.ConsumeAsync` by consolidating them into the existing `GetStructEnumerator` single-pass walk.

**Focus Area**: Code-Level Efficiency — reducing redundant iteration and allocation on a hot path called for every test node update in `dotnet test` server mode.

## Approach

`GetTestNodeDetails` already uses `PropertyBag.GetStructEnumerator()` to collect `TimingProperty`, `StandardOutputProperty`, and `StandardErrorProperty` in one O(N) walk. However, `ConsumeAsync` made two additional `OfType<T>()` calls after that:

1. `testNodeUpdateMessage.TestNode.Properties.OfType<FileArtifactProperty>()` — ran for **every** test node update (all states)
2. `testNodeUpdateMessage.TestNode.Properties.OfType<TestMetadataProperty>()` — ran for **every** test node update in IDE / `dotnet test` mode

Both `OfType<T>()` calls do a full O(N) linked-list walk (N = number of properties on the `PropertyBag`). This change adds `FileArtifactProperty` and `TestMetadataProperty` cases to the existing `switch` inside the `GetStructEnumerator` loop, so both types are collected in the same pass.

Results are stored on `TestNodeDetails` (two new `FileArtifactProperty[]` and `TestMetadataProperty[]` fields) and consumed from there.

## Energy Efficiency Evidence

**Proxy metric**: PropertyBag linked-list iteration count (CPU cycles / memory accesses per test).

| Scenario | Before (O(N) passes per test update) | After |
|---|---|---|
| Non-IDE mode | 2 passes (GetStructEnumerator + OfType\(FileArtifactProperty\)) | 1 pass |
| IDE / dotnet-test mode | 3 passes (GetStructEnumerator + OfType\(FileArtifactProperty\) + OfType\(TestMetadataProperty\)) | 1 pass |

For a 1 000-test suite with an average of 4 properties per node:
- **Before**: ~8 000 linked-list dereferences (non-IDE) or ~12 000 (IDE mode) per run
- **After**: ~4 000 linked-list dereferences per run
- **Saving**: 50–67% reduction in PropertyBag iteration overhead in `ConsumeAsync`

`OfType<T>()` also allocates an array per call when `_property is not null` (the common case — at minimum a `TestNodeStateProperty` is always present). Eliminating these calls removes up to ~2 000 short-lived array allocations per 1 000-test run, reducing GC pressure.

_Limitation_: Wall-clock savings are small on short test runs; the gain scales linearly with test count and average property count per node.

## Green Software Foundation Context

**Hardware Efficiency**: Fewer memory dereferences per test node update = lower instruction count and reduced DRAM access energy. CPU utilisation becomes more proportional to actual work rather than repeated traversal overhead.

**Software Carbon Intensity (SCI)**: Lower CPU cycles per test execution reduces E in the `SCI = (E × I + M) / R` equation, directly lowering carbon intensity per test run.

## Trade-offs

- **Complexity**: Marginal — two new `case` branches in an existing `switch` and two new fields on `TestNodeDetails`. The pattern is consistent with existing cases in the same method.
- **Memory**: Two small arrays are materialised on `TestNodeDetails`. In typical runs these are `Array.Empty<T>()` (zero heap allocation).
- **Unconditional trait collection**: `GetTestNodeDetails` now collects traits even in non-IDE mode (one extra `case` evaluation per property per test). The overhead is negligible — an additional branch in a `switch` that evaluates to false for all non-trait properties.

## Reproducibility

```bash
# Build
./build.sh

# Run unit tests
./build.sh -test

# Observe the change
git show HEAD -- src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
```

## Test Status

CI validation pending (no local .NET SDK in agent environment). The change:
- Does not alter the `GetTestNodeDetails` method signature — the reflection-based unit test in `DotnetTestDataConsumerTests.cs` is unaffected
- Does not change observable behaviour — only consolidates _where_ property collection happens
- All existing `DotnetTestDataConsumerTests` cases are expected to pass unchanged




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/28060270778/agentic_workflow) workflow. · 3.4K AIC · ⌖ 52 AIC · ⊞ 58.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28060270778, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/28060270778 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->