### PR TITLE
Add testconfig.json JSON schema for SchemaStore publication

### DIFF
--- a/docs/testconfig.schema.json
+++ b/docs/testconfig.schema.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json",
+  "title": "MSTest / Microsoft.Testing.Platform testconfig.json",
+  "description": "Configuration file consumed by Microsoft.Testing.Platform (MTP) and MSTest. The file is named 'testconfig.json' (or '<AssemblyName>.testconfig.json' once it is copied next to the test executable). See https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-configure.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON schema, enabling editor completion and validation."
+    },
+    "mstest": {
+      "$ref": "#/definitions/mstest"
+    },
+    "platformOptions": {
+      "$ref": "#/definitions/platformOptions"
+    },
+    "environmentVariables": {
+      "type": "object",
+      "description": "Environment variables to apply to the test host process. Mirrors the <EnvironmentVariables> element of legacy .runsettings. Declaring at least one entry opts the run into the test host controller process model. Do not store secrets here.",
+      "additionalProperties": {
+        "type": ["string", "number", "boolean", "null"]
+      }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "mstest": {
+      "type": "object",
+      "description": "MSTest-specific settings. This is the JSON equivalent of the <MSTest> (or <MSTestV2>) section of a .runsettings file.",
+      "additionalProperties": false,
+      "properties": {
+        "timeout": {
+          "type": "object",
+          "description": "Timeouts (in milliseconds) for tests and fixture methods.",
+          "additionalProperties": false,
+          "properties": {
+            "test": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Default timeout, in milliseconds, applied to every test method."
+            },
+            "assemblyInitialize": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [AssemblyInitialize] methods."
+            },
+            "assemblyCleanup": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [AssemblyCleanup] methods."
+            },
+            "classInitialize": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [ClassInitialize] methods."
+            },
+            "classCleanup": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [ClassCleanup] methods."
+            },
+            "testInitialize": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [TestInitialize] methods."
+            },
+            "testCleanup": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [TestCleanup] methods."
+            },
+            "useCooperativeCancellation": {
+              "type": "boolean",
+              "description": "When true, MSTest uses cooperative cancellation for timeouts instead of aborting the thread. Defaults to false."
+            }
+          }
+        },
+        "execution": {
+          "type": "object",
+          "description": "Test execution behavior settings.",
+          "additionalProperties": false,
+          "properties": {
+            "randomizeTestOrder": {
+              "type": "boolean",
+              "description": "When true, randomizes the order in which tests run. Defaults to false. Mutually exclusive with 'orderTestsByNameInClass'."
+            },
+            "randomTestOrderSeed": {
+              "type": "integer",
+              "description": "Seed used when 'randomizeTestOrder' is true, to make the randomized order reproducible."
+            },
+            "mapInconclusiveToFailed": {
+              "type": "boolean",
+              "description": "When true, inconclusive test outcomes are reported as failures. Defaults to false."
+            },
+            "mapNotRunnableToFailed": {
+              "type": "boolean",
+              "description": "When true, not-runnable test outcomes are reported as failures. Defaults to true."
+            },
+            "treatDiscoveryWarningsAsErrors": {
+              "type": "boolean",
+              "description": "When true, warnings raised during test discovery are treated as errors. Defaults to false."
+            },
+            "considerEmptyDataSourceAsInconclusive": {
+              "type": "boolean",
+              "description": "When true, a data-driven test whose data source yields no rows is reported as inconclusive instead of failing. Defaults to false."
+            },
+            "launchDebuggerOnAssertionFailure": {
+              "type": "string",
+              "description": "Controls whether the debugger is launched when an assertion fails.",
+              "enum": ["Disabled", "Enabled", "EnabledExcludingCI"]
+            },
+            "executionApartmentState": {
+              "type": "string",
+              "description": "COM apartment state used to run tests. Defaults to MTA. STA is only honored on Windows.",
+              "enum": ["STA", "MTA"]
+            },
+            "disableAppDomain": {
+              "type": "boolean",
+              "description": "When true, disables AppDomain creation (.NET Framework only). Defaults to false."
+            },
+            "collectSourceInformation": {
+              "type": "boolean",
+              "description": "When true, source file and line information is collected during discovery. Defaults to true."
+            }
+          }
+        },
+        "parallelism": {
+          "type": "object",
+          "description": "Test parallelization settings.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "When true, enables test parallelization. Defaults to false."
+            },
+            "workers": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of worker threads used for parallelization. 0 means use the number of logical processors."
+            },
+            "scope": {
+              "type": "string",
+              "description": "Granularity at which tests are parallelized. Use 'class' to run classes in parallel or 'method' to run individual methods in parallel.",
+              "enum": ["class", "method", "ClassLevel", "MethodLevel"]
+            }
+          }
+        },
+        "output": {
+          "type": "object",
+          "description": "Output and diagnostics settings.",
+          "additionalProperties": false,
+          "properties": {
+            "captureTrace": {
+              "type": "boolean",
+              "description": "When true, captures Debug and Trace output during test execution. Defaults to true."
+            }
+          }
+        },
+        "deployment": {
+          "type": "object",
+          "description": "Test deployment settings.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "When true, deployment is enabled. Defaults to true."
+            },
+            "deployTestSourceDependencies": {
+              "type": "boolean",
+              "description": "When true, dependencies of the test source are deployed. Defaults to true."
+            },
+            "deleteDeploymentDirectoryAfterTestRunIsComplete": {
+              "type": "boolean",
+              "description": "When true, the deployment directory is deleted after the test run completes. Defaults to true."
+            }
+          }
+        },
+        "assemblyResolution": {
+          "type": "array",
+          "description": "Additional directories probed when resolving test assembly dependencies (.NET Framework only).",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Directory to probe. Environment variables (for example %HOMEDRIVE%) and relative paths are supported."
+              },
+              "includeSubDirectories": {
+                "type": ["boolean", "string"],
+                "description": "When true, subdirectories of 'path' are also probed. Defaults to false."
+              }
+            }
+          }
+        },
+        "orderTestsByNameInClass": {
+          "type": "boolean",
+          "description": "When true, tests within a class run in alphabetical order by name. Defaults to false. Mutually exclusive with 'execution.randomizeTestOrder'."
+        }
+      }
+    },
+    "platformOptions": {
+      "type": "object",
+      "description": "Microsoft.Testing.Platform host options.",
+      "additionalProperties": true,
+      "properties": {
+        "resultDirectory": {
+          "type": "string",
+          "description": "Directory where test results are written."
+        },
+        "currentWorkingDirectory": {
+          "type": "string",
+          "description": "Working directory of the platform process."
+        },
+        "testHostWorkingDirectory": {
+          "type": "string",
+          "description": "Working directory of the test host process."
+        },
+        "exitProcessOnUnhandledException": {
+          "type": "boolean",
+          "description": "When true, the process exits when an unhandled exception is observed. Defaults to false."
+        },
+        "telemetry": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "isDevelopmentRepository": {
+              "type": "boolean",
+              "description": "Marks the repository as a development repository for telemetry purposes."
+            }
+          }
+        },
+        "testHostControllersManager": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "singleConnectionNamedPipeServer": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "waitConnectionTimeoutSeconds": {
+                  "type": "number",
+                  "description": "Seconds to wait for the test host to connect to the named pipe server."
+                }
+              }
+            },
+            "namedPipeClient": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "connectTimeoutSeconds": {
+                  "type": "number",
+                  "description": "Seconds to wait for the named pipe client to connect."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/testconfig.schema.md
+++ b/docs/testconfig.schema.md
@@ -1,0 +1,100 @@
+# testconfig.json JSON schema
+
+[`testconfig.schema.json`](./testconfig.schema.json) is the JSON Schema (draft-07) for the
+`testconfig.json` configuration file consumed by Microsoft.Testing.Platform (MTP) and MSTest.
+
+It covers:
+
+- the MSTest section (`mstest:*` — `timeout`, `execution`, `parallelism`, `output`, `deployment`,
+  `assemblyResolution`, `orderTestsByNameInClass`);
+- the Microsoft.Testing.Platform host section (`platformOptions:*`);
+- the `environmentVariables` section.
+
+The schema is the source for IDE auto-completion and validation when authoring `testconfig.json`.
+
+## Referencing the schema
+
+Editors that honor [SchemaStore](https://www.schemastore.org) (Visual Studio, VS Code, Rider, …)
+pick the schema up automatically once the SchemaStore catalog entry below is published, because the
+file is named `testconfig.json` (or `<AssemblyName>.testconfig.json`).
+
+You can also opt in explicitly by adding a `$schema` property to your file:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json",
+  "mstest": {
+    "parallelism": {
+      "enabled": true,
+      "scope": "method"
+    }
+  }
+}
+```
+
+## Publishing to SchemaStore
+
+SchemaStore does not need to host the schema body — it can reference a schema hosted in this
+repository. To register the schema, open a PR against
+[`SchemaStore/schemastore`](https://github.com/SchemaStore/schemastore) that adds the following
+entry to the `schemas` array in
+[`src/api/json/catalog.json`](https://github.com/SchemaStore/schemastore/blob/master/src/api/json/catalog.json)
+(entries are kept alphabetically by `name`):
+
+```json
+{
+  "name": "MSTest testconfig.json",
+  "description": "Configuration file for MSTest and Microsoft.Testing.Platform.",
+  "fileMatch": ["testconfig.json", "*.testconfig.json"],
+  "url": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
+}
+```
+
+SchemaStore also runs the schema through its own test suite, so keep the file valid draft-07 and
+make sure the sample `testconfig.json` files in the repo continue to validate.
+
+## How versioning works
+
+There are two layers of versioning to keep in mind:
+
+1. **The schema dialect** — declared by the top-level `$schema` keyword inside
+   `testconfig.schema.json` (currently `http://json-schema.org/draft-07/schema#`). SchemaStore
+   recommends draft-07 for the broadest editor support; only change it if every consuming editor
+   supports the newer dialect.
+
+2. **The schema content** — `testconfig.json` is **not** itself versioned (there is no `version`
+   key in the file). Because the URL referenced by SchemaStore points at the `main` branch, the
+   schema is **evolved in place**: when a new `mstest:*` or `platformOptions:*` key ships, update
+   `testconfig.schema.json` in the same PR and the change is live for everyone as soon as it merges
+   to `main`. No SchemaStore change is required for content updates — only the one-time catalog
+   registration above.
+
+   This "rolling latest" model is the norm for configuration schemas whose options only grow and
+   stay backward compatible. If we ever needed to expose multiple frozen versions side by side,
+   SchemaStore supports a `versions` object in the catalog entry that maps a version string to a
+   pinned schema URL, for example:
+
+   ```json
+   "versions": {
+     "v3": "https://raw.githubusercontent.com/microsoft/testfx/v3.x/docs/testconfig.schema.json",
+     "v4": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
+   }
+   ```
+
+   We do not use that today; the single rolling `main` URL is sufficient.
+
+## Keeping the schema in sync
+
+The schema must track the keys actually read by the configuration parsers. The source of truth is:
+
+- `MSTestSettings.SetSettingsFromConfig` and the `Parse*Setting` helpers in
+  [`src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs`](../src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs);
+- `MSTestAdapterSettings.ToSettings(IConfiguration)` and `ReadAssemblyResolutionPath` in
+  [`src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs`](../src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs);
+- `RunConfigurationSettings.SetRunConfigurationSettingsFromConfig` in
+  [`src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs`](../src/Adapter/MSTestAdapter.PlatformServices/RunConfigurationSettings.cs);
+- `PlatformConfigurationConstants` in
+  [`src/Platform/Microsoft.Testing.Platform/Configurations/PlatformConfigurationConstants.cs`](../src/Platform/Microsoft.Testing.Platform/Configurations/PlatformConfigurationConstants.cs).
+
+When you add, rename, or remove a configuration key in any of those, update
+`testconfig.schema.json` in the same change.


### PR DESCRIPTION
## What

Adds a draft-07 JSON Schema for `testconfig.json`, the configuration file consumed by Microsoft.Testing.Platform (MTP) and MSTest, plus a maintainer doc.

Implements **Task 1** of #9381 (publish the MSTest testconfig.json schema to SchemaStore).

### Files
- `docs/testconfig.schema.json` — the schema. Covers the full `mstest:*` surface (`timeout`, `execution`, `parallelism`, `output`, `deployment`, `assemblyResolution`, `orderTestsByNameInClass`), the `platformOptions:*` host options, and the `environmentVariables` section. Enums, ranges and per-key descriptions are derived from the actual parsers (`MSTestSettings.Configuration.cs`, `MSTestAdapterSettings.cs`, `RunConfigurationSettings.cs`, `PlatformConfigurationConstants.cs`).
- `docs/testconfig.schema.md` — how to reference the schema, the SchemaStore submission steps, how versioning works (rolling `main` URL; no in-file version), and a "keep in sync" pointer to the parser source-of-truth files.

### Validation
The schema was validated against the canonical `testconfig.json` example used in the repo's acceptance tests, and confirmed to reject bad enums, sub-minimum timeouts, unknown keys, and missing required `path` in `assemblyResolution`.

## SchemaStore registration

The companion SchemaStore catalog PR is open: **SchemaStore/schemastore#5842**. It is a self-hosted/external registration pointing at `https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json`, so it only goes green once this PR merges to `main` and the URL resolves.

## Follow-ups

Tasks 2–5 from #9381 are tracked separately: #9402, #9401, #9403, #9404.