### PR TITLE
[DO NOT MERGE] Survey: gauge source-gen support across acceptance assets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,13 @@ variables:
   # Cannot use key:value syntax in root defined variables
   - name: _TeamName
     value: MSTest
+  # THROWAWAY SURVEY BRANCH — do not merge.
+  # Turns on the source-gen survey in TestAssetFixtureBase: every acceptance fixture attempts to build
+  # its asset under MetadataMode.SourceGeneration (opt-out) and RECORDS the outcome via SourceGenSurvey
+  # (tagged "##SGSURVEY##" console lines) instead of asserting, so a single CI run gauges how many
+  # acceptance assets cannot support source generation today. Remove before merging.
+  - name: MSTEST_ACCEPTANCE_SOURCEGEN_SURVEY
+    value: 1
   - name: _RunAsInternal
     value: False
   - name: _RunAsPublic

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/SourceGenSurvey.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/SourceGenSurvey.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.TestInfrastructure;
+
+/// <summary>
+/// THROWAWAY SURVEY HELPER — do not merge.
+///
+/// <para>
+/// Records, per acceptance asset, whether it can be built under a source-generation
+/// <see cref="MetadataMode"/>. <see cref="TestAssetFixtureBase"/> drives this in survey mode by
+/// attempting the source-gen build for every fixture (opt-out) and reporting the outcome here
+/// instead of failing the test. The goal is to gauge how many existing acceptance assets cannot
+/// support source generation today, and why.
+/// </para>
+///
+/// <para>
+/// Each outcome is emitted as a single tagged console line (so it surfaces in the CI test-step log,
+/// which streams test-host stdout when <c>TestingPlatformCaptureOutput=false</c>) and appended to a
+/// report file under <c>artifacts/log/sourcegen-survey</c> as a backup.
+/// </para>
+/// </summary>
+public static class SourceGenSurvey
+{
+    /// <summary>
+    /// Distinctive console tag so survey lines can be grepped out of the (noisy) CI test log.
+    /// </summary>
+    public const string Tag = "##SGSURVEY##";
+
+    private static readonly Lock Gate = new();
+
+    private static readonly Lazy<string> LazyReportFile = new(CreateReportFile);
+
+    private static readonly string Os =
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows"
+        : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux"
+        : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "macos"
+        : "unknown";
+
+    /// <summary>
+    /// Records the outcome of a source-gen build attempt for an asset.
+    /// </summary>
+    /// <param name="assetName">The acceptance asset (project) name.</param>
+    /// <param name="mode">The source-gen metadata mode that was attempted.</param>
+    /// <param name="result">The build result, or <see langword="null"/> when the build was skipped.</param>
+    /// <param name="skippedReason">When <paramref name="result"/> is <see langword="null"/>, why it was skipped.</param>
+    public static void Record(string assetName, MetadataMode mode, DotnetMuxerResult? result, string? skippedReason = null)
+    {
+        string outcome = result is null
+            ? "SKIP"
+            : result.ExitCode == 0 ? "PASS" : "FAIL";
+
+        string reason = result is null
+            ? skippedReason ?? "skipped"
+            : result.ExitCode == 0 ? string.Empty : ExtractFirstError(result);
+
+        // Single line, key=value, reason last (it may contain spaces).
+        string line = $"{Tag} os={Os} mode={mode} result={outcome} asset={assetName} reason={reason}";
+
+        lock (Gate)
+        {
+            Console.WriteLine(line);
+            try
+            {
+                File.AppendAllText(LazyReportFile.Value, line + Environment.NewLine);
+            }
+            catch
+            {
+                // Best-effort backup file; the console line is the source of truth.
+            }
+        }
+    }
+
+    private static string ExtractFirstError(DotnetMuxerResult result)
+    {
+        foreach (string outputLine in result.StandardOutputLines)
+        {
+            int idx = outputLine.IndexOf(": error ", StringComparison.Ordinal);
+            if (idx >= 0)
+            {
+                // Keep it compact and single-line: from the error code onward, trimmed.
+                return outputLine[(idx + 2)..].Trim();
+            }
+        }
+
+        return $"exitcode={result.ExitCode} (no compiler error line found)";
+    }
+
+    private static string CreateReportFile()
+    {
+        string dir = Path.Combine(Constants.Root, "artifacts", "log", "sourcegen-survey");
+        Directory.CreateDirectory(dir);
+        return Path.Combine(dir, $"results-{Os}-{Environment.ProcessId}.txt");
+    }
+}

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -38,6 +38,25 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     /// </summary>
     protected virtual IReadOnlyList<MetadataMode> SourceGenMetadataModes => [];
 
