### PR TITLE
Forward buildTransitive props through build/ for MTP extensions

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/buildTransitive/Microsoft.Testing.Extensions.AzureDevOpsReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/buildTransitive/Microsoft.Testing.Extensions.AzureDevOpsReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.AzureDevOpsReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.AzureDevOpsReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/buildTransitive/Microsoft.Testing.Extensions.AzureDevOpsReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/buildTransitive/Microsoft.Testing.Extensions.AzureDevOpsReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.AzureDevOpsReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.AzureDevOpsReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/buildTransitive/Microsoft.Testing.Extensions.AzureFoundry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/buildTransitive/Microsoft.Testing.Extensions.AzureFoundry.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.AzureFoundry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.AzureFoundry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/buildTransitive/Microsoft.Testing.Extensions.AzureFoundry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/buildTransitive/Microsoft.Testing.Extensions.AzureFoundry.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.AzureFoundry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.AzureFoundry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/buildTransitive/Microsoft.Testing.Extensions.CrashDump.props
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/buildTransitive/Microsoft.Testing.Extensions.CrashDump.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.CrashDump.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.CrashDump.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/buildTransitive/Microsoft.Testing.Extensions.CrashDump.props
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/buildTransitive/Microsoft.Testing.Extensions.CrashDump.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.CrashDump.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.CrashDump.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/buildTransitive/Microsoft.Testing.Extensions.CtrfReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/buildTransitive/Microsoft.Testing.Extensions.CtrfReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.CtrfReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.CtrfReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/buildTransitive/Microsoft.Testing.Extensions.CtrfReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/buildTransitive/Microsoft.Testing.Extensions.CtrfReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.CtrfReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.CtrfReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/buildTransitive/Microsoft.Testing.Extensions.HangDump.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/buildTransitive/Microsoft.Testing.Extensions.HangDump.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.HangDump.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HangDump.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/buildTransitive/Microsoft.Testing.Extensions.HangDump.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/buildTransitive/Microsoft.Testing.Extensions.HangDump.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HangDump.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.HangDump.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/buildTransitive/Microsoft.Testing.Extensions.HotReload.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/buildTransitive/Microsoft.Testing.Extensions.HotReload.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HotReload.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.HotReload.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/buildTransitive/Microsoft.Testing.Extensions.HotReload.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/buildTransitive/Microsoft.Testing.Extensions.HotReload.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.HotReload.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HotReload.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/buildTransitive/Microsoft.Testing.Extensions.HtmlReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/buildTransitive/Microsoft.Testing.Extensions.HtmlReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.HtmlReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HtmlReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/buildTransitive/Microsoft.Testing.Extensions.HtmlReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/buildTransitive/Microsoft.Testing.Extensions.HtmlReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.HtmlReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.HtmlReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/buildTransitive/Microsoft.Testing.Extensions.JUnitReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/buildTransitive/Microsoft.Testing.Extensions.JUnitReport.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.JUnitReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.JUnitReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/buildTransitive/Microsoft.Testing.Extensions.JUnitReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/buildTransitive/Microsoft.Testing.Extensions.JUnitReport.props
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.JUnitReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.JUnitReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/buildTransitive/Microsoft.Testing.Extensions.Retry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/buildTransitive/Microsoft.Testing.Extensions.Retry.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.Retry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.Retry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/buildTransitive/Microsoft.Testing.Extensions.Retry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/buildTransitive/Microsoft.Testing.Extensions.Retry.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.Retry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.Retry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/buildTransitive/Microsoft.Testing.Extensions.Telemetry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/buildTransitive/Microsoft.Testing.Extensions.Telemetry.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.Telemetry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.Telemetry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/buildTransitive/Microsoft.Testing.Extensions.Telemetry.props
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/buildTransitive/Microsoft.Testing.Extensions.Telemetry.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.Telemetry.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.Telemetry.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/buildTransitive/Microsoft.Testing.Extensions.TrxReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/buildTransitive/Microsoft.Testing.Extensions.TrxReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.TrxReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Extensions.TrxReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/buildTransitive/Microsoft.Testing.Extensions.TrxReport.props
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/buildTransitive/Microsoft.Testing.Extensions.TrxReport.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Extensions.TrxReport.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Extensions.TrxReport.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/buildTransitive/Microsoft.Testing.Platform.props
+++ b/src/Platform/Microsoft.Testing.Platform/buildTransitive/Microsoft.Testing.Platform.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Platform.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildThisFileDirectory)))))\Microsoft.Testing.Platform.props" />
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/buildTransitive/Microsoft.Testing.Platform.props
+++ b/src/Platform/Microsoft.Testing.Platform/buildTransitive/Microsoft.Testing.Platform.props
@@ -1,3 +1,3 @@
 ﻿<Project>
-  <Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\Microsoft.Testing.Platform.props" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\build\Microsoft.Testing.Platform.props" />
 </Project>


### PR DESCRIPTION
## Summary

Fixes Rule E-1 from the MSBuild File Quality Report (#9414).

All MTP extension `buildTransitive/*.props` files forwarded **directly** to `buildMultiTargeting/` instead of forwarding through the corresponding `build/` file. The standard NuGet convention is `buildTransitive/ → build/ → (shared location)`, which establishes a clear ownership chain and makes it obvious that transitive consumers receive a subset of what direct consumers see.

Each import was changed from:

```xml
<Import Project="$(MSBuildThisFileDirectory)..\..\buildMultiTargeting\<pkg>.props" />
```

to:

```xml
<Import Project="$(MSBuildThisFileDirectory)..\..\build\<pkg>.props" />
```

The existing `build/*.props` files already forward to `buildMultiTargeting/`, so the **resolved behavior is unchanged** — only the ownership chain is corrected.

## Packages affected (12)

AzureDevOpsReport, AzureFoundry, CrashDump, CtrfReport, HangDump, HotReload, HtmlReport, JUnitReport, Retry, Telemetry, TrxReport, and the base `Microsoft.Testing.Platform`.

`Microsoft.Testing.Platform.MSBuild` is intentionally out of scope (not listed in the issue and uses a different layout).

Fixes part of #9414.