### PR TITLE
[perf-improver] perf: avoid List(TestResult) allocation in RunTestMethodAsync non-data-driven fast path

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -130,8 +130,21 @@ internal sealed class TestMethodRunner
                 }
             }
 
-            _testContext.SetOutcome(GetAggregateOutcome(testResults));
-            return testResults;
+            UnitTestOutcome fastPathOutcome = GetAggregateOutcome(testResults);
+            _testContext.SetOutcome(fastPathOutcome);
+
+            // Set a result in case no result is present, preserving the safeguard from the slow path
+            // (ExecuteAsync dereferences result[0] in its finally block).
+            return testResults.Length == 0
+                ?
+                [
+                    new TestResult
+                    {
+                        Outcome = fastPathOutcome,
+                        TestFailureException = new TestFailedException(UnitTestOutcome.Error, Resource.UTA_NoTestResult),
+                    },
+                ]
+                : testResults;
         }
 
         // Slow path for data-driven tests.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -108,12 +108,34 @@ internal sealed class TestMethodRunner
         DebugEx.Assert(_test != null, "Test should not be null.");
         DebugEx.Assert(_testMethodInfo.MethodInfo != null, "Test method should not be null.");
 
-        List<TestResult> results = [];
         if (_testMethodInfo.Executor == null)
         {
             throw ApplicationStateGuard.Unreachable();
         }
 
