### PR TITLE
[perf-improver] perf: skip allocation in CaptureLifecycleProperties when no user properties set

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -312,7 +312,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <param name="propertiesToMerge">The properties to merge in. May be <see langword="null"/>.</param>
     internal void MergeProperties(IReadOnlyDictionary<string, object?>? propertiesToMerge)
     {
-        if (propertiesToMerge is null)
+        if (propertiesToMerge is null or { Count: 0 })
         {
             return;
         }
@@ -343,6 +343,12 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// stored on a <c>TestAssemblyInfo</c> / <c>TestClassInfo</c> and later merged into other
     /// contexts via <see cref="MergeProperties(IReadOnlyDictionary{string, object?}?)"/>.
     /// <para>
+    /// Returns <see langword="null"/> when there are no non-label properties to capture
+    /// (the common case when <c>AssemblyInitialize</c> / <c>ClassInitialize</c> do not set
+    /// properties on <c>TestContext</c>). <see cref="MergeProperties"/> already handles a
+    /// <see langword="null"/> argument as a no-op, so callers need not special-case this.
+    /// </para>
+    /// <para>
     /// The snapshot is shallow: keys and value references are copied as-is. Reference-type
     /// values stored in the bag (e.g. a mocked file system, a connection pool, a list) are
     /// shared across every context the snapshot is later merged into. Mutations of those
@@ -358,15 +364,15 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// thread-affinity expectation of <c>AssemblyInitialize</c> / <c>ClassInitialize</c>.
     /// </para>
     /// </summary>
-    /// <returns>A read-only snapshot of the current properties.</returns>
-    internal IReadOnlyDictionary<string, object?> CaptureLifecycleProperties()
+    /// <returns>
+    /// A read-only snapshot of the current properties (excluding per-context labels), or
+    /// <see langword="null"/> if there are no such properties to snapshot.
+    /// </returns>
+    internal IReadOnlyDictionary<string, object?>? CaptureLifecycleProperties()
     {
-        Dictionary<string, object?> snapshot;
+        Dictionary<string, object?>? snapshot = null;
         lock (_propertiesLock)
         {
-#pragma warning disable IDE0028 // Collection initialization can be simplified - capacity hint is intentional.
-            snapshot = new Dictionary<string, object?>(_properties.Count);
-#pragma warning restore IDE0028
             foreach (KeyValuePair<string, object?> kvp in _properties)
             {
                 if (kvp.Key == FullyQualifiedTestClassNameLabel || kvp.Key == TestNameLabel)
@@ -374,11 +380,14 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
                     continue;
                 }
 
+#pragma warning disable IDE0028 // Collection initialization can be simplified - capacity hint is intentional.
+                snapshot ??= new Dictionary<string, object?>(_properties.Count);
+#pragma warning restore IDE0028
                 snapshot[kvp.Key] = kvp.Value;
             }
         }
 
-        return new ReadOnlyDictionary<string, object?>(snapshot);
+        return snapshot is null ? null : new ReadOnlyDictionary<string, object?>(snapshot);
     }
 
     /// <summary>

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestAssemblyInfoTests.cs
@@ -265,6 +265,22 @@ public class TestAssemblyInfoTests : TestContainer
         _testAssemblyInfo.PostAssemblyInitProperties.Should().ContainKey("UserKey");
     }
 
+    public async Task RunAssemblyInitializeShouldLeavePostAssemblyInitPropertiesNullWhenAssemblyInitSetsNoProperties()
+    {
+        // AssemblyInitialize exists and succeeds but sets no TestContext.Properties.
+        DummyTestClass.AssemblyInitializeMethodBody = _ => { };
+        _testAssemblyInfo.AssemblyInitializeMethod = typeof(DummyTestClass).GetMethod("AssemblyInitializeMethod")!;
+
+        TestContextImplementation testContext = GetTestContext();
+        TestResult result = await _testAssemblyInfo.RunAssemblyInitializeAsync(testContext);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+
+        // CaptureLifecycleProperties returns null when no non-label properties were set,
+        // so MergeProperties can short-circuit without acquiring a lock on each test's context.
+        _testAssemblyInfo.PostAssemblyInitProperties.Should().BeNull();
+    }
+
     public async Task RunAssemblyInitializeShouldLeavePostAssemblyInitPropertiesNullWhenAssemblyInitMethodIsNull()
     {
         _testAssemblyInfo.AssemblyInitializeMethod = null;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestClassInfoTests.cs
@@ -448,6 +448,21 @@ public class TestClassInfoTests : TestContainer
         _testClassInfo.PostClassInitProperties.Should().NotContainKey(TestContext.FullyQualifiedTestClassNameLabel);
     }
 
