### PR TITLE
Run OutputTests parallel-output tests locally, skip them on CI

### DIFF
--- a/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
@@ -14,11 +14,9 @@ public class OutputTests : CLITestBase
     private const string TestAssetName = "OutputTestProject";
 
     [TestMethod]
-    [Ignore("Fails on CI.")]
     public async Task OutputIsNotMixedWhenTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest1");
 
     [TestMethod]
-    [Ignore("Fails on CI.")]
     public async Task OutputIsNotMixedWhenAsyncTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest2");
 
     private static async Task ValidateOutputForClassAsync(string className)

--- a/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
@@ -14,11 +14,11 @@ public class OutputTests : CLITestBase
     private const string TestAssetName = "OutputTestProject";
 
     [TestMethod]
-    [Ignore("Flaky on constrained CI agents (notably Windows Debug). ValidateOutputForClassAsync asserts the 3 methods overlap in wall-clock time to prove they ran in parallel, but the thread pool does not reliably schedule them concurrently before the short (40-100ms) methods finish, so the overlap guard fails. Re-enabling needs the asset to force overlap deterministically (e.g. a Barrier).")]
+    [CICondition(ConditionMode.Exclude)] // Asserts the methods overlap in wall-clock time to prove parallelism; the thread pool doesn't reliably schedule them concurrently on constrained CI agents (notably Windows Debug). Runs locally where scheduling is reliable.
     public async Task OutputIsNotMixedWhenTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest1");
 
     [TestMethod]
-    [Ignore("Flaky on constrained CI agents (notably Windows Debug). ValidateOutputForClassAsync asserts the 3 methods overlap in wall-clock time to prove they ran in parallel, but the thread pool does not reliably schedule them concurrently before the short (40-100ms) methods finish, so the overlap guard fails. Re-enabling needs the asset to force overlap deterministically (e.g. a Barrier).")]
+    [CICondition(ConditionMode.Exclude)] // Asserts the methods overlap in wall-clock time to prove parallelism; the thread pool doesn't reliably schedule them concurrently on constrained CI agents (notably Windows Debug). Runs locally where scheduling is reliable.
     public async Task OutputIsNotMixedWhenAsyncTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest2");
 
     private static async Task ValidateOutputForClassAsync(string className)

--- a/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/OutputTests.cs
@@ -14,9 +14,11 @@ public class OutputTests : CLITestBase
     private const string TestAssetName = "OutputTestProject";
 
     [TestMethod]
+    [Ignore("Flaky on constrained CI agents (notably Windows Debug). ValidateOutputForClassAsync asserts the 3 methods overlap in wall-clock time to prove they ran in parallel, but the thread pool does not reliably schedule them concurrently before the short (40-100ms) methods finish, so the overlap guard fails. Re-enabling needs the asset to force overlap deterministically (e.g. a Barrier).")]
     public async Task OutputIsNotMixedWhenTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest1");
 
     [TestMethod]
+    [Ignore("Flaky on constrained CI agents (notably Windows Debug). ValidateOutputForClassAsync asserts the 3 methods overlap in wall-clock time to prove they ran in parallel, but the thread pool does not reliably schedule them concurrently before the short (40-100ms) methods finish, so the overlap guard fails. Re-enabling needs the asset to force overlap deterministically (e.g. a Barrier).")]
     public async Task OutputIsNotMixedWhenAsyncTestsRunInParallel() => await ValidateOutputForClassAsync("UnitTest2");
 
     private static async Task ValidateOutputForClassAsync(string className)


### PR DESCRIPTION
## Summary

The two `OutputTests` parallel-output integration tests were marked `[Ignore("Fails on CI.")]`. They pass locally, on Linux/macOS, and in Release, but fail on the **Windows Debug** CI leg.

### Root cause

`ValidateOutputForClassAsync` (OutputTests.cs:41–43) requires the three test methods to **overlap** in wall-clock time (`Assert.IsTrue(someStartedBeforeFirstEnded)`) to prove they ran in parallel before checking that their output isn't interleaved. The asset (`OutputTestProject/UnitTest1.cs`) sleeps 40–100ms per method under `[Parallelize(Workers = 0)]` to encourage overlap. On the constrained Windows Debug agent the thread pool doesn't reliably schedule the three short methods concurrently, so the overlap guard fails. The behavior is genuinely environment-dependent, not stale.

### Fix

Instead of ignoring these everywhere, they now use the built-in **`[CICondition(ConditionMode.Exclude)]`** so they:
- **run locally** (where the value is — they catch real output-interleaving regressions, and scheduling is reliable), and
- **skip only in CI environments** (Azure Pipelines `TF_BUILD`, GitHub Actions, etc. via the framework's `CIEnvironmentDetector`).

### Verification

| Scenario | Result |
| --- | --- |
| Local (no CI env vars) | 2 run, **2 passed**, 0 skipped |
| `TF_BUILD=true` set | 0 failed, **2 skipped** — _"Test is not supported in CI environments"_ |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>