### PR TITLE
[test-improver] test: add edge case tests for PreferTestCleanupOverDispose and PreferTestInitializeOverConstructor analyzers

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestCleanupOverDisposeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestCleanupOverDisposeAnalyzerTests.cs
@@ -189,4 +189,74 @@ public sealed class PreferTestCleanupOverDisposeAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTestClassHasFullDisposePattern_OnlyParameterlessDisposeDiagnostic()
+    {
+        // In the full dispose pattern, only the parameterless Dispose() that implements IDisposable
+        // should be flagged; Dispose(bool disposing) should not, as it has a parameter.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass : IDisposable
+            {
+                public void [|Dispose|]()
+                {
+                    Dispose(true);
+                    GC.SuppressFinalize(this);
+                }
+
+                protected virtual void Dispose(bool disposing)
+                {
+                    // Cleanup resources
+                }
+            }
+            """;
+        string fixedCode = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                    Dispose(true);
+                    GC.SuppressFinalize(this);
+                }
+
+                protected virtual void Dispose(bool disposing)
+                {
+                    // Cleanup resources
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasBothDisposeAndTestCleanup_DiagnosticOnDispose()
+    {
+        // Even when a [TestCleanup] method already exists, Dispose() is still flagged —
+        // users should not implement both patterns simultaneously.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass : IDisposable
+            {
+                [TestCleanup]
+                public void Cleanup() { }
+
+                public void [|Dispose|]() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestInitializeOverConstructorAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestInitializeOverConstructorAnalyzerTests.cs
@@ -232,4 +232,24 @@ public sealed class PreferTestInitializeOverConstructorAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTestClassHasStaticConstructor_NoDiagnostic()
+    {
+        // Static constructors are not instance constructors; the analyzer only flags
+        // explicit parameterless instance constructors.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                static MyTestClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

Add 3 edge case tests across two related "prefer test lifecycle over C# lifecycle" analyzer test files (`PreferTestCleanupOverDisposeAnalyzerTests` and `PreferTestInitializeOverConstructorAnalyzerTests`). These tests cover real code paths through the analyzers that were previously untested.

## Approach

**PreferTestCleanupOverDisposeAnalyzerTests** — 2 new tests:

1. **`WhenTestClassHasFullDisposePattern_OnlyParameterlessDisposeDiagnostic`**
   The full dispose pattern uses two methods: `public void Dispose()` (the `IDisposable` interface implementation) and `protected virtual void Dispose(bool disposing)` (the parameterized cleanup helper). The analyzer checks `IsDisposeImplementation`, which only matches the interface implementation. This test verifies:
   - Only `Dispose()` is flagged; `Dispose(bool)` is not
   - The fixer renames `Dispose()` to `TestCleanup()` and leaves `Dispose(bool)` intact

2. **`WhenTestClassHasBothDisposeAndTestCleanup_DiagnosticOnDispose`**
   When a test class has both a `[TestCleanup]` method and implements `IDisposable.Dispose()`, the analyzer should still flag `Dispose()` — the existence of `TestCleanup` does not suppress the diagnostic. This guards against the misconception that having a `TestCleanup` makes the `Dispose` pattern acceptable.

**PreferTestInitializeOverConstructorAnalyzerTests** — 1 new test:

3. **`WhenTestClassHasStaticConstructor_NoDiagnostic`**
   The analyzer targets only *explicit parameterless instance constructors* via `InstanceConstructors.FirstOrDefault(x => !x.IsImplicitlyDeclared && x.Parameters.Length == 0)`. Roslyn's `InstanceConstructors` property excludes static constructors by design. This test verifies that a static constructor in a `[TestClass]` does not trigger the rule.

## Test Results

All 14 tests pass (7 per file, 3 new + 11 existing):

```
Test run summary: Passed!
  total: 14
  failed: 0
  succeeded: 14
  skipped: 0
  duration: ~18s
```

Command used:
```bash
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "FullyQualifiedName~PreferTestCleanupOverDisposeAnalyzerTests|FullyQualifiedName~PreferTestInitializeOverConstructorAnalyzerTests"
```

## Trade-offs

- Minimal maintenance burden: tests cover clear, well-defined analyzer behavior with no hard-coded timing or environment sensitivity.
- The `WhenTestClassHasBothDisposeAndTestCleanup_DiagnosticOnDispose` test uses `VerifyAnalyzerAsync` (not `VerifyCodeFixAsync`) since applying the fixer would produce a second `TestCleanup()` method — a known limitation worth documenting through the test itself.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28063622457/agentic_workflow) workflow. · 1.8K AIC · ⌖ 40.8 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28063622457, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28063622457 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->