### PR TITLE
Add missing changelog entries for IBlockingDataConsumer and orderTestsByNameInClass

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -38,6 +38,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Handshake from the test host orchestrator in the dotnet test pipe protocol, advertising the orchestration feature (e.g. retry) by @Copilot in [#9215](https://github.com/microsoft/testfx/pull/9215)
 * Add --zero-tests-policy &lt;allow-skipped|strict&gt; and make 'allow-skipped' the default so an all-skipped run no longer fails with exit code 8 (use 'strict' for the previous behavior) by @Evangelink in [#9415](https://github.com/microsoft/testfx/pull/9415)
 * Add testconfig.json JSON schema for SchemaStore publication and IDE validation by @Evangelink in [#9405](https://github.com/microsoft/testfx/pull/9405)
+* Add experimental `IBlockingDataConsumer` marker interface for synchronous inline data consumption by @Evangelink in [#9426](https://github.com/microsoft/testfx/pull/9426)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -36,7 +36,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add [ArchitectureConditionAttribute] to gate tests by process architecture by @Evangelink in [#9233](https://github.com/microsoft/testfx/pull/9233)
 * Add MSTEST0071 analyzer and code fix for redundant test method display name by @Evangelink in [#9272](https://github.com/microsoft/testfx/pull/9272)
 * Add [ExecutableConditionAttribute] to conditionally run tests based on tool availability by @Evangelink in [#9369](https://github.com/microsoft/testfx/pull/9369)
-* Move `orderTestsByNameInClass` testconfig.json key under `mstest:execution:` (flat `mstest:orderTestsByNameInClass` still works but emits a deprecation warning) by @Evangelink in [#9430](https://github.com/microsoft/testfx/pull/9430)
+* Move `orderTestsByNameInClass` testconfig.json key to `mstest:execution:orderTestsByNameInClass` (flat `mstest:orderTestsByNameInClass` still works but emits a deprecation warning) by @Evangelink in [#9430](https://github.com/microsoft/testfx/pull/9430)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -36,6 +36,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add [ArchitectureConditionAttribute] to gate tests by process architecture by @Evangelink in [#9233](https://github.com/microsoft/testfx/pull/9233)
 * Add MSTEST0071 analyzer and code fix for redundant test method display name by @Evangelink in [#9272](https://github.com/microsoft/testfx/pull/9272)
 * Add [ExecutableConditionAttribute] to conditionally run tests based on tool availability by @Evangelink in [#9369](https://github.com/microsoft/testfx/pull/9369)
+* Move `orderTestsByNameInClass` testconfig.json key under `mstest:execution:` (flat `mstest:orderTestsByNameInClass` still works but emits a deprecation warning) by @Evangelink in [#9430](https://github.com/microsoft/testfx/pull/9430)
 
 ### Fixed
 


### PR DESCRIPTION
Two changelog entries missing after recent merges:

- **`IBlockingDataConsumer`** ([`#9426`](https://github.com/microsoft/testfx/pull/9426), merged 2026-06-25): experimental marker interface for synchronous inline data consumption — was in `PublicAPI.Unshipped.txt` but not in `Changelog-Platform.md`.
- **`orderTestsByNameInClass` key move** ([`#9430`](https://github.com/microsoft/testfx/pull/9430), merged 2026-06-25): `testconfig.json` key moved to `mstest:execution:orderTestsByNameInClass` with backward-compat deprecation warning for flat key — not in `Changelog.md`.

Found by the [adhoc-qa](https://github.com/microsoft/testfx/actions/runs/28222591670) workflow.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/28222591670/agentic_workflow) workflow. · 388.6 AIC · ⌖ 23.5 AIC · ⊞ 51.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28222591670, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/28222591670 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->