### PR TITLE
Add experimental IBlockingDataConsumer for inline data consumption

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Testing.Platform.Extensions;
 
 /// <summary>
-/// Marker interface for a <see cref="IDataConsumer"/> that must consume the data synchronously,
+/// Marker interface for a <see cref="IDataConsumer"/> that must consume the data inline,
 /// before the call to publish the data returns to the producer.
 /// </summary>
 /// <remarks>

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Extensions;
+
+/// <summary>
+/// Marker interface for a <see cref="IDataConsumer"/> that must consume the data synchronously,
+/// before the call to publish the data returns to the producer.
+/// </summary>
+/// <remarks>
+/// A regular <see cref="IDataConsumer"/> consumes data asynchronously: the data is queued and
+/// processed on a background loop, so there is no guarantee about when <see cref="IDataConsumer.ConsumeAsync"/>
+/// runs relative to the producer continuing its work. A consumer that additionally implements
+/// <see cref="IBlockingDataConsumer"/> is instead invoked inline by the message bus, so the producer's
+/// call to publish does not return until <see cref="IDataConsumer.ConsumeAsync"/> has completed.
+/// This is useful for extensions that need to guarantee a piece of work happens before the producer
+/// proceeds (for example, before a test starts running).
+/// </remarks>
+[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
+public interface IBlockingDataConsumer : IDataConsumer;

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
@@ -26,7 +26,10 @@ namespace Microsoft.Testing.Platform.Extensions;
 /// Inline consumption is serialized: only one <see cref="IDataConsumer.ConsumeAsync"/> call runs at a
 /// time per consumer. As a consequence, a blocking consumer must not, from within its
 /// <see cref="IDataConsumer.ConsumeAsync"/>, publish data that is routed back to itself, as that would
-/// deadlock.
+/// deadlock. Note that publishing data where the producer is the consumer itself (same UID) is safe,
+/// because the message bus skips delivering a producer's data back to that same producer; the deadlock
+/// risk is specifically re-entrant publishing that routes back to this consumer under a
+/// <em>different</em> producer UID.
 /// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Testing.Platform.Extensions;
 /// before the call to publish the data returns to the producer.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A regular <see cref="IDataConsumer"/> consumes data asynchronously: the data is queued and
 /// processed on a background loop, so there is no guarantee about when <see cref="IDataConsumer.ConsumeAsync"/>
 /// runs relative to the producer continuing its work. A consumer that additionally implements
@@ -15,6 +16,18 @@ namespace Microsoft.Testing.Platform.Extensions;
 /// call to publish does not return until <see cref="IDataConsumer.ConsumeAsync"/> has completed.
 /// This is useful for extensions that need to guarantee a piece of work happens before the producer
 /// proceeds (for example, before a test starts running).
+/// </para>
+/// <para>
+/// Because consumption happens inline, any exception thrown by <see cref="IDataConsumer.ConsumeAsync"/>
+/// propagates back to the producer that published the data, rather than being observed later during
+/// drain. Implementations should therefore avoid throwing for non-fatal conditions.
+/// </para>
+/// <para>
+/// Inline consumption is serialized: only one <see cref="IDataConsumer.ConsumeAsync"/> call runs at a
+/// time per consumer. As a consequence, a blocking consumer must not, from within its
+/// <see cref="IDataConsumer.ConsumeAsync"/>, publish data that is routed back to itself, as that would
+/// deadlock.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IBlockingDataConsumer : IDataConsumer;

--- a/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AsynchronousMessageBus.cs
@@ -83,7 +83,12 @@ internal sealed class AsynchronousMessageBus : BaseMessageBus, IMessageBus, IDis
 
                 if (!_consumerProcessor.TryGetValue(consumer, out IAsyncConsumerDataProcessor? asyncMultiProducerMultiConsumerDataProcessor))
                 {
-                    asyncMultiProducerMultiConsumerDataProcessor = new AsyncConsumerDataProcessor(consumer, _task, _testApplicationCancellationTokenSource.CancellationToken);
+                    // A consumer that implements the IBlockingDataConsumer marker interface must consume the data
+                    // inline (the publisher blocks until consumption completes) instead of going through the
+                    // asynchronous background processing loop.
+                    asyncMultiProducerMultiConsumerDataProcessor = consumer is IBlockingDataConsumer
+                        ? new BlockingConsumerDataProcessor(consumer, _testApplicationCancellationTokenSource.CancellationToken)
+                        : new AsyncConsumerDataProcessor(consumer, _task, _testApplicationCancellationTokenSource.CancellationToken);
                     _consumerProcessor.Add(consumer, asyncMultiProducerMultiConsumerDataProcessor);
                 }
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -66,7 +66,7 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
         // We still wait for any in-flight inline consumption to finish before the processor can be
         // disposed: acquiring the single permit guarantees no consumer is currently executing, and we
         // release it immediately afterwards. The message bus marks itself disabled before calling this,
-        // so no new data can reach this processor while we wait.
+        // so the platform stops issuing new publishes to this processor while we wait.
         //
         // We intentionally wait without the cancellation token: an in-flight consumption already
         // receives the token and will unwind promptly on shutdown, but we must still wait for it to

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace Microsoft.Testing.Platform.Messages;
+
+/// <summary>
+/// Processor used for <see cref="IBlockingDataConsumer"/> instances. Unlike <see cref="AsyncConsumerDataProcessor"/>,
+/// which queues data and processes it on a background loop, this processor consumes the data inline so the publisher
+/// blocks until <see cref="IDataConsumer.ConsumeAsync"/> has completed.
+/// </summary>
+[DebuggerDisplay("DataConsumer = {DataConsumer.Uid}")]
+internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcessor
+{
+    private readonly CancellationToken _cancellationToken;
+
+    // Serialize the inline consumption so that we honor the same "process only 1 data at a time"
+    // guarantee that the asynchronous processor provides through its single reader.
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private long _receivedCount;
+
+    public BlockingConsumerDataProcessor(IDataConsumer dataConsumer, CancellationToken cancellationToken)
+    {
+        DataConsumer = dataConsumer;
+        _cancellationToken = cancellationToken;
+    }
+
+    public IDataConsumer DataConsumer { get; }
+
+    public long ReceivedCount => Volatile.Read(ref _receivedCount);
+
+    public async Task PublishAsync(IDataProducer dataProducer, IData data)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+
+        // We don't consume the data if the consumer is the producer of the data.
+        if (dataProducer.Uid == DataConsumer.Uid)
+        {
+            return;
+        }
+
+        Interlocked.Increment(ref _receivedCount);
+
+        await _semaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await DataConsumer.ConsumeAsync(dataProducer, data, _cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    // The data is consumed inline in PublishAsync, so there is never anything left to drain.
+    public Task DrainDataAsync() => Task.CompletedTask;
+
+    // The data is consumed inline in PublishAsync, so there is no background loop to complete.
+    public Task CompleteAddingAsync() => Task.CompletedTask;
+
+    public void Dispose()
+        => _semaphore.Dispose();
+}

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -36,13 +36,15 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
     {
         _cancellationToken.ThrowIfCancellationRequested();
 
+        // Increment unconditionally (even for self-produced data we skip below) to keep the same
+        // ReceivedCount semantics as AsyncConsumerDataProcessor.
+        Interlocked.Increment(ref _receivedCount);
+
         // We don't consume the data if the consumer is the producer of the data.
         if (dataProducer.Uid == DataConsumer.Uid)
         {
             return;
         }
-
-        Interlocked.Increment(ref _receivedCount);
 
         await _semaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
         try
@@ -58,8 +60,25 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
     // The data is consumed inline in PublishAsync, so there is never anything left to drain.
     public Task DrainDataAsync() => Task.CompletedTask;
 
-    // The data is consumed inline in PublishAsync, so there is no background loop to complete.
-    public Task CompleteAddingAsync() => Task.CompletedTask;
+    public async Task CompleteAddingAsync()
+    {
+        // The data is consumed inline in PublishAsync, so there is no background loop to complete.
+        // We still wait for any in-flight inline consumption to finish before the processor can be
+        // disposed: acquiring the single permit guarantees no consumer is currently executing, and we
+        // release it immediately afterwards. The message bus marks itself disabled before calling this,
+        // so no new data can reach this processor while we wait.
+        try
+        {
+            await _semaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException oc) when (oc.CancellationToken == _cancellationToken)
+        {
+            // The application is shutting down. Nothing left to wait for.
+            return;
+        }
+
+        _semaphore.Release();
+    }
 
     public void Dispose()
         => _semaphore.Dispose();

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -67,16 +67,13 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
         // disposed: acquiring the single permit guarantees no consumer is currently executing, and we
         // release it immediately afterwards. The message bus marks itself disabled before calling this,
         // so no new data can reach this processor while we wait.
-        try
-        {
-            await _semaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException oc) when (oc.CancellationToken == _cancellationToken)
-        {
-            // The application is shutting down. Nothing left to wait for.
-            return;
-        }
-
+        //
+        // We intentionally wait without the cancellation token: an in-flight consumption already
+        // receives the token and will unwind promptly on shutdown, but we must still wait for it to
+        // release the permit before Dispose runs to avoid an ObjectDisposedException on the release.
+        // This mirrors AsyncConsumerDataProcessor.CompleteAddingAsync, which unconditionally awaits its
+        // consume task on every path.
+        await _semaphore.WaitAsync().ConfigureAwait(false);
         _semaphore.Release();
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -77,6 +77,13 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
         _semaphore.Release();
     }
 
+    // We intentionally do not dispose the SemaphoreSlim. Disposing it would introduce an
+    // ObjectDisposedException failure mode if AsynchronousMessageBus.Dispose ran while a PublishAsync
+    // was still in-flight (the in-flight call would hit _semaphore.Release on a disposed instance).
+    // SemaphoreSlim only owns an unmanaged WaitHandle if its AvailableWaitHandle is accessed, which we
+    // never do, so it is safe to let the GC reclaim it. This matches AsyncConsumerDataProcessor, which
+    // does not dispose a synchronization primitive either.
     public void Dispose()
-        => _semaphore.Dispose();
+    {
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -34,11 +34,11 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
 
     public async Task PublishAsync(IDataProducer dataProducer, IData data)
     {
-        _cancellationToken.ThrowIfCancellationRequested();
-
-        // Increment unconditionally (even for self-produced data we skip below) to keep the same
-        // ReceivedCount semantics as AsyncConsumerDataProcessor.
+        // Increment unconditionally and before honoring cancellation, to keep the same ReceivedCount
+        // semantics as AsyncConsumerDataProcessor (even self-produced data we skip below is counted).
         Interlocked.Increment(ref _receivedCount);
+
+        _cancellationToken.ThrowIfCancellationRequested();
 
         // We don't consume the data if the consumer is the producer of the data.
         if (dataProducer.Uid == DataConsumer.Uid)

--- a/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/BlockingConsumerDataProcessor.cs
@@ -81,8 +81,8 @@ internal sealed class BlockingConsumerDataProcessor : IAsyncConsumerDataProcesso
     // ObjectDisposedException failure mode if AsynchronousMessageBus.Dispose ran while a PublishAsync
     // was still in-flight (the in-flight call would hit _semaphore.Release on a disposed instance).
     // SemaphoreSlim only owns an unmanaged WaitHandle if its AvailableWaitHandle is accessed, which we
-    // never do, so it is safe to let the GC reclaim it. This matches AsyncConsumerDataProcessor, which
-    // does not dispose a synchronization primitive either.
+    // never do, so it is safe to let the GC reclaim it. AsyncConsumerDataProcessor similarly does not
+    // dispose its synchronization primitive (its channel is not even IDisposable).
     public void Dispose()
     {
     }

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+[TPEXP]Microsoft.Testing.Platform.Extensions.IBlockingDataConsumer

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BlockingDataConsumerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BlockingDataConsumerTests.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public class BlockingDataConsumerTests : AcceptanceTestBase<BlockingDataConsumerTests.TestAssetFixture>
+{
+    private const string AssetName = "BlockingDataConsumerTests";
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task BlockingDataConsumer_IsConsumedInline_BeforePublishReturns(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        // The asset publishes an in-progress message to a blocking consumer that sleeps inside
+        // ConsumeAsync. It then verifies, right after PublishAsync returns, that the consumption has
+        // already completed (proving the publish blocked until ConsumeAsync finished). The asset
+        // reports a passing test only when that invariant holds, so a green run validates the
+        // blocking behavior end-to-end.
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string TestCode = """
+#file BlockingDataConsumerTests.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <UseAppHost>true</UseAppHost>
+        <LangVersion>preview</LangVersion>
+        <NoWarn>$(NoWarn);TPEXP</NoWarn>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+    </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Requests;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+builder.RegisterTestFramework(
+    _ => new TestFrameworkCapabilities(),
+    (_, __) => new DummyTestFramework());
+
+builder.TestHost.AddDataConsumer(_ => new BlockingConsumer());
+
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();
+
+public class DummyTestFramework : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestFramework);
+
+    public string Version => "1.0.0";
+
+    public string DisplayName => "Dummy Test Framework";
+
+    public string Description => "A dummy test framework for testing blocking data consumers";
+
+    public Type[] DataTypesProduced => [typeof(TestNodeUpdateMessage)];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        // Publish an in-progress update. Because the consumer is a blocking data consumer that sleeps
+        // inside ConsumeAsync, this call must not return until the consumption has completed.
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+            context.Request.Session.SessionUid,
+            new TestNode() { Uid = "1", DisplayName = "BlockingValidation", Properties = new(InProgressTestNodeStateProperty.CachedInstance) }));
+
+        // If consumption was performed inline (i.e. the publish blocked), the flag is already set.
+        // With a regular asynchronous consumer this would still be false here because the slow
+        // ConsumeAsync would run on the background processing loop after the publish returned.
+        bool consumedInline = BlockingConsumer.HasCompletedConsumption;
+
+        TestNodeStateProperty resultState = consumedInline
+            ? PassedTestNodeStateProperty.CachedInstance
+            : new FailedTestNodeStateProperty("Blocking consumer did not consume the data inline before PublishAsync returned.");
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+            context.Request.Session.SessionUid,
+            new TestNode() { Uid = "1", DisplayName = "BlockingValidation", Properties = new(resultState) }));
+
+        context.Complete();
+    }
+}
+
+internal class BlockingConsumer : IBlockingDataConsumer
+{
+    public static volatile bool HasCompletedConsumption;
+
+    public Type[] DataTypesConsumed => [typeof(TestNodeUpdateMessage)];
+
+    public string Uid => nameof(BlockingConsumer);
+
+    public string Version => "1.0.0";
+
+    public string DisplayName => nameof(BlockingConsumer);
+
+    public string Description => nameof(BlockingConsumer);
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        // Only react to the in-progress message; ignore the final result message we publish below.
+        if (value is TestNodeUpdateMessage { TestNode.Properties: { } properties }
+            && properties.SingleOrDefault<InProgressTestNodeStateProperty>() is not null)
+        {
+            // Sleep to widen the window: if the publish did not block, the producer would observe
+            // HasCompletedConsumption as false right after PublishAsync returned.
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+            HasCompletedConsumption = true;
+        }
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+                TestCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BlockingDataConsumerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BlockingDataConsumerTests.cs
@@ -85,6 +85,10 @@ public class DummyTestFramework : ITestFramework, IDataProducer
 
     public async Task ExecuteRequestAsync(ExecuteRequestContext context)
     {
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+            context.Request.Session.SessionUid,
+            new TestNode() { Uid = "1", DisplayName = "BlockingValidation", Properties = new(DiscoveredTestNodeStateProperty.CachedInstance) }));
+
         // Publish an in-progress update. Because the consumer is a blocking data consumer that sleeps
         // inside ConsumeAsync, this call must not return until the consumption has completed.
         await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -168,6 +168,51 @@ public sealed class AsynchronousMessageBusTests
         }
     }
 
+    [TestMethod]
+    public async Task BlockingDataConsumer_ConsumesInline_BeforePublishReturns()
+    {
+        using MessageBusProxy proxy = new();
+        BlockingConsumer consumer = new("BlockingConsumer");
+        using var asynchronousMessageBus = new AsynchronousMessageBus(
+            [consumer],
+            new CTRLPlusCCancellationTokenSource(),
+            new SystemTask(),
+            new NopLoggerFactory(),
+            new SystemEnvironment());
+        await asynchronousMessageBus.InitAsync();
+        proxy.SetBuiltMessageBus(asynchronousMessageBus);
+
+        DummyProducer producer = new("BlockingProducer", typeof(BlockingData));
+        await proxy.PublishAsync(producer, new BlockingData());
+
+        // A blocking consumer must consume the data inline, so it is already consumed by the time
+        // PublishAsync returns, without needing a drain.
+        Assert.HasCount(1, consumer.ConsumedData);
+
+        await asynchronousMessageBus.DisableAsync();
+    }
+
+    [TestMethod]
+    public async Task BlockingDataConsumer_WhenConsumerIsProducer_ShouldNotConsumeOwnData()
+    {
+        using MessageBusProxy proxy = new();
+        BlockingConsumer consumer = new("BlockingConsumer");
+        using var asynchronousMessageBus = new AsynchronousMessageBus(
+            [consumer],
+            new CTRLPlusCCancellationTokenSource(),
+            new SystemTask(),
+            new NopLoggerFactory(),
+            new SystemEnvironment());
+        await asynchronousMessageBus.InitAsync();
+        proxy.SetBuiltMessageBus(asynchronousMessageBus);
+
+        await proxy.PublishAsync(consumer, new BlockingData());
+
+        Assert.HasCount(0, consumer.ConsumedData);
+
+        await asynchronousMessageBus.DisableAsync();
+    }
+
     private sealed class NopLoggerFactory : ILoggerFactory
     {
         public ILogger CreateLogger(string categoryName) => new NopLogger();
@@ -403,6 +448,42 @@ public sealed class AsynchronousMessageBusTests
             public string? Description => nameof(InvalidDataToProduce);
         }
     }
+
+    private sealed class BlockingData : IData
+    {
+        public string DisplayName => nameof(BlockingData);
+
+        public string? Description => nameof(BlockingData);
+    }
+
+#pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates.
+    private sealed class BlockingConsumer : IBlockingDataConsumer, IDataProducer
+    {
+        public BlockingConsumer(string id) => Uid = id;
+
+        public List<IData> ConsumedData { get; } = [];
+
+        public Type[] DataTypesConsumed => [typeof(BlockingData)];
+
+        public Type[] DataTypesProduced => [typeof(BlockingData)];
+
+        public string Uid { get; }
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => string.Empty;
+
+        public string Description => string.Empty;
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+        public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+        {
+            ConsumedData.Add(value);
+            return Task.CompletedTask;
+        }
+    }
+#pragma warning restore TPEXP
 
     private sealed class DummyProducer : IDataProducer
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -169,7 +169,7 @@ public sealed class AsynchronousMessageBusTests
     }
 
     [TestMethod]
-    public async Task BlockingDataConsumer_ConsumesInline_BeforePublishReturns()
+    public async Task BlockingDataConsumer_PublishAsync_DoesNotReturnUntilConsumeCompletes()
     {
         using MessageBusProxy proxy = new();
         BlockingConsumer consumer = new("BlockingConsumer");
@@ -183,10 +183,22 @@ public sealed class AsynchronousMessageBusTests
         proxy.SetBuiltMessageBus(asynchronousMessageBus);
 
         DummyProducer producer = new("BlockingProducer", typeof(BlockingData));
-        await proxy.PublishAsync(producer, new BlockingData());
 
-        // A blocking consumer must consume the data inline, so it is already consumed by the time
-        // PublishAsync returns, without needing a drain.
+        // Start publishing. Because the consumer is blocking, PublishAsync must not complete until
+        // ConsumeAsync completes, which we control through the gate below.
+        Task publishTask = proxy.PublishAsync(producer, new BlockingData());
+
+        // Wait for the consumer to be invoked inline. This proves the consumption happens as part of
+        // the publish call rather than being deferred to a background loop.
+        await consumer.ConsumeStarted.Task;
+
+        // The consumer is still gated, so the publish call cannot have returned yet.
+        Assert.IsFalse(publishTask.IsCompleted);
+
+        // Release the gate and let consumption (and therefore the publish) complete.
+        consumer.AllowConsumeToComplete.SetResult(true);
+        await publishTask;
+
         Assert.HasCount(1, consumer.ConsumedData);
 
         await asynchronousMessageBus.DisableAsync();
@@ -197,6 +209,11 @@ public sealed class AsynchronousMessageBusTests
     {
         using MessageBusProxy proxy = new();
         BlockingConsumer consumer = new("BlockingConsumer");
+
+        // Release the gate upfront: if the consumer were (incorrectly) invoked for its own data, the
+        // test would fail fast on the assertion below instead of hanging on the gate.
+        consumer.AllowConsumeToComplete.SetResult(true);
+
         using var asynchronousMessageBus = new AsynchronousMessageBus(
             [consumer],
             new CTRLPlusCCancellationTokenSource(),
@@ -463,6 +480,10 @@ public sealed class AsynchronousMessageBusTests
 
         public List<IData> ConsumedData { get; } = [];
 
+        public TaskCompletionSource<bool> ConsumeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> AllowConsumeToComplete { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public Type[] DataTypesConsumed => [typeof(BlockingData)];
 
         public Type[] DataTypesProduced => [typeof(BlockingData)];
@@ -477,10 +498,11 @@ public sealed class AsynchronousMessageBusTests
 
         public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
-        public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+        public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
         {
+            ConsumeStarted.TrySetResult(true);
+            await AllowConsumeToComplete.Task;
             ConsumedData.Add(value);
-            return Task.CompletedTask;
         }
     }
 #pragma warning restore TPEXP

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -190,7 +190,7 @@ public sealed class AsynchronousMessageBusTests
 
         // Wait for the consumer to be invoked inline. This proves the consumption happens as part of
         // the publish call rather than being deferred to a background loop.
-        await consumer.ConsumeStarted.Task;
+        await consumer.ConsumeStarted.Task.TimeoutAfterAsync(TimeoutHelper.DefaultHangTimeSpanTimeout);
 
         // The consumer is still gated, so the publish call cannot have returned yet.
         Assert.IsFalse(publishTask.IsCompleted);
@@ -575,7 +575,7 @@ public sealed class AsynchronousMessageBusTests
                 }
 
                 ConsumeStarted.TrySetResult(true);
-                await AllowConsumeToComplete.Task;
+                await AllowConsumeToComplete.Task.TimeoutAfterAsync(TimeoutHelper.DefaultHangTimeSpanTimeout);
 
                 if (ConsumeDelay > TimeSpan.Zero)
                 {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -230,6 +230,64 @@ public sealed class AsynchronousMessageBusTests
         await asynchronousMessageBus.DisableAsync();
     }
 
+    [TestMethod]
+    public async Task BlockingDataConsumer_SerializesConcurrentPublishes()
+    {
+        using MessageBusProxy proxy = new();
+        BlockingConsumer consumer = new("BlockingConsumer")
+        {
+            ConsumeDelay = TimeSpan.FromMilliseconds(20),
+        };
+
+        // Don't gate consumption for this test; we want it to run as soon as it is invoked.
+        consumer.AllowConsumeToComplete.SetResult(true);
+
+        using var asynchronousMessageBus = new AsynchronousMessageBus(
+            [consumer],
+            new CTRLPlusCCancellationTokenSource(),
+            new SystemTask(),
+            new NopLoggerFactory(),
+            new SystemEnvironment());
+        await asynchronousMessageBus.InitAsync();
+        proxy.SetBuiltMessageBus(asynchronousMessageBus);
+
+        const int publishCount = 8;
+        DummyProducer producer = new("BlockingProducer", typeof(BlockingData));
+        await Task.WhenAll(Enumerable.Range(0, publishCount)
+            .Select(_ => Task.Run(async () => await proxy.PublishAsync(producer, new BlockingData()), TestContext.CancellationToken)));
+
+        // Even though publishes happen concurrently, the blocking processor must serialize the inline
+        // consumption so the consumer never observes overlapping ConsumeAsync calls.
+        Assert.AreEqual(1, consumer.MaxObservedConcurrency);
+        Assert.HasCount(publishCount, consumer.ConsumedData);
+
+        await asynchronousMessageBus.DisableAsync();
+    }
+
+    [TestMethod]
+    public async Task BlockingDataConsumer_WhenConsumeThrows_PublishAsyncSurfacesTheException()
+    {
+        using MessageBusProxy proxy = new();
+        ThrowingBlockingConsumer consumer = new();
+        using var asynchronousMessageBus = new AsynchronousMessageBus(
+            [consumer],
+            new CTRLPlusCCancellationTokenSource(),
+            new SystemTask(),
+            new NopLoggerFactory(),
+            new SystemEnvironment());
+        await asynchronousMessageBus.InitAsync();
+        proxy.SetBuiltMessageBus(asynchronousMessageBus);
+
+        DummyProducer producer = new("BlockingProducer", typeof(BlockingData));
+
+        // Because the consumer runs inline, its exception must propagate to the publishing producer.
+        InvalidOperationException ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            async () => await proxy.PublishAsync(producer, new BlockingData()));
+        Assert.AreEqual("Blocking consumer failure", ex.Message);
+
+        await asynchronousMessageBus.DisableAsync();
+    }
+
     private sealed class NopLoggerFactory : ILoggerFactory
     {
         public ILogger CreateLogger(string categoryName) => new NopLogger();
@@ -476,6 +534,8 @@ public sealed class AsynchronousMessageBusTests
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates.
     private sealed class BlockingConsumer : IBlockingDataConsumer, IDataProducer
     {
+        private int _currentConcurrency;
+
         public BlockingConsumer(string id) => Uid = id;
 
         public List<IData> ConsumedData { get; } = [];
@@ -483,6 +543,12 @@ public sealed class AsynchronousMessageBusTests
         public TaskCompletionSource<bool> ConsumeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public TaskCompletionSource<bool> AllowConsumeToComplete { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // When set, ConsumeAsync delays for this duration while inside the consumption to widen the
+        // window in which a missing serialization guarantee would surface as overlapping calls.
+        public TimeSpan ConsumeDelay { get; set; } = TimeSpan.Zero;
+
+        public int MaxObservedConcurrency { get; private set; }
 
         public Type[] DataTypesConsumed => [typeof(BlockingData)];
 
@@ -500,10 +566,50 @@ public sealed class AsynchronousMessageBusTests
 
         public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
         {
-            ConsumeStarted.TrySetResult(true);
-            await AllowConsumeToComplete.Task;
-            ConsumedData.Add(value);
+            int concurrency = Interlocked.Increment(ref _currentConcurrency);
+            try
+            {
+                lock (ConsumedData)
+                {
+                    MaxObservedConcurrency = Math.Max(MaxObservedConcurrency, concurrency);
+                }
+
+                ConsumeStarted.TrySetResult(true);
+                await AllowConsumeToComplete.Task;
+
+                if (ConsumeDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(ConsumeDelay, cancellationToken);
+                }
+
+                lock (ConsumedData)
+                {
+                    ConsumedData.Add(value);
+                }
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _currentConcurrency);
+            }
         }
+    }
+
+    private sealed class ThrowingBlockingConsumer : IBlockingDataConsumer
+    {
+        public Type[] DataTypesConsumed => [typeof(BlockingData)];
+
+        public string Uid => nameof(ThrowingBlockingConsumer);
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => string.Empty;
+
+        public string Description => string.Empty;
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+        public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Blocking consumer failure");
     }
 #pragma warning restore TPEXP
 


### PR DESCRIPTION
## Summary

Implements the `IBlockingDataConsumer` marker interface proposed in #6529, allowing an extension to guarantee a piece of work happens **before** the producer proceeds (e.g. before a test starts).

A regular `IDataConsumer` consumes data asynchronously: data is queued and processed on a background loop, so there is no guarantee about when `ConsumeAsync` runs relative to the producer continuing. A consumer that additionally implements `IBlockingDataConsumer` is invoked inline by the message bus, so the producer's call to `PublishAsync` does not return until `ConsumeAsync` has completed.

## Design

Following the discussion on the issue (Evangelink / Youssef):
- `IBlockingDataConsumer` is a **pure marker interface** that extends `IDataConsumer` — no `ShouldConsume`/`IsInterestingData` filter.
- **No new registration API** — consumers register through the existing `ITestHostManager.AddDataConsumer`.
- Marked `[Experimental("TPEXP")]`.

## Changes

- **`Extensions/IBlockingDataConsumer.cs`** — new experimental marker interface `IBlockingDataConsumer : IDataConsumer`.
- **`Messages/BlockingConsumerDataProcessor.cs`** — new `IAsyncConsumerDataProcessor` whose `PublishAsync` awaits `ConsumeAsync` inline (serialized via `SemaphoreSlim` to preserve the "one item at a time" guarantee). `DrainDataAsync`/`CompleteAddingAsync` are no-ops since nothing is queued. Keeps the existing producer-equals-consumer skip.
- **`Messages/AsynchronousMessageBus.cs`** — in `InitAsync`, consumers implementing `IBlockingDataConsumer` get a `BlockingConsumerDataProcessor`; all other consumers keep the async processor. Non-blocking behavior is unchanged.
- **`PublicAPI.Unshipped.txt`** — adds the new experimental type.
- **Tests** — two new tests verifying that (1) data is consumed before `PublishAsync` returns (no drain needed) and (2) a blocking consumer does not consume its own produced data.

## Validation

- Platform builds clean for net8.0 / net9.0 / netstandard2.0.
- All 7 `AsynchronousMessageBusTests` pass (including the 2 new ones).

## Open question for review

The marker is `IBlockingDataConsumer : IDataConsumer` (per Evangelink's suggestion) rather than the issue's original `: ITestHostExtension` proposal — happy to switch if reviewers prefer the latter.

Fixes #6529