### PR TITLE
Remove duplicated reflection helpers in ReflectHelper

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -6,6 +6,7 @@ using System.Security;
 #endif
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -145,41 +146,7 @@ internal class ReflectHelper
     /// <param name="owningType">The reflected type that owns <paramref name="categoryAttributeProvider"/>.</param>
     /// <returns>Categories defined.</returns>
     internal static string[] GetTestCategories(MemberInfo categoryAttributeProvider, Type owningType)
-    {
-        Attribute[] methodAttributes = GetCustomAttributesCached(categoryAttributeProvider);
-        Attribute[] typeAttributes = GetCustomAttributesCached(owningType);
-        Attribute[] assemblyAttributes = GetCustomAttributesCached(owningType.Assembly);
-
-        // Avoid LINQ iterator allocations by iterating the cached attribute arrays directly.
-        // This follows the same allocation-free pattern used by GetTestPropertiesAsTraits.
-        List<string>? categories = null;
-
-        foreach (Attribute attribute in methodAttributes)
-        {
-            if (attribute is TestCategoryBaseAttribute categoryAttr)
-            {
-                (categories ??= []).AddRange(categoryAttr.TestCategories);
-            }
-        }
-
-        foreach (Attribute attribute in typeAttributes)
-        {
-            if (attribute is TestCategoryBaseAttribute categoryAttr)
-            {
-                (categories ??= []).AddRange(categoryAttr.TestCategories);
-            }
-        }
-
-        foreach (Attribute attribute in assemblyAttributes)
-        {
-            if (attribute is TestCategoryBaseAttribute categoryAttr)
-            {
-                (categories ??= []).AddRange(categoryAttr.TestCategories);
-            }
-        }
-
-        return categories is null ? [] : [.. categories];
-    }
+        => PlatformServiceProvider.Instance.ReflectionOperations.GetTestCategories(categoryAttributeProvider, owningType);
 
     /// <summary>
     /// Gets the parallelization level set on an assembly.
@@ -232,52 +199,7 @@ internal class ReflectHelper
     /// <param name="testPropertyProvider">The member to inspect.</param>
     /// <returns>List of traits.</returns>
     internal static Trait[] GetTestPropertiesAsTraits(MethodInfo testPropertyProvider)
-    {
-        Attribute[] attributesFromMethod = GetCustomAttributesCached(testPropertyProvider);
-        Attribute[] attributesFromClass = testPropertyProvider.ReflectedType is { } testClass ? GetCustomAttributesCached(testClass) : [];
-        int countTestPropertyAttribute = 0;
-        foreach (Attribute attribute in attributesFromMethod)
-        {
-            if (attribute is TestPropertyAttribute)
-            {
-                countTestPropertyAttribute++;
-            }
-        }
-
-        foreach (Attribute attribute in attributesFromClass)
-        {
-            if (attribute is TestPropertyAttribute)
-            {
-                countTestPropertyAttribute++;
-            }
-        }
-
-        if (countTestPropertyAttribute == 0)
-        {
-            // This is the common case that we optimize for. This method used to be an iterator (uses yield return) which is allocating unnecessarily in common cases.
-            return [];
-        }
-
-        var traits = new Trait[countTestPropertyAttribute];
-        int index = 0;
-        foreach (Attribute attribute in attributesFromMethod)
-        {
-            if (attribute is TestPropertyAttribute testProperty)
-            {
-                traits[index++] = new Trait(testProperty.Name, testProperty.Value);
-            }
-        }
-
-        foreach (Attribute attribute in attributesFromClass)
-        {
-            if (attribute is TestPropertyAttribute testProperty)
-            {
-                traits[index++] = new Trait(testProperty.Name, testProperty.Value);
-            }
-        }
-
-        return traits;
-    }
+        => PlatformServiceProvider.Instance.ReflectionOperations.GetTestPropertiesAsTraits(testPropertyProvider);
 
     /// <summary>
     /// Get attribute defined on a method which is of given type of subtype of given type.


### PR DESCRIPTION
## Summary

Addresses part of #9499 (Code Duplication Analysis).

`ReflectHelper.GetTestCategories` and `ReflectHelper.GetTestPropertiesAsTraits` (static methods) duplicated the algorithm bodies of the `IReflectionOperations` extension methods of the same name in `ReflectionHelper`. The static `ReflectHelper.GetCustomAttributesCached` helper already delegates to `PlatformServiceProvider.Instance.ReflectionOperations`, so the two static methods are now thin delegates to the shared extension methods — removing ~70 lines of true duplication with zero behavior change.

The `ReflectionHelper` extension methods are the "live" implementations (used by `TypeEnumerator`); `ReflectHelper.GetTestCategories` (static) had no production callers and `ReflectHelper.GetTestPropertiesAsTraits` (static) is only referenced from a unit test, which keeps working via the delegate.

## Scope notes

The dedup-analysis issue lists 21 candidates. The remaining items were intentionally left as-is:
- **Jsonite folder** (4 high-priority items): vendored third-party BSD-licensed code (Alexandre Mutel, 2016) — must not be refactored.
- **`ReflectHelper` vs `ReflectionOperations`**: intentional architectural split (singleton facade vs service); merging would break the `ReflectHelper.Instance` surface.
- **`SynchronizationContextPreservingAsyncTaskMethodBuilder`**: generic/non-generic struct pair required by the compile-time async-builder pattern; cannot be unified.
- **Assert-condition analyzers / other analyzers**: every analyzer in the project repeats the `Initialize` boilerplate by convention; extracting a base for just two would be locally inconsistent.
- **Report engines**: the duplication is constructor forwarding across two assemblies, which can't be DRYed via inheritance.

## Validation

- `MSTestAdapter.PlatformServices` builds clean (0 warnings, 0 errors).
- `ReflectionOperationsTests` (47) and `TestPropertyAttributeTests` (3) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>