### PR TITLE
[test-improver] test: add edge case tests for IgnoreStringMethodReturnValueAnalyzer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreStringMethodReturnValueAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreStringMethodReturnValueAnalyzerTests.cs
@@ -156,4 +156,72 @@ public sealed class IgnoreStringMethodReturnValueAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenDiscardAssignmentIgnoresReturnValue_NoDiagnostic()
+    {
+        string code = """
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    string str = "Hello World";
+
+                    // Discard assignment: outer operation is IAssignmentOperation, not IInvocationOperation,
+                    // so the analyzer's early-return guard fires and no diagnostic is reported.
+                    _ = str.Contains("Hello");
+                    _ = str.StartsWith("Hello");
+                    _ = str.EndsWith("World");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenStringMethodReturnValueIgnoredInsideLambda_Diagnostic()
+    {
+        string code = """
+            using System;
+
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    string str = "Hello World";
+
+                    // ExpressionStatement inside a lambda block body is still an ExpressionStatement
+                    // operation, so the analyzer fires inside the lambda just as it does at method level.
+                    Action action = () => { [|str.Contains("Hello")|]; };
+                    Action action2 = () => { [|str.StartsWith("World")|]; };
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenStringMethodResultUsedAsReceiverForChainedCall_NoDiagnostic()
+    {
+        string code = """
+            public class TestClass
+            {
+                public void TestMethod()
+                {
+                    string str = "Hello World";
+
+                    // The ExpressionStatement's outermost operation is GetHashCode() (on System.Boolean),
+                    // not Contains/StartsWith/EndsWith on System.String, so no diagnostic is reported.
+                    // The string method's return value IS used — as the receiver of GetHashCode().
+                    str.Contains("Hello").GetHashCode();
+                    str.StartsWith("Hello").GetHashCode();
+                    str.EndsWith("World").GetHashCode();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreStringMethodReturnValueAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreStringMethodReturnValueAnalyzerTests.cs
@@ -158,7 +158,7 @@ public sealed class IgnoreStringMethodReturnValueAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenDiscardAssignmentIgnoresReturnValue_NoDiagnostic()
+    public async Task WhenExplicitDiscardAssignment_NoDiagnostic()
     {
         string code = """
             public class TestClass
@@ -167,7 +167,7 @@ public sealed class IgnoreStringMethodReturnValueAnalyzerTests
                 {
                     string str = "Hello World";
 
-                    // Discard assignment: outer operation is IAssignmentOperation, not IInvocationOperation,
+                    // Discard assignment: outer operation is ISimpleAssignmentOperation, not IInvocationOperation,
                     // so the analyzer's early-return guard fires and no diagnostic is reported.
                     _ = str.Contains("Hello");
                     _ = str.StartsWith("Hello");


### PR DESCRIPTION
## Goal and Rationale

`IgnoreStringMethodReturnValueAnalyzer` (MSTEST0055) had only 5 tests, all covering the happy path (diagnostic fires / doesn't fire based on whether the result of `Contains`, `StartsWith`, or `EndsWith` is used). Three distinct code paths in the analyzer's guard logic were completely untested:

| Untested path | Guard |
|---|---|
| Discard assignment `_ = str.Contains(...)` | `expressionStatementOperation.Operation is not IInvocationOperation` early return |
| String method call inside a lambda block body | ExpressionStatement inside lambda — should still fire |
| String method result used as a receiver in a chained call | `IsStringMethodCall` on the outer call (not a string method) — should not fire |

## Approach

Added three `[TestMethod]` entries to `IgnoreStringMethodReturnValueAnalyzerTests.cs`:

| Test | What it covers |
|---|---|
| `WhenDiscardAssignmentIgnoresReturnValue_NoDiagnostic` | `_ = str.Contains("Hello")` → outer operation is `IAssignmentOperation`, not `IInvocationOperation` → early return, no diagnostic |
| `WhenStringMethodReturnValueIgnoredInsideLambda_Diagnostic` | `() => { str.Contains("Hello"); }` → ExpressionStatement inside lambda body triggers diagnostic |
| `WhenStringMethodResultUsedAsReceiverForChainedCall_NoDiagnostic` | `str.Contains("Hello").GetHashCode()` → outermost ExpressionStatement operation is `GetHashCode()` on `System.Boolean`, not a string method → no diagnostic on `Contains` |

## Trade-offs

Purely additive — no production code changes, no new dependencies.

## Test Status

All 8 tests pass (5 existing + 3 new):

```
Test run summary: Passed!
  total: 8
  failed: 0
  succeeded: 8
  duration: 5s 537ms
```

## Reproducibility

```bash
.dotnet/dotnet run --project test/UnitTests/MSTest.Analyzers.UnitTests/ -f net8.0 --no-build -- \
  --filter "FullyQualifiedName~IgnoreStringMethodReturnValueAnalyzerTests"
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28270598749/agentic_workflow) workflow. · 1.1K AIC · ⌖ 25.3 AIC · ⊞ 58.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28270598749, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28270598749 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->