### PR TITLE
Fix Perf timing nightly: read MicrosoftNETTestSdkVersion from Directory.Packages.props

### DIFF
--- a/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario1.cs
+++ b/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario1.cs
@@ -36,7 +36,7 @@ internal class Scenario1 : IStep<NoInputOutput, SingleProject>
     public async Task<SingleProject> ExecuteAsync(NoInputOutput payload, IContext context)
     {
         Console.WriteLine($"Creating Scenario1 {_numberOfClass} classes, {_methodsPerClass} methods per class, ExecutionScope {_executionScope} with {_workers} workers");
-        var versionsPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "eng", "Versions.props"));
+        var versionsPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "Directory.Packages.props"));
         string microsoftNETTestSdkVersion = versionsPropFileDoc.Descendants("MicrosoftNETTestSdkVersion").Single().Value;
         string msTestVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, MSTestTestFrameworkPackageNamePrefix);
 

--- a/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario1.cs
+++ b/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario1.cs
@@ -36,8 +36,8 @@ internal class Scenario1 : IStep<NoInputOutput, SingleProject>
     public async Task<SingleProject> ExecuteAsync(NoInputOutput payload, IContext context)
     {
         Console.WriteLine($"Creating Scenario1 {_numberOfClass} classes, {_methodsPerClass} methods per class, ExecutionScope {_executionScope} with {_workers} workers");
-        var versionsPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "Directory.Packages.props"));
-        string microsoftNETTestSdkVersion = versionsPropFileDoc.Descendants("MicrosoftNETTestSdkVersion").Single().Value;
+        var cpmPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "Directory.Packages.props"));
+        string microsoftNETTestSdkVersion = cpmPropFileDoc.Descendants("MicrosoftNETTestSdkVersion").Single().Value;
         string msTestVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, MSTestTestFrameworkPackageNamePrefix);
 
         StringBuilder stringBuilder = new();


### PR DESCRIPTION
## Problem

The **Perf timing nightly** workflow has failed every night (e.g. runs on 6/23 and 6/24) with:

```
Unhandled exception: System.AggregateException ... ---> System.InvalidOperationException: Sequence contains no elements
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source)
   at MSTest.Performance.Runner.Steps.Scenario1.ExecuteAsync(...) Scenario1.cs:line 40
```

## Root cause

`MicrosoftNETTestSdkVersion` was moved out of `eng/Versions.props` into `Directory.Packages.props` (central package management). `Scenario1.ExecuteAsync` still loaded it from `eng/Versions.props`, so `Descendants("MicrosoftNETTestSdkVersion").Single()` matched zero elements and threw, aborting every perf pipeline.

`AcceptanceTestBase` already reads this property from `Directory.Packages.props`; this change makes `Scenario1` consistent.

## Fix

Point `Scenario1` at `Directory.Packages.props`.

## Validation

- `Directory.Packages.props` contains exactly one `MicrosoftNETTestSdkVersion` element (value `18.4.0`), so `.Single()` is safe.
- `MSTest.Performance.Runner` builds cleanly in Release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>