### PR TITLE
[code-simplifier] refactor: remove intermediate StringBuilder in InvokeTestingPlatformTask.Execute

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
@@ -70,11 +70,9 @@ public partial class InvokeTestingPlatformTask
         bool returnValue = base.Execute();
         if (_toolCommand is not null)
         {
-            StringBuilder sb = new();
-            sb.AppendLine();
-            sb.AppendLine("=== COMMAND LINE ===");
-            sb.AppendLine(_toolCommand);
-            _output.AppendLine(sb.ToString());
+            _output.AppendLine();
+            _output.AppendLine("=== COMMAND LINE ===");
+            _output.AppendLine(_toolCommand);
         }
 
         // Persist the output to the file.


### PR DESCRIPTION
## Code Simplification — 2026-06-26

This PR simplifies the `Execute()` method in `InvokeTestingPlatformTask.Execution.cs` (introduced in #9435) to improve code clarity and eliminate an unnecessary allocation.

### Files Simplified

- `src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs` — removed intermediate `StringBuilder` in `Execute()`

### Improvement

**Before:**
```csharp
if (_toolCommand is not null)
{
    StringBuilder sb = new();
    sb.AppendLine();
    sb.AppendLine("=== COMMAND LINE ===");
    sb.AppendLine(_toolCommand);
    _output.AppendLine(sb.ToString());
}
```

**After:**
```csharp
if (_toolCommand is not null)
{
    _output.AppendLine();
    _output.AppendLine("=== COMMAND LINE ===");
    _output.AppendLine(_toolCommand);
}
```

The intermediate `StringBuilder sb` was created only to immediately call `_output.AppendLine(sb.ToString())`. Appending directly to `_output` is equivalent (minus an incidental extra blank line that `AppendLine(sb.ToString())` added because `sb` already ended with `Environment.NewLine`).

### Changes Based On

Recent changes from:
- #9435 — Split `InvokeTestingPlatformTask` into focused partial-class files

### Testing

- ✅ No functional changes — the command-line section in the log file is identical except for one fewer trailing blank line (cosmetic improvement)
- ✅ No new APIs added; internal implementation detail only

### Review Focus

Please verify that appending the three lines directly to `_output` produces the same log-file content as the original (minus the accidental extra blank line from wrapping via `AppendLine(sb.ToString())`).


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/28242249982/agentic_workflow) workflow. · 229.8 AIC · ⌖ 17.3 AIC · ⊞ 9.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-27T14:10:19.544Z --> on Jun 27, 2026, 2:10 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 28242249982, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/28242249982 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->