### PR TITLE
Move orderTestsByNameInClass under mstest:execution: in testconfig.json

### DIFF
--- a/docs/testconfig.schema.json
+++ b/docs/testconfig.schema.json
@@ -122,6 +122,10 @@
             "collectSourceInformation": {
               "type": "boolean",
               "description": "When true, source file and line information is collected during discovery. Defaults to true."
+            },
+            "orderTestsByNameInClass": {
+              "type": "boolean",
+              "description": "When true, tests within a class run in alphabetical order by name. Defaults to false. Mutually exclusive with 'randomizeTestOrder'."
             }
           }
         },
@@ -197,7 +201,8 @@
         },
         "orderTestsByNameInClass": {
           "type": "boolean",
-          "description": "When true, tests within a class run in alphabetical order by name. Defaults to false. Mutually exclusive with 'execution.randomizeTestOrder'."
+          "deprecated": true,
+          "description": "Deprecated. Use 'execution.orderTestsByNameInClass' instead. When true, tests within a class run in alphabetical order by name. Defaults to false. Mutually exclusive with 'execution.randomizeTestOrder'."
         }
       }
     },

--- a/docs/testconfig.schema.md
+++ b/docs/testconfig.schema.md
@@ -5,8 +5,8 @@
 
 It covers:
 