+    // THROWAWAY SURVEY BRANCH — do not merge.
+    // When this environment variable is truthy, every fixture (opt-out, ignoring SourceGenMetadataModes)
+    // attempts to build these source-gen variants, and the outcome is RECORDED rather than asserted, so
+    // a single CI run gauges how many acceptance assets cannot support source generation today.
+    // Scoped to SourceGeneration for this first pass to bound CI cost; AOT is a planned second pass.
+    private const string SurveyEnvironmentVariable = "MSTEST_ACCEPTANCE_SOURCEGEN_SURVEY";
+
+    private static readonly MetadataMode[] SurveyModes = [MetadataMode.SourceGeneration];
+
+    private static bool IsSurveyEnabled
+    {
+        get
+        {
+            string? value = Environment.GetEnvironmentVariable(SurveyEnvironmentVariable);
+            return value is not null
+                && (value == "1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
     public string GetAssetPath(string assetID)
         => !_testAssets.TryGetValue(assetID, out TestAsset? testAsset)
             ? throw new ArgumentNullException(nameof(assetID), $"Cannot find target path for test asset '{assetID}'")
@@ -50,6 +69,16 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", callerMemberName: assetName, cancellationToken: cancellationToken);
         testAsset.DotnetResult = result;
         _testAssets.TryAdd(assetId, testAsset);
+
+        // THROWAWAY SURVEY BRANCH — do not merge.
+        // Survey mode takes precedence over the normal opt-in path: build the survey modes for EVERY
+        // fixture and record the outcome instead of asserting, so we can gauge source-gen support
+        // across the whole acceptance suite from a single (green) CI run.
+        if (IsSurveyEnabled)
+        {
+            await RunSourceGenSurveyAsync(testAsset, assetName, result, cancellationToken);
+            return;
+        }
 
         // Opt-in: for each source-gen metadata mode the fixture declares, build a second variant with
         // the matching generator injected, into an isolated bin/<sub> + obj/<sub> output, so the same
@@ -73,6 +102,53 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
                         $"The {mode} build of acceptance asset '{assetName}' failed with exit code {sourceGenResult.ExitCode}.{Environment.NewLine}{sourceGenResult}");
                 }
             }
