### PR TITLE
[test-improver] test: add edge case tests for DoNotUseShadowingAnalyzer (MSTEST0036)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseShadowingAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseShadowingAnalyzerTests.cs
@@ -385,8 +385,8 @@ public sealed class DoNotUseShadowingAnalyzerTests
     [TestMethod]
     public async Task WhenTestClassShadowsGrandparentMemberThroughIntermediateClass_Diagnostic()
     {
-        // GetBaseMembers walks the full inheritance chain, so shadowing of a grandparent
-        // member through an intermediate class (that does not redeclare the member) is detected.
+        // Shadowing of a grandparent member through an intermediate class (that does not
+        // redeclare the member) is reported, as the full inheritance chain is considered.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
             public class GrandparentClass
@@ -411,8 +411,8 @@ public sealed class DoNotUseShadowingAnalyzerTests
     [TestMethod]
     public async Task WhenTestClassHasSamePropertyNameAsBaseClassButDifferentType_NoDiagnostic()
     {
-        // IsMemberShadowing requires the property types to match via SymbolEqualityComparer.
-        // A property with the same name but a different type is not considered shadowing.
+        // A property with the same name but a different type is not considered shadowing,
+        // so no diagnostic is reported.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
             public class BaseClass
@@ -433,8 +433,7 @@ public sealed class DoNotUseShadowingAnalyzerTests
     [TestMethod]
     public async Task WhenTestClassHasSameFieldNameAsBaseClass_NoDiagnostic()
     {
-        // IsMemberShadowing only handles IMethodSymbol and IPropertySymbol; fields (IFieldSymbol)
-        // fall through to the final 'return false', so no diagnostic is reported for field hiding.
+        // Field hiding is not reported; only shadowed methods and properties trigger a diagnostic.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
             public class BaseClass

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseShadowingAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseShadowingAnalyzerTests.cs
@@ -381,4 +381,74 @@ public sealed class DoNotUseShadowingAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenTestClassShadowsGrandparentMemberThroughIntermediateClass_Diagnostic()
+    {
+        // GetBaseMembers walks the full inheritance chain, so shadowing of a grandparent
+        // member through an intermediate class (that does not redeclare the member) is detected.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            public class GrandparentClass
+            {
+                public void Method() { }
+            }
+
+            public class IntermediateClass : GrandparentClass
+            {
+            }
+
+            [TestClass]
+            public class DerivedClass : IntermediateClass
+            {
+                public void [|Method|]() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasSamePropertyNameAsBaseClassButDifferentType_NoDiagnostic()
+    {
+        // IsMemberShadowing requires the property types to match via SymbolEqualityComparer.
+        // A property with the same name but a different type is not considered shadowing.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            public class BaseClass
+            {
+                public int Property { get; }
+            }
+
+            [TestClass]
+            public class DerivedClass : BaseClass
+            {
+                public new string Property { get; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasSameFieldNameAsBaseClass_NoDiagnostic()
+    {
+        // IsMemberShadowing only handles IMethodSymbol and IPropertySymbol; fields (IFieldSymbol)
+        // fall through to the final 'return false', so no diagnostic is reported for field hiding.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            public class BaseClass
+            {
+                public int Field = 0;
+            }
+
+            [TestClass]
+            public class DerivedClass : BaseClass
+            {
+                public new int Field = 0;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`DoNotUseShadowingAnalyzer` (MSTEST0036) had 18 tests, but three distinct code paths in the analyzer's logic were completely untested:

| Untested path | Guard |
|---|---|
| Multi-level inheritance — shadowing a grandparent member through an empty intermediate class | `GetBaseMembers` while-loop walking all `BaseType` ancestors |
| Property with same name but different type | `SymbolEqualityComparer.Default.Equals(propertySymbol.Type, basePropertySymbol.Type)` guard in `IsMemberShadowing` |
| Field with same name as base field | `IsMemberShadowing` returns `false` for `IFieldSymbol` (only `IMethodSymbol` and `IPropertySymbol` are handled) |

## Approach

Added three `[TestMethod]` entries to `DoNotUseShadowingAnalyzerTests.cs`:

| Test | What it covers |
|---|---|
| `WhenTestClassShadowsGrandparentMemberThroughIntermediateClass_Diagnostic` | `[TestClass]` `DerivedClass : IntermediateClass : GrandparentClass` where only `GrandparentClass` declares `Method()` and `DerivedClass` redeclares it → `GetBaseMembers` walks through the empty `IntermediateClass` to find `GrandparentClass.Method`, diagnostic fires |
| `WhenTestClassHasSamePropertyNameAsBaseClassButDifferentType_NoDiagnostic` | Base has `int Property`, derived has `new string Property` — types differ, `SymbolEqualityComparer` check returns false → no diagnostic |
| `WhenTestClassHasSameFieldNameAsBaseClass_NoDiagnostic` | Base has `int Field`, derived has `new int Field` — `IsMemberShadowing` has no `IFieldSymbol` branch → falls through to `return false` → no diagnostic |

## Coverage Impact

| | Before | After |
|---|---|---|
| Tests in `DoNotUseShadowingAnalyzerTests` | 18 | 21 |

## Trade-offs

Purely additive — no production code changes, no new dependencies.

## Test Status

All 21/21 tests pass (`net8.0`, `Debug`):

```
Test run summary: Passed!
  total: 21
  failed: 0
  succeeded: 21
  duration: 4s 902ms
```

## Reproducibility

```bash
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "FullyQualifiedName~DoNotUseShadowingAnalyzerTests"
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28339350434/agentic_workflow) workflow. · 868.9 AIC · ⌖ 24 AIC · ⊞ 58.1K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28339350434, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28339350434 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->