### PR TITLE
[test-improver] test: add edge case tests for UseExecuteAsyncOverrideFixer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseExecuteAsyncOverrideFixerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseExecuteAsyncOverrideFixerTests.cs
@@ -199,4 +199,61 @@ public sealed class UseExecuteAsyncOverrideFixerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task ExecuteMethodWithoutPublicModifier_ShouldNotOfferCodeFix()
+    {
+        // The fixer requires a public modifier; a protected override Execute should not be transformed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class C : TestMethodAttribute
+            {
+                protected override TestResult[] {|CS0115:Execute|}(ITestMethod testMethod)
+                {
+                    return new TestResult[] { };
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task ExecuteMethodWithZeroParameters_ShouldNotOfferCodeFix()
+    {
+        // The fixer requires exactly one parameter; Execute with no parameters should not be transformed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class C : TestMethodAttribute
+            {
+                public override TestResult[] {|CS0115:Execute|}()
+                {
+                    return new TestResult[] { };
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task ExecuteMethodWithWrongParameterType_ShouldNotOfferCodeFix()
+    {
+        // The fixer requires an ITestMethod parameter; a different parameter type should not be transformed.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class C : TestMethodAttribute
+            {
+                public override TestResult[] {|CS0115:Execute|}(int testMethod)
+                {
+                    return new TestResult[] { };
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`UseExecuteAsyncOverrideFixer` has an `IsExecuteMethodOverride` guard with four conditions. Three of those conditions were exercised only by the "happy path" (transform Execute → ExecuteAsync) tests, leaving the guard's early-return branches untested:

| Untested branch | Guard condition |
|---|---|
| Missing `public` modifier | `!modifiers.Any(SyntaxKind.PublicKeyword)` |
| Zero parameters | `Parameters.Count != 1` |
| Wrong parameter type | parameter name ≠ `ITestMethod` |

## Approach

Added three `VerifyCodeFixAsync(code, code)` tests — each triggers CS0115 (so the fixer is invoked), but the guard returns `false`, meaning no code fix is offered and the source stays unchanged.

1. **`ExecuteMethodWithoutPublicModifier_ShouldNotOfferCodeFix`** — `protected override TestResult[] Execute(ITestMethod)` → no transformation.
2. **`ExecuteMethodWithZeroParameters_ShouldNotOfferCodeFix`** — `public override TestResult[] Execute()` → no transformation.
3. **`ExecuteMethodWithWrongParameterType_ShouldNotOfferCodeFix`** — `public override TestResult[] Execute(int testMethod)` → no transformation.

## Test Status

All 9 tests pass (6 existing + 3 new):

```
Test run summary: Passed!
  total: 9
  failed: 0
  succeeded: 9
```

## Trade-offs

Purely additive — no production code changes, no new dependencies.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28206652085/agentic_workflow) workflow. · 1.1K AIC · ⌖ 24.6 AIC · ⊞ 58K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28206652085, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28206652085 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->