### PR TITLE
Add TimeoutFromConfigTests covering JSON testconfig.json timeout path

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfigTests.TestAssetFixture>
+{
+    private static readonly Dictionary<string, (string MethodFullName, string Prefix, string EnvVarSuffix, string ConfigKeyName)> InfoByKind = new()
+    {
+        ["assemblyInit"] = ("TestClass.AssemblyInit", "Assembly initialize", "ASSEMBLYINIT", "assemblyInitialize"),
+        ["assemblyCleanup"] = ("TestClass.AssemblyCleanupMethod", "Assembly cleanup", "ASSEMBLYCLEANUP", "assemblyCleanup"),
+        ["classInit"] = ("TestClass.ClassInit", "Class initialize", "CLASSINIT", "classInitialize"),
+        ["baseClassInit"] = ("TestClassBase.ClassInitBase", "Class initialize", "BASE_CLASSINIT", "classInitialize"),
+        ["classCleanup"] = ("TestClass.ClassCleanupMethod", "Class cleanup", "CLASSCLEANUP", "classCleanup"),
+        ["baseClassCleanup"] = ("TestClassBase.ClassCleanupBase", "Class cleanup", "BASE_CLASSCLEANUP", "classCleanup"),
+        ["testInit"] = ("TestClass.TestInit", "Test initialize", "TESTINIT", "testInitialize"),
+        ["testCleanup"] = ("TestClass.TestCleanupMethod", "Test cleanup", "TESTCLEANUP", "testCleanup"),
+    };
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task AssemblyInitialize_WhenTimeoutExpires_FromConfig_AssemblyInitializeIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "assemblyInit");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ClassInitialize_WhenTimeoutExpires_FromConfig_ClassInitializeIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "classInit");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task BaseClassInitialize_WhenTimeoutExpires_FromConfig_ClassInitializeIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "baseClassInit");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task ClassCleanup_WhenTimeoutExpires_FromConfig_ClassCleanupIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "classCleanup");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task BaseClassCleanup_WhenTimeoutExpires_FromConfig_ClassCleanupIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "baseClassCleanup");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task AssemblyCleanup_WhenTimeoutExpires_FromConfig_AssemblyCleanupIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "assemblyCleanup");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task TestInitialize_WhenTimeoutExpires_FromConfig_TestInitializeIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "testInit");
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task TestCleanup_WhenTimeoutExpires_FromConfig_TestCleanupIsCanceled(string tfm)
+        => await RunAndAssertFromConfigAsync(tfm, "testCleanup");
+
+    private static async Task RunAndAssertFromConfigAsync(string tfm, string entryKind)
+    {
+        const int timeoutValue = 300;
+        string configKey = InfoByKind[entryKind].ConfigKeyName;
+        string testConfig = $$"""
+{
+  "mstest": {
+    "timeout": {
+      "{{configKey}}": {{timeoutValue}}
+    }
+  }
+}
+""";
+
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        string testConfigFilePath = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.json");
+        File.WriteAllText(testConfigFilePath, testConfig);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--config-file {testConfigFilePath}", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" });
+        testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after {timeoutValue}ms");
+    }
+
+    public sealed class TestAssetFixture : TestAssetFixtureBase
+    {
+        public const string ProjectName = "TimeoutCodeWithNoTimeoutFromConfig";
+
+        public string TargetAssetPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchCodeWithReplace("$TimeoutAttribute$", string.Empty)
+                .PatchCodeWithReplace("$ProjectName$", ProjectName)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file $ProjectName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+</Project>
+
+#file UnitTest1.cs
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+public class TestClassBase
+{
+    $TimeoutAttribute$
+    [ClassInitialize(inheritanceBehavior: InheritanceBehavior.BeforeEachDerivedClass)]
+    public static async Task ClassInitBase(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_BASE_CLASSINIT") == "1")
+        {
+            testContext.CancellationTokenSource.Cancel();
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("LONG_WAIT_BASE_CLASSINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSINIT") == "1")
+        {
+            await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [ClassCleanup(inheritanceBehavior: InheritanceBehavior.BeforeEachDerivedClass)]
+    public static async Task ClassCleanupBase()
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_BASE_CLASSCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+}
+
+[TestClass]
+public class TestClass : TestClassBase
+{
+    $TimeoutAttribute$
+    [AssemblyInitialize]
+    public static async Task AssemblyInit(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_ASSEMBLYINIT") == "1")
+        {
+            testContext.CancellationTokenSource.Cancel();
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("LONG_WAIT_ASSEMBLYINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYINIT") == "1")
+        {
+            await Task.Delay(60_000, testContext.CancellationTokenSource.Token);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [AssemblyCleanup]
+    public static async Task AssemblyCleanupMethod()
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_ASSEMBLYCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_CLASSINIT") == "1")
+        {
+            testContext.CancellationTokenSource.Cancel();
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("LONG_WAIT_CLASSINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else if (Environment.GetEnvironmentVariable("TIMEOUT_CLASSINIT") == "1")
+        {
+            await Task.Delay(60_000, testContext.CancellationTokenSource.Token);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [ClassCleanup]
+    public static async Task ClassCleanupMethod()
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_CLASSCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_CLASSCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [TestInitialize]
+    public async Task TestInit()
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTINIT") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    $TimeoutAttribute$
+    [TestCleanup]
+    public async Task TestCleanupMethod()
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    [TestMethod]
+    public Task Test1() => Task.CompletedTask;
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
@@ -61,7 +61,7 @@ public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfi
     public async Task TestCleanup_WhenTimeoutExpires_FromConfig_TestCleanupIsCanceled(string tfm)
         => await RunAndAssertFromConfigAsync(tfm, "testCleanup");
 
-    private static async Task RunAndAssertFromConfigAsync(string tfm, string entryKind)
+    private async Task RunAndAssertFromConfigAsync(string tfm, string entryKind)
     {
         const int timeoutValue = 300;
         string configKey = InfoByKind[entryKind].ConfigKeyName;
@@ -79,7 +79,7 @@ public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfi
         string testConfigFilePath = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.json");
         File.WriteAllText(testConfigFilePath, testConfig);
 
-        TestHostResult testHostResult = await testHost.ExecuteAsync($"--config-file {testConfigFilePath}", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" });
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--config-file \"{testConfigFilePath}\"", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" }, cancellationToken: TestContext.CancellationToken);
         testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after {timeoutValue}ms");
     }
 
@@ -125,16 +125,7 @@ public class TestClassBase
     [ClassInitialize(inheritanceBehavior: InheritanceBehavior.BeforeEachDerivedClass)]
     public static async Task ClassInitBase(TestContext testContext)
     {
-        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_BASE_CLASSINIT") == "1")
-        {
-            testContext.CancellationTokenSource.Cancel();
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("LONG_WAIT_BASE_CLASSINIT") == "1")
-        {
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSINIT") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSINIT") == "1")
         {
             await Task.Delay(10_000, testContext.CancellationTokenSource.Token);
         }
@@ -148,7 +139,7 @@ public class TestClassBase
     [ClassCleanup(inheritanceBehavior: InheritanceBehavior.BeforeEachDerivedClass)]
     public static async Task ClassCleanupBase()
     {
-        if (Environment.GetEnvironmentVariable("LONG_WAIT_BASE_CLASSCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSCLEANUP") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_BASE_CLASSCLEANUP") == "1")
         {
             await Task.Delay(10_000);
         }
@@ -167,16 +158,7 @@ public class TestClass : TestClassBase
     [AssemblyInitialize]
     public static async Task AssemblyInit(TestContext testContext)
     {
-        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_ASSEMBLYINIT") == "1")
-        {
-            testContext.CancellationTokenSource.Cancel();
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("LONG_WAIT_ASSEMBLYINIT") == "1")
-        {
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYINIT") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYINIT") == "1")
         {
             await Task.Delay(60_000, testContext.CancellationTokenSource.Token);
         }
@@ -190,7 +172,7 @@ public class TestClass : TestClassBase
     [AssemblyCleanup]
     public static async Task AssemblyCleanupMethod()
     {
-        if (Environment.GetEnvironmentVariable("LONG_WAIT_ASSEMBLYCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYCLEANUP") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_ASSEMBLYCLEANUP") == "1")
         {
             await Task.Delay(10_000);
         }
@@ -204,16 +186,7 @@ public class TestClass : TestClassBase
     [ClassInitialize]
     public static async Task ClassInit(TestContext testContext)
     {
-        if (Environment.GetEnvironmentVariable("TESTCONTEXT_CANCEL_CLASSINIT") == "1")
-        {
-            testContext.CancellationTokenSource.Cancel();
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("LONG_WAIT_CLASSINIT") == "1")
-        {
-            await Task.Delay(10_000);
-        }
-        else if (Environment.GetEnvironmentVariable("TIMEOUT_CLASSINIT") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_CLASSINIT") == "1")
         {
             await Task.Delay(60_000, testContext.CancellationTokenSource.Token);
         }
@@ -227,7 +200,7 @@ public class TestClass : TestClassBase
     [ClassCleanup]
     public static async Task ClassCleanupMethod()
     {
-        if (Environment.GetEnvironmentVariable("LONG_WAIT_CLASSCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_CLASSCLEANUP") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_CLASSCLEANUP") == "1")
         {
             await Task.Delay(10_000);
         }
@@ -241,7 +214,7 @@ public class TestClass : TestClassBase
     [TestInitialize]
     public async Task TestInit()
     {
-        if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTINIT") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTINIT") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_TESTINIT") == "1")
         {
             await Task.Delay(10_000);
         }
@@ -255,7 +228,7 @@ public class TestClass : TestClassBase
     [TestCleanup]
     public async Task TestCleanupMethod()
     {
-        if (Environment.GetEnvironmentVariable("LONG_WAIT_TESTCLEANUP") == "1" || Environment.GetEnvironmentVariable("TIMEOUT_TESTCLEANUP") == "1")
+        if (Environment.GetEnvironmentVariable("TIMEOUT_TESTCLEANUP") == "1")
         {
             await Task.Delay(10_000);
         }


### PR DESCRIPTION
Follow-up to #9381 (Task 3). Fixes #9401.

`TimeoutFromRunSettingsTests` covers all 8 fixture-type timeouts via XML `.runsettings` only. This adds a parallel `TimeoutFromConfigTests` that exercises the previously-untested `mstest:timeout:*` JSON `testconfig.json` path end-to-end.

## What it does
1. Generates a JSON config at runtime with a single `mstest:timeout:<key>` set to a 300 ms deadline.
2. Passes it via `--config-file` and runs the test host.
3. Asserts each fixture method is timed out with the correct message.

Covers the same 8 method kinds: `assemblyInitialize`, `assemblyCleanup`, `classInitialize`, base-class `classInitialize`, `classCleanup`, base-class `classCleanup`, `testInitialize`, `testCleanup`.

## Notes
- Uses a distinct generated asset (`TimeoutCodeWithNoTimeoutFromConfig`) to avoid clashing with the runsettings fixture.
- Each test writes a unique `{guid}.json` config, so the shared asset stays read-only — no `[DoNotParallelize]` needed (same pattern as the runsettings test).
- The assertion matches the literal `timed out after 300ms` (the configured value), not a rendered duration, so `AcceptanceAssert.DurationPattern` isn't required.

## Verification
- `.\build.cmd -pack` succeeded.
- New tests: **24/24 passed** (8 kinds × net462/net8.0/net11.0).