### PR TITLE
docs: add missing changelog entries for VideoRecorder (`#9377`) and TreeNode filter fix (`#9458`)

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -39,6 +39,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add --zero-tests-policy &lt;allow-skipped|strict&gt; and make 'allow-skipped' the default so an all-skipped run no longer fails with exit code 8 (use 'strict' for the previous behavior) by @Evangelink in [#9415](https://github.com/microsoft/testfx/pull/9415)
 * Add testconfig.json JSON schema for SchemaStore publication and IDE validation by @Evangelink in [#9405](https://github.com/microsoft/testfx/pull/9405)
 * Add experimental `IBlockingDataConsumer` marker interface for synchronous inline data consumption by @Evangelink in [#9426](https://github.com/microsoft/testfx/pull/9426)
+* Add experimental `Microsoft.Testing.Extensions.VideoRecorder` extension for screen recording during test runs (requires ffmpeg; `--capture-video` opt-in) by @Evangelink in [#9377](https://github.com/microsoft/testfx/pull/9377)
 
 ### Fixed
 
@@ -76,6 +77,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Harden report TFM resolution for custom/non-OS platforms (browserwasm) by @Evangelink in [#9137](https://github.com/microsoft/testfx/pull/9137)
 * Fix --list-tests json output under --server mode by streaming discovered tests to the SDK over the dotnet-test pipe by @Evangelink in [#9192](https://github.com/microsoft/testfx/pull/9192)
 * Make AzureDevOps summary report file name unique per assembly by @Evangelink in [#9264](https://github.com/microsoft/testfx/pull/9264)
+* Fix `--treenode-filter` + `--filter-uid` mutual exclusion: validated up front at CLI parse time (proper `InvalidCommandLine` exit code) instead of a late `NotSupportedException`; documentation gaps for the `!` NOT operator and property-filter semantics addressed by @Evangelink in [#9458](https://github.com/microsoft/testfx/pull/9458)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -77,7 +77,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Harden report TFM resolution for custom/non-OS platforms (browserwasm) by @Evangelink in [#9137](https://github.com/microsoft/testfx/pull/9137)
 * Fix --list-tests json output under --server mode by streaming discovered tests to the SDK over the dotnet-test pipe by @Evangelink in [#9192](https://github.com/microsoft/testfx/pull/9192)
 * Make AzureDevOps summary report file name unique per assembly by @Evangelink in [#9264](https://github.com/microsoft/testfx/pull/9264)
-* Fix `--treenode-filter` + `--filter-uid` mutual exclusion: validated up front at CLI parse time (proper `InvalidCommandLine` exit code) instead of a late `NotSupportedException`; documentation gaps for the `!` NOT operator and property-filter semantics addressed by @Evangelink in [#9458](https://github.com/microsoft/testfx/pull/9458)
+* Fix `--treenode-filter` + `--filter-uid` mutual exclusion: validated during command-line validation (proper `InvalidCommandLine` exit code) instead of a late `NotSupportedException`; documentation gaps for the `!` NOT operator and property-filter semantics addressed by @Evangelink in [#9458](https://github.com/microsoft/testfx/pull/9458)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 


### PR DESCRIPTION
Two changelog entries were omitted from `docs/Changelog-Platform.md` when their PRs were merged on 2026-06-26:

- **`Added`**: `Microsoft.Testing.Extensions.VideoRecorder` (`#9377`) — new preview extension for screen recording during test runs.
- **`Fixed`**: TreeNode filter `--treenode-filter` + `--filter-uid` mutual exclusion moved to proper CLI validation time (`#9458`), plus documentation improvements for the `!` NOT operator.

Both entries are added to the `## [2.3.0] - UNRELEASED` section in the correct (`Added`/`Fixed`) subsections.

*Generated by the Adhoc QA workflow.*




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/28281520191/agentic_workflow) workflow. · 1.3K AIC · ⌖ 23.8 AIC · ⊞ 51.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28281520191, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/28281520191 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->