+    public async Task GetResultOrRunClassInitializeAsyncShouldLeavePostClassInitPropertiesNullWhenClassInitSetsNoProperties()
+    {
+        // ClassInitialize exists and succeeds but sets no TestContext.Properties.
+        DummyTestClass.ClassInitializeMethodBody = _ => { };
+        _testClassInfo.ClassInitializeMethod = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.ClassInitializeMethod));
+
+        TestContextImplementation realTestContext = new(null, _testClassType.FullName, new Dictionary<string, object?>(), null, null);
+        TestResult result = await _testClassInfo.GetResultOrRunClassInitializeAsync(realTestContext, string.Empty, string.Empty, string.Empty, string.Empty);
+
+        result.Outcome.Should().Be(UnitTestOutcome.Passed);
+
+        // CaptureLifecycleProperties returns null when no non-label properties were set.
+        _testClassInfo.PostClassInitProperties.Should().BeNull();
+    }
+
     public async Task GetResultOrRunClassInitializeAsyncShouldLeavePostClassInitPropertiesNullWhenClassInitMethodIsNull()
     {
         _testClassInfo.ClassInitializeMethod = null;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -513,7 +513,7 @@ public class TestContextImplementationTests : TestContainer
         snapshot.Should().ContainKey("UserKey");
         snapshot!["UserKey"].Should().Be("UserValue");
         snapshot.Should().ContainKey("AnotherKey");
-        snapshot["AnotherKey"].Should().Be(7);
+        snapshot!["AnotherKey"].Should().Be(7);
         snapshot.Should().NotContainKey("FullyQualifiedTestClassName");
         snapshot.Should().NotContainKey("TestName");
     }
@@ -522,7 +522,8 @@ public class TestContextImplementationTests : TestContainer
     {
         _testContextImplementation = CreateTestContextImplementation();
 
-        // Only per-context labels are present; no user-defined properties.
+        // Context has no properties at all; no labels were seeded because the ITestMethod mock is
+        // unconfigured (FullClassName/Name return null) and testClassFullName is null.
         IReadOnlyDictionary<string, object?>? snapshot = _testContextImplementation.CaptureLifecycleProperties();
 
         snapshot.Should().BeNull();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -471,6 +471,16 @@ public class TestContextImplementationTests : TestContainer
         _testContextImplementation.Properties["Key"].Should().Be("Original");
     }
 
+    public void MergePropertiesShouldIgnoreEmptyDictionary()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+        _testContextImplementation.Properties["Key"] = "Original";
+
+        _testContextImplementation.MergeProperties(new Dictionary<string, object?>());
+
+        _testContextImplementation.Properties["Key"].Should().Be("Original");
+    }
+
     public void MergePropertiesShouldNotOverwritePerContextLabels()
     {
         _testMethod.Setup(tm => tm.FullClassName).Returns("A.C.M");
@@ -497,14 +507,25 @@ public class TestContextImplementationTests : TestContainer
         _testContextImplementation.Properties["UserKey"] = "UserValue";
         _testContextImplementation.Properties["AnotherKey"] = 7;
 
-        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+        IReadOnlyDictionary<string, object?>? snapshot = _testContextImplementation.CaptureLifecycleProperties();
 
+        snapshot.Should().NotBeNull();
         snapshot.Should().ContainKey("UserKey");
-        snapshot["UserKey"].Should().Be("UserValue");
+        snapshot!["UserKey"].Should().Be("UserValue");
         snapshot.Should().ContainKey("AnotherKey");
         snapshot["AnotherKey"].Should().Be(7);
         snapshot.Should().NotContainKey("FullyQualifiedTestClassName");
         snapshot.Should().NotContainKey("TestName");
+    }
+
+    public void CaptureLifecyclePropertiesShouldReturnNullWhenNoNonLabelPropertiesExist()
+    {
+        _testContextImplementation = CreateTestContextImplementation();
+
+        // Only per-context labels are present; no user-defined properties.
+        IReadOnlyDictionary<string, object?>? snapshot = _testContextImplementation.CaptureLifecycleProperties();
+
+        snapshot.Should().BeNull();
     }
 
     public void CaptureLifecyclePropertiesShouldReturnSnapshotIndependentOfTheLiveBag()
@@ -512,13 +533,14 @@ public class TestContextImplementationTests : TestContainer
         _testContextImplementation = CreateTestContextImplementation();
         _testContextImplementation.Properties["Key"] = "OriginalValue";
 
-        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+        IReadOnlyDictionary<string, object?>? snapshot = _testContextImplementation.CaptureLifecycleProperties();
 
         // Mutating the live bag must not affect the snapshot.
         _testContextImplementation.Properties["Key"] = "ChangedValue";
         _testContextImplementation.Properties["NewKey"] = "NewValue";
 
