### PR TITLE
[code-simplifier] refactor: simplify nested ternary and duplicate assignments in recent changes

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -212,13 +212,12 @@ internal sealed partial class MSTestSettings
 
         if (configuration["mstest:parallelism:workers"] is string workers)
         {
-            settings.ParallelizationWorkers = int.TryParse(workers, out int parallelWorkers)
-                ? parallelWorkers == 0
-                    ? Environment.ProcessorCount
-                    : parallelWorkers > 0
-                        ? parallelWorkers
-                        : throw new AdapterSettingsException(string.Format(CultureInfo.CurrentCulture, Resource.InvalidParallelWorkersValue, workers))
-                : throw new AdapterSettingsException(string.Format(CultureInfo.CurrentCulture, Resource.InvalidParallelWorkersValue, workers));
+            if (!int.TryParse(workers, out int parallelWorkers) || parallelWorkers < 0)
+            {
+                throw new AdapterSettingsException(string.Format(CultureInfo.CurrentCulture, Resource.InvalidParallelWorkersValue, workers));
+            }
+
+            settings.ParallelizationWorkers = parallelWorkers == 0 ? Environment.ProcessorCount : parallelWorkers;
         }
 
         if (configuration["mstest:parallelism:scope"] is string value)

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
@@ -76,16 +76,18 @@ internal sealed class VideoRecorderSessionHandler :
         _options = options;
 
         _enabled = commandLineOptions.IsOptionSet(VideoRecorderCommandLineProvider.EnableOptionName);
-        if (!_enabled)
+        if (_enabled)
         {
-            _persistMode = options.PersistMode;
-            _granularity = options.Granularity;
-            return;
+            ApplyCommandLineOverrides(options, commandLineOptions);
         }
 
-        ApplyCommandLineOverrides(options, commandLineOptions);
         _persistMode = options.PersistMode;
         _granularity = options.Granularity;
+
+        if (!_enabled)
+        {
+            return;
+        }
 
         string outputDirectory = options.OutputDirectory
             ?? Path.Combine(configuration.GetTestResultDirectory(), "VideoRecordings");


### PR DESCRIPTION
## Code Simplification — 2026-06-27

This PR simplifies recently modified code to improve clarity, consistency, and maintainability while preserving all functionality.

### Files Simplified

- `src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs` — Replace nested ternary chain with an if/else chain
- `src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs` — Eliminate duplicate field assignments in constructor

### Improvements Made

#### 1. Removed Nested Ternary (`MSTestSettings.Configuration.cs`)

The `parallelism:workers` parsing in `SetSettingsFromConfig` used a nested ternary chain:
```csharp
// Before — nested ternary (violates project guidelines)
settings.ParallelizationWorkers = int.TryParse(workers, out int parallelWorkers)
    ? parallelWorkers == 0
        ? Environment.ProcessorCount
        : parallelWorkers > 0
            ? parallelWorkers
            : throw new AdapterSettingsException(...)
    : throw new AdapterSettingsException(...);
```
```csharp
// After — if/else chain
if (!int.TryParse(workers, out int parallelWorkers) || parallelWorkers < 0)
{
    throw new AdapterSettingsException(...);
}
settings.ParallelizationWorkers = parallelWorkers == 0 ? Environment.ProcessorCount : parallelWorkers;
```
The project guidelines explicitly state: *"Avoid nested ternary operators — prefer switch statements or if/else chains."* This file was modified by PR #9453 (merged 2026-06-26).

#### 2. Eliminated Duplicate Assignments (`VideoRecorderSessionHandler.cs`)

The constructor (new file from PR #9377, merged 2026-06-26) set `_persistMode` and `_granularity` in both the enabled and disabled branches:
```csharp
// Before — duplicate assignments in two branches
if (!_enabled)
{
    _persistMode = options.PersistMode;   // ← duplicate
    _granularity = options.Granularity;   // ← duplicate
    return;
}
ApplyCommandLineOverrides(options, commandLineOptions);
_persistMode = options.PersistMode;       // ← duplicate
_granularity = options.Granularity;       // ← duplicate
```
```csharp
// After — single assignment after the conditional
if (_enabled)
{
    ApplyCommandLineOverrides(options, commandLineOptions);
}
_persistMode = options.PersistMode;
_granularity = options.Granularity;
if (!_enabled)
{
    return;
}
```

### Changes Based On

Recent changes from:
- #9453 — *Clarify and document 0-value behavior for `timeout:*` testconfig.json keys* (modified `MSTestSettings.Configuration.cs`)
- #9377 — *Add experimental Microsoft.Testing.Extensions.VideoRecorder extension for MTP* (new `VideoRecorderSessionHandler.cs`)

### Testing

- ✅ `MSTestAdapter.PlatformServices` builds cleanly (0 warnings, 0 errors) for `net8.0` and `net9.0`
- ✅ `Microsoft.Testing.Extensions.VideoRecorder` builds cleanly (0 warnings, 0 errors) for `net8.0`, `net9.0`, and `netstandard2.0`
- ✅ No functional changes — behavior is identical in both cases

### Review Focus

Please verify:
- The if/else refactor preserves the original `parallelism:workers` validation (parse failure or negative → throw, `0` → `ProcessorCount`, positive → value)
- The constructor reorder correctly defers `_recorder` creation to when `_enabled` is true


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/28290860861/agentic_workflow) workflow. · 252.5 AIC · ⌖ 23.5 AIC · ⊞ 9.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-28T13:55:40.146Z --> on Jun 28, 2026, 1:55 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 28290860861, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/28290860861 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->