### PR TITLE
[efficiency-improver] perf: direct-allocate arrays in IPC CommandLineOption and FileArtifact deserializers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -43,7 +43,7 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
     protected override CommandLineOptionMessages DeserializeCore(Stream stream)
     {
         string? moduleName = null;
-        List<CommandLineOptionMessage>? commandLineOptionMessages = null;
+        CommandLineOptionMessage[]? commandLineOptionMessages = null;
 
         ushort fieldCount = ReadUShort(stream);
 
@@ -75,7 +75,7 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
     private static CommandLineOptionMessage[] ReadCommandLineOptionMessagesPayload(Stream stream)
     {
         int length = ReadInt(stream);
-        CommandLineOptionMessage[] commandLineOptionMessages = new CommandLineOptionMessage[length];
+        var commandLineOptionMessages = new CommandLineOptionMessage[length];
 
         for (int i = 0; i < length; i++)
         {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -69,14 +69,14 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
             }
         }
 
-        return new(moduleName, commandLineOptionMessages is null ? [] : [.. commandLineOptionMessages]);
+        return new(moduleName, commandLineOptionMessages ?? []);
     }
 
-    private static List<CommandLineOptionMessage> ReadCommandLineOptionMessagesPayload(Stream stream)
+    private static CommandLineOptionMessage[] ReadCommandLineOptionMessagesPayload(Stream stream)
     {
-        List<CommandLineOptionMessage> commandLineOptionMessages = [];
-
         int length = ReadInt(stream);
+        CommandLineOptionMessage[] commandLineOptionMessages = new CommandLineOptionMessage[length];
+
         for (int i = 0; i < length; i++)
         {
             string? name = null, description = null;
@@ -113,7 +113,7 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
                 }
             }
 
-            commandLineOptionMessages.Add(new CommandLineOptionMessage(name, description, isHidden, isBuiltIn));
+            commandLineOptionMessages[i] = new CommandLineOptionMessage(name, description, isHidden, isBuiltIn);
         }
 
         return commandLineOptionMessages;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -56,7 +56,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     {
         string? executionId = null;
         string? instanceId = null;
-        List<FileArtifactMessage>? fileArtifactMessages = null;
+        FileArtifactMessage[]? fileArtifactMessages = null;
 
         ushort fieldCount = ReadUShort(stream);
 
@@ -92,7 +92,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     private static FileArtifactMessage[] ReadFileArtifactMessagesPayload(Stream stream)
     {
         int length = ReadInt(stream);
-        FileArtifactMessage[] fileArtifactMessages = new FileArtifactMessage[length];
+        var fileArtifactMessages = new FileArtifactMessage[length];
 
         for (int i = 0; i < length; i++)
         {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -86,14 +86,14 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
             }
         }
 
-        return new(executionId, instanceId, fileArtifactMessages is null ? [] : [.. fileArtifactMessages]);
+        return new(executionId, instanceId, fileArtifactMessages ?? []);
     }
 
-    private static List<FileArtifactMessage> ReadFileArtifactMessagesPayload(Stream stream)
+    private static FileArtifactMessage[] ReadFileArtifactMessagesPayload(Stream stream)
     {
-        List<FileArtifactMessage> fileArtifactMessages = [];
-
         int length = ReadInt(stream);
+        FileArtifactMessage[] fileArtifactMessages = new FileArtifactMessage[length];
+
         for (int i = 0; i < length; i++)
         {
             string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null;
@@ -137,7 +137,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
                 }
             }
 
-            fileArtifactMessages.Add(new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid));
+            fileArtifactMessages[i] = new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid);
         }
 
         return fileArtifactMessages;


### PR DESCRIPTION
## Goal and Rationale

Eliminate `List<T>` intermediate allocations and `[.. spread]` copy operations in the two remaining IPC deserializers that still used that pattern:

- `CommandLineOptionMessagesSerializer.ReadCommandLineOptionMessagesPayload`
- `FileArtifactMessagesSerializer.ReadFileArtifactMessagesPayload`

**Focus Area**: Code-Level Efficiency — removing redundant allocation and array-copying in the IPC deserialization path.