-        snapshot["Key"].Should().Be("OriginalValue");
+        snapshot.Should().NotBeNull();
+        snapshot!["Key"].Should().Be("OriginalValue");
         snapshot.Should().NotContainKey("NewKey");
     }
 
@@ -528,13 +550,14 @@ public class TestContextImplementationTests : TestContainer
         var bag = new List<int> { 1 };
         _testContextImplementation.Properties["RefKey"] = bag;
 
-        IReadOnlyDictionary<string, object?> snapshot = _testContextImplementation.CaptureLifecycleProperties();
+        IReadOnlyDictionary<string, object?>? snapshot = _testContextImplementation.CaptureLifecycleProperties();
 
         // The snapshot is shallow: the snapshot's value and the live bag share the same instance.
         // Mutating the instance must therefore be visible through both. This guards the documented
         // contract on CaptureLifecycleProperties from accidentally regressing to a deep copy.
+        snapshot.Should().NotBeNull();
         bag.Add(2);
-        ((List<int>)snapshot["RefKey"]!).Should().BeEquivalentTo(new[] { 1, 2 });
+        ((List<int>)snapshot!["RefKey"]!).Should().BeEquivalentTo(new[] { 1, 2 });
     }
 
     public void CaptureLifecyclePropertiesAndMergePropertiesShouldNotLockOnExposedPropertyBag()


### PR DESCRIPTION
## Goal and rationale

`CaptureLifecycleProperties()` is called once per `[AssemblyInitialize]` / `[ClassInitialize]` execution to snapshot any `TestContext.Properties` entries set during init, so they can be propagated to each test's context. In the **common case** — where neither init method sets any properties — the method unconditionally allocated two objects:

1. `new Dictionary<string, object?>(capacity)` — the snapshot buffer
2. `new ReadOnlyDictionary<string, object?>(snapshot)` — the immutable wrapper

Those two objects are then stored in `PostAssemblyInitProperties` / `PostClassInitProperties` and passed to every test via `MergeProperties`. `MergeProperties` already returned early for `null`, but not for an **empty** dictionary, so it also acquired a lock per call before doing nothing.

## Approach

- **`CaptureLifecycleProperties`**: change to lazy allocation. The `Dictionary` is allocated only on the first non-label entry. If the loop finds nothing to snapshot, the method returns `null` (return type changed from `IReadOnlyDictionary<string,object?>` to `IReadOnlyDictionary<string,object?>?`). This is a single-pass implementation — no extra iteration.
- **`MergeProperties`**: extend the null guard to `null or { Count: 0 }`, so an empty dict is also short-circuited cheaply (defensive, and matches the new null-return convention).
- **No caller changes**: `PostAssemblyInitProperties` and `PostClassInitProperties` are already declared as nullable; `MergeProperties(null)` already short-circuits.

## Performance evidence

Every test class that has `[AssemblyInitialize]` or `[ClassInitialize]` (but doesn't write to `TestContext.Properties` in it) benefits:

| Call site | Before | After |
|---|---|---|
| `CaptureLifecycleProperties` (empty) | 2 heap allocs | 0 allocs |
| `MergeProperties(emptySnapshot)` per test | lock acquire + empty loop | 1 null-check, return |
| `MergeProperties(null)` per test | 1 null-check, return | 1 null/count-check, return |

For a test suite with an `[AssemblyInitialize]` / `[ClassInitialize]` that sets no properties:
- −2 heap allocations at init time
- −2 lock acquisitions per test (one for `PostAssemblyInitProperties`, one for `PostClassInitProperties` merge in `RunSingleTestAsync`)

In a 1000-test suite, that's ~2000 lock acquisitions avoided.

## Trade-offs

None significant. The change is backward-compatible: callers that store the snapshot in nullable fields already handle `null`; `MergeProperties(null)` was already a no-op.

## Reproducibility

```bash
# Build and run unit tests for MSTestAdapter.PlatformServices
./build.sh -test -projects test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestAdapter.PlatformServices.UnitTests.csproj

# Or for just the new tests, after build:
dotnet run --project test/UnitTests/MSTestAdapter.PlatformServices.UnitTests -f net8.0 --no-build -- \
  --treenode-filter "/*/*/*/TestContextImplementationTests/CaptureLifecyclePropertiesShouldReturnNullWhenNoNonLabelPropertiesExist"
```

## Test status

No SDK is available in this CI environment, so local build/test could not be run. The change is confined to the `MSTestAdapter.PlatformServices` project and its unit tests; all callers already handle `null` snapshots.




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/28291508097/agentic_workflow) workflow. · 2.6K AIC · ⌖ 26.5 AIC · ⊞ 57.7K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28291508097, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/28291508097 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->