### PR TITLE
[perf-improver] perf: defer class-cleanup TestContextImplementation allocation to last test in class

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -237,11 +237,13 @@ internal sealed class UnitTestRunner
                 }
             }
 
-            testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, testMethod.FullClassName, testContextProperties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
-
             _classCleanupManager.MarkTestComplete(testMethod, out bool isLastTestInClass);
             if (isLastTestInClass)
             {
+                // Defer TestContextImplementation allocation to only the last test in each class,
+                // saving one dict-copy + CancellationTokenRegistration per non-last test.
+                testContextForClassCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, testMethod.FullClassName, testContextProperties, messageLogger, testContextForTestExecution.Context.CurrentTestOutcome);
+
                 if (testMethodInfo is not null)
                 {
                     // Flow properties set during AssemblyInitialize and ClassInitialize so the
@@ -276,7 +278,10 @@ internal sealed class UnitTestRunner
             if (testMethodInfo?.Parent.Parent.IsAssemblyInitializeExecuted == true &&
                 _classCleanupManager.ShouldRunEndOfAssemblyCleanup)
             {
-                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, testContextProperties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
+                // testContextForClassCleanup is guaranteed non-null here: ShouldRunEndOfAssemblyCleanup
+                // becomes true only after MarkClassComplete, which is called exclusively inside the
+                // isLastTestInClass block above — where testContextForClassCleanup is allocated.
+                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, testContextProperties, messageLogger, testContextForClassCleanup!.Context.CurrentTestOutcome);
 
                 // Flow properties set during AssemblyInitialize so the AssemblyCleanup method
                 // observes them. Class-init properties are intentionally NOT flowed here because

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -281,7 +281,8 @@ internal sealed class UnitTestRunner
                 // testContextForClassCleanup is guaranteed non-null here: ShouldRunEndOfAssemblyCleanup
                 // becomes true only after MarkClassComplete, which is called exclusively inside the
                 // isLastTestInClass block above — where testContextForClassCleanup is allocated.
-                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, testContextProperties, messageLogger, testContextForClassCleanup!.Context.CurrentTestOutcome);
+                DebugEx.Assert(testContextForClassCleanup is not null, "testContextForClassCleanup should not be null when running assembly cleanup.");
+                testContextForAssemblyCleanup = PlatformServiceProvider.Instance.GetTestContext(testMethod: null, null, testContextProperties, messageLogger, testContextForClassCleanup.Context.CurrentTestOutcome);
 
                 // Flow properties set during AssemblyInitialize so the AssemblyCleanup method
                 // observes them. Class-init properties are intentionally NOT flowed here because

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -420,9 +420,11 @@ public sealed class UnitTestRunnerTests : TestContainer
         thirdResults[0].Outcome.Should().Be(UnitTestOutcome.Passed);
         int allocationsForThird = _testablePlatformServiceProvider.GetTestContextCallCount - countBeforeThird;
 
-        // The last-test run allocates more contexts because it creates the class/assembly cleanup contexts
-        // that are deferred from all non-last tests.
-        allocationsForThird.Should().BeGreaterThan(allocationsForSecond);
+        // The last-test run allocates exactly two more contexts than a non-last test: the class-cleanup
+        // context and the assembly-cleanup context, both of which are deferred from all non-last tests.
+        // Asserting the exact delta (rather than a loose "greater than") catches the regression this test
+        // guards against, where a non-last test mistakenly allocates the deferred class-cleanup context.
+        allocationsForThird.Should().Be(allocationsForSecond + 2);
     }
 
     #endregion

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -385,6 +385,46 @@ public sealed class UnitTestRunnerTests : TestContainer
         contextsAllocatedForSecondRun.Should().BeLessThan(contextsAllocatedForFirstRun);
     }
 
+    public async Task RunSingleTestShouldDeferClassCleanupContextAllocationToLastTestInClass()
+    {
+        Type type = typeof(DummyTestClassWithCleanupMethods);
+        TestMethod testMethod1 = CreateTestMethod("TestMethod", type.FullName!, "A", displayName: null);
+        TestMethod testMethod2 = CreateTestMethod("TestMethod2", type.FullName!, "A", displayName: null);
+        TestMethod testMethod3 = CreateTestMethod("TestMethod3", type.FullName!, "A", displayName: null);
+        var unitTestElement1 = new UnitTestElement(testMethod1);
+        var unitTestElement2 = new UnitTestElement(testMethod2);
+        var unitTestElement3 = new UnitTestElement(testMethod3);
+        var unitTestRunner = new UnitTestRunner(new MSTestSettings(), [unitTestElement1, unitTestElement2, unitTestElement3]);
+
+        _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A"))
+            .Returns(Assembly.GetExecutingAssembly());
+
+        DummyTestClassWithCleanupMethods.ClassCleanupMethodBody = () => { };
+        DummyTestClassWithCleanupMethods.AssemblyCleanupMethodBody = () => { };
+
+        // Run the first test to warm up assembly/class initialize (slow path, sets cached results).
+        TestResult[] firstResults = await unitTestRunner.RunSingleTestAsync(unitTestElement1, _testRunParameters, null!);
+        firstResults[0].Outcome.Should().Be(UnitTestOutcome.Passed);
+
+        // Second test (non-last): both assembly-init and class-init take the fast path (no contexts),
+        // and the class-cleanup context is NOT allocated (deferred to the last test).
+        int countBeforeSecond = _testablePlatformServiceProvider.GetTestContextCallCount;
+        TestResult[] secondResults = await unitTestRunner.RunSingleTestAsync(unitTestElement2, _testRunParameters, null!);
+        secondResults[0].Outcome.Should().Be(UnitTestOutcome.Passed);
+        int allocationsForSecond = _testablePlatformServiceProvider.GetTestContextCallCount - countBeforeSecond;
+
+        // Third test (last in class): takes fast paths for init, but allocates a class-cleanup context
+        // and an assembly-cleanup context. Allocation count must exceed the middle test's count.
+        int countBeforeThird = _testablePlatformServiceProvider.GetTestContextCallCount;
+        TestResult[] thirdResults = await unitTestRunner.RunSingleTestAsync(unitTestElement3, _testRunParameters, null!);
+        thirdResults[0].Outcome.Should().Be(UnitTestOutcome.Passed);
+        int allocationsForThird = _testablePlatformServiceProvider.GetTestContextCallCount - countBeforeThird;
+
+        // The last-test run allocates more contexts because it creates the class/assembly cleanup contexts
+        // that are deferred from all non-last tests.
+        allocationsForThird.Should().BeGreaterThan(allocationsForSecond);
+    }
+
     #endregion
 
     #region private helpers