-- the MSTest section (`mstest:*` — `timeout`, `execution`, `parallelism`, `output`, `deployment`,
-  `assemblyResolution`, `orderTestsByNameInClass`);
+- the MSTest section (`mstest:*` — `timeout`, `execution` (including `orderTestsByNameInClass`),
+  `parallelism`, `output`, `deployment`, `assemblyResolution`);
 - the Microsoft.Testing.Platform host section (`platformOptions:*`);
 - the `environmentVariables` section.
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -175,14 +175,19 @@ internal sealed partial class MSTestSettings
     internal static void SetSettingsFromConfig(IConfiguration configuration, IMessageLogger? logger, MSTestSettings settings)
     {
         // 'orderTestsByNameInClass' has moved under 'execution:' for consistency with the other execution settings.
-        // Keep reading the old flat 'mstest:orderTestsByNameInClass' key for backward compatibility, emitting a deprecation warning.
-        if (configuration["mstest:orderTestsByNameInClass"] is not null)
+        // Prefer the new 'mstest:execution:orderTestsByNameInClass' key. Only fall back to the deprecated flat
+        // 'mstest:orderTestsByNameInClass' key (emitting a deprecation warning) when the new key is absent, so users
+        // can keep both keys for cross-version compatibility without being warned and without spurious parse warnings.
+        if (configuration["mstest:execution:orderTestsByNameInClass"] is not null)
+        {
+            ParseBooleanSetting(configuration, "execution:orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
+        }
+        else if (configuration["mstest:orderTestsByNameInClass"] is not null)
         {
             logger?.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey);
             ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
         }
 
-        ParseBooleanSetting(configuration, "execution:orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
         ParseBooleanSetting(configuration, "execution:randomizeTestOrder", logger, value => settings.RandomizeTestOrder = value);
         ParseSignedIntegerSetting(configuration, "execution:randomTestOrderSeed", logger, value => settings.RandomTestOrderSeed = value);
         ParseBooleanSetting(configuration, "output:captureTrace", logger, value => settings.CaptureDebugTraces = value);

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -174,7 +174,15 @@ internal sealed partial class MSTestSettings
     /// <param name="settings">The MSTest settings.</param>
     internal static void SetSettingsFromConfig(IConfiguration configuration, IMessageLogger? logger, MSTestSettings settings)
     {
-        ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
+        // 'orderTestsByNameInClass' has moved under 'execution:' for consistency with the other execution settings.
+        // Keep reading the old flat 'mstest:orderTestsByNameInClass' key for backward compatibility, emitting a deprecation warning.
+        if (configuration["mstest:orderTestsByNameInClass"] is not null)
+        {
+            logger?.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey);
+            ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
+        }
+
+        ParseBooleanSetting(configuration, "execution:orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
         ParseBooleanSetting(configuration, "execution:randomizeTestOrder", logger, value => settings.RandomizeTestOrder = value);
         ParseSignedIntegerSetting(configuration, "execution:randomTestOrderSeed", logger, value => settings.RandomTestOrderSeed = value);
         ParseBooleanSetting(configuration, "output:captureTrace", logger, value => settings.CaptureDebugTraces = value);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
@@ -371,6 +371,10 @@ but received {4} argument(s), with types '{5}'.</value>
     <value>Both 'RandomizeTestOrder' and 'OrderTestsByNameInClass' are set. 'OrderTestsByNameInClass' will be ignored.</value>
     <comment>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</comment>
   </data>
+  <data name="DeprecatedFlatOrderTestsByNameInClassKey" xml:space="preserve">
+    <value>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</value>
+    <comment>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</comment>
+  </data>
   <data name="UTA_AssemblyCleanupMethodWasUnsuccesful" xml:space="preserve">
     <value>Assembly Cleanup method {0}.{1} failed. Error Message: {2}. StackTrace: {3}</value>
     <comment>{0} is the declaring type name. {1} is the assembly cleanup method name. {2} is the error message. {3} is the stack trace.</comment>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
@@ -372,7 +372,7 @@ but received {4} argument(s), with types '{5}'.</value>
     <comment>{Locked="RandomizeTestOrder"}{Locked="OrderTestsByNameInClass"}</comment>
   </data>
   <data name="DeprecatedFlatOrderTestsByNameInClassKey" xml:space="preserve">
-    <value>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</value>
+    <value>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</value>
     <comment>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</comment>
   </data>
   <data name="UTA_AssemblyCleanupMethodWasUnsuccesful" xml:space="preserve">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
@@ -166,6 +166,11 @@ byl však přijat tento počet argumentů: {4} s typy {5}.</target>
         <target state="translated">položka nasazení {0} (adresář výstupu {1})</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
@@ -167,8 +167,8 @@ byl však přijat tento počet argumentů: {4} s typy {5}.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
@@ -166,6 +166,11 @@ aber empfing {4} Argument(e) mit den Typen „{5}“.</target>
         <target state="translated">Bereitstellungselement "{0}" (Ausgabeverzeichnis "{1}")</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
@@ -167,8 +167,8 @@ aber empfing {4} Argument(e) mit den Typen „{5}“.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
@@ -166,6 +166,11 @@ pero recibió {4} argumentos, con los tipos '{5}'.</target>
         <target state="translated">elemento de implementación '{0}' (directorio de salida '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
@@ -167,8 +167,8 @@ pero recibió {4} argumentos, con los tipos '{5}'.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
@@ -166,6 +166,11 @@ mais a reçu {4} argument(s), avec les types « {5} ».</target>
         <target state="translated">élément de déploiement '{0}' (répertoire de sortie '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
@@ -167,8 +167,8 @@ mais a reçu {4} argument(s), avec les types « {5} ».</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
@@ -167,8 +167,8 @@ ma ha ricevuto {4} argomenti, con tipi '{5}'.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
@@ -166,6 +166,11 @@ ma ha ricevuto {4} argomenti, con tipi '{5}'.</target>
         <target state="translated">elemento di distribuzione '{0}' (directory di output '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
@@ -168,8 +168,8 @@ but received {4} argument(s), with types '{5}'.</source>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
@@ -167,6 +167,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">配置項目 '{0}' (出力ディレクトリ '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
@@ -167,8 +167,8 @@ but received {4} argument(s), with types '{5}'.</source>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
@@ -166,6 +166,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">배포 항목 '{0}'(출력 디렉터리 '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
@@ -167,8 +167,8 @@ ale odebrał argumenty {4} z typami „{5}”.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
@@ -166,6 +166,11 @@ ale odebrał argumenty {4} z typami „{5}”.</target>
         <target state="translated">element wdrożenia „{0}” (katalog wyjściowy „{1}”)</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
@@ -166,6 +166,11 @@ mas {4} argumentos recebidos, com tipos '{5}'.</target>
         <target state="translated">item de implantação '{0}' (diretório de saída '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
@@ -167,8 +167,8 @@ mas {4} argumentos recebidos, com tipos '{5}'.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
@@ -167,8 +167,8 @@ but received {4} argument(s), with types '{5}'.</source>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
@@ -166,6 +166,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">элемент развертывания "{0}" (выходной каталог "{1}")</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
@@ -167,8 +167,8 @@ ancak, '{5}' türünde {4} bağımsız değişken aldı.</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
@@ -166,6 +166,11 @@ ancak, '{5}' türünde {4} bağımsız değişken aldı.</target>
         <target state="translated">'{0}' dağıtım öğesi (çıktı dizini '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
@@ -167,8 +167,8 @@ but received {4} argument(s), with types '{5}'.</source>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
@@ -166,6 +166,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">部署项“{0}”(输出目录“{1}”)</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
@@ -167,8 +167,8 @@ but received {4} argument(s), with types '{5}'.</source>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
       <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
-        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
-        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated and will be removed in a future version. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
         <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
       </trans-unit>
       <trans-unit id="DiscoveryErrors">

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
@@ -166,6 +166,11 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">部署項目 '{0}' (輸出目錄 '{1}')</target>
         <note>{0} is the deployment item path. {1} is the output directory.</note>
       </trans-unit>
+      <trans-unit id="DeprecatedFlatOrderTestsByNameInClassKey">
+        <source>The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</source>
+        <target state="new">The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead.</target>
+        <note>{Locked="mstest:orderTestsByNameInClass"}{Locked="mstest:execution:orderTestsByNameInClass"}</note>
+      </trans-unit>
       <trans-unit id="DiscoveryErrors">
         <source>Discovery failed for source '{0}' with {1} errors:
 {2}</source>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationSettingsTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ConfigurationSettingsTests.cs
@@ -181,7 +181,8 @@ public sealed class ConfigurationSettingsTests : AcceptanceTestBase<Configuratio
       "mapInconclusiveToFailed": true,
       "mapNotRunnableToFailed": true,
       "treatDiscoveryWarningsAsErrors": true,
-      "considerEmptyDataSourceAsInconclusive": true
+      "considerEmptyDataSourceAsInconclusive": true,
+      "orderTestsByNameInClass": true
     },
     "deployment": {
       "enabled": true,

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -1203,7 +1203,7 @@ public class MSTestSettingsTests : TestContainer
             { "mstest:execution:mapNotRunnableToFailed", "true" },
             { "mstest:execution:treatDiscoveryWarningsAsErrors", "true" },
             { "mstest:execution:considerEmptyDataSourceAsInconclusive", "true" },
-            { "mstest:orderTestsByNameInClass", "true" },
+            { "mstest:execution:orderTestsByNameInClass", "true" },
             { "mstest:execution:randomizeTestOrder", "true" },
             { "mstest:execution:randomTestOrderSeed", "-12345" },
             { "mstest:output:captureTrace", "true" },
@@ -1240,6 +1240,50 @@ public class MSTestSettingsTests : TestContainer
         settings.DisableParallelization.Should().BeFalse();
         settings.ParallelizationWorkers.Should().Be(4);
         settings.ParallelizationScope.Should().Be(ExecutionScope.ClassLevel);
+    }
+
+    public void ConfigJson_WithDeprecatedFlatOrderTestsByNameInClassKey_ValueIsSetAndWarningIsEmitted()
+    {
+        // Arrange - using the deprecated flat key
+        var configDictionary = new Dictionary<string, string>
+        {
+            { "mstest:orderTestsByNameInClass", "true" },
+        };
+
+        var mockConfig = new Mock<IConfiguration>();
+        mockConfig.Setup(config => config[It.IsAny<string>()])
+                  .Returns((string key) => configDictionary.TryGetValue(key, out string? value) ? value : null);
+
+        var settings = new MSTestSettings();
+
+        // Act
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+
+        // Assert
+        settings.OrderTestsByNameInClass.Should().BeTrue();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead."), Times.Once);
+    }
+
+    public void ConfigJson_WithExecutionOrderTestsByNameInClassKey_ValueIsSetAndNoWarningIsEmitted()
+    {
+        // Arrange - using the new grouped key
+        var configDictionary = new Dictionary<string, string>
+        {
+            { "mstest:execution:orderTestsByNameInClass", "true" },
+        };
+
+        var mockConfig = new Mock<IConfiguration>();
+        mockConfig.Setup(config => config[It.IsAny<string>()])
+                  .Returns((string key) => configDictionary.TryGetValue(key, out string? value) ? value : null);
+
+        var settings = new MSTestSettings();
+
+        // Act
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+
+        // Assert
+        settings.OrderTestsByNameInClass.Should().BeTrue();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead."), Times.Never);
     }
 
     public void ConfigJson_Parllelism_Enabled_True() => ConfigJson_Parllelism_Enabled_Core(true);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -6,6 +6,7 @@ using AwesomeAssertions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -1261,7 +1262,7 @@ public class MSTestSettingsTests : TestContainer
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead."), Times.Once);
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey), Times.Once);
     }
 
     public void ConfigJson_WithExecutionOrderTestsByNameInClassKey_ValueIsSetAndNoWarningIsEmitted()
@@ -1283,7 +1284,31 @@ public class MSTestSettingsTests : TestContainer
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
-        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "The 'mstest:orderTestsByNameInClass' configuration key is deprecated. Use 'mstest:execution:orderTestsByNameInClass' instead."), Times.Never);
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey), Times.Never);
+    }
+
+    public void ConfigJson_WithBothOrderTestsByNameInClassKeys_NewExecutionKeyTakesPrecedenceAndNoWarningIsEmitted()
+    {
+        // Arrange - both the new grouped key and the deprecated flat key are present with conflicting values.
+        // The new key must win and, since it is present, the deprecated key is ignored without a warning.
+        var configDictionary = new Dictionary<string, string>
+        {
+            { "mstest:orderTestsByNameInClass", "false" },
+            { "mstest:execution:orderTestsByNameInClass", "true" },
+        };
+
+        var mockConfig = new Mock<IConfiguration>();
+        mockConfig.Setup(config => config[It.IsAny<string>()])
+                  .Returns((string key) => configDictionary.TryGetValue(key, out string? value) ? value : null);
+
+        var settings = new MSTestSettings();
+
+        // Act
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+
+        // Assert
+        settings.OrderTestsByNameInClass.Should().BeTrue();
+        _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey), Times.Never);
     }
 
     public void ConfigJson_Parllelism_Enabled_True() => ConfigJson_Parllelism_Enabled_Core(true);


