### PR TITLE
[code-simplifier] Simplify RunAndAssertFromConfigAsync: cache InfoByKind lookup in local variable

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
@@ -64,12 +64,12 @@ public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfi
     private async Task RunAndAssertFromConfigAsync(string tfm, string entryKind)
     {
         const int timeoutValue = 300;
-        string configKey = InfoByKind[entryKind].ConfigKeyName;
+        var info = InfoByKind[entryKind];
         string testConfig = $$"""
 {
   "mstest": {
     "timeout": {
-      "{{configKey}}": {{timeoutValue}}
+      "{{info.ConfigKeyName}}": {{timeoutValue}}
     }
   }
 }
@@ -79,8 +79,8 @@ public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfi
         string testConfigFilePath = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.json");
         File.WriteAllText(testConfigFilePath, testConfig);
 
-        TestHostResult testHostResult = await testHost.ExecuteAsync($"--config-file \"{testConfigFilePath}\"", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" }, cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after {timeoutValue}ms");
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--config-file \"{testConfigFilePath}\"", environmentVariables: new() { [$"TIMEOUT_{info.EnvVarSuffix}"] = "1" }, cancellationToken: TestContext.CancellationToken);
+        testHostResult.AssertOutputContains($"{info.Prefix} method '{info.MethodFullName}' timed out after {timeoutValue}ms");
     }
 
     public sealed class TestAssetFixture : TestAssetFixtureBase

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs
@@ -64,7 +64,7 @@ public sealed class TimeoutFromConfigTests : AcceptanceTestBase<TimeoutFromConfi
     private async Task RunAndAssertFromConfigAsync(string tfm, string entryKind)
     {
         const int timeoutValue = 300;
-        var info = InfoByKind[entryKind];
+        (string MethodFullName, string Prefix, string EnvVarSuffix, string ConfigKeyName) info = InfoByKind[entryKind];
         string testConfig = $$"""
 {
   "mstest": {


### PR DESCRIPTION
## Code Simplification — 2026-06-25

This PR simplifies code recently added in #9429 to improve clarity and reduce redundant dictionary lookups.

### Files Simplified

- `test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutFromConfigTests.cs` — caches the `InfoByKind[entryKind]` tuple lookup in a local `info` variable instead of repeating the dictionary access four times in `RunAndAssertFromConfigAsync`.

### Improvements Made

**Reduced Redundant Lookups**
- The original code performed 4 separate `InfoByKind[entryKind]` accesses (one explicitly saved as `configKey`, three inline). This is now a single dictionary lookup stored in `var info`, with all four fields accessed via named tuple properties (`info.ConfigKeyName`, `info.EnvVarSuffix`, `info.Prefix`, `info.MethodFullName`).

**Enhanced Clarity**
- All four pieces of entry metadata are now visibly sourced from the same lookup, making it immediately clear they all come from the same dictionary entry.
- Eliminates the inconsistency of `configKey` being a local variable while the other three fields were accessed inline.

### Changes Based On

Recent changes from:
- #9429 — Add TimeoutFromConfigTests covering JSON testconfig.json timeout path

### Testing

- ✅ No functional changes — behavior is identical (single dictionary lookup vs four lookups of the same key)
- ✅ Purely mechanical variable extraction with no logic changes

### Review Focus

Please verify:
- `info.ConfigKeyName` replaces the old `configKey` local
- `info.EnvVarSuffix`, `info.Prefix`, `info.MethodFullName` replace the three inline `InfoByKind[entryKind].*` accesses
- No behavioral change: the tuple value type means this is one lookup + struct copy vs four lookups


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/28174885585/agentic_workflow) workflow. · 231.5 AIC · ⌖ 17.2 AIC · ⊞ 9.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-26T14:02:49.252Z --> on Jun 26, 2026, 2:02 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 28174885585, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/28174885585 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->