### PR TITLE
[efficiency-improver] perf: eliminate LINQ iterator allocations in MSTest Analyzer DerivesFrom interface check

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/ITypeSymbolExtensions.cs
+++ b/src/Analyzers/MSTest.Analyzers/RoslynAnalyzerHelpers/ITypeSymbolExtensions.cs
@@ -48,16 +48,19 @@ internal static class ITypeSymbolExtensions
 
         if (!baseTypesOnly && candidateBaseType.TypeKind == TypeKind.Interface)
         {
-            IEnumerable<ITypeSymbol> allInterfaces = symbol.AllInterfaces.OfType<ITypeSymbol>();
-            if (SymbolEqualityComparer.Default.Equals(candidateBaseType.OriginalDefinition, candidateBaseType))
+            // Avoid OfType<ITypeSymbol>() + optional Select() + Contains() chain — each creates a heap-allocated
+            // LINQ iterator state machine. AllInterfaces is ImmutableArray<INamedTypeSymbol>; iterating it
+            // directly uses the struct enumerator (zero heap allocation).
+            bool useOriginalDefinition = SymbolEqualityComparer.Default.Equals(candidateBaseType.OriginalDefinition, candidateBaseType);
+            foreach (INamedTypeSymbol iface in symbol.AllInterfaces)
             {
-                // Candidate base type is not a constructed generic type, so use original definition for interfaces.
-                allInterfaces = allInterfaces.Select(i => i.OriginalDefinition);
-            }
-
-            if (allInterfaces.Contains(candidateBaseType, SymbolEqualityComparer.Default))
-            {
-                return true;
+                // When the candidate is not a constructed generic type, compare via OriginalDefinition
+                // (mirrors the original Select(i => i.OriginalDefinition) projection).
+                ITypeSymbol candidate = useOriginalDefinition ? iface.OriginalDefinition : iface;
+                if (SymbolEqualityComparer.Default.Equals(candidate, candidateBaseType))
+                {
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
## Goal and Rationale

Eliminate up to 2 heap-allocated LINQ iterator state machines from `DerivesFrom()` in `ITypeSymbolExtensions.cs`, a helper called by `Inherits()`, which is invoked **36+ times** across the MSTest.Analyzers suite — once per method/type symbol during analysis.

**Focus Area**: Code-Level Efficiency — removing redundant iterator allocations in a per-symbol hot path.

## Approach

The original code used a three-step LINQ chain over `ImmutableArray<INamedTypeSymbol>`:

```csharp
// Before: up to 2 heap iterator allocations per call
IEnumerable<ITypeSymbol> allInterfaces = symbol.AllInterfaces.OfType<ITypeSymbol>();  // iterator #1
if (useOrigDef)
    allInterfaces = allInterfaces.Select(i => i.OriginalDefinition);                  // iterator #2
if (allInterfaces.Contains(candidateBaseType, SymbolEqualityComparer.Default))        // traverses both
    return true;
```

Replaced with a single direct `foreach` loop:

```csharp
// After: zero heap allocations (ImmutableArray<T> struct enumerator)
bool useOriginalDefinition = SymbolEqualityComparer.Default.Equals(
    candidateBaseType.OriginalDefinition, candidateBaseType);
foreach (INamedTypeSymbol iface in symbol.AllInterfaces)
{
    ITypeSymbol candidate = useOriginalDefinition ? iface.OriginalDefinition : iface;
    if (SymbolEqualityComparer.Default.Equals(candidate, candidateBaseType))
        return true;
}
```

`ImmutableArray<T>.GetEnumerator()` returns a **struct** enumerator, so the `foreach` above is zero-allocation — it compiles directly to an index-based loop over the backing array.

## Energy Efficiency Evidence

**Proxy metric**: managed heap allocations per analyzer invocation (GC pressure / DRAM churn).

| | Before | After |
|---|---|---|
| `OfType<ITypeSymbol>()` iterator | 1 heap alloc per `DerivesFrom` call on an interface | 0 |
| `Select(i => i.OriginalDefinition)` iterator | 1 heap alloc (conditional — when candidate is non-generic) | 0 |
| Iterator traversal in `Contains` | through 1–2 state machine wrappers | direct index loop |

`DerivesFrom` / `Inherits` is called at least once per method and class symbol the analyzer visits. In a project with 200 test methods across 30 classes, a single background analysis pass fires these 36+ times — before any class-level attribute checks. Removing the iterator allocations lowers Gen-0 GC pressure across the entire IDE and CI analysis lifecycle.

**Reasoning linking proxy to energy**: Each Gen-0 collection pauses the analysis thread briefly, consuming CPU cycles that produce no useful work. Fewer short-lived allocations → fewer collections → less wasted CPU energy per compilation.

## Green Software Foundation Context

🌱 **Hardware Efficiency**: Using the ImmutableArray struct enumerator avoids indirection through a virtual `MoveNext()` dispatch chain, making better use of the hardware's instruction pipeline.

🌱 **Software Carbon Intensity (SCI)**: MSTest.Analyzers runs on every developer machine and every CI build in any MSTest project. Reducing per-symbol allocation compounds across millions of analysis invocations per day across the .NET ecosystem.

## Trade-offs

None. The logic is semantically identical:
- `INamedTypeSymbol : ITypeSymbol`, so `OfType<ITypeSymbol>()` was a no-op type filter (every element already satisfies the constraint).
- The ternary `useOriginalDefinition ? iface.OriginalDefinition : iface` exactly mirrors the original `Select(i => i.OriginalDefinition)` branch.
- `Contains` with `SymbolEqualityComparer.Default` is replicated by the `if (Equals(candidate, candidateBaseType))` early-return.

The resulting code is also shorter and easier to read.

## Reproducibility

```bash
# Run all MSTest.Analyzers unit tests (covers DerivesFrom indirectly via every
# analyzer that calls Inherits() in its AnalyzeSymbol callback):
dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests -f net8.0 --no-build
```

## Test Status

CI validation pending (no local .NET SDK in agent environment). The change is a pure algorithmic refactor — identical semantics, different allocation profile. All 36+ call sites in the analyzer suite exercise this code path via their existing unit tests.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/28267711099/agentic_workflow) workflow. · 1.5K AIC · ⌖ 39.6 AIC · ⊞ 58.8K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28267711099, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/28267711099 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->