### PR TITLE
Anchor SDK-bundled packages so Dependabot bumps them

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -133,8 +133,10 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <!--
-    Declare below packages that are referenced through MSTest.Sdk but don't have a direct
-    PackageReference in this repo, so that Dependabot can discover and update them.
+    Declare below packages that are bundled through MSTest.Sdk (baked into the shipped SDK
+    templates) and are not otherwise consumed by a built project, so that Dependabot can
+    discover and update them. Their only PackageReference in this repo is the inert anchor
+    described in condition 2 below.
 
     Two conditions must BOTH hold for Dependabot to bump one of these, and missing either one
     silently stops the updates:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -136,11 +136,22 @@
     Declare below packages that are referenced through MSTest.Sdk but don't have a direct
     PackageReference in this repo, so that Dependabot can discover and update them.
 
-    The version MUST be a literal here (not an MSBuild property such as
-    $(MicrosoftPlaywrightVersion)): Dependabot does not update a Central Package Management
-    PackageVersion whose Version is an MSBuild property interpolation when the package has no
-    direct PackageReference, so a property-based version silently stops receiving updates.
-    See dependabot/dependabot-core#5812 and dependabot/dependabot-core#7183.
+    Two conditions must BOTH hold for Dependabot to bump one of these, and missing either one
+    silently stops the updates:
+
+      1. The version MUST be a literal here (not an MSBuild property such as
+         $(MicrosoftPlaywrightVersion)): Dependabot does not update a Central Package Management
+         PackageVersion whose Version is an MSBuild property interpolation.
+         See dependabot/dependabot-core#5812 and dependabot/dependabot-core#7183.
+
+      2. The package MUST have a real PackageReference somewhere in the repo's restore graph:
+         Dependabot only updates a CPM PackageVersion that is actually referenced by a project;
+         an "orphan" PackageVersion (declared here but referenced nowhere) is ignored. Because
+         these packages are only baked into the shipped SDK templates (Sdk/Features/*.targets)
+         and never referenced by a built project, we add inert anchor references
+         (PackageReference with ExcludeAssets="all") in
+         test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj.
+         Without those anchors Dependabot never proposed bumps (see #9362).
 
     Each literal version is duplicated as the matching *Version property (defined near the top of
     this file) which is the value actually consumed by the build and baked into the MSTest.Sdk

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -47,6 +47,22 @@
     <PackageDownload Include="Aspire.Hosting.Testing" Version="[$(AspireHostingTestingVersion)]" />
   </ItemGroup>
 
+  <!--
+    Dependabot anchor for the packages bundled by MSTest.Sdk (Microsoft.Playwright.MSTest.v4,
+    Aspire.Hosting.Testing). These are baked into the shipped SDK templates (Sdk/Features/*.targets)
+    and have no other PackageReference in the repo, so their Central Package Management PackageVersion
+    entries in Directory.Packages.props are "orphans" that Dependabot ignores (it only updates package
+    versions that are actually referenced by a project). Referencing them here (with ExcludeAssets="all"
+    so none of their assets such as compile/runtime/build targets, e.g. Playwright's browser install,
+    flow into this test project) puts them into a real restore graph so Dependabot proposes bumps. The
+    _ValidateBundledSdkFeatureVersions target in Directory.Packages.props then guards the matching
+    Microsoft properties against drift after a bump. See https://github.com/microsoft/testfx/issues/9362.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Playwright.MSTest.v4" ExcludeAssets="all" />
+    <PackageReference Include="Aspire.Hosting.Testing" ExcludeAssets="all" />
+  </ItemGroup>
+
   <Target Name="CopyNuGetPackagesForTestAssets" BeforeTargets="BeforeBuild">
     <ItemGroup>
       <MicrosoftTestingExtensionsCodeCoveragePackage Include="$(PkgMicrosoft_Testing_Extensions_CodeCoverage)\microsoft.testing.extensions.codecoverage.*.nupkg" />

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -56,7 +56,8 @@
     so none of their assets such as compile/runtime/build targets, e.g. Playwright's browser install,
     flow into this test project) puts them into a real restore graph so Dependabot proposes bumps. The
     _ValidateBundledSdkFeatureVersions target in Directory.Packages.props then guards the matching
-    Microsoft properties against drift after a bump. See https://github.com/microsoft/testfx/issues/9362.
+    version properties (MicrosoftPlaywrightVersion, AspireHostingTestingVersion) against drift after
+    a bump. See https://github.com/microsoft/testfx/issues/9362.
   -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright.MSTest.v4" ExcludeAssets="all" />


### PR DESCRIPTION
## Problem

Dependabot stopped proposing version bumps for the packages bundled by MSTest SDK — most visibly Playwright, which stayed at `1.60.0` even after `1.61.0` shipped (#9362). `Aspire.Hosting.Testing` is affected by the exact same defect.

Both `Microsoft.Playwright.MSTest.v4` and `Aspire.Hosting.Testing` are declared as Central Package Management `PackageVersion` entries in `Directory.Packages.props`, but they are only baked into the shipped MSTest.Sdk templates (`Sdk/Features/*.targets`) — they have **no real `PackageReference`** anywhere in the repo's restore graph.

Dependabot's NuGet updater only bumps a CPM `PackageVersion` that is **actually referenced by a project**. An "orphan" `PackageVersion` (declared but referenced nowhere) is ignored by design. PR #9365 fixed only one of the two required conditions (it switched the versions from MSBuild-property interpolation to literals), but left the packages orphaned, so the bumps still never appeared.

## Fix

- Add **inert anchor references** for both packages in the CI-built `MSTest.Acceptance.IntegrationTests` project, using `PackageReference ... ExcludeAssets="all"`. This puts them into a real restore graph (so Dependabot discovers them and proposes bumps) **without** pulling any of their assets — compile/runtime/build targets such as Playwright's browser-install — into the test project.
- Correct the now-misleading comment in `Directory.Packages.props` to document that **both** conditions must hold (literal version **and** a real `PackageReference`), and point at where the anchors live.

Versions are unchanged; Dependabot can take it from here. The existing `_ValidateBundledSdkFeatureVersions` target still guards the matching `Microsoft*Version` properties against drift after a bump.

## Verification

- `dotnet restore` of `MSTest.Acceptance.IntegrationTests` succeeds.
- `project.assets.json` now lists both as **direct** top-level dependencies tied to their CPM versions:
  - `Microsoft.Playwright.MSTest.v4 >= 1.60.0`
  - `Aspire.Hosting.Testing >= 13.2.1`
- `ExcludeAssets="all"` keeps all package assets out of the test project (no Playwright browser-install targets run).

Fixes #9362