### PR TITLE
Forward Azure DevOps logging commands over the dotnet test pipe (multi-assembly)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
@@ -252,7 +252,7 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         => await EmitLineAsync($"{AzureDevOpsBuildAddTagCommandPrefix}{tag}", cancellationToken).ConfigureAwait(false);
 
     private async Task EmitLineAsync(string line, CancellationToken cancellationToken)
-        => await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
+        => await _outputDevice.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
 
     private string GetArtifactName()
         => _artifactNameOverride is { } artifactName && !RoslynString.IsNullOrWhiteSpace(artifactName)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
@@ -84,7 +84,7 @@ internal sealed class AzureDevOpsLogGroupReporter : IDataConsumer, ITestSessionL
 
             string name = $"{_testApplicationModuleInfo.TryGetAssemblyName() ?? "unknown"} ({_targetFrameworkMoniker.Value})";
             string line = $"##[group]{AzDoEscaper.Escape(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.LogGroupHeader, name))}";
-            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
+            await _outputDevice.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
             _groupOpened = true;
         }
         catch (OperationCanceledException)
@@ -108,7 +108,7 @@ internal sealed class AzureDevOpsLogGroupReporter : IDataConsumer, ITestSessionL
                 return;
             }
 
-            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData("##[endgroup]"), testSessionContext.CancellationToken).ConfigureAwait(false);
+            await _outputDevice.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData("##[endgroup]"), testSessionContext.CancellationToken).ConfigureAwait(false);
             _groupOpened = false;
         }
         catch (OperationCanceledException)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -162,7 +162,7 @@ internal sealed class AzureDevOpsReporter :
         bool isQuarantined = _quarantineFile?.Matches(testName) == true;
         if (isQuarantined && Interlocked.Exchange(ref _quarantineBuildTagEmitted, 1) == 0)
         {
-            await _outputDisplay.DisplayAsync(this, new FormattedTextOutputDeviceData(QuarantineBuildTagLine), cancellationToken).ConfigureAwait(false);
+            await _outputDisplay.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(QuarantineBuildTagLine), cancellationToken).ConfigureAwait(false);
         }
 
         string severity = GetSeverity(testName, isQuarantined);
@@ -183,7 +183,7 @@ internal sealed class AzureDevOpsReporter :
             _logger.LogTrace($"Showing failure message '{line}'.");
         }
 
-        await _outputDisplay.DisplayAsync(this, new FormattedTextOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
+        await _outputDisplay.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
     }
 
     internal static /* for testing */ string? GetErrorText(string testDisplayName, string? explanation, Exception? exception, string severity, IFileSystem fileSystem, ILogger logger, string targetFrameworkMoniker)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSlowTestReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSlowTestReporter.cs
@@ -263,7 +263,7 @@ internal sealed class AzureDevOpsSlowTestReporter : IDataConsumer, ITestSessionL
             line = $"{line}  {decoration}";
         }
 
-        await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
+        await _outputDevice.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(line), cancellationToken).ConfigureAwait(false);
     }
 
     private TimeSpan ResolveThreshold(string testName)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -239,7 +239,7 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
             }
 
             string line = $"##vso[task.uploadsummary]{AzDoEscaper.Escape(path)}";
