### PR TITLE
Address TreeNode filter completeness and correctness gaps (#9437)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -304,7 +304,7 @@ The XML-based test result file format used by Visual Studio, Azure DevOps, and `
 
 ### TreeNodeFilter
 
-An MTP component (`TreeNodeFilter.cs`) that evaluates filter expressions against test node properties to select which tests to run. Filter expressions support Boolean algebra: `&` (AND), `|` (OR), `!` (NOT), and property comparisons (e.g., `FullyQualifiedName~MyTest`). Internally, filter expressions are parsed into a `FilterExpression` tree and evaluated recursively.
+An MTP component (`TreeNodeFilter.cs`) that evaluates filter expressions against test node properties to select which tests to run. Filter expressions support Boolean algebra: `&` (AND), `|` (OR), `!` (NOT), and property comparisons (e.g., `/**[Tag=Smoke]`). Wildcard patterns (`*`) are supported in both path segments and property values. Internally, filter expressions are parsed into a `FilterExpression` tree and evaluated recursively.
 
 ## V
 

--- a/docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md
+++ b/docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md
@@ -45,7 +45,7 @@ You can combine operators
 The `!` (unary NOT) operator negates a condition. It must appear immediately after an opening parenthesis.
 
 - `/A/(!*Slow*)` -> All nodes under A whose name does not contain `Slow`
-- `/A/(B*)&(!*C)` -> All nodes under A whose name starts with B and does not end with C
+- `/A/(!*Integration*)` -> All nodes under A whose name does not contain `Integration`
 
 ## Filtering with the `**` path operator
 

--- a/docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md
+++ b/docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md
@@ -8,6 +8,7 @@ Available operators
 
 - `&`    -> and
 - `|`    -> or
+- `!`    -> unary NOT (must appear immediately after an opening parenthesis, e.g. `(!A*)`)
 - `()`   -> order, mandatory when defining multiple conditions
 - `=`    -> equals
 - `!=`   -> not equal
@@ -38,6 +39,15 @@ C-->G;
 You can combine operators
 `/A/(B*)&(!*C)`
 -> All nodes under A whose name starts with B and does not end with C
+
+## Filtering with NOT
+
+The `!` (unary NOT) operator negates a condition. It must appear immediately after an opening parenthesis.
+
+- `/A/(!*Slow*)` -> All nodes under A whose name does not contain `Slow`
+- `/A/(B*)&(!*C)` -> All nodes under A whose name starts with B and does not end with C
+
+## Filtering with the `**` path operator
 
 In addition to all the previously mentioned operators, for path filtering we want to allow one more operator `**`.
 `/A/**`
@@ -79,6 +89,8 @@ You can combine operators:
 /!\ We don't want to allow values without key
 
 /!\ Wildcard only apply to value of the property
+
+> **Note for test framework authors**: The property filter syntax (`[Key=Value]`) evaluates against `TestMetadataProperty` entries in a node's `PropertyBag` only. Properties stored as other `IProperty` subtypes are silently not matched. To make test traits filterable via `--treenode-filter`, expose them as `TestMetadataProperty` instances.
 
 ## Real life examples
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -227,6 +227,12 @@ internal sealed class PlatformCommandLineProvider : CommandLineOptionsProviderBa
             return ValidationResult.InvalidTask(PlatformResources.PlatformCommandLineMinimumExpectedTestsIncompatibleDiscoverTests);
         }
 
+        if (commandLineOptions.IsOptionSet(FilterUidOptionKey)
+            && commandLineOptions.IsOptionSet(TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter))
+        {
+            return ValidationResult.InvalidTask(PlatformResources.OnlyOneFilterSupported);
+        }
+
         // The '--server dotnettestcli' protocol path requires '--dotnet-test-pipe' to connect to the
         // dotnet test pipe. Without it, the dotnet test connection silently never activates and the
         // application falls back to console mode, leading to confusing behavior. Both options are

--- a/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionFilterFactory.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/ConsoleTestExecutionFilterFactory.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Resources;
 
 namespace Microsoft.Testing.Platform.Requests;
