### PR TITLE
Fix broken main: acceptance source-gen harness leaks nested bin/obj into multi-project asset builds

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderTests.cs
@@ -32,6 +32,15 @@ public sealed class AssemblyFixtureProviderTests : AcceptanceTestBase<AssemblyFi
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {
+        // This asset has a multi-targeting ProjectReference (ProviderLibrary). The default
+        // SourceGeneration build redirects bin/obj to an isolated sub-folder, but RAR for the net8.0
+        // leg ends up resolving ProviderLibrary's transitive MSTest.TestFramework.Extensions.dll from
+        // the net10.0 reflection output (bin/Release/net10.0) instead of the net8.0 one. That produces
+        // MSB3277 System.* version conflicts (8.0.0.0 vs 9.0.0.0) which the source-gen build promotes to
+        // errors via MSBuildTreatWarningsAsErrors. The test only exercises the reflection build, so opt
+        // out of the source-gen build; it stays reflection-only.
+        protected override IReadOnlyList<MetadataMode> SourceGenMetadataModes => [];
+
         public const string AssetName = "AssemblyFixtureProviderAcceptance";
         public const string TestProjectName = "AssemblyFixtureProvider.Tests";
         public const string LibraryProjectName = "ProviderLibrary";

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderTests.cs
@@ -32,15 +32,6 @@ public sealed class AssemblyFixtureProviderTests : AcceptanceTestBase<AssemblyFi
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {
-        // This asset has a multi-targeting ProjectReference (ProviderLibrary). The default
-        // SourceGeneration build redirects bin/obj to an isolated sub-folder, but RAR for the net8.0
-        // leg ends up resolving ProviderLibrary's transitive MSTest.TestFramework.Extensions.dll from
-        // the net10.0 reflection output (bin/Release/net10.0) instead of the net8.0 one. That produces
-        // MSB3277 System.* version conflicts (8.0.0.0 vs 9.0.0.0) which the source-gen build promotes to
-        // errors via MSBuildTreatWarningsAsErrors. The test only exercises the reflection build, so opt
-        // out of the source-gen build; it stays reflection-only.
-        protected override IReadOnlyList<MetadataMode> SourceGenMetadataModes => [];
-
         public const string AssetName = "AssemblyFixtureProviderAcceptance";
         public const string TestProjectName = "AssemblyFixtureProvider.Tests";
         public const string LibraryProjectName = "ProviderLibrary";

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
@@ -122,8 +122,17 @@ $$"""
       MicrosoftTestingPlatformEntryPoint, SelfRegisteredExtensions) be double-compiled into this build.
       Re-exclude them here. This runs in CustomBeforeMicrosoftCommonProps (before the SDK seeds
       DefaultItemExcludes), so the SDK appends its own excludes after ours.
+
+      The nested '**/obj/**;**/bin/**' globs matter for multi-project assets. The reflection build (which
+      always runs first, into the default bin/Release) leaves a referenced project's outputs on disk, e.g.
+      'SomeRef/bin/Release/<tfm>/*.dll'. When this (later) source-gen build evaluates the host project, the
+      SDK's default item globs would otherwise pull those stray DLLs in as None/Content items, and RAR then
+      treats a wrong-TFM copy (for example a net10.0 'MSTest.TestFramework.Extensions.dll', assembly version
+      9.0.0.0) as a candidate for the net8.0 leg -> MSB3277, which MSBuildTreatWarningsAsErrors promotes to an
+      error. The root-level 'bin/**;obj/**' does not match the nested 'SomeRef/bin/**', so exclude nested
+      bin/obj as well to keep a referenced project's leftover reflection outputs out of this build's globs.
     -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**;bin/**;**/obj/**;**/bin/**</DefaultItemExcludes>
   </PropertyGroup>
   <ItemGroup>
     <!--


### PR DESCRIPTION
## Problem

`main` has been red across many consecutive official builds (e.g. [build 3010746](https://dnceng.visualstudio.com/internal/_build/results?buildId=3010746&view=results)).

The failing test is `MSTest.Acceptance.IntegrationTests.AssemblyFixtureProviderTests.AssemblyFixtureProvider_FromReferencedLibrary_RunsAssemblyInitializeAndCleanup`. It fails in its `ClassInitialize` because the **source-gen build variant** of the `AssemblyFixtureProviderAcceptance` asset fails to compile with `MSB3277`.

## Root cause (a harness bug, not a product bug)

`TestAssetFixtureBase.InitializeAsync` builds each acceptance asset **twice in the same directory**: first the reflection build (default `bin/Release`), then the source-gen build (with `bin`/`obj` redirected to a `*SourceGen` sub-folder).

For a **multi-project** asset — `AssemblyFixtureProviderAcceptance`'s test project references `ProviderLibrary` — the first (reflection) build leaves `ProviderLibrary/bin/Release/<tfm>/*.dll` on disk. When the later source-gen build then **evaluates** the host project, the SDK's default item globs pull those stray DLLs in as `None` items (confirmed in the binlog: `AddItem None -> ProviderLibrary\bin\Release\net10.0\MSTest.TestFramework.Extensions.dll`). RAR then treats the wrong-TFM copy (a net10.0 `MSTest.TestFramework.Extensions.dll`, assembly version `9.0.0.0`) as a candidate for the **net8.0** leg:

```
error MSB3277: Found conflicts between different versions of "System.Runtime" ... 8.0.0.0 vs 9.0.0.0
  ...ProviderLibrary\bin\Release\net10.0\MSTest.TestFramework.Extensions.dll
```

`MSBuildTreatWarningsAsErrors=true` (passed only to the source-gen build) promotes this to an error, so `ClassInitialize` throws.

The injected props already re-excluded `bin/obj`, but only at the **asset root** (`bin/**;obj/**`), which does not match the nested `ProviderLibrary/bin/**`. The reflection build (#1) is unaffected because at its evaluation time the referenced project's `bin` is still empty — only the later source-gen build (#2) runs in a directory polluted by #1.

## Fix

Broaden the injected `DefaultItemExcludes` in `AcceptanceSourceGen` to also exclude **nested** bin/obj (`**/obj/**;**/bin/**`), so a referenced project's leftover reflection outputs stay out of the source-gen build's globs. This is the proper harness fix and keeps the existing redirect-based design.

With the harness corrected, the `AssemblyFixtureProvider` opt-out is unnecessary, so the asset is restored to source-gen coverage.

## Verification

- Reproduced the original `MSB3277` from the CI binlog (`binlog-mcp`).
- Ran the `AssemblyFixtureProvider` acceptance tests (which drive both the reflection and source-gen builds via the fixture) — **all 3 pass** across `net462`/`net8.0`/`net10.0`.