### PR TITLE
Add missing changelog entries for ExecutableConditionAttribute and testconfig.json schema

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -36,6 +36,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Azure DevOps per-assembly log groups by @Evangelink in [#9177](https://github.com/microsoft/testfx/pull/9177)
 * Add Azure DevOps history-driven slow-test threshold enricher by @Evangelink in [#9182](https://github.com/microsoft/testfx/pull/9182)
 * Handshake from the test host orchestrator in the dotnet test pipe protocol, advertising the orchestration feature (e.g. retry) by @Copilot in [#9215](https://github.com/microsoft/testfx/pull/9215)
+* Add testconfig.json JSON schema for SchemaStore publication and IDE validation by @Evangelink in [#9405](https://github.com/microsoft/testfx/pull/9405)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -35,6 +35,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add Span\<T> and Memory\<T> overloads to Assert.HasCount and extend MSTEST0037 coverage by @Evangelink in [#9176](https://github.com/microsoft/testfx/pull/9176)
 * Add [ArchitectureConditionAttribute] to gate tests by process architecture by @Evangelink in [#9233](https://github.com/microsoft/testfx/pull/9233)
 * Add MSTEST0071 analyzer and code fix for redundant test method display name by @Evangelink in [#9272](https://github.com/microsoft/testfx/pull/9272)
+* Add [ExecutableConditionAttribute] to conditionally run tests based on tool availability by @Evangelink in [#9369](https://github.com/microsoft/testfx/pull/9369)
 
 ### Fixed
 


### PR DESCRIPTION
Two user-facing changelog entries were missed when the PRs were merged:

- **`docs/Changelog.md`**: Add entry for `[ExecutableConditionAttribute]` ([`#9369`](https://github.com/microsoft/testfx/pull/9369)) in the 4.3.0 UNRELEASED `Added` section.
- **`docs/Changelog-Platform.md`**: Add entry for testconfig.json JSON schema for SchemaStore publication and IDE validation ([`#9405`](https://github.com/microsoft/testfx/pull/9405)) in the 2.3.0 UNRELEASED `Added` section.

Found during adhoc QA pass (2026-06-25).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/28152526454/agentic_workflow) workflow. · 515.7 AIC · ⌖ 23.5 AIC · ⊞ 51.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28152526454, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/28152526454 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->