+        }
+    }
+
+    // THROWAWAY SURVEY BRANCH — do not merge.
+    private async Task RunSourceGenSurveyAsync(TestAsset testAsset, string assetName, DotnetMuxerResult reflectionResult, CancellationToken cancellationToken)
+    {
+        // Build the union of the survey modes (measured for every fixture, opt-out) and any modes the
+        // fixture already declares (so already-converted classes whose tests run in those modes still
+        // find their bin/<sub> output and stay green). Everything is non-fatal in survey mode.
+        MetadataMode[] modesToBuild = [.. SurveyModes.Concat(SourceGenMetadataModes).Distinct()];
+        var results = new Dictionary<MetadataMode, DotnetMuxerResult?>();
+
+        foreach (MetadataMode mode in modesToBuild)
+        {
+            // If even the plain reflection build failed, the asset is broken independently of source
+            // generation; record a skip so it does not count as a source-gen failure.
+            if (reflectionResult.ExitCode != 0)
+            {
+                results[mode] = null;
+                continue;
+            }
+
+            try
+            {
+                string sourceGenArgs = await AcceptanceSourceGen.PrepareBuildArgumentsAsync(testAsset.TargetAssetPath, mode);
+                results[mode] = await DotnetCli.RunAsync(
+                    $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
+                    failIfReturnValueIsNotZero: false,
+                    callerMemberName: $"{assetName}_{AcceptanceSourceGen.GetOutputSubFolder(mode)}_survey",
+                    cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Never let the survey itself fail a test class; record and continue.
+                SourceGenSurvey.Record(assetName, mode, result: null, skippedReason: $"survey-exception: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        // Record one survey line per measured (opt-out) mode.
+        foreach (MetadataMode mode in SurveyModes)
+        {
+            results.TryGetValue(mode, out DotnetMuxerResult? modeResult);
+            SourceGenSurvey.Record(
+                assetName,
+                mode,
+                modeResult,
+                skippedReason: reflectionResult.ExitCode != 0 ? "reflection-build-failed" : null);
         }
     }
 


### PR DESCRIPTION
## ⚠️ Throwaway measurement branch — DO NOT MERGE

This is an **exploration** to answer one question before we roll out source generation across the acceptance suite: **how many existing acceptance assets cannot build under source generation today, and why?**

It builds on the foundation merged in #9370.

## How it works

- A global pipeline variable `MSTEST_ACCEPTANCE_SOURCEGEN_SURVEY=1` turns on **survey mode** in `TestAssetFixtureBase`.
- In survey mode, **every** fixture (opt-out, ignoring `SourceGenMetadataModes`) attempts to build its asset under **`MetadataMode.SourceGeneration`** and **records** the outcome via `SourceGenSurvey` instead of asserting — so a single CI run measures the whole suite without turning it red.
- Each outcome is one tagged console line (streamed to the CI test log because `TestingPlatformCaptureOutput=false`) plus a backup file under `artifacts/log/sourcegen-survey`:
  ```
  ##SGSURVEY## os=linux mode=SourceGeneration result=FAIL asset=FrameworkOnlyTests reason=error CS0234: ...ReflectionMetadataHook...
  ##SGSURVEY## os=linux mode=SourceGeneration result=PASS asset=TestInconclusive reason=
  ```
- To keep already-converted classes green, survey builds the **union** of `{SourceGeneration}` and each fixture's declared modes (non-fatally), so `InconclusiveTests` / `TestRunParametersTests` still find their `bin/<sub>` outputs.

## Scope / caveats

- **SourceGeneration mode only** for this first pass, to bound CI cost. AOT (`MSTest.AotReflection.SourceGeneration`) is a planned second pass (its gaps are a superset).
- Survey runs only in the **Debug** test legs (Win/Linux/Mac), which are the ones that run acceptance assets.
- This roughly **doubles asset-build work** in those legs, so they will be noticeably slower and **may approach job timeouts**. That's acceptable for a one-off measurement — console survey lines stream live, so even a leg that times out yields partial data. If a leg consistently times out, we'll narrow scope (e.g. one OS, or `MSTest.Acceptance` only).

## What to do with the results

Once CI runs, I'll grep `##SGSURVEY##` out of the three Debug test logs, dedupe by asset, and produce a per-OS PASS/FAIL summary bucketed by failure reason (no adapter ref, generics, inherited `[TestClass]`, cross-assembly reflection, VSTest-host, …). That gives us the concrete exclusion list and the size of the rollout for the real (opt-in) follow-up PRs.

## Local validation

39/39 pilot tests pass; survey records `FrameworkOnly=FAIL (CS0234 ReflectionMetadataHook)`, `TestInconclusive=PASS`, `TestRunParameters=PASS`.

<sub>Co-authored-by: Copilot</sub>