### PR TITLE
[code-simplifier] refactor: replace nested ternaries with if/else in DotnetTestDataConsumer

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -272,12 +272,33 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
             }
         }
 
-        FileArtifactProperty[] artifacts = firstArtifact is null
-            ? []
-            : artifactsOverflow is not null ? [.. artifactsOverflow] : [firstArtifact];
-        TestMetadataProperty[] traits = firstTrait is null
-            ? []
-            : traitsOverflow is not null ? [.. traitsOverflow] : [firstTrait];
+        FileArtifactProperty[] artifacts;
+        if (firstArtifact is null)
+        {
+            artifacts = [];
+        }
+        else if (artifactsOverflow is not null)
+        {
+            artifacts = [.. artifactsOverflow];
+        }
+        else
+        {
+            artifacts = [firstArtifact];
+        }
+
+        TestMetadataProperty[] traits;
+        if (firstTrait is null)
+        {
+            traits = [];
+        }
+        else if (traitsOverflow is not null)
+        {
+            traits = [.. traitsOverflow];
+        }
+        else
+        {
+            traits = [firstTrait];
+        }
 
         string? standardOutput = standardOutputProperty?.StandardOutput;
         string? standardError = standardErrorProperty?.StandardError;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -272,33 +272,13 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
             }
         }
 
-        FileArtifactProperty[] artifacts;
-        if (firstArtifact is null)
-        {
-            artifacts = [];
-        }
-        else if (artifactsOverflow is not null)
-        {
-            artifacts = [.. artifactsOverflow];
-        }
-        else
-        {
-            artifacts = [firstArtifact];
-        }
+        FileArtifactProperty[] artifacts = firstArtifact is null
+            ? []
+            : artifactsOverflow is not null ? [.. artifactsOverflow] : [firstArtifact];
 
-        TestMetadataProperty[] traits;
-        if (firstTrait is null)
-        {
-            traits = [];
-        }
-        else if (traitsOverflow is not null)
-        {
-            traits = [.. traitsOverflow];
-        }
-        else
-        {
-            traits = [firstTrait];
-        }
+        TestMetadataProperty[] traits = firstTrait is null
+            ? []
+            : traitsOverflow is not null ? [.. traitsOverflow] : [firstTrait];
 
         string? standardOutput = standardOutputProperty?.StandardOutput;
         string? standardError = standardErrorProperty?.StandardError;


### PR DESCRIPTION
## Code Simplification — 2026-06-24

This PR simplifies recently modified code in `DotnetTestDataConsumer.cs` to improve clarity while preserving all functionality.

### Files Simplified

- `src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs` — Replaced nested ternary operators with if/else chains

### Improvement Made

PR #9380 introduced a single-pass `PropertyBag` collection pattern that included two nested ternary expressions:

```csharp
// Before — nested ternary operators
FileArtifactProperty[] artifacts = firstArtifact is null
    ? []
    : artifactsOverflow is not null ? [.. artifactsOverflow] : [firstArtifact];
TestMetadataProperty[] traits = firstTrait is null
    ? []
    : traitsOverflow is not null ? [.. traitsOverflow] : [firstTrait];
```

Rewritten as explicit if/else chains per [project coding guidelines](https://github.com/microsoft/testfx/blob/main/.editorconfig), which state:
> **Avoid nested ternary operators** — prefer switch statements or if/else chains. Choose clarity over brevity.

```csharp
// After — clear if/else chains
FileArtifactProperty[] artifacts;
if (firstArtifact is null)
{
    artifacts = [];
}
else if (artifactsOverflow is not null)
{
    artifacts = [.. artifactsOverflow];
}
else
{
    artifacts = [firstArtifact];
}
// (identical pattern for traits)
```

### Changes Based On

Recent changes from:
- #9380 — `[efficiency-improver] perf: single-pass PropertyBag collection in DotnetTestData`

### Testing

- ✅ No functional changes — behavior is identical (purely structural refactor)
- ✅ Logic equivalence verified: all three branches (`null`, overflow, single-item) remain identical

### Review Focus

Please verify:
- The three-way branch logic is preserved exactly
- Style matches project conventions


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/28103347976/agentic_workflow) workflow. · 93.4 AIC · ⌖ 17.7 AIC · ⊞ 9.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-25T13:57:58.728Z --> on Jun 25, 2026, 1:57 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 28103347976, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/28103347976 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->