@@ -27,7 +28,7 @@ internal sealed class ConsoleTestExecutionFilterFactory(ICommandLineOptions comm
         bool hasTestNodeUidFilter = _commandLineService.TryGetOptionArgumentList(PlatformCommandLineProvider.FilterUidOptionKey, out string[]? uidFilter);
         ITestExecutionFilter filter = (hasTreenodeFilter, hasTestNodeUidFilter) switch
         {
-            (true, true) => throw new NotSupportedException(PlatformResources.OnlyOneFilterSupported),
+            (true, true) => throw ApplicationStateGuard.Unreachable(),
             (true, false) => new TreeNodeFilter(treenodeFilter![0]),
             (false, true) => new TestNodeUidListFilter([.. uidFilter!.Select(x => new TestNodeUid(x))]),
             (false, false) => new NopFilter(),

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.cs
@@ -53,6 +53,8 @@ internal static partial class PlatformResources
 
     internal static string @PlatformCommandLineMinimumExpectedTestsIncompatibleDiscoverTests => GetResourceString("PlatformCommandLineMinimumExpectedTestsIncompatibleDiscoverTests");
 
+    internal static string @OnlyOneFilterSupported => GetResourceString("OnlyOneFilterSupported");
+
     internal static string @PlatformCommandLineMinimumExpectedTestsOptionSingleArgument => GetResourceString("PlatformCommandLineMinimumExpectedTestsOptionSingleArgument");
 
     internal static string @PlatformCommandLinePortOptionSingleArgument => GetResourceString("PlatformCommandLinePortOptionSingleArgument");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ExecutionTests.cs
@@ -125,6 +125,17 @@ Test discovery summary: found 1 test\(s\)\ - .*\.(dll|exe) \(net.+\|.+\)
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
+    public async Task Exec_WhenBothTreeNodeFilterAndUidFilterAreSpecified_ResultIsNotOk(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--filter-uid 0 --treenode-filter \"<whatever>\"", cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.InvalidCommandLine);
+        testHostResult.AssertOutputContains("Passing both '--treenode-filter' and '--filter-uid' is unsupported.");
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
     public async Task Exec_WhenMinimumExpectedTestsIsSpecifiedAndEnoughTestsRun_ResultIsOk(string tfm)
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/PlatformCommandLineProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/PlatformCommandLineProviderTests.cs
@@ -200,6 +200,21 @@ public sealed class PlatformCommandLineProviderTests
     }
 
     [TestMethod]
+    public async Task IsInvalid_When_Both_FilterUid_And_TreenodeFilter_Provided()
+    {
+        var provider = new PlatformCommandLineProvider();
+        var options = new Dictionary<string, string[]>
+        {
+            { PlatformCommandLineProvider.FilterUidOptionKey, ["uid0"] },
+            { TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter, ["/A/B"] },
+        };
+
+        ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
+        Assert.IsFalse(validateOptionsResult.IsValid);
+        Assert.AreEqual(PlatformResources.OnlyOneFilterSupported, validateOptionsResult.ErrorMessage);
+    }
+
+    [TestMethod]
     [DataRow("0")]
     [DataRow("-1")]
     public async Task IsInvalid_When_MinimumExpectedTests_Is_Not_Positive(string minimumExpectedTests)


### PR DESCRIPTION
Fixes #9437.

Addresses all five tasks from the issue covering documentation gaps, a late-validation bug, and a missing acceptance-test scenario in the TreeNode filter system.

### Changes

**Task 1 — Document the `!` NOT operator** (`docs/mstest-runner-graphqueryfiltering/graph-query-filtering.md`)
- Added `!` (unary NOT) to the "Available operators" table.
- Added a "Filtering with NOT" section with examples (e.g. `/A/(!*Slow*)`).

**Task 2 — Fix the glossary `TreeNodeFilter` entry** (`docs/glossary.md`)
- Replaced the invalid VSTest `~` example (`FullyQualifiedName~MyTest`) with valid treenode-filter syntax (`/**[Tag=Smoke]`) and noted wildcard support.

**Task 3 — Move `--treenode-filter` + `--filter-uid` mutual exclusion to CLI validation**
- `PlatformCommandLineProvider.ValidateCommandLineOptionsAsync` now returns a proper `ValidationResult.InvalidTask(PlatformResources.OnlyOneFilterSupported)` up front.
- `ConsoleTestExecutionFilterFactory.TryCreateAsync`'s `(true, true)` branch now throws `ApplicationStateGuard.Unreachable()` instead of a late `NotSupportedException`.

**Task 4 — Add acceptance test for the dual-filter conflict** (`ExecutionTests.cs`)
- New test `Exec_WhenBothTreeNodeFilterAndUidFilterAreSpecified_ResultIsNotOk` asserting `ExitCode.InvalidCommandLine` and the expected error message.

**Task 5 — Document that property filters only match `TestMetadataProperty`**
- Added a note for test framework authors in `graph-query-filtering.md`.

### Notes
- No `.resx`/`.xlf` changes were needed — the `OnlyOneFilterSupported` resource already exists.
- `Microsoft.Testing.Platform` builds cleanly (0 warnings, 0 errors). The acceptance test consumes packed NuGets and should be validated with `.\build.cmd -pack -test -integrationTest`.