### PR TITLE
[code-simplifier] refactor: simplify duplicate catch blocks and attribute-loop consistency

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -319,17 +319,15 @@ internal sealed class SourceGeneratedReflectionOperations : IReflectionOperation
         TAttribute? first = null;
         foreach (Attribute attr in GetCustomAttributesCached(attributeProvider))
         {
-            if (attr is not TAttribute match)
+            if (attr is TAttribute match)
             {
-                continue;
-            }
+                if (first is not null)
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Found multiple attributes of type '{0}' when only one was expected.", typeof(TAttribute)));
+                }
 
-            if (first is not null)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Found multiple attributes of type '{0}' when only one was expected.", typeof(TAttribute)));
+                first = match;
             }
-
-            first = match;
         }
 
         return first;

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
@@ -56,11 +56,7 @@ internal sealed class PackagedAppTestHostHandle : ITestHostHandle
                 Directory.Delete(_deploymentDirectory, recursive: true);
             }
         }
-        catch (IOException ex)
-        {
-            Debug.WriteLine($"Best-effort cleanup of deployment directory '{_deploymentDirectory}' failed: {ex}");
-        }
-        catch (UnauthorizedAccessException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             Debug.WriteLine($"Best-effort cleanup of deployment directory '{_deploymentDirectory}' failed: {ex}");
         }


### PR DESCRIPTION
## Code Simplification — 2026-06-29

This PR simplifies two small pieces of recently modified code to improve clarity and consistency, without any behavioral change.

### Files Simplified

- `src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs` — combine two identical catch blocks
- `src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs` — align loop pattern with adjacent methods

### Improvements Made

#### 1. PackagedAppTestHostHandle — eliminate duplicate catch bodies (from #9454)

The `Dispose` method had two `catch` blocks with **identical** handler bodies:

```csharp
// Before
catch (IOException ex)
{
    Debug.WriteLine($"Best-effort cleanup of deployment directory '{_deploymentDirectory}' failed: {ex}");
}
catch (UnauthorizedAccessException ex)
{
    Debug.WriteLine($"Best-effort cleanup of deployment directory '{_deploymentDirectory}' failed: {ex}");
}
```

Combined into a single handler using a C# exception filter, eliminating the duplication:

```csharp
// After
catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
{
    Debug.WriteLine($"Best-effort cleanup of deployment directory '{_deploymentDirectory}' failed: {ex}");
}
```

#### 2. SourceGeneratedReflectionOperations.GetSingleAttributeOrDefault — loop consistency (from #9479)

The `GetSingleAttributeOrDefault` method used a `is not T / continue` guard, while the two adjacent methods (`IsAttributeDefined` and `GetFirstAttributeOrDefault`) that were introduced in the same PR use a direct positive `is T` match. Aligned the style:

```csharp
// Before (uses negated guard + continue)
if (attr is not TAttribute match)
{
    continue;
}
if (first is not null) { throw ...; }
first = match;

// After (positive match, consistent with adjacent methods)
if (attr is TAttribute match)
{
    if (first is not null) { throw ...; }
    first = match;
}
```

### Changes Based On

Recent changes from:
- #9454 — Add generic ITestHostLauncher extension point + PackagedApp reference extension
- #9479 — perf: eliminate LINQ iterator allocations in SourceGeneratedReflectionOperations attribute lookup

### Testing

- ✅ No functional changes — behavior is identical
- ✅ No tests need updating; the changes are purely structural


<!-- gh-aw-tracker-id: code-simplifier -->




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Code Simplifier](https://github.com/microsoft/testfx/actions/runs/28379496570/agentic_workflow) workflow. · 217.9 AIC · ⌖ 18.3 AIC · ⊞ 9.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+code-simplifier%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/code-simplifier.md@main
```
</details>

> - [x] expires <!-- gh-aw-expires: 2026-06-30T14:46:28.063Z --> on Jun 30, 2026, 2:46 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, version: 1.0.63, model: claude-sonnet-4.6, id: 28379496570, workflow_id: code-simplifier, run: https://github.com/microsoft/testfx/actions/runs/28379496570 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/code-simplifier -->