### PR TITLE
[test-improver] test: add edge case tests for RemoveClassCleanupBehaviorArgumentFixer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/RemoveClassCleanupBehaviorArgumentFixerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/RemoveClassCleanupBehaviorArgumentFixerTests.cs
@@ -87,6 +87,78 @@ public sealed class RemoveClassCleanupBehaviorArgumentFixerTests
     }
 
     [TestMethod]
+    public async Task WhenClassCleanupBehaviorIsFirstArgument_RemovesBehaviorKeepsInheritance()
+    {
+        // Exercises the branch where ClassCleanupBehavior appears before InheritanceBehavior,
+        // ensuring the first argument is removed and the remaining one is preserved.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace TestProject;
+
+            [TestClass]
+            public class UnitTest1
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+
+                [{|CS1729:ClassCleanup({|CS0103:ClassCleanupBehavior|}.EndOfClass, InheritanceBehavior.None)|}]
+                public void ClassClean()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace TestProject;
+
+            [TestClass]
+            public class UnitTest1
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+
+                [ClassCleanup(InheritanceBehavior.None)]
+                public void ClassClean()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenClassCleanupBehaviorReferencedOutsideAttribute_NoFix()
+    {
+        // Exercises the guard: the fixer only applies when ClassCleanupBehavior appears
+        // inside an AttributeArgument. A reference in a regular method body should not be fixed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace TestProject;
+
+            [TestClass]
+            public class UnitTest1
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                    _ = {|CS0103:ClassCleanupBehavior|}.EndOfClass;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
     public async Task WhenClassCleanupBehaviorWithMultiLineBody_PreservesIndentation()
     {
         string code = """


### PR DESCRIPTION
## Goal and Rationale

`RemoveClassCleanupBehaviorArgumentFixer` had only 2 tests covering the "happy path" (sole argument removed, second of two arguments removed). Two code paths inside the fixer were completely untested:

1. **`ClassCleanupBehavior` as the *first* of two arguments** — the fixer removes the first argument and preserves the remaining `InheritanceBehavior` argument. This is the mirror of the existing test where `ClassCleanupBehavior` is *second*.
2. **`attributeArgument is null` guard** — when a `CS0103` diagnostic for `ClassCleanupBehavior` fires *outside* an attribute argument (e.g. in a method body), the fixer explicitly skips registration. This path was never exercised by a test.

## Approach

Added two new `[TestMethod]` entries to `RemoveClassCleanupBehaviorArgumentFixerTests.cs`:

| Test | What it covers |
|---|---|
| `WhenClassCleanupBehaviorIsFirstArgument_RemovesBehaviorKeepsInheritance` | `[ClassCleanup(ClassCleanupBehavior.EndOfClass, InheritanceBehavior.None)]` → `[ClassCleanup(InheritanceBehavior.None)]` |
| `WhenClassCleanupBehaviorReferencedOutsideAttribute_NoFix` | `_ = ClassCleanupBehavior.EndOfClass;` in a method body — no fix registered, code unchanged |

## Trade-offs

Both tests are simple and low-maintenance. The "no fix" test uses `VerifyCodeFixAsync(code, code)`, the same pattern used elsewhere in the codebase for cases where a diagnostic fires but no fix is appropriate.

## Test Status

All 4 tests pass (`2` pre-existing + `2` new):

```
passed WhenClassCleanupBehaviorArgument_Simple
passed WhenClassCleanupBehaviorWithMultiLineBody_PreservesIndentation
passed WhenClassCleanupBehaviorIsFirstArgument_RemovesBehaviorKeepsInheritance  ← new
passed WhenClassCleanupBehaviorReferencedOutsideAttribute_NoFix                 ← new
```

Command:
```
.dotnet/dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests/ -f net8.0 --no-build -c Debug -- --filter "FullyQualifiedName~RemoveClassCleanupBehaviorArgumentFixerTests"
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28135825139/agentic_workflow) workflow. · 2.3K AIC · ⌖ 25.3 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28135825139, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28135825139 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->