@@ -498,6 +538,12 @@ public sealed class UnitTestRunnerTests : TestContainer
 
         [TestMethod]
         public void TestMethod() => TestMethodBody?.Invoke(TestContext);
+
+        [TestMethod]
+        public void TestMethod2() => TestMethodBody?.Invoke(TestContext);
+
+        [TestMethod]
+        public void TestMethod3() => TestMethodBody?.Invoke(TestContext);
     }
 
     private class DummyTestClassAttribute : TestClassAttribute;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -394,7 +394,7 @@ public sealed class UnitTestRunnerTests : TestContainer
         var unitTestElement1 = new UnitTestElement(testMethod1);
         var unitTestElement2 = new UnitTestElement(testMethod2);
         var unitTestElement3 = new UnitTestElement(testMethod3);
-        var unitTestRunner = new UnitTestRunner(new MSTestSettings(), [unitTestElement1, unitTestElement2, unitTestElement3]);
+        UnitTestRunner unitTestRunner = CreateUnitTestRunner([unitTestElement1, unitTestElement2, unitTestElement3]);
 
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.LoadAssembly("A"))
             .Returns(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
## Goal and Rationale

In `RunSingleTestAsync`, a `TestContextImplementation` for class cleanup was allocated unconditionally for every test — even when `isLastTestInClass` was `false` and the context was never used. The `TestContextImplementation` constructor copies the `testContextProperties` dictionary and registers a `CancellationTokenRegistration`, so this is a non-trivial per-test allocation.

The fix is the same pattern as PR #9433 (which deferred assembly-init and class-init contexts to the slow path): **defer the class-cleanup context to only the last test in each class**.

## Approach

Move the `GetTestContext(...)` call for `testContextForClassCleanup` from an unconditional position before `MarkTestComplete` into the `if (isLastTestInClass)` block.

**Safety invariant**: the assembly-cleanup branch reads `testContextForClassCleanup!.Context.CurrentTestOutcome`. That branch only runs when `ShouldRunEndOfAssemblyCleanup` is `true`, which requires `MarkClassComplete` to have been called — and `MarkClassComplete` is called exclusively inside the `isLastTestInClass` block. So `testContextForClassCleanup` is guaranteed non-null when the assembly-cleanup branch is reached. A comment documents this reasoning.

## Performance Evidence

**Allocation savings**: For a test suite with *C* classes averaging *K* tests each:
- **Before**: allocates `C × K` class-cleanup `TestContextImplementation` objects per run  
- **After**: allocates `C × 1` (one per class, only for the last test)
- **Savings**: `C × (K−1)` allocations eliminated — each saving one dictionary copy + one `CancellationTokenRegistration`

For a typical suite with 50 test classes averaging 10 tests each:
- Eliminated ~450 unnecessary `TestContextImplementation` allocations per run

This is the same pattern and magnitude as the assembly-init/class-init fast paths introduced in #9433.

**Methodology**: Code inspection + allocation counting via `TestablePlatformServiceProvider.GetTestContextCallCount` (same mechanism used in the existing unit tests for #9433).

## Trade-offs

None. The context was allocated but never used; removing the allocation changes no observable behaviour.

## Test Status

✅ Build/tests: local SDK not available in CI agent (pinned SDK 11.0.100-preview, not installed). Verification delegated to CI.

The new unit test `RunSingleTestShouldDeferClassCleanupContextAllocationToLastTestInClass` verifies that:
1. A middle test in a class (warm path) allocates fewer contexts than the last test (which correctly allocates the class-cleanup and assembly-cleanup contexts).
2. All three tests pass with `UnitTestOutcome.Passed`.

## Reproducibility

```csharp
// TestablePlatformServiceProvider.GetTestContextCallCount tracks all GetTestContext() calls.
// Middle test: count increases by 1 (test-exec context only).
// Last test: count increases by 3 (test-exec + class-cleanup + assembly-cleanup contexts).
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/28243694549/agentic_workflow) workflow. · 2.3K AIC · ⌖ 40 AIC · ⊞ 57.7K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28243694549, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/28243694549 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->