### PR TITLE
[perf-improver] perf: add Linux job to nightly perf-timing workflow

### DIFF
--- a/.github/workflows/perf-timing-nightly.yml
+++ b/.github/workflows/perf-timing-nightly.yml
@@ -1,9 +1,9 @@
 name: Perf timing nightly
 
-# Phase 1 for microsoft/testfx#9312: artifact-only perf timing collection.
+# Artifact-only perf timing collection for microsoft/testfx#9312.
 # This workflow does not gate PRs and only uploads PlainProcess Result.json
-# files for trend tracking. PlainProcess is Windows-only until #9311 merges;
-# once that lands, this job can move to Linux for better reproducibility.
+# files for trend tracking. Runs on both Windows and Linux so results can be
+# compared across platforms (Linux runners tend to have more consistent timing).
 
 on:
   schedule:
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  collect:
-    name: Collect PlainProcess timing
+  collect-windows:
+    name: Collect PlainProcess timing (Windows)
     runs-on: windows-latest
     timeout-minutes: 120
 
@@ -69,7 +69,57 @@ jobs:
       - name: Upload Result.json
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: perf-timing-result-json
+          name: perf-timing-result-json-windows
           path: artifacts\perf-results\
+          if-no-files-found: error
+          retention-days: 90
+
+  collect-linux:
+    name: Collect PlainProcess timing (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Build packages
+        run: ./build.sh -pack -c Release
+
+      - name: Mark timing start
+        run: touch /tmp/perf_timing_start
+
+      - name: Run PlainProcess timing pipeline
+        env:
+          Microsoft_Testing_TestInfrastructure_TempDirectory_Cleanup: '0'
+        run: |
+          "$GITHUB_WORKSPACE/.dotnet/dotnet" run --project test/Performance/MSTest.Performance.Runner -c Release -- execute --pipelineNameFilter "*PlainProcess*"
+
+      - name: Stage Result.json files
+        run: |
+          set -e
+          STAGING_DIR="$GITHUB_WORKSPACE/artifacts/perf-results"
+          mkdir -p "$STAGING_DIR"
+
+          RESULT_ROOT="$GITHUB_WORKSPACE/artifacts/tmp/Release/testsuite"
+          mapfile -d '' -t RESULTS < <(find "$RESULT_ROOT" -name "Result.json" -type f -newer /tmp/perf_timing_start -print0 2>/dev/null)
+
+          if [ "${#RESULTS[@]}" -eq 0 ]; then
+            echo "::error::No Result.json files were found under '$RESULT_ROOT' after the PlainProcess run."
+            exit 1
+          fi
+
+          for i in "${!RESULTS[@]}"; do
+            IDX=$(( i + 1 ))
+            DEST_DIR="$STAGING_DIR/result-$(printf '%03d' "$IDX")"
+            mkdir -p "$DEST_DIR"
+            cp "${RESULTS[$i]}" "$DEST_DIR/Result.json"
+            echo "Staged '${RESULTS[$i]}'"
+          done
+
+      - name: Upload Result.json
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: perf-timing-result-json-linux
+          path: artifacts/perf-results/
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/perf-timing-nightly.yml
+++ b/.github/workflows/perf-timing-nightly.yml
@@ -86,7 +86,7 @@ jobs:
         run: ./build.sh -pack -c Release
 
       - name: Mark timing start
-        run: touch /tmp/perf_timing_start
+        run: touch "$RUNNER_TEMP/perf_timing_start"
 
       - name: Run PlainProcess timing pipeline
         env:
@@ -96,12 +96,12 @@ jobs:
 
       - name: Stage Result.json files
         run: |
-          set -e
+          set -euo pipefail
           STAGING_DIR="$GITHUB_WORKSPACE/artifacts/perf-results"
           mkdir -p "$STAGING_DIR"
 
           RESULT_ROOT="$GITHUB_WORKSPACE/artifacts/tmp/Release/testsuite"
-          mapfile -d '' -t RESULTS < <(find "$RESULT_ROOT" -name "Result.json" -type f -newer /tmp/perf_timing_start -print0 2>/dev/null)
+          mapfile -d '' -t RESULTS < <(find "$RESULT_ROOT" -name "Result.json" -type f -newer "$RUNNER_TEMP/perf_timing_start" -print0 2>/dev/null)
 
           if [ "${#RESULTS[@]}" -eq 0 ]; then
             echo "::error::No Result.json files were found under '$RESULT_ROOT' after the PlainProcess run."


### PR DESCRIPTION
Fulfils the TODO from #9376 / PR #9311 now that the `PlainProcess` pipeline supports Linux/macOS.

## Changes
- Rename the existing `collect` job to `collect-windows` (no functional change).
- Add a new `collect-linux` job (`ubuntu-latest`) that mirrors the Windows job using bash and forward-slash paths.
- Use a sentinel-file approach (`touch /tmp/perf_timing_start` + `find -newer`) to locate result files instead of parsing ISO 8601 timestamps in bash.
- Rename the Windows artifact to `perf-timing-result-json-windows`; the new Linux artifact is `perf-timing-result-json-linux`.
- Update the stale header comment (remove the now-resolved #9311 TODO).

## Notes
- No code-path changes — CI infrastructure only.
- Verified both `Scenario1_PlainProcess` and `Scenario1_ClassLevel_PlainProcess` are registered for `[OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX]`, so the Linux `*PlainProcess*` filter produces results.
- Trade-off: nightly CI now runs two jobs (~2× machine-minutes) on free-tier runners.

Closes #9376