### PR TITLE
Ship Microsoft.Testing.Platform.Internal.DotnetTest as a preview package

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -49,7 +49,7 @@
 
     <!--
       Keep this package preview even in stabilized/official builds. It inherits VersionPrefix from
-      src/Platform/Directory.Build.props ($(TestingPlatformVersionPrefix)) and the repo 'preview' PreReleaseVersionLabel,
+      src/Platform/Directory.Build.props ($(TestingPlatformVersionPrefix)) and the repo-wide PreReleaseVersionLabel (eng/Versions.props),
       so it ships as <TestingPlatformVersionPrefix>-preview.* today. Without this, a stabilized MTP release
       (DotNetFinalVersionKind=release) would drop the suffix and publish a STABLE 'Internal' package - which we do not
       want while the dotnet test shared-source surface is still partial. Mirrors MSTest.SourceGeneration.

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/Microsoft.Testing.Platform.Internal.DotnetTest.csproj
@@ -41,11 +41,20 @@
     <DevelopmentDependency>true</DevelopmentDependency>
 
     <!--
-      IsShipping=false keeps this package OUT of nuget.org and in the internal (NonShipping) feed used for cross-repo
-      dependency flow (dotnet/sdk). NOTE: the exact internal-feed shipping mechanism still needs confirmation with
-      the Arcade team (see PR discussion).
+      IsShipping=true publishes this package (signed) on the same train as the rest of Microsoft.Testing.Platform so
+      it can flow to dotnet/sdk via the normal dependency flow. The 'Internal' in the name plus the always-preview
+      version (see SuppressFinalPackageVersion below) make clear it is an implementation detail, NOT a public API.
     -->
-    <IsShipping>false</IsShipping>
+    <IsShipping>true</IsShipping>
+
+    <!--
+      Keep this package preview even in stabilized/official builds. It inherits VersionPrefix from
+      src/Platform/Directory.Build.props ($(TestingPlatformVersionPrefix)) and the repo 'preview' PreReleaseVersionLabel,
+      so it ships as <TestingPlatformVersionPrefix>-preview.* today. Without this, a stabilized MTP release
+      (DotNetFinalVersionKind=release) would drop the suffix and publish a STABLE 'Internal' package - which we do not
+      want while the dotnet test shared-source surface is still partial. Mirrors MSTest.SourceGeneration.
+    -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
 
     <!-- NU5128: source-only package has no lib/ assembly, only contentFiles. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
@@ -7,8 +7,9 @@ stay a **single source of truth** across the [microsoft/testfx](https://github.c
 break).
 
 > ⚠️ This package is an **implementation detail** of `dotnet test` integration — that is what the `Internal` in the
-> name signals. It is `IsShipping=false` (not published to nuget.org) and is **not** intended for direct end-user
-> consumption. (A *public* MTP client/orchestration library was proposed in
+> name signals. It ships as a **preview** package (`IsShipping=true`, always preview via `SuppressFinalPackageVersion`)
+> on the same train as the rest of Microsoft.Testing.Platform so it can flow to dotnet/sdk, and is **not** intended for
+> direct end-user consumption. (A *public* MTP client/orchestration library was proposed in
 > [#5667](https://github.com/microsoft/testfx/issues/5667); that is a separate effort, closed pending a real use
 > case.)
 


### PR DESCRIPTION
## What

Promote the internal, source-only `Microsoft.Testing.Platform.Internal.DotnetTest` package from `IsShipping=false` to **`IsShipping=true`**, and add **`SuppressFinalPackageVersion=true`**.

## Why

This package shares — as compiled source — the `dotnet test` ↔ Microsoft.Testing.Platform wire contract and terminal reporter so dotnet/sdk can stop hand-copying them (single source of truth). For dotnet/sdk to consume it, the package has to actually publish and flow via the normal dependency flow.

- `IsShipping=true` publishes it (signed) on the same `2.3.0-preview.*` train as the rest of Microsoft.Testing.Platform (it already inherits `VersionPrefix = $(TestingPlatformVersionPrefix)` from `src/Platform/Directory.Build.props`).
- `SuppressFinalPackageVersion=true` keeps it **preview even in stabilized/official builds** (`DotNetFinalVersionKind=release`), so a stabilized MTP release never accidentally publishes a *stable* package named `Internal`. This mirrors how `MSTest.SourceGeneration` pins itself to preview. The shared-source surface is still partial (models/serializers not shared yet), so always-preview is intentional.

The `Internal` name + the `-preview` suffix keep it clearly an implementation detail, not a public API.

## Validation

`build.cmd -pack` on this project succeeds with 0 warnings and lands the package in `artifacts/packages/<config>/Shipping/` (`Microsoft.Testing.Platform.Internal.DotnetTest.2.3.0-dev.nupkg` locally; `2.3.0-preview.*` in CI/official). `PACKAGE.md` is auto-wired as the package readme by `Directory.Build.targets`.

## Follow-up

The consuming side is drafted in **dotnet/sdk#54959** (replaces the hand-copied `IPC/ObjectFieldIds.cs` + `Terminal/` reporter with a `PackageReference`). It needs this package to publish + flow into dotnet/sdk before the namespace/reporter reconciliation can be completed.