+        // Fast path for non-data-driven tests (the common case).
+        // A single attribute scan replaces the two scans done by TryExecuteDataSourceBasedTestsAsync and
+        // TryExecuteFoldedDataDrivenTestsAsync, and avoids allocating a List<TestResult> that would
+        // immediately be spread back into a TestResult[].
+        if (_test.DataType != DynamicDataType.ITestDataSource && !IsDataDrivenTest())
+        {
+            _testContext.SetDisplayName(_test.DisplayName);
+            TestResult[] testResults = await ExecuteTestAsync(_testContext, _testMethodInfo).ConfigureAwait(false);
+
+            foreach (TestResult testResult in testResults)
+            {
+                if (StringEx.IsNullOrWhiteSpace(testResult.DisplayName))
+                {
+                    testResult.DisplayName = _test.DisplayName;
+                }
+            }
+
+            _testContext.SetOutcome(GetAggregateOutcome(testResults));
+            return testResults;
+        }
+
+        // Slow path for data-driven tests.
+        List<TestResult> results = [];
         bool isDataDriven = false;
         if (_test.DataType == DynamicDataType.ITestDataSource)
         {
@@ -137,6 +159,9 @@ internal sealed class TestMethodRunner
         }
         else
         {
+            // IsDataDrivenTest() returned true but neither Try...Async method handled the test
+            // (e.g., multiple DataSourceAttributes → TryExecuteDataSourceBasedTestsAsync returns false).
+            // Execute as a normal non-data-driven test, preserving existing behavior.
             _testContext.SetDisplayName(_test.DisplayName);
             TestResult[] testResults = await ExecuteTestAsync(_testContext, _testMethodInfo).ConfigureAwait(false);
 
@@ -174,6 +199,26 @@ internal sealed class TestMethodRunner
         }
 
         return [.. results];
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this test method has a <see cref="DataSourceAttribute"/> or
+    /// implements <see cref="UTF.ITestDataSource"/>, indicating it requires the data-driven execution path.
+    /// A single attribute-cache pass checks for both, replacing the two separate scans that would otherwise
+    /// be performed by <see cref="TryExecuteDataSourceBasedTestsAsync"/> and
+    /// <see cref="TryExecuteFoldedDataDrivenTestsAsync"/>.
+    /// </summary>
+    private bool IsDataDrivenTest()
+    {
+        foreach (Attribute attribute in PlatformServiceProvider.Instance.ReflectionOperations.GetCustomAttributesCached(_testMethodInfo.MethodInfo))
+        {
+            if (attribute is DataSourceAttribute or UTF.ITestDataSource)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task<bool> TryExecuteDataSourceBasedTestsAsync(List<TestResult> results)
@@ -476,7 +521,7 @@ internal sealed class TestMethodRunner
     /// </summary>
     /// <param name="results">Results.</param>
     /// <returns>Aggregate outcome.</returns>
-    private static UnitTestOutcome GetAggregateOutcome(List<TestResult> results)
+    private static UnitTestOutcome GetAggregateOutcome(IReadOnlyList<TestResult> results)
     {
         // In case results are not present, set outcome as unknown.
         if (results.Count == 0)


### PR DESCRIPTION
## Goal and Rationale

For the vast majority of test executions — non-data-driven tests — `RunTestMethodAsync` was paying three unnecessary costs on every call:

1. **Two attribute scans**: `TryExecuteDataSourceBasedTestsAsync` scans all cached method attributes for `DataSourceAttribute`; if that returns `false`, `TryExecuteFoldedDataDrivenTestsAsync` scans them again for `ITestDataSource` implementors.
2. **`List<TestResult>` allocation**: a `List<TestResult>` is created even though only `ExecuteTestAsync` will be called (which already returns `TestResult[]`).
3. **Spread allocation**: `return [.. results]` converts the list back to an array, allocating a second short-lived `TestResult[]`.

In a typical suite with 1,000 non-data-driven tests, this adds ~80 KB of short-lived allocations and ~2,000 extra attribute-scan iterations per run.

## Approach

**New `IsDataDrivenTest()` private method**: one pass over `GetCustomAttributesCached` that checks `attribute is DataSourceAttribute or UTF.ITestDataSource` — combining both scans into one.

**Fast path** (new): if `_test.DataType != DynamicDataType.ITestDataSource` **and** `IsDataDrivenTest()` returns `false`, the method:
- Calls `ExecuteTestAsync` directly
- Returns its `TestResult[]` without allocating a `List<TestResult>`
- Performs one attribute-cache scan instead of two

**Slow path** (unchanged): all data-driven tests continue through the existing `List<TestResult>` path.

**`GetAggregateOutcome` signature**: widened from `List<TestResult>` to `IReadOnlyList<TestResult>` so both the fast-path `TestResult[]` and slow-path `List<TestResult>` can call it (arrays and lists both implement `IReadOnlyList<T>`).

## Performance Evidence

Per non-data-driven test, the change eliminates approximately:
- 1 `List<TestResult>` object (~56 bytes: 24-byte header + internal capacity-4 backing array)
- 1 `TestResult[]` spread allocation (~24 bytes, length 1)
- 1 redundant attribute-cache enumeration (second `TryExecute...` scan avoided)

For a 1,000-test non-data-driven suite: **~80 KB fewer short-lived allocations** and **~2,000 fewer attribute-scan iterations** per run.

No local SDK is available in this CI agent; build/test verification is delegated to CI.

## Trade-offs

- Very slight code duplication: the "set display name → execute → set outcome" block appears in both the fast path and the slow path's `else` branch. The `else` branch is an edge case (test has `DataSourceAttribute` but multiple such attributes cause `TryExecuteDataSourceBasedTestsAsync` to skip it), so it is never exercised on common paths.
- No behavioral changes: the fast path is only reached when both `DataType != ITestDataSource` and `IsDataDrivenTest()` is `false`, ensuring data-driven tests are unaffected.

## Test Status

Delegated to CI. Existing unit tests in `TestMethodRunnerTests.cs` exercise both the new fast path (non-data-driven) and the unchanged slow path (data-driven) code paths.

## Reproducibility

```sh
# Build and run adapter unit tests
./build.sh -test
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Perf Improver](https://github.com/microsoft/testfx/actions/runs/28380470299/agentic_workflow) workflow. · 1.7K AIC · ⌖ 26.2 AIC · ⊞ 57.7K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+perf-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/perf-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Perf Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28380470299, workflow_id: perf-improver, run: https://github.com/microsoft/testfx/actions/runs/28380470299 -->

<!-- gh-aw-workflow-id: perf-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/perf-improver -->