### PR TITLE
Exclude inner-build-only MTP logic from the cross-targeting outer build

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -17,8 +17,9 @@
   </ItemGroup>
 
   <!-- Add assembly attribute metadata for reflection usage. -->
-  <!-- This is an inner-build-only concern: the cross-targeting (outer) build of a multi-targeted -->
-  <!-- project produces no assembly, so '$(TargetFramework)' is empty there and we must not emit it. -->
+  <!-- This is an inner-build-only concern: in the cross-targeting (outer) build of a multi-targeted -->
+  <!-- project, '$(TargetFramework)' is empty and no assembly is produced, so AssemblyMetadata items -->
+  <!-- are inert there and must not be emitted. -->
   <ItemGroup>
     <AssemblyMetadata Include="Microsoft.Testing.Platform.Application" Value="true" Condition=" '$(TargetFramework)' != '' AND '$(IsTestingPlatformApplication)' == 'true' " />
   </ItemGroup>

--- a/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
+++ b/src/Platform/Microsoft.Testing.Platform/buildMultiTargeting/Microsoft.Testing.Platform.targets
@@ -16,12 +16,16 @@
     <ProjectCapability Include="TestContainer" />
   </ItemGroup>
 
-  <!-- Add assembly attribute metadata for reflection usage -->
+  <!-- Add assembly attribute metadata for reflection usage. -->
+  <!-- This is an inner-build-only concern: the cross-targeting (outer) build of a multi-targeted -->
+  <!-- project produces no assembly, so '$(TargetFramework)' is empty there and we must not emit it. -->
   <ItemGroup>
-    <AssemblyMetadata Include="Microsoft.Testing.Platform.Application" Value="true" Condition=" '$(IsTestingPlatformApplication)' == 'true' " />
+    <AssemblyMetadata Include="Microsoft.Testing.Platform.Application" Value="true" Condition=" '$(TargetFramework)' != '' AND '$(IsTestingPlatformApplication)' == 'true' " />
   </ItemGroup>
 
-  <Target Name="_MTPAddArguments" BeforeTargets="ComputeRunArguments">
+  <!-- 'dotnet run' only ever drives an inner build, so this target is an inner-build-only concern. -->
+  <!-- Guarding on a non-empty '$(TargetFramework)' keeps it out of the cross-targeting (outer) build. -->
+  <Target Name="_MTPAddArguments" BeforeTargets="ComputeRunArguments" Condition=" '$(TargetFramework)' != '' ">
     <PropertyGroup>
       <RunArguments Condition=" '$(TestingPlatformCommandLineArguments)' != '' ">$(RunArguments) $(TestingPlatformCommandLineArguments)</RunArguments>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

The core `Microsoft.Testing.Platform` package funnels `build/`, `buildTransitive/`, and `buildMultiTargeting/` into a single `buildMultiTargeting/Microsoft.Testing.Platform.targets` file, so inner-build-only logic also ran in the cross-targeting (outer) build of multi-targeted projects (#8043).

This PR guards the two operations that are **clearly** inner-build-only and safe to exclude from the outer build, using the standard outer-build discriminator `'$(TargetFramework)' != ''` (the same idiom already used in `Microsoft.Testing.Platform.MSBuild.targets`):

- **`AssemblyMetadata "Microsoft.Testing.Platform.Application"`** — the outer build produces no assembly, so this was inert there; inner builds still emit it unchanged.
- **`_MTPAddArguments` target** — it hooks `ComputeRunArguments`, which only ever runs in an inner build (`dotnet run` cannot drive a cross-targeting outer build).

## Intentionally left unchanged

The remaining items called out in #8043 are **not** touched here because removing them from the outer build is potentially breaking and needs Test Explorer team validation:

- The `ProjectCapability` items (`TestingPlatformServer`, `TestContainer`, `TestingPlatformServer.ExitOnProcessExitCapability`, `TestingPlatformServer.UseListTestsOptionForDiscoveryCapability`) — VS Test Explorer likely reads these at the project/outer level for multi-TFM projects, so keeping them is the non-breaking choice.
- `IsTestingPlatformApplication` — it is the gate the outer-build capability declarations depend on, so it must remain in the outer build while those capabilities do.

## Why a guard rather than a folder restructure

The package packs `build/` and `buildTransitive/` per-TFM (e.g. `build/net8.0/`) while `buildMultiTargeting/` has no TFM subfolder. That makes sibling relative-path imports between the per-TFM folders fragile (a consumer's `$(TargetFramework)` doesn't always match the resolved asset folder). The `'$(TargetFramework)' != ''` guard is functionally equivalent for these two items and robust.

## Notes

- No tests assert on these two items.
- The runtime reflection path (`IPlatformInformation`) reads `Microsoft.Testing.Platform.Application.BuildTimeUTC`, which is set in the `.csproj` and is untouched.

Partially addresses #8043.

Fixes: #8043