-            await _outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
+            await _outputDevice.DisplayAsync(this, new AzureDevOpsCommandOutputDeviceData(line), testSessionContext.CancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/RegisterSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/RegisterSerializers.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Testing.Platform.IPC.Serializers;
  * TestSessionEventSerializer: 8
  * HandshakeMessageSerializer: 9
  * TestInProgressMessagesSerializer: 10
+ * AzureDevOpsLogMessageSerializer: 11
 */
 
 [Embedded]
@@ -37,5 +38,6 @@ internal static class RegisterSerializers
         namedPipeBase.RegisterSerializer(new TestSessionEventSerializer(), typeof(TestSessionEvent));
         namedPipeBase.RegisterSerializer(new HandshakeMessageSerializer(), typeof(HandshakeMessage));
         namedPipeBase.RegisterSerializer(new TestInProgressMessagesSerializer(), typeof(TestInProgressMessages));
+        namedPipeBase.RegisterSerializer(new AzureDevOpsLogMessageSerializer(), typeof(AzureDevOpsLogMessage));
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsCommandOutputDeviceData.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsCommandOutputDeviceData.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// Marks an output-device line as an Azure DevOps pipeline command (for example <c>##[group]</c>,
+/// <c>##[endgroup]</c> or <c>##vso[...]</c>) produced by the AzureDevOpsReport extension that must
+/// reach the pipeline log even under the dotnet test pipe protocol.
+/// </summary>
+/// <remarks>
+/// In a single-assembly run this renders like any other <see cref="TextOutputDeviceData"/> (the
+/// terminal output device writes its <see cref="TextOutputDeviceData.Text"/> verbatim). Under the
+/// dotnet test pipe protocol the host installs <see cref="DotnetTestPassthroughOutputDevice"/>, which
+/// recognizes this marker and forwards the line to the SDK over the protocol (version 1.2.0+), so the
+/// Azure DevOps logging commands are not swallowed in multi-assembly runs.
+/// </remarks>
+internal sealed class AzureDevOpsCommandOutputDeviceData : TextOutputDeviceData
+{
+    public AzureDevOpsCommandOutputDeviceData(string text)
+        : base(text)
+    {
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsCommandOutputDeviceData.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsCommandOutputDeviceData.cs
@@ -4,16 +4,17 @@
 namespace Microsoft.Testing.Platform.OutputDevice;
 
 /// <summary>
-/// Marks an output-device line as an Azure DevOps pipeline command (for example <c>##[group]</c>,
-/// <c>##[endgroup]</c> or <c>##vso[...]</c>) produced by the AzureDevOpsReport extension that must
-/// reach the pipeline log even under the dotnet test pipe protocol.
+/// Marks an output-device line produced by the AzureDevOpsReport extension that must reach the Azure
+/// DevOps pipeline log even under the dotnet test pipe protocol. This is usually an Azure DevOps logging
+/// command (for example <c>##[group]</c>, <c>##[endgroup]</c> or <c>##vso[...]</c>), but it also carries
+/// the extension's other report output, such as the slow-test progress lines.
 /// </summary>
 /// <remarks>
 /// In a single-assembly run this renders like any other <see cref="TextOutputDeviceData"/> (the
 /// terminal output device writes its <see cref="TextOutputDeviceData.Text"/> verbatim). Under the
 /// dotnet test pipe protocol the host installs <see cref="DotnetTestPassthroughOutputDevice"/>, which
 /// recognizes this marker and forwards the line to the SDK over the protocol (version 1.2.0+), so the
-/// Azure DevOps logging commands are not swallowed in multi-assembly runs.
+/// AzureDevOpsReport output is not swallowed in multi-assembly runs.
 /// </remarks>
 internal sealed class AzureDevOpsCommandOutputDeviceData : TextOutputDeviceData
 {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsLogIssueFormatter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/AzureDevOpsLogIssueFormatter.cs
@@ -23,11 +23,21 @@ internal static class AzureDevOpsLogIssueFormatter
 
     /// <summary>
     /// Returns <c>true</c> when the current process is running on an Azure DevOps agent
+    /// (<c>TF_BUILD=true</c>), regardless of the <c>TESTINGPLATFORM_AZDO_OUTPUT</c> opt-out. Use this
+    /// for the AzureDevOpsReport extension's explicit <c>--report-azdo</c> output (the user opted in via
+    /// the option), and reserve <see cref="IsAzureDevOpsEnvironment"/> for the platform's automatic
+    /// <c>##vso[task.logissue]</c> emission, which the opt-out disables.
+    /// </summary>
+    public static bool IsAzureDevOpsAgent(IEnvironment environment)
+        => bool.TryParse(environment.GetEnvironmentVariable("TF_BUILD"), out bool tfBuild) && tfBuild;
+
+    /// <summary>
+    /// Returns <c>true</c> when the current process is running on an Azure DevOps agent
     /// (TF_BUILD=true) and the user has not opted out via <c>TESTINGPLATFORM_AZDO_OUTPUT=off|false|0</c>.
     /// </summary>
     public static bool IsAzureDevOpsEnvironment(IEnvironment environment)
     {
-        if (!bool.TryParse(environment.GetEnvironmentVariable("TF_BUILD"), out bool tfBuild) || !tfBuild)
+        if (!IsAzureDevOpsAgent(environment))
         {
             return false;
         }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/DotnetTestPassthroughOutputDevice.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/DotnetTestPassthroughOutputDevice.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.IPC.Models;
+using Microsoft.Testing.Platform.ServerMode;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// The host output device used under the dotnet test pipe protocol. Like
+/// <see cref="NopPlatformOutputDevice"/> it discards regular host output (the SDK's TerminalTestReporter
+/// owns user-facing rendering), but it additionally forwards lines marked with
+/// <see cref="AzureDevOpsCommandOutputDeviceData"/> to the SDK as <see cref="AzureDevOpsLogMessage"/> so
+/// the AzureDevOpsReport extension's logging commands (##[group], ##vso[...]) still reach the pipeline
+/// log in multi-assembly runs.
+/// </summary>
+/// <remarks>
+/// Forwarding is gated on the SDK negotiating protocol version 1.2.0 or later
+/// (<see cref="DotnetTestConnection.IsLogForwardingSupported"/>); against an older SDK the marked lines
+/// are swallowed exactly like the no-op device, so no unknown message id is ever sent. The
+/// <see cref="DotnetTestConnection"/> and the dotnet test execution id are resolved lazily because both
+/// become available only after the output device is built (the connection is created and the execution
+/// id env var is set during <c>AfterCommonServiceSetupAsync</c>).
+/// </remarks>
+internal sealed class DotnetTestPassthroughOutputDevice : IPlatformOutputDevice
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public DotnetTestPassthroughOutputDevice(IServiceProvider serviceProvider)
+        => _serviceProvider = serviceProvider;
+
+    public string Uid => nameof(DotnetTestPassthroughOutputDevice);
+
+    public string Version => PlatformVersion.Version;
+
+    public string DisplayName => nameof(DotnetTestPassthroughOutputDevice);
+
+    public string Description => "Output device that discards host output but forwards Azure DevOps logging commands to the SDK under the dotnet test pipe protocol.";
+
+    // Returning false keeps this device from being registered as a data consumer, matching NopPlatformOutputDevice.
+    public Task<bool> IsEnabledAsync() => Task.FromResult(false);
+
+    public async Task DisplayAsync(IOutputDeviceDataProducer producer, IOutputDeviceData data, CancellationToken cancellationToken)
+    {
+        // Preserve the deliberate pipe-protocol suppression: only Azure DevOps command lines are
+        // forwarded; everything else is swallowed exactly like NopPlatformOutputDevice.
+        if (data is not AzureDevOpsCommandOutputDeviceData commandData)
+        {
+            return;
+        }
+
+        // The dotnet test pipe protocol (DotnetTestConnection) is never active on browser, so the
+        // browser-unsupported members below are unreachable there; suppress CA1416 accordingly.
+#pragma warning disable CA1416 // Validate platform compatibility
+        if (_serviceProvider.GetService<IPushOnlyProtocol>() is not DotnetTestConnection connection
+            || !connection.IsLogForwardingSupported)
+        {
+            return;
+        }
+
+        string? executionId = _serviceProvider.GetEnvironment().GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
+        await connection.SendMessageAsync(new AzureDevOpsLogMessage(executionId, DotnetTestConnection.InstanceId, commandData.Text)).ConfigureAwait(false);
+#pragma warning restore CA1416 // Validate platform compatibility
+    }
+
+    public Task DisplayBannerAsync(string? bannerMessage, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task DisplayBeforeSessionStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task DisplayAfterSessionEndRunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task HandleProcessRoleAsync(TestProcessRole processRole, CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/OutputDeviceManager.cs
@@ -20,11 +20,25 @@ internal sealed class PlatformOutputDeviceManager
     internal async Task<ProxyOutputDevice> BuildAsync(ServiceProvider serviceProvider, bool useServerModeOutputDevice, bool isPipeProtocol)
     {
         // Under the dotnet test pipe protocol, the SDK's TerminalTestReporter owns all
-        // user-facing output, so we deliberately install a no-op device here. See #7161
+        // user-facing output, so the host must not produce console output of its own. See #7161
         // and dotnet/sdk#51615 for the broader context.
+        //
+        // Outside Azure DevOps there is nothing to forward, so we keep the pure no-op device. Under
+        // Azure DevOps the AzureDevOpsReport extension produces logging commands (##[group],
+        // ##vso[...]) that must still reach the pipeline log; DotnetTestPassthroughOutputDevice
+        // forwards those marked lines to the SDK over the protocol while discarding everything else.
+        // The forwarder gates on the agent only (TF_BUILD), NOT the TESTINGPLATFORM_AZDO_OUTPUT opt-out:
+        // that opt-out is scoped to the platform's automatic ##vso[task.logissue] emission, and honoring
+        // it here would make multi-assembly forwarding inconsistent with single-assembly runs (where the
+        // extension's output is gated on TF_BUILD alone).
         if (isPipeProtocol)
         {
-            return new ProxyOutputDevice(new NopPlatformOutputDevice(), serverModeOutputDevice: null);
+            IPlatformOutputDevice pipeProtocolOutputDevice =
+                AzureDevOpsLogIssueFormatter.IsAzureDevOpsAgent(serviceProvider.GetEnvironment())
+                    ? new DotnetTestPassthroughOutputDevice(serviceProvider)
+                    : new NopPlatformOutputDevice();
+
+            return new ProxyOutputDevice(pipeProtocolOutputDevice, serverModeOutputDevice: null);
         }
 
         // SetPlatformOutputDevice isn't public yet. Before exposing it, we should decide

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -127,7 +127,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             bool.TryParse(isIDEValue, out bool isIDE) &&
             isIDE;
 
-        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersion) == true)
+        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersion) is true)
         {
             bool isCompatible = IsVersionCompatible(protocolVersion, supportedProtocolVersions);
             IsLogForwardingSupported = isCompatible
@@ -150,28 +150,29 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 
     public async Task SendMessageAsync(IRequest message)
     {
-        RoslynDebug.Assert(_dotnetTestPipeClient is not null);
+        NamedPipeClient dotnetTestPipeClient = _dotnetTestPipeClient
+            ?? throw new InvalidOperationException("The dotnet test pipe client is not connected.");
 
         switch (message)
         {
             case DiscoveredTestMessages discoveredTestMessages:
-                await _dotnetTestPipeClient.RequestReplyAsync<DiscoveredTestMessages, VoidResponse>(discoveredTestMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                await dotnetTestPipeClient.RequestReplyAsync<DiscoveredTestMessages, VoidResponse>(discoveredTestMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
 
             case TestResultMessages testResultMessages:
-                await _dotnetTestPipeClient.RequestReplyAsync<TestResultMessages, VoidResponse>(testResultMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                await dotnetTestPipeClient.RequestReplyAsync<TestResultMessages, VoidResponse>(testResultMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
 
             case FileArtifactMessages fileArtifactMessages:
-                await _dotnetTestPipeClient.RequestReplyAsync<FileArtifactMessages, VoidResponse>(fileArtifactMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                await dotnetTestPipeClient.RequestReplyAsync<FileArtifactMessages, VoidResponse>(fileArtifactMessages, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
 
             case TestSessionEvent testSessionEvent:
-                await _dotnetTestPipeClient.RequestReplyAsync<TestSessionEvent, VoidResponse>(testSessionEvent, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                await dotnetTestPipeClient.RequestReplyAsync<TestSessionEvent, VoidResponse>(testSessionEvent, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
 
             case AzureDevOpsLogMessage azureDevOpsLogMessage:
-                await _dotnetTestPipeClient.RequestReplyAsync<AzureDevOpsLogMessage, VoidResponse>(azureDevOpsLogMessage, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                await dotnetTestPipeClient.RequestReplyAsync<AzureDevOpsLogMessage, VoidResponse>(azureDevOpsLogMessage, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
         }
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -87,6 +87,11 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 
     public bool IsIDE { get; private set; }
 
+    // True once the handshake negotiated protocol version 1.2.0 or later, which is when the SDK is
+    // able to receive AzureDevOpsLogMessage forwards. The host gates forwarding on this so an older
+    // SDK (1.0.0/1.1.0) never receives an unknown message id.
+    public bool IsLogForwardingSupported { get; private set; }
+
     public async Task<bool> IsCompatibleProtocolAsync(string hostType, IReadOnlyDictionary<byte, string>? additionalHandshakeProperties = null)
     {
         RoslynDebug.Assert(_dotnetTestPipeClient is not null);
@@ -122,8 +127,16 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             bool.TryParse(isIDEValue, out bool isIDE) &&
             isIDE;
 
-        return response.Properties?.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersion) == true &&
-            IsVersionCompatible(protocolVersion, supportedProtocolVersions);
+        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersion) == true)
+        {
+            bool isCompatible = IsVersionCompatible(protocolVersion, supportedProtocolVersions);
+            IsLogForwardingSupported = isCompatible
+                && Version.TryParse(protocolVersion, out Version? negotiatedVersion)
+                && negotiatedVersion >= new Version(1, 2, 0);
+            return isCompatible;
+        }
+
+        return false;
     }
 
     private string GetExecutionMode()
@@ -155,6 +168,10 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 
             case TestSessionEvent testSessionEvent:
                 await _dotnetTestPipeClient.RequestReplyAsync<TestSessionEvent, VoidResponse>(testSessionEvent, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+                break;
+
+            case AzureDevOpsLogMessage azureDevOpsLogMessage:
+                await _dotnetTestPipeClient.RequestReplyAsync<AzureDevOpsLogMessage, VoidResponse>(azureDevOpsLogMessage, _cancellationTokenSource.CancellationToken).ConfigureAwait(false);
                 break;
         }
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -92,10 +92,21 @@ internal static class ProtocolConstants
     // When both sides advertise 1.1.0 and we negotiate to that version, the SDK can keep its
     // live output enabled.
     //
-    // NOTE: The no-op output device is installed for all pipe-protocol connections, regardless
-    // of the negotiated protocol version. With an old SDK that only supports 1.0.0, both sides
-    // will produce no live output (the SDK suppresses its TerminalTestReporter to avoid colliding
-    // with the host output it expected before this change). Users must update to an SDK that
-    // negotiates 1.1.0 to see live output via the SDK's TerminalTestReporter.
-    internal const string SupportedVersions = "1.0.0;1.1.0";
+    // 1.2.0 adds the AzureDevOpsLogMessage: under the pipe protocol the host installs a no-op output
+    // device (see below), so any Azure DevOps logging commands (##[group], ##vso[...]) produced by the
+    // AzureDevOpsReport extension would otherwise be swallowed. When both sides negotiate 1.2.0 the host
+    // forwards those marked lines to the SDK over the pipe, and the SDK writes them verbatim to its
+    // TerminalTestReporter so they reach the pipeline log. An older SDK that only negotiates 1.1.0 never
+    // receives the message (the host gates forwarding on the negotiated version), so it stays compatible.
+    //
+    // NOTE: Under the pipe protocol the host installs a no-op output device for regular output
+    // regardless of the negotiated protocol version (the SDK's TerminalTestReporter owns user-facing
+    // output). The sole exception is when running on an Azure DevOps agent with a negotiated version of
+    // 1.2.0 or later: the host then installs a forwarder that still discards regular output but relays
+    // Azure DevOps logging commands as AzureDevOpsLogMessage (see OutputDeviceManager.BuildAsync).
+    // With an old SDK that only supports 1.0.0, both sides will produce no live output (the SDK
+    // suppresses its TerminalTestReporter to avoid colliding with the host output it expected before
+    // this change). Users must update to an SDK that negotiates 1.1.0 to see live output via the SDK's
+    // TerminalTestReporter.
+    internal const string SupportedVersions = "1.0.0;1.1.0;1.2.0";
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/AzureDevOpsLogMessage.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/AzureDevOpsLogMessage.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.IPC.Models;
+
+// A single line of Azure DevOps "passthrough" output produced by the AzureDevOpsReport extension
+// (e.g. ##[group], ##[endgroup], ##vso[...]) that must reach the pipeline log even though the pipe
+// protocol installs a no-op output device on the host. The SDK writes LogText verbatim to its
+// TerminalTestReporter. Introduced with protocol version 1.2.0; the host only sends it when the SDK
+// negotiates 1.2.0 or later.
+internal sealed record AzureDevOpsLogMessage(string? ExecutionId, string? InstanceId, string? LogText) : IRequest;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -176,3 +176,13 @@ internal static class TestInProgressMessageFieldsId
     public const ushort Uid = 1;
     public const ushort DisplayName = 2;
 }
+
+[Embedded]
+internal static class AzureDevOpsLogMessageFieldsId
+{
+    public const int MessagesSerializerId = 11;
+
+    public const ushort ExecutionId = 1;
+    public const ushort InstanceId = 2;
+    public const ushort LogText = 3;
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC.Models;
+
+namespace Microsoft.Testing.Platform.IPC.Serializers;
+
+/*
+    |---FieldCount---| 2 bytes
+
+    |---ExecutionId Id---| (2 bytes)
+    |---ExecutionId Size---| (4 bytes)
+    |---ExecutionId Value---| (n bytes)
+
+    |---InstanceId Id---| (2 bytes)
+    |---InstanceId Size---| (4 bytes)
+    |---InstanceId Value---| (n bytes)
+
+    |---LogText Id---| (2 bytes)
+    |---LogText Size---| (4 bytes)
+    |---LogText Value---| (n bytes)
+*/
+
+internal sealed class AzureDevOpsLogMessageSerializer : NamedPipeSerializer<AzureDevOpsLogMessage>, INamedPipeSerializer
+{
+    public override int Id => AzureDevOpsLogMessageFieldsId.MessagesSerializerId;
+
+    protected override AzureDevOpsLogMessage DeserializeCore(Stream stream)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+        string? logText = null;
+
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case AzureDevOpsLogMessageFieldsId.ExecutionId:
+                    executionId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case AzureDevOpsLogMessageFieldsId.InstanceId:
+                    instanceId = ReadStringValue(stream, fieldSize);
+                    break;
+
+                case AzureDevOpsLogMessageFieldsId.LogText:
+                    logText = ReadStringValue(stream, fieldSize);
+                    break;
+
+                default:
+                    // If we don't recognize the field id, skip the payload corresponding to that field
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
+            }
+        }
+
+        return new(executionId, instanceId, logText);
+    }
+
+    protected override void SerializeCore(AzureDevOpsLogMessage objectToSerialize, Stream stream)
+    {
+        RoslynDebug.Assert(stream.CanSeek, "We expect a seekable stream.");
+
+        WriteUShort(stream, GetFieldCount(objectToSerialize));
+
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.ExecutionId, objectToSerialize.ExecutionId);
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.InstanceId, objectToSerialize.InstanceId);
+        WriteField(stream, AzureDevOpsLogMessageFieldsId.LogText, objectToSerialize.LogText);
+    }
+
+    private static ushort GetFieldCount(AzureDevOpsLogMessage message) =>
+        (ushort)((message.ExecutionId is null ? 0 : 1) +
+        (message.InstanceId is null ? 0 : 1) +
+        (message.LogText is null ? 0 : 1));
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeAzureDevOpsForwardingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeAzureDevOpsForwardingTests.cs
@@ -99,11 +99,15 @@ public sealed class DotnetTestPipeAzureDevOpsForwardingTests : AcceptanceTestBas
         var testHost = TestInfrastructure.TestHost.LocateFrom(
             AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
 
-        // 1.2.0 is negotiated, but without TF_BUILD the host is not on an Azure DevOps agent, so the
-        // AzureDevOpsReport extension produces nothing and the forwarder stays a no-op.
+        // 1.2.0 is negotiated, but TF_BUILD=false means the host is not on an Azure DevOps agent, so the
+        // AzureDevOpsReport extension produces nothing and the forwarder stays a no-op. We set TF_BUILD
+        // explicitly to "false" rather than leaving it unset because CI itself runs on an Azure DevOps
+        // agent (where TF_BUILD=true is inherited), which would otherwise make this scenario impossible to
+        // exercise.
         FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
             testHost,
             extraArguments: "--report-azdo",
+            environmentVariables: new Dictionary<string, string?> { ["TF_BUILD"] = "false" },
             supportedProtocolVersions: HostAdvertisedProtocolVersions,
             cancellationToken: TestContext.CancellationToken);
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeAzureDevOpsForwardingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeAzureDevOpsForwardingTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// Acceptance tests for forwarding Azure DevOps logging commands over the
+/// <c>--server dotnettestcli --dotnet-test-pipe</c> protocol.
+/// <para>
+/// Under the pipe protocol the host installs a no-op output device, so the AzureDevOpsReport
+/// extension's logging commands (<c>##[group]</c>, <c>##vso[...]</c>) would otherwise be swallowed
+/// in multi-assembly runs. Protocol 1.2.0 adds <c>AzureDevOpsLogMessage</c> (serializer id 11): when
+/// both sides negotiate 1.2.0 and the host is running on an Azure DevOps agent, those marked lines are
+/// forwarded to the SDK instead of being dropped. These tests assert that contract on the wire via the
+/// black-box <see cref="FakeDotnetTestSdk"/> harness.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class DotnetTestPipeAzureDevOpsForwardingTests : AcceptanceTestBase<DotnetTestPipeAzureDevOpsForwardingTests.TestAssetFixture>
+{
+    private const string AssetName = "DotnetTestPipeAzureDevOpsForwarding";
+
+    // Mirrors ProtocolConstants.SupportedVersions on the host side: the host advertises 1.2.0, the
+    // version that introduced AzureDevOpsLogMessage forwarding.
+    private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0;1.2.0";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task DotnetTestPipe_WhenSdkSupports120AndRunningInAzureDevOps_ForwardsLogGroupCommands()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            extraArguments: "--report-azdo",
+            environmentVariables: new Dictionary<string, string?> { ["TF_BUILD"] = "true" },
+            supportedProtocolVersions: HostAdvertisedProtocolVersions,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual(
+            "1.2.0",
+            result.NegotiatedProtocolVersion,
+            "When both sides advertise 1.2.0, negotiation should select 1.2.0 to enable Azure DevOps log forwarding.");
+
+        string[] forwardedLines = GetForwardedAzureDevOpsLines(result);
+
+        Assert.Contains(
+            line => line.StartsWith("##[group]", StringComparison.Ordinal),
+            forwardedLines,
+            $"Expected a forwarded '##[group]' command. Forwarded lines: [{string.Join(" | ", forwardedLines)}].");
+        Assert.Contains(
+            "##[endgroup]",
+            forwardedLines,
+            $"Expected a forwarded '##[endgroup]' command. Forwarded lines: [{string.Join(" | ", forwardedLines)}].");
+
+        // The forwarded frames carry the same InstanceId as the handshake so the SDK can correlate the
+        // logging commands back to the originating assembly in a multi-assembly run.
+        Assert.IsNotNull(result.ReceivedHandshake);
+        Assert.IsTrue(result.ReceivedHandshake.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.InstanceId, out string? handshakeInstanceId));
+        string[] forwardedInstanceIds = [..
+            result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.AzureDevOpsLogMessage)
+                .Select(m => DotnetTestPipeProtocol.DecodeAzureDevOpsLogMessageBody(m.Body).InstanceId)
+                .Where(id => id is not null)
+                .Select(id => id!)
+                .Distinct()];
+        string onlyInstanceId = Assert.ContainsSingle(forwardedInstanceIds);
+        Assert.AreEqual(handshakeInstanceId, onlyInstanceId);
+    }
+
+    [TestMethod]
+    public async Task DotnetTestPipe_WhenSdkOnlySupports110_DoesNotForwardLogMessages()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        // An older SDK that does not understand AzureDevOpsLogMessage advertises only up to 1.1.0.
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            extraArguments: "--report-azdo",
+            environmentVariables: new Dictionary<string, string?> { ["TF_BUILD"] = "true" },
+            supportedProtocolVersions: "1.0.0;1.1.0",
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual(
+            "1.1.0",
+            result.NegotiatedProtocolVersion,
+            "An SDK that supports up to 1.1.0 should negotiate down to 1.1.0.");
+
+        Assert.IsEmpty(
+            result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.AzureDevOpsLogMessage),
+            "No AzureDevOpsLogMessage should be forwarded when the negotiated protocol is below 1.2.0.");
+    }
+
+    [TestMethod]
+    public async Task DotnetTestPipe_WhenNotRunningInAzureDevOps_DoesNotForwardLogMessages()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        // 1.2.0 is negotiated, but without TF_BUILD the host is not on an Azure DevOps agent, so the
+        // AzureDevOpsReport extension produces nothing and the forwarder stays a no-op.
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            extraArguments: "--report-azdo",
+            supportedProtocolVersions: HostAdvertisedProtocolVersions,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreEqual("1.2.0", result.NegotiatedProtocolVersion);
+
+        Assert.IsEmpty(
+            result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.AzureDevOpsLogMessage),
+            "No AzureDevOpsLogMessage should be forwarded when not running on an Azure DevOps agent.");
+    }
+
+    private static string[] GetForwardedAzureDevOpsLines(FakeDotnetTestSdkResult result)
+        => [..
+            result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.AzureDevOpsLogMessage)
+                .Select(m => DotnetTestPipeProtocol.DecodeAzureDevOpsLogMessageBody(m.Body).LogText)
+                .Where(text => text is not null)
+                .Select(text => text!)];
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string Sources = """
+#file DotnetTestPipeAzureDevOpsForwarding.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseAppHost>true</UseAppHost>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="$MicrosoftTestingPlatformVersion$" />
+  </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, __) => new DummyTestFramework());
+        builder.AddAzureDevOpsProvider();
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DummyTestFramework : ITestFramework
+{
+    public string Uid => nameof(DummyTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DummyTestFramework);
+    public string Description => nameof(DummyTestFramework);
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        context.Complete();
+        return Task.CompletedTask;
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            Sources
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -32,7 +32,7 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
     private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0;1.2.0";
 
     [TestMethod]
-    public async Task DotnetTestPipe_TestAppAdvertises100And110_NegotiatesDownToV100WithOldSdk()
+    public async Task DotnetTestPipe_TestAppAdvertisesAllSupportedVersions_NegotiatesDownToV100WithOldSdk()
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(
             AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -25,11 +25,11 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
 
     public TestContext TestContext { get; set; } = null!;
 
-    // The test host (testfx) now advertises both protocol 1.0.0 and 1.1.0. The 1.1.0 bump signals
-    // that TerminalOutputDevice is no longer plugged in under the pipe protocol (see
-    // microsoft/testfx#7161 and dotnet/sdk#51615). This mirrors ProtocolConstants.SupportedVersions
-    // on the host side.
-    private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0";
+    // The test host (testfx) now advertises protocol 1.0.0, 1.1.0 and 1.2.0. The 1.1.0 bump signalled
+    // that TerminalOutputDevice is no longer plugged in under the pipe protocol (microsoft/testfx#7161
+    // and dotnet/sdk#51615); 1.2.0 added AzureDevOpsLogMessage forwarding. This mirrors
+    // ProtocolConstants.SupportedVersions on the host side.
+    private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0;1.2.0";
 
     [TestMethod]
     public async Task DotnetTestPipe_TestAppAdvertises100And110_NegotiatesDownToV100WithOldSdk()
@@ -50,7 +50,7 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
         Assert.AreEqual(
             HostAdvertisedProtocolVersions,
             appVersions,
-            "The test app should advertise both 1.0.0 and 1.1.0 once the TerminalOutputDevice bump landed.");
+            "The test app should advertise 1.0.0, 1.1.0 and 1.2.0 once the AzureDevOpsLogMessage forwarding bump landed.");
 
         Assert.AreEqual(
             FakeDotnetTestSdk.DefaultSupportedProtocolVersions,
@@ -64,11 +64,11 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
         var testHost = TestInfrastructure.TestHost.LocateFrom(
             AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
 
-        // The fake SDK advertises both versions, so negotiation should pick the highest mutually
-        // supported version: 1.1.0.
+        // The fake SDK advertises up to 1.1.0, so negotiation should pick the highest mutually
+        // supported version: 1.1.0 (even though the host also supports 1.2.0).
         FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
             testHost,
-            supportedProtocolVersions: HostAdvertisedProtocolVersions,
+            supportedProtocolVersions: "1.0.0;1.1.0",
             cancellationToken: TestContext.CancellationToken);
 
         Assert.IsNotNull(result.ReceivedHandshake, "Test app never sent a handshake message.");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -40,6 +40,7 @@ internal static class DotnetTestPipeProtocol
         public const int TestSessionEvent = 8;
         public const int HandshakeMessage = 9;
         public const int TestInProgressMessages = 10;
+        public const int AzureDevOpsLogMessage = 11;
     }
 
     public static class HandshakeProperties
@@ -69,6 +70,13 @@ internal static class DotnetTestPipeProtocol
         public const ushort SessionType = 1;
         public const ushort SessionUid = 2;
         public const ushort ExecutionId = 3;
+    }
+
+    public static class AzureDevOpsLogMessageFields
+    {
+        public const ushort ExecutionId = 1;
+        public const ushort InstanceId = 2;
+        public const ushort LogText = 3;
     }
 
     /// <summary>
@@ -219,6 +227,44 @@ internal static class DotnetTestPipeProtocol
         }
 
         return (sessionType, sessionUid, executionId);
+    }
+
+    /// <summary>
+    /// Decodes the body of a <see cref="SerializerIds.AzureDevOpsLogMessage"/> frame.
+    /// Format: <c>ushort fieldCount; (ushort fieldId, int fieldSize, payload)*fieldCount</c>
+    /// where every field is a length-prefixed UTF-8 string. Returns <c>null</c> for absent fields.
+    /// </summary>
+    public static (string? ExecutionId, string? InstanceId, string? LogText) DecodeAzureDevOpsLogMessageBody(byte[] body)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+        string? logText = null;
+
+        using MemoryStream stream = new(body, writable: false);
+        ushort fieldCount = ReadUShort(stream);
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case AzureDevOpsLogMessageFields.ExecutionId:
+                    executionId = ReadFixedSizeString(stream, fieldSize);
+                    break;
+                case AzureDevOpsLogMessageFields.InstanceId:
+                    instanceId = ReadFixedSizeString(stream, fieldSize);
+                    break;
+                case AzureDevOpsLogMessageFields.LogText:
+                    logText = ReadFixedSizeString(stream, fieldSize);
+                    break;
+                default:
+                    stream.Seek(fieldSize, SeekOrigin.Current);
+                    break;
+            }
+        }
+
+        return (executionId, instanceId, logText);
     }
 
     /// <summary>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
@@ -428,7 +428,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         => segments.Aggregate(OutsideResultsDirectory, Path.Combine);
 
     private string[] GetFormattedLines()
-        => [.. _outputData.OfType<FormattedTextOutputDeviceData>().Select(output => output.Text)];
+        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
 
     private string[] GetWarnings()
         => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport;
@@ -61,7 +61,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreateFailedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
         Assert.IsEmpty(GetWarnings());
     }
 
@@ -88,9 +88,9 @@ public sealed class AzureDevOpsArtifactUploaderTests
                 "##vso[build.addbuildtag]has-hangdump",
                 "##vso[build.addbuildtag]has-test-failures",
             },
-            GetFormattedLines(),
+            GetCommandLines(),
             SequenceOrder.InAnyOrder);
-        Assert.DoesNotContain(line => line.Contains("artifact.upload", StringComparison.Ordinal), GetFormattedLines());
+        Assert.DoesNotContain(line => line.Contains("artifact.upload", StringComparison.Ordinal), GetCommandLines());
         Assert.IsEmpty(GetWarnings());
     }
 
@@ -112,7 +112,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreateFailedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        string[] lines = GetFormattedLines();
+        string[] lines = GetCommandLines();
         Assert.HasCount(2, lines);
         Assert.IsTrue(lines.All(line => line.StartsWith("##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]", StringComparison.Ordinal)));
         Assert.DoesNotContain(line => line.Contains("build.addbuildtag", StringComparison.Ordinal), lines);
@@ -137,7 +137,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
 
         Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("inside.trx")}" },
-            GetFormattedLines());
+            GetCommandLines());
     }
 
     [TestMethod]
@@ -166,7 +166,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
                 "##vso[build.addbuildtag]has-test-failures",
                 $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("test.trx")}",
             },
-            GetFormattedLines());
+            GetCommandLines());
     }
 
     [TestMethod]
@@ -190,7 +190,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
 
         Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("keep.trx")}" },
-            GetFormattedLines());
+            GetCommandLines());
     }
 
     [TestMethod]
@@ -214,7 +214,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-hangdump",
             },
-            GetFormattedLines(),
+            GetCommandLines(),
             SequenceOrder.InAnyOrder);
     }
 
@@ -232,7 +232,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer("GenericProducer", "Generic"), CreateFileArtifact(InResults("hang", "dump.dmp")), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
     }
 
     [TestMethod]
@@ -249,7 +249,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.ConsumeAsync(CreateProducer(), CreatePassedTestNodeUpdateMessage(), CancellationToken.None).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.DoesNotContain("##vso[build.addbuildtag]has-test-failures", GetFormattedLines());
+        Assert.DoesNotContain("##vso[build.addbuildtag]has-test-failures", GetCommandLines());
     }
 
     [TestMethod]
@@ -273,7 +273,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         Assert.AreSequenceEqual(
             new[] { "Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags." },
             GetWarnings());
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
     }
 
     [TestMethod]
@@ -291,7 +291,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
         Assert.IsEmpty(GetWarnings());
     }
 
@@ -309,7 +309,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionStartingAsync(new TestSessionContext()).ConfigureAwait(false);
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
         Assert.IsEmpty(GetWarnings());
     }
 
@@ -333,7 +333,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
 
         Assert.AreSequenceEqual(
             new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{escapedSpecialPath}" },
-            GetFormattedLines());
+            GetCommandLines());
     }
 
     [DataRow(AzureDevOpsCommandLineOptions.AzureDevOpsUploadArtifactInclude, @"C:\absolute\*.trx")]
@@ -427,8 +427,8 @@ public sealed class AzureDevOpsArtifactUploaderTests
     private static string OutsideResults(params string[] segments)
         => segments.Aggregate(OutsideResultsDirectory, Path.Combine);
 
-    private string[] GetFormattedLines()
-        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
+    private string[] GetCommandLines()
+        => [.. _outputData.OfType<AzureDevOpsCommandOutputDeviceData>().Select(data => data.Text)];
 
     private string[] GetWarnings()
         => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
@@ -65,7 +65,7 @@ public sealed class AzureDevOpsLogGroupReporterTests
 
         await reporter.OnTestSessionStartingAsync(new TestSessionContext());
 
-        string[] lines = GetFormattedLines();
+        string[] lines = GetCommandLines();
         Assert.HasCount(1, lines);
         string headerPrefix = AzureDevOpsResources.LogGroupHeader.Replace("{0}", string.Empty);
         Assert.StartsWith($"##[group]{headerPrefix}MyAssembly (", lines[0]);
@@ -79,7 +79,7 @@ public sealed class AzureDevOpsLogGroupReporterTests
         await reporter.OnTestSessionStartingAsync(new TestSessionContext());
         await reporter.OnTestSessionFinishingAsync(new TestSessionContext());
 
-        string[] lines = GetFormattedLines();
+        string[] lines = GetCommandLines();
         Assert.HasCount(2, lines);
         Assert.StartsWith("##[group]", lines[0]);
         Assert.AreEqual("##[endgroup]", lines[1]);
@@ -92,7 +92,7 @@ public sealed class AzureDevOpsLogGroupReporterTests
 
         await reporter.OnTestSessionFinishingAsync(new TestSessionContext());
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
     }
 
     [TestMethod]
@@ -108,7 +108,7 @@ public sealed class AzureDevOpsLogGroupReporterTests
             CreateTestNodeUpdateMessage("t1", new PassedTestNodeStateProperty()),
             CancellationToken.None);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
     }
 
     private static TestNodeUpdateMessage CreateTestNodeUpdateMessage(string uid, TestNodeStateProperty state)
@@ -136,8 +136,8 @@ public sealed class AzureDevOpsLogGroupReporterTests
             _loggerFactoryMock.Object);
     }
 
-    private string[] GetFormattedLines()
-        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
+    private string[] GetCommandLines()
+        => [.. _outputData.OfType<AzureDevOpsCommandOutputDeviceData>().Select(data => data.Text)];
 
     private sealed class TestSessionContext : ITestSessionContext
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
@@ -137,7 +137,7 @@ public sealed class AzureDevOpsLogGroupReporterTests
     }
 
     private string[] GetFormattedLines()
-        => [.. _outputData.OfType<FormattedTextOutputDeviceData>().Select(output => output.Text)];
+        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
 
     private sealed class TestSessionContext : ITestSessionContext
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
@@ -199,7 +199,7 @@ public sealed class AzureDevOpsSummaryReporterTests
     private static IDataProducer CreateProducer() => new TestProducer();
 
     private string[] GetFormattedLines()
-        => [.. _outputData.OfType<FormattedTextOutputDeviceData>().Select(output => output.Text)];
+        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
 
     private string[] GetWarnings()
         => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsSummaryReporterTests.cs
@@ -63,7 +63,7 @@ public sealed class AzureDevOpsSummaryReporterTests
         await reporter.ConsumeAsync(CreateProducer(), CreatePassed("t1"), CancellationToken.None).ConfigureAwait(false);
         await reporter.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
-        Assert.IsEmpty(GetFormattedLines());
+        Assert.IsEmpty(GetCommandLines());
     }
 
     [TestMethod]
@@ -157,7 +157,7 @@ public sealed class AzureDevOpsSummaryReporterTests
         string written = System.Text.Encoding.UTF8.GetString(memoryStream.ToArray());
         Assert.Contains("MyAssembly", written);
 
-        string[] lines = GetFormattedLines();
+        string[] lines = GetCommandLines();
         Assert.HasCount(1, lines);
         Assert.StartsWith("##vso[task.uploadsummary]", lines[0]);
         Assert.Contains("azdo-summary-", lines[0]);
@@ -198,8 +198,8 @@ public sealed class AzureDevOpsSummaryReporterTests
 
     private static IDataProducer CreateProducer() => new TestProducer();
 
-    private string[] GetFormattedLines()
-        => [.. _outputData.OfType<TextOutputDeviceData>().Select(output => output.Text)];
+    private string[] GetCommandLines()
+        => [.. _outputData.OfType<AzureDevOpsCommandOutputDeviceData>().Select(data => data.Text)];
 
     private string[] GetWarnings()
         => [.. _outputData.OfType<WarningMessageOutputDeviceData>().Select(output => output.Message)];

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
@@ -37,6 +37,7 @@ public sealed class DotnetTestProtocolContractTests
             [TestSessionEventFieldsId.MessagesSerializerId] = nameof(TestSessionEventFieldsId),
             [HandshakeMessageFieldsId.MessagesSerializerId] = nameof(HandshakeMessageFieldsId),
             [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
+            [AzureDevOpsLogMessageFieldsId.MessagesSerializerId] = nameof(AzureDevOpsLogMessageFieldsId),
         };
 
         Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
@@ -51,6 +52,7 @@ public sealed class DotnetTestProtocolContractTests
         Assert.AreEqual(nameof(TestSessionEventFieldsId), serializerIds[8]);
         Assert.AreEqual(nameof(HandshakeMessageFieldsId), serializerIds[9]);
         Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
+        Assert.AreEqual(nameof(AzureDevOpsLogMessageFieldsId), serializerIds[11]);
     }
 
     [TestMethod]
@@ -138,6 +140,6 @@ public sealed class DotnetTestProtocolContractTests
         // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
         // constant as "always true" (MSTEST0032).
         string[] versions = [ProtocolConstants.SupportedVersions];
-        Assert.AreEqual("1.0.0;1.1.0", versions[0]);
+        Assert.AreEqual("1.0.0;1.1.0;1.2.0", versions[0]);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -32,6 +32,32 @@ public sealed class ProtocolTests
     }
 
     [TestMethod]
+    public void AzureDevOpsLogMessageSerializeDeserialize()
+    {
+        object serializer = new AzureDevOpsLogMessageSerializer();
+        var message = new AzureDevOpsLogMessage("MyExecId", "MyInstId", "##[group]Tests: MyAssembly (net9.0)");
+
+        AzureDevOpsLogMessage actual = RoundTrip(serializer, message);
+
+        Assert.AreEqual(message.ExecutionId, actual.ExecutionId);
+        Assert.AreEqual(message.InstanceId, actual.InstanceId);
+        Assert.AreEqual(message.LogText, actual.LogText);
+    }
+
+    [TestMethod]
+    public void AzureDevOpsLogMessageSerializeDeserialize_WithNullOptionalFields()
+    {
+        object serializer = new AzureDevOpsLogMessageSerializer();
+        var message = new AzureDevOpsLogMessage(null, null, "##[endgroup]");
+
+        AzureDevOpsLogMessage actual = RoundTrip(serializer, message);
+
+        Assert.IsNull(actual.ExecutionId);
+        Assert.IsNull(actual.InstanceId);
+        Assert.AreEqual("##[endgroup]", actual.LogText);
+    }
+
+    [TestMethod]
     public void DiscoveredTestMessagesSerializeDeserialize()
     {
         object serializer = new DiscoveredTestMessagesSerializer();
@@ -360,6 +386,7 @@ public sealed class ProtocolTests
             [TestSessionEventFieldsId.MessagesSerializerId] = nameof(TestSessionEventFieldsId),
             [HandshakeMessageFieldsId.MessagesSerializerId] = nameof(HandshakeMessageFieldsId),
             [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
+            [AzureDevOpsLogMessageFieldsId.MessagesSerializerId] = nameof(AzureDevOpsLogMessageFieldsId),
         };
 
         Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
@@ -374,6 +401,7 @@ public sealed class ProtocolTests
         Assert.AreEqual(nameof(TestSessionEventFieldsId), serializerIds[8]);
         Assert.AreEqual(nameof(HandshakeMessageFieldsId), serializerIds[9]);
         Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
+        Assert.AreEqual(nameof(AzureDevOpsLogMessageFieldsId), serializerIds[11]);
     }
 
     // The SessionEventTypes byte values flow over IPC to dotnet test in the dotnet/sdk repository.
@@ -429,6 +457,6 @@ public sealed class ProtocolTests
         // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
         // constant as "always true" (MSTEST0032).
         string[] versions = [ProtocolConstants.SupportedVersions];
-        Assert.AreEqual("1.0.0;1.1.0", versions[0]);
+        Assert.AreEqual("1.0.0;1.1.0;1.2.0", versions[0]);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/AzureDevOpsLogIssueFormatterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/AzureDevOpsLogIssueFormatterTests.cs
@@ -111,4 +111,37 @@ public sealed class AzureDevOpsLogIssueFormatterTests
 
         Assert.IsTrue(AzureDevOpsLogIssueFormatter.IsAzureDevOpsEnvironment(environment.Object));
     }
+
+    [DataRow("off")]
+    [DataRow("false")]
+    [DataRow("0")]
+    [TestMethod]
+    public void IsAzureDevOpsAgent_IgnoresOptOutAndReturnsTrueWhenTfBuildIsTrue(string optOutValue)
+    {
+        // The opt-out only governs the platform's automatic ##vso[task.logissue] emission; the explicit
+        // --report-azdo extension output (which is what the passthrough device forwards) must stay enabled.
+        var environment = new Mock<IEnvironment>();
+        environment.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("true");
+        environment.Setup(e => e.GetEnvironmentVariable("TESTINGPLATFORM_AZDO_OUTPUT")).Returns(optOutValue);
+
+        Assert.IsTrue(AzureDevOpsLogIssueFormatter.IsAzureDevOpsAgent(environment.Object));
+    }
+
+    [TestMethod]
+    public void IsAzureDevOpsAgent_ReturnsFalseWhenTfBuildIsAbsent()
+    {
+        var environment = new Mock<IEnvironment>();
+        environment.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns((string?)null);
+
+        Assert.IsFalse(AzureDevOpsLogIssueFormatter.IsAzureDevOpsAgent(environment.Object));
+    }
+
+    [TestMethod]
+    public void IsAzureDevOpsAgent_ReturnsFalseWhenTfBuildIsFalse()
+    {
+        var environment = new Mock<IEnvironment>();
+        environment.Setup(e => e.GetEnvironmentVariable("TF_BUILD")).Returns("false");
+
+        Assert.IsFalse(AzureDevOpsLogIssueFormatter.IsAzureDevOpsAgent(environment.Object));
+    }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/DotnetTestPassthroughOutputDeviceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/DotnetTestPassthroughOutputDeviceTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.ServerMode;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class DotnetTestPassthroughOutputDeviceTests
+{
+    private static readonly IOutputDeviceDataProducer Producer = Mock.Of<IOutputDeviceDataProducer>();
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsFalse_LikeNopDevice()
+    {
+        var device = new DotnetTestPassthroughOutputDevice(Mock.Of<IServiceProvider>());
+        Assert.IsFalse(await device.IsEnabledAsync());
+    }
+
+    [TestMethod]
+    public async Task DisplayAsync_WithNonMarkerData_IsSwallowedWithoutResolvingTheConnection()
+    {
+        // A strict mock fails the test if the device touches the service provider at all: non-marker
+        // output must be discarded as early as NopPlatformOutputDevice would, preserving the deliberate
+        // pipe-protocol suppression.
+        var serviceProvider = new Mock<IServiceProvider>(MockBehavior.Strict);
+        var device = new DotnetTestPassthroughOutputDevice(serviceProvider.Object);
+
+        await device.DisplayAsync(Producer, new FormattedTextOutputDeviceData("##[group]not a marker"), CancellationToken.None);
+
+        serviceProvider.Verify(p => p.GetService(It.IsAny<Type>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DisplayAsync_WithMarkerButNoConnection_IsSwallowedWithoutThrowing()
+    {
+        // The marker is recognized (so the connection is looked up), but with no dotnet test connection
+        // resolved there is nothing to forward to and the line is dropped.
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(p => p.GetService(typeof(IPushOnlyProtocol))).Returns(null!);
+        var device = new DotnetTestPassthroughOutputDevice(serviceProvider.Object);
+
+        await device.DisplayAsync(Producer, new AzureDevOpsCommandOutputDeviceData("##[group]Tests: A (net9.0)"), CancellationToken.None);
+
+        serviceProvider.Verify(p => p.GetService(typeof(IPushOnlyProtocol)), Times.Once);
+    }
+}


### PR DESCRIPTION
## What

Makes the `Microsoft.Testing.Extensions.AzureDevOpsReport` extension's logging commands (`##[group]`, `##[endgroup]`, `##vso[...]`) work in **multi-assembly `dotnet test` runs**, where they were previously swallowed.

## Why

Under the `dotnet test` pipe protocol (`--server dotnettestcli`), the host installs a **no-op output device** (`OutputDeviceManager.BuildAsync`) because the SDK's `TerminalTestReporter` owns all user-facing output (see #7161 / dotnet/sdk#51615). Every AzDO reporter emits through `IOutputDevice`, so in multi-assembly runs **all** of its output — log groups, `##vso[task.logissue]` failure annotations, slow-test lines, artifact-upload/build-tag commands, summary commands — was dropped on the floor. Single-assembly runs (real terminal) were unaffected.

## How

Selective passthrough over the pipe protocol, gated so old SDKs are never affected:

- **Protocol 1.2.0** — new `AzureDevOpsLogMessage` (serializer id **11**, fields `ExecutionId`/`InstanceId`/`LogText`) added to the dotnet-test wire contract; `ProtocolConstants.SupportedVersions` bumped to `1.0.0;1.1.0;1.2.0`. `ObjectFieldIds.cs`/`Constants.cs` are the source-shared contract (kept aligned with dotnet/sdk).
- **Version gating** — `DotnetTestConnection.IsLogForwardingSupported` is true only when the negotiated version is ≥ 1.2.0, so the host never sends id 11 to a 1.0.0/1.1.0 SDK.
- **Marker type** — new internal `AzureDevOpsCommandOutputDeviceData : TextOutputDeviceData`. Because it derives from `TextOutputDeviceData` (not `FormattedTextOutputDeviceData`), single-assembly rendering routes through the existing `case TextOutputDeviceData` and is **byte-for-byte unchanged**.
- **`DotnetTestPassthroughOutputDevice`** — under the pipe protocol on an Azure DevOps agent, this replaces the no-op device: it forwards only marked lines via the protocol and swallows everything else (preserving the deliberate suppression). It gates on `TF_BUILD` only (new `AzureDevOpsLogIssueFormatter.IsAzureDevOpsAgent`), **not** the `TESTINGPLATFORM_AZDO_OUTPUT` opt-out — that opt-out is scoped to the platform's *automatic* `##vso[task.logissue]` emission, and single-assembly extension output is gated on `TF_BUILD` alone, so multi-assembly must match.
- The 5 AzDO emitters now emit the marker.

Zero new public API (all new types are internal; the extension already has `InternalsVisibleTo`).

## Tests

- **Unit:** `AzureDevOpsLogMessage` serializer round-trip (incl. null fields); `DotnetTestPassthroughOutputDevice` swallow behavior; `IsAzureDevOpsAgent` opt-out independence; the `SerializerIds_AreStable` / `ProtocolVersion_IsStable` wire tripwires (and their mirror in the standalone contract test project) updated for id 11 and 1.2.0.
- **Acceptance** (`DotnetTestPipe/DotnetTestPipeAzureDevOpsForwardingTests`): black-box over the wire via the fake-SDK harness — forwards `##[group]`/`##[endgroup]` (with matching `InstanceId`) at 1.2.0 + AzDO; does **not** forward at 1.1.0; does **not** forward off an AzDO agent. Existing pipe baseline tests updated for the version bump.

All green locally: 9/9 DotnetTestPipe acceptance, platform unit + contract tripwires, 158 AzDO extension unit tests.

## Out of scope / follow-ups

- **SDK consumption (the rendering half).** The `dotnet test` SDK must add the aligned id-11 deserializer + reply `VoidResponse`, then write `LogText` to its `TerminalTestReporter` — and that must land **before** any SDK advertises 1.2.0. This PR is safe in the meantime (forwarding is version-gated).
- **Parallel group interleaving** is an SDK-side rendering concern; the forwarded `InstanceId` lets the SDK scope `##[group]`/`##[endgroup]` per assembly.
- Non-command `WarningMessageOutputDeviceData` emits remain swallowed in multi-asm (unchanged behavior; not targeted here).