## Approach

The binary protocol stream includes a `length` prefix for each message list. The old code created an empty `List<T>` (default capacity 4), read `length`, then populated via `.Add()`, and finally returned the list to the caller which spread it `[.. list]` into an array.

**Before (both serializers):**
```csharp
// Payload reader:
List<T> items = [];             // allocation #1: List<T>, cap=4
int length = ReadInt(stream);
for (int i = 0; i < length; i++)
    items.Add(new T(...));      // may reallocate backing array 1–3× if length > 4

return items;                   // returns List<T> to DeserializeCore

// DeserializeCore:
items is null ? [] : [.. items] // allocation #2 + O(N) Array.Copy
```

**After:**
```csharp
// Payload reader:
int length = ReadInt(stream);
T[] items = new T[length];      // single exact-size allocation
for (int i = 0; i < length; i++)
    items[i] = new T(...);      // no backing-array reallocation

return items;                   // T[] — used directly, no copy

// DeserializeCore:
items ?? []                     // no copy
```

`DiscoveredTestMessagesSerializer` and `TestResultMessagesSerializer` (merged in #9408) already use this correct pattern. This PR completes the series — all six IPC serializers now follow the same approach.

## Energy Efficiency Evidence

**Proxy metric**: managed heap allocation count + array-copy operations per `dotnet test` invocation.

| | Before | After |
|---|---|---|
| `List<CommandLineOptionMessage>` allocation | 1 per `--list-options` session | 0 |
| `[.. commandLineOptionMessages]` copy | 1 per session | 0 |
| `List<FileArtifactMessage>` allocation | 1 per artifact batch | 0 |
| `[.. fileArtifactMessages]` copy | 1 per artifact batch | 0 |
| Potential `List<T>` backing-array reallocations | 0–3× when item count > 4 | 0 |

**Reasoning linking proxy to energy**: Each `List<T>` → `T[]` spread invokes `Array.Copy` (O(N) memcpy). Eliminating these avoids wasted CPU cycles and DRAM bandwidth during deserialization. GC pressure is also reduced: fewer short-lived `List<T>` objects means fewer Gen-0 collections.

_Context_: `CommandLineOptionMessages` is sent once per `dotnet test` session (at startup for `--list-options`). `FileArtifactMessages` is sent whenever tests produce file artifacts (e.g. coverage reports, crash dumps). Both are lower-frequency than `TestResultMessages`, but completing the series removes the inconsistency and avoids confusion for future contributors.

## Green Software Foundation Context

🌱 **Hardware Efficiency**: Pre-sized arrays avoid `List<T>` internal-buffer doubling (up to 3 backing-array reallocations + copies before capacity is reached). Fewer internal copies = fewer CPU instructions.

🌱 **Software Carbon Intensity (SCI)**: Each `dotnet test` invocation triggers these paths. Eliminating allocations lowers E in `SCI = (E × I + M) / R`, and the improvement compounds across millions of CI runs in the .NET ecosystem.

## Trade-offs

None. The byte stream written to and read from the IPC pipe is **identical** before and after — pure internal refactor. The resulting code is also simpler (fewer lines, consistent with sibling serializers).

## Reproducibility

```bash
# Round-trip tests cover all serialize/deserialize paths:
dotnet run --project test/UnitTests/Microsoft.Testing.Platform.UnitTests -f net8.0 -- \
  --treenode-filter "/*/*/*/ProtocolTests/*"
dotnet run --project test/UnitTests/Microsoft.Testing.Platform.UnitTests -f net8.0 -- \
  --treenode-filter "/*/*/*/ProtocolEdgeCaseTests/*"
```

## Test Status

CI validation pending (no local .NET SDK in agent environment). The change is a pure internal allocation refactor — no observable behaviour changes. Existing round-trip protocol tests in `ProtocolTests.cs` and `ProtocolEdgeCaseTests.cs` cover all serialise/deserialise paths.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/28203618980/agentic_workflow) workflow. · 550.6 AIC · ⌖ 40.3 AIC · ⊞ 58.6K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28203618980, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/28203618980 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->