### PR DESCRIPTION
Fixes #9402

`orderTestsByNameInClass` was the only behavioral control read from the flat `mstest:` root, while all analogous settings (`randomizeTestOrder`, `mapInconclusiveToFailed`, …) live under `mstest:execution:`. This PR moves it under `execution:` with full backward compatibility.

## Changes

- **`MSTestSettings.Configuration.cs`** — reads `mstest:execution:orderTestsByNameInClass`. The deprecated flat `mstest:orderTestsByNameInClass` key is still honored but emits a deprecation warning (the new grouped key wins if both are present).
- **`Resource.resx` + `.xlf`** — added the `DeprecatedFlatOrderTestsByNameInClassKey` warning string; xlf files regenerated via the build.
- **`docs/testconfig.schema.json`** — added `orderTestsByNameInClass` under `execution`, and marked the flat top-level key `"deprecated": true`. Updated `docs/testconfig.schema.md`.
- **Tests** — updated the canonical config in `MSTestSettingsTests.cs` to the new key and added two tests asserting (a) the deprecated flat key still works *with* a warning and (b) the new key works *without* one. Added `orderTestsByNameInClass` under `execution` in the `ConfigurationSettingsTests.cs` example.

## Verification

- Full build succeeded (0 warnings / 0 errors).
- The 7 `ConfigJson` unit tests (including the 2 new back-compat tests) pass.
- Schema validated as well-formed JSON.