### PR TITLE
[link-checker] Fix broken documentation links

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2753,7 +2753,7 @@ A list of changes since last release are available [of v2.0.0-beta4...v2.0.0](ht
 
 ## <a name="2.0.0-beta4" />[2.0.0-beta4] - 2019-04-10
 
-A list of changes since last release are available [of 2.0.0-beta2...v2.0.0-beta4](https://github.com/microsoft/testfx/compare/2.0.0-beta2...v2.0.0-beta4)
+A list of changes since last release are available [of 2.0.0-beta2...v2.0.0-beta4](https://github.com/microsoft/testfx/compare/v2.0.0-beta2...v2.0.0-beta4)
 
 ### Changed
 
@@ -2768,7 +2768,7 @@ A list of changes since last release are available [of 2.0.0-beta2...v2.0.0-beta
 
 ## <a name="2.0.0-beta2" />[2.0.0-beta2] - 2019-02-15
 
-A list of changes since last release are available [of 1.4.0...2.0.0-beta2](https://github.com/microsoft/testfx/compare/1.4.0...2.0.0-beta2)
+A list of changes since last release are available [of 1.4.0...2.0.0-beta2](https://github.com/microsoft/testfx/compare/1.4.0...v2.0.0-beta2)
 
 ### Changed
 
@@ -2783,7 +2783,7 @@ A list of changes since last release are available [of 1.4.0...2.0.0-beta2](http
 
 ## <a name="1.4.0" />[1.4.0] - 2018-11-26
 
-A list of changes since last release are available [of 1.4.0-beta...1.4.0](https://github.com/microsoft/testfx/compare/1.4.0-beta...1.4.0)
+A list of changes since last release are available [of 1.4.0-beta...1.4.0](https://github.com/microsoft/testfx/compare/v1.4.0-beta...1.4.0)
 
 ### Added
 
@@ -2805,7 +2805,7 @@ A list of changes since last release are available [of 1.4.0-beta...1.4.0](https
 
 ## <a name="1.4.0-beta" />[1.4.0-beta] 2018-10-17
 
-A list of changes since last release are available [of 1.3.2...1.4.0-beta](https://github.com/microsoft/testfx/compare/1.3.2...1.4.0-beta)
+A list of changes since last release are available [of 1.3.2...1.4.0-beta](https://github.com/microsoft/testfx/compare/v1.3.2...v1.4.0-beta)
 
 ### Added
 

--- a/docs/testconfig.schema.md
+++ b/docs/testconfig.schema.md
@@ -76,7 +76,6 @@ There are two layers of versioning to keep in mind:
 
    ```json
    "versions": {
-     "v3": "https://raw.githubusercontent.com/microsoft/testfx/v3.x/docs/testconfig.schema.json",
      "v4": "https://raw.githubusercontent.com/microsoft/testfx/main/docs/testconfig.schema.json"
    }
    ```


### PR DESCRIPTION
## Summary

Fixed **5 broken documentation links** found during daily link check.

---

### Links Fixed

#### `docs/Changelog.md` — 4 old MSTest compare links with missing `v` tag prefix

The changelog entries for versions 1.3.2–2.0.0-beta4 used tag references without the `v` prefix that GitHub requires. All actual Git tags in the repository use the `v` prefix (e.g. `v1.3.2`, `v1.4.0-beta`), except for `1.4.0` which was tagged without a prefix.

| Old URL (broken) | New URL (fixed) |
|---|---|
| `compare/1.3.2...1.4.0-beta` | `compare/v1.3.2...v1.4.0-beta` |
| `compare/1.4.0-beta...1.4.0` | `compare/v1.4.0-beta...1.4.0` |
| `compare/1.4.0...2.0.0-beta2` | `compare/1.4.0...v2.0.0-beta2` |
| `compare/2.0.0-beta2...v2.0.0-beta4` | `compare/v2.0.0-beta2...v2.0.0-beta4` |

#### `docs/testconfig.schema.md` — Removed dead `v3.x` branch URL from hypothetical example

The schema doc contained an example `versions` object referencing `https://raw.githubusercontent.com/microsoft/testfx/v3.x/docs/testconfig.schema.json`. This URL is permanently broken because:
1. The `v3.x` branch does not exist in this repository.
2. `testconfig.schema.json` was added after v3 was EOL (added June 2026), so no v3 release ever contained the file.

The `v3` entry was removed from the example since it was misleading. The `v4` entry pointing to `main` remains.

---

### Links Added to Unfixable Cache

The following were identified as unfixable and added to cache memory to skip on future runs:

- **`microsoft/testanywhere` compare links (×6)** — The `microsoft/testanywhere` repo was deleted. These are historical MTP changelog entries from before the project was moved to `microsoft/testfx`. Cannot be fixed.
- **`v1.4.3...v1.5.0` platform compare** — Tags `v1.4.3` and `v1.5.0` only existed in the old testanywhere repo; they were never created in testfx.
- **`v4.2.3...v4.3.0`** — Unreleased upcoming version. Will resolve once v4.3.0 is tagged.
- **`(localhost/redacted) — Intentional example URL in documentation.

> **Note:** The ~2800+ other "broken" links in the report were either HTTP 429 rate-limit responses from NuGet.org (links are valid) or URL-parsing artifacts where the link checker incorrectly included trailing `)` or `)]` from Markdown syntax in the extracted URL.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Daily Link Checker & Fixer](https://github.com/microsoft/testfx/actions/runs/28236523613/agentic_workflow) workflow. · 820.4 AIC · ⌖ 24.6 AIC · ⊞ 43.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+link-checker%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/link-checker.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Daily Link Checker & Fixer, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28236523613, workflow_id: link-checker, run: https://github.com/microsoft/testfx/actions/runs/28236523613 -->

<!-- gh-aw-workflow-id: link-checker -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/link-checker -->