### PR TITLE
Add C++/CLI + MSTest acceptance tests (VSTest and MTP)

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliMtpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliMtpTests.cs
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Guards that MSTest test classes authored in a <b>C++/CLI managed assembly</b> can be hosted on
+/// <b>Microsoft.Testing.Platform (MTP)</b> as a self-contained test executable (no <c>vstest.console.exe</c>).
+/// A C++/CLI <c>Application</c> with a managed <c>main</c> calls the same MTP hosting API the generated C#
+/// entry point uses (<c>TestApplication.CreateBuilderAsync</c> / <c>AddMSTest</c> / <c>BuildAsync</c> /
+/// <c>RunAsync</c>), and the test asserts the produced exe discovers and runs the tests.
+/// </summary>
+/// <remarks>
+/// C++/CLI <c>.vcxproj</c> projects do not resolve NuGet assets, so the MTP + MSTest .NET Framework runtime
+/// closure is harvested by building a tiny C# <c>net472</c> <c>EnableMSTestRunner</c> project (which lets NuGet
+/// resolve the full dependency closure into its output), then deployed next to the C++/CLI exe.
+/// </remarks>
+[TestClass]
+[OSCondition(OperatingSystems.Windows, IgnoreMessage = "C++/CLI requires the MSVC '/clr' toolset and is Windows-only.")]
+public sealed class CppCliMtpTests : AcceptanceTestBase<NopAssetFixture>
+{
+    private const string AssetName = "CppCliMtp";
+    private const string HarvestClosureRelativePath = @"harvest\bin\Release\net472";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task MSTestTestsInCppCliAssembly_AreHostedAndRun_ByMtp()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+
+        // Classic C++/CLI (.NET Framework '/clr') only needs the MSVC toolset; absent on SDK-only build legs.
+        string? vsInstallPath = await CppCliTestSupport.TryFindVsInstallWithCppToolsetAsync(cancellationToken);
+        if (vsInstallPath is null)
+        {
+            Assert.Inconclusive("Skipping: no Visual Studio install with the MSVC C++ toolset (Microsoft.VisualStudio.Component.VC.Tools.x86.x64) was found.");
+            return;
+        }
+
+        string msbuildExe = await FindMsbuildWithVsWhereAsync(cancellationToken);
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            SourceCode.PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        Dictionary<string, string?> cleanEnvironment = CppCliTestSupport.BuildEnvironmentWithoutCodeCoverage();
+
+        // 1) Harvest the MTP + MSTest net472 runtime closure by building the C# project with the dotnet SDK,
+        //    letting NuGet resolve the full dependency closure into harvest\bin\Release\net472.
+        DotnetMuxerResult harvestResult = await DotnetCli.RunAsync(
+            $"build \"{Path.Combine(testAsset.TargetAssetPath, "harvest", "Harvest.csproj")}\" -c Release",
+            workingDirectory: testAsset.TargetAssetPath,
+            failIfReturnValueIsNotZero: false,
+            cancellationToken: cancellationToken);
+        Assert.AreEqual(0, harvestResult.ExitCode, $"Harvesting the MTP closure failed.{Environment.NewLine}{harvestResult}");
+
+        string closureDir = Path.Combine(testAsset.TargetAssetPath, HarvestClosureRelativePath);
+        Assert.IsTrue(
+            File.Exists(Path.Combine(closureDir, "Microsoft.Testing.Platform.dll")),
+            $"Expected the harvested MTP closure under '{closureDir}'.");
+
+        // 2) Build the C++/CLI MTP host exe with full Visual Studio MSBuild (the dotnet muxer cannot build a vcxproj).
+        //    The vcxproj references the harvested closure assemblies via <HintPath>.
+        string vcxproj = Path.Combine(testAsset.TargetAssetPath, $"{AssetName}.vcxproj");
+        string binlogFile = Path.Combine(TempDirectory.TestSuiteDirectory, $"{nameof(MSTestTestsInCppCliAssembly_AreHostedAndRun_ByMtp)}.binlog");
+        using var buildCommandLine = new CommandLine();
+        int buildExitCode = await buildCommandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{msbuildExe}\" \"{vcxproj}\" /p:Configuration=Debug /p:Platform=x64 /restore:false /bl:\"{binlogFile}\"",
+            cleanEnvironment,
+            cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
+            cancellationToken: cancellationToken);
+        Assert.AreEqual(
+            0,
+            buildExitCode,
+            $"C++/CLI build failed.{Environment.NewLine}{buildCommandLine.StandardOutput}{Environment.NewLine}{buildCommandLine.ErrorOutput}");
+
+        string exeDir = Path.Combine(testAsset.TargetAssetPath, "x64", "Debug");
+        string testExe = Path.Combine(exeDir, $"{AssetName}.exe");
+        Assert.IsTrue(File.Exists(testExe), $"Built C++/CLI MTP host was not found at '{testExe}'.");
+
+        // 3) Deploy the runtime closure (and the binding-redirect app.config) next to the C++/CLI exe.
+        foreach (string dll in Directory.GetFiles(closureDir, "*.dll"))
+        {
+            File.Copy(dll, Path.Combine(exeDir, Path.GetFileName(dll)), overwrite: true);
+        }
+
+        string harvestConfig = Path.Combine(closureDir, "Harvest.exe.config");
+        if (File.Exists(harvestConfig))
+        {
+            File.Copy(harvestConfig, Path.Combine(exeDir, $"{AssetName}.exe.config"), overwrite: true);
+        }
+
+        // 4) Run the C++/CLI exe as an MTP test host and assert discovery + execution.
+        using var runCommandLine = new CommandLine();
+        int runExitCode = await runCommandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{testExe}\" --output Detailed",
+            cleanEnvironment,
+            workingDirectory: exeDir,
+            cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
+            cancellationToken: cancellationToken);
+
+        string output = runCommandLine.StandardOutput;
+        Assert.AreEqual(
+            0,
+            runExitCode,
+            $"MTP run did not succeed.{Environment.NewLine}{output}{Environment.NewLine}{runCommandLine.ErrorOutput}");
+
+        Assert.Contains("Add_TwoPlusTwo_IsFour", output);
+        Assert.Contains("Strings_AreEqual", output);
+        Assert.Contains("Booleans_Work", output);
+        // The MTP summary line is emitted by the platform host, proving the exe really hosted MTP.
+        Assert.Contains("Passed!", output);
+    }
+
+    private const string SourceCode = """
+#file harvest/Harvest.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateTestingPlatformEntryPoint>true</GenerateTestingPlatformEntryPoint>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>latest</LangVersion>
+    <!-- This project only exists to let NuGet resolve the MTP + MSTest runtime closure for the C++/CLI host. -->
+    <NoWarn>$(NoWarn);MSTEST0032</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+</Project>
+
+#file harvest/HarvestPlaceholder.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class HarvestPlaceholder
+{
+    // Present only so the harvester is a valid test project; the C++/CLI exe carries the real tests.
+    [TestMethod]
+    public void Placeholder()
+    {
+    }
+}
+
+#file CppCliMtp.vcxproj
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C1D2E3F4-5A6B-4C7D-8E9F-0A1B2C3D4E5F}</ProjectGuid>
+    <RootNamespace>CppCliMtp</RootNamespace>
+    <Keyword>ManagedCProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <ClosureDir>$(MSBuildThisFileDirectory)harvest\bin\Release\net472</ClosureDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="MtpHost.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Testing.Platform">
+      <HintPath>$(ClosureDir)\Microsoft.Testing.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestAdapter">
+      <HintPath>$(ClosureDir)\MSTest.TestAdapter.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestFramework">
+      <HintPath>$(ClosureDir)\MSTest.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestFramework.Extensions">
+      <HintPath>$(ClosureDir)\MSTest.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>
+
+#file MtpHost.cpp
+using namespace System;
+using namespace System::Collections::Generic;
+using namespace System::Reflection;
+using namespace Microsoft::VisualStudio::TestTools::UnitTesting;
+using namespace Microsoft::Testing::Platform::Builder;
+
+[TestClass]
+public ref class MtpCalculatorTests
+{
+public:
+    [TestMethod]
+    void Add_TwoPlusTwo_IsFour() { Assert::AreEqual(4, 2 + 2); }
+
+    [TestMethod]
+    void Strings_AreEqual() { Assert::AreEqual(gcnew String("Hello"), gcnew String("Hello")); }
+
+    [TestMethod]
+    void Booleans_Work() { Assert::IsTrue(1 == 1); Assert::IsFalse(1 == 2); }
+};
+
+ref class AssemblyProvider
+{
+public:
+    static IEnumerable<Assembly^>^ Get()
+    {
+        return gcnew array<Assembly^>{ Assembly::GetExecutingAssembly() };
+    }
+};
+
+// Managed entry point hosting MTP. C++/CLI has no 'await', so Tasks are driven via ->Result.
+int main(array<String^>^ args)
+{
+    ITestApplicationBuilder^ builder = TestApplication::CreateBuilderAsync(args)->Result;
+
+    // AddMSTest is a C# extension method; call it as a static method from C++/CLI.
+    Func<IEnumerable<Assembly^>^>^ getAssemblies = gcnew Func<IEnumerable<Assembly^>^>(&AssemblyProvider::Get);
+    TestApplicationBuilderExtensions::AddMSTest(builder, getAssemblies);
+
+    ITestApplication^ app = builder->BuildAsync()->Result;
+    try
+    {
+        return app->RunAsync()->Result;
+    }
+    finally
+    {
+        delete app;
+    }
+}
+""";
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliMtpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliMtpTests.cs
@@ -41,7 +41,14 @@ public sealed class CppCliMtpTests : AcceptanceTestBase<NopAssetFixture>
             return;
         }
 
-        string msbuildExe = await FindMsbuildWithVsWhereAsync(cancellationToken);
+        // Derive MSBuild from the same VS install we validated above, so the C++ targets/toolset are
+        // guaranteed available (locating MSBuild independently could pick a different install on multi-VS machines).
+        string? msbuildExe = CppCliTestSupport.TryGetMSBuildPathFromVsInstall(vsInstallPath);
+        if (msbuildExe is null)
+        {
+            Assert.Inconclusive($"Skipping: MSBuild.exe was not found under the located Visual Studio install '{vsInstallPath}'.");
+            return;
+        }
 
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             AssetName,
@@ -170,7 +177,7 @@ public class HarvestPlaceholder
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <CharacterSet>Unicode</CharacterSet>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Shared helpers for the C++/CLI acceptance tests (<see cref="CppCliVSTestTests"/> and
+/// <see cref="CppCliMtpTests"/>): locating a Visual Studio install with the MSVC toolset and building a
+/// child-process environment without the code-coverage profiler variables.
+/// </summary>
+internal static class CppCliTestSupport
+{
+    // The code-coverage profiler environment variables the acceptance host injects; inheriting them into a
+    // nested .NET Framework test host breaks the run, so they are stripped from the child process environment.
+    private static readonly string[] CodeCoverageEnvironmentVariables =
+    [
+        "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler",
+        "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler",
+        "CORECLR_PROFILER_PATH_32",
+        "CORECLR_PROFILER_PATH_64",
+        "CORECLR_ENABLE_PROFILING",
+        "CORECLR_PROFILER",
+        "COR_PROFILER_PATH_32",
+        "COR_PROFILER_PATH_64",
+        "COR_ENABLE_PROFILING",
+        "COR_PROFILER",
+        "CODE_COVERAGE_SESSION_NAME",
+        "CODE_COVERAGE_PIPE_PATH",
+        "MicrosoftInstrumentationEngine_LogLevel",
+        "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation",
+        "MicrosoftInstrumentationEngine_FileLogPath",
+    ];
+
+    /// <summary>
+    /// Returns the installation path of a Visual Studio install that has the MSVC C++ toolset (needed to
+    /// compile C++/CLI with classic <c>/clr</c>), or <see langword="null"/> when none is found. Classic
+    /// C++/CLI targets .NET Framework and only requires the toolset; the dedicated C++/CLI-support component
+    /// is for <c>/clr:netcore</c>.
+    /// </summary>
+    public static async Task<string?> TryFindVsInstallWithCppToolsetAsync(CancellationToken cancellationToken)
+    {
+        string vswherePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft Visual Studio",
+            "Installer",
+            "vswhere.exe");
+        if (!File.Exists(vswherePath))
+        {
+            return null;
+        }
+
+        using var commandLine = new CommandLine();
+        int exitCode = await commandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{vswherePath}\" -latest -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath",
+            cancellationToken: cancellationToken);
+        if (exitCode != 0)
+        {
+            return null;
+        }
+
+        string installPath = commandLine.StandardOutput.Trim();
+        return string.IsNullOrEmpty(installPath) ? null : installPath;
+    }
+
+    /// <summary>
+    /// Builds a copy of the current process environment with the code-coverage profiler variables removed,
+    /// for use as a child-process environment (pass with <c>cleanDefaultEnvironmentVariableIfCustomAreProvided: true</c>).
+    /// </summary>
+    public static Dictionary<string, string?> BuildEnvironmentWithoutCodeCoverage()
+    {
+        var environmentVariables = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            string key = (string)entry.Key;
+            if (CodeCoverageEnvironmentVariables.Contains(key, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            environmentVariables[key] = entry.Value?.ToString();
+        }
+
+        return environmentVariables;
+    }
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
@@ -65,6 +65,18 @@ internal static class CppCliTestSupport
     }
 
     /// <summary>
+    /// Returns the path to <c>MSBuild.exe</c> inside the given Visual Studio install. Deriving MSBuild from
+    /// the same install that was validated to contain the VC toolset (rather than locating it independently)
+    /// guarantees the C++ targets/toolset are available when building the <c>.vcxproj</c> on machines with
+    /// multiple Visual Studio instances. Returns <see langword="null"/> when not found.
+    /// </summary>
+    public static string? TryGetMSBuildPathFromVsInstall(string vsInstallPath)
+    {
+        string msbuildPath = Path.Combine(vsInstallPath, "MSBuild", "Current", "Bin", "MSBuild.exe");
+        return File.Exists(msbuildPath) ? msbuildPath : null;
+    }
+
+    /// <summary>
     /// Builds a copy of the current process environment with the code-coverage profiler variables removed,
     /// for use as a child-process environment (pass with <c>cleanDefaultEnvironmentVariableIfCustomAreProvided: true</c>).
     /// </summary>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliTestSupport.cs
@@ -14,8 +14,10 @@ internal static class CppCliTestSupport
 {
     // The code-coverage profiler environment variables the acceptance host injects; inheriting them into a
     // nested .NET Framework test host breaks the run, so they are stripped from the child process environment.
-    private static readonly string[] CodeCoverageEnvironmentVariables =
-    [
+    // IDE0028 (collection expression) is suppressed: a collection expression cannot carry the comparer.
+#pragma warning disable IDE0028 // Simplify collection initialization
+    private static readonly HashSet<string> CodeCoverageEnvironmentVariables = new(StringComparer.OrdinalIgnoreCase)
+    {
         "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler",
         "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler",
         "CORECLR_PROFILER_PATH_32",
@@ -31,7 +33,8 @@ internal static class CppCliTestSupport
         "MicrosoftInstrumentationEngine_LogLevel",
         "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation",
         "MicrosoftInstrumentationEngine_FileLogPath",
-    ];
+    };
+#pragma warning restore IDE0028 // Simplify collection initialization
 
     /// <summary>
     /// Returns the installation path of a Visual Studio install that has the MSVC C++ toolset (needed to
@@ -86,7 +89,7 @@ internal static class CppCliTestSupport
         foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
         {
             string key = (string)entry.Key;
-            if (CodeCoverageEnvironmentVariables.Contains(key, StringComparer.OrdinalIgnoreCase))
+            if (CodeCoverageEnvironmentVariables.Contains(key))
             {
                 continue;
             }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.IO.Compression;
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -32,7 +31,7 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
         // Classic C++/CLI (.NET Framework '/clr') only needs the MSVC toolset; the dedicated C++/CLI-support
         // component is for '/clr:netcore'. The toolset is absent on SDK-only build legs, so when it is missing
         // we make the test inconclusive rather than fail.
-        string? vsInstallPath = await TryFindVsInstallWithCppToolsetAsync(cancellationToken);
+        string? vsInstallPath = await CppCliTestSupport.TryFindVsInstallWithCppToolsetAsync(cancellationToken);
         if (vsInstallPath is null)
         {
             Assert.Inconclusive("Skipping: no Visual Studio install with the MSVC C++ toolset (Microsoft.VisualStudio.Component.VC.Tools.x86.x64) was found.");
@@ -60,7 +59,7 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
         // The acceptance host itself runs under a code-coverage profiler; those COR_*/CORECLR_* environment
         // variables would be inherited by the nested .NET Framework test host and break the VSTest run, so we
         // build a clean environment (everything except the code-coverage variables) for the child processes.
-        Dictionary<string, string?> cleanEnvironment = BuildEnvironmentWithoutCodeCoverage();
+        Dictionary<string, string?> cleanEnvironment = CppCliTestSupport.BuildEnvironmentWithoutCodeCoverage();
 
         // Build the C++/CLI test assembly with full Visual Studio MSBuild; the dotnet SDK muxer cannot build a vcxproj.
         string vcxproj = Path.Combine(testAsset.TargetAssetPath, $"{AssetName}.vcxproj");
@@ -106,31 +105,6 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
         Assert.Contains("Booleans_Work", output);
     }
 
-    private static async Task<string?> TryFindVsInstallWithCppToolsetAsync(CancellationToken cancellationToken)
-    {
-        string vswherePath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
-            "Microsoft Visual Studio",
-            "Installer",
-            "vswhere.exe");
-        if (!File.Exists(vswherePath))
-        {
-            return null;
-        }
-
-        using var commandLine = new CommandLine();
-        int exitCode = await commandLine.RunAsyncAndReturnExitCodeAsync(
-            $"\"{vswherePath}\" -latest -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath",
-            cancellationToken: cancellationToken);
-        if (exitCode != 0)
-        {
-            return null;
-        }
-
-        string installPath = commandLine.StandardOutput.Trim();
-        return string.IsNullOrEmpty(installPath) ? null : installPath;
-    }
-
     private static string ExtractShippingPackage(TempDirectory destination, string packageId, string version)
     {
         string nupkg = Path.Combine(Constants.ArtifactsPackagesShipping, $"{packageId}.{version}.nupkg");
@@ -139,44 +113,6 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
         string target = Path.Combine(destination.Path, packageId);
         ZipFile.ExtractToDirectory(nupkg, target);
         return target;
-    }
-
-    // The code-coverage profiler environment variables the acceptance host injects; inheriting them into the
-    // nested .NET Framework VSTest host breaks the run, so they are stripped from the child process environment.
-    private static readonly string[] CodeCoverageEnvironmentVariables =
-    [
-        "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler",
-        "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler",
-        "CORECLR_PROFILER_PATH_32",
-        "CORECLR_PROFILER_PATH_64",
-        "CORECLR_ENABLE_PROFILING",
-        "CORECLR_PROFILER",
-        "COR_PROFILER_PATH_32",
-        "COR_PROFILER_PATH_64",
-        "COR_ENABLE_PROFILING",
-        "COR_PROFILER",
-        "CODE_COVERAGE_SESSION_NAME",
-        "CODE_COVERAGE_PIPE_PATH",
-        "MicrosoftInstrumentationEngine_LogLevel",
-        "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation",
-        "MicrosoftInstrumentationEngine_FileLogPath",
-    ];
-
-    private static Dictionary<string, string?> BuildEnvironmentWithoutCodeCoverage()
-    {
-        var environmentVariables = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
-        {
-            string key = (string)entry.Key;
-            if (CodeCoverageEnvironmentVariables.Contains(key, StringComparer.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            environmentVariables[key] = entry.Value?.ToString();
-        }
-
-        return environmentVariables;
     }
 
     private const string SourceCode = """

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.IO.Compression;
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Guards the (legacy, VSTest-bound) scenario where MSTest test classes are authored in a
+/// <b>C++/CLI managed assembly</b> rather than C#. This is the realistic migration target for internal
+/// teams moving off the deprecated CppUnitTestFramework for projects that can compile with <c>/clr</c>.
+/// The test builds a tiny C++/CLI test assembly against the freshly-built MSTest packages and runs it
+/// through <c>vstest.console.exe</c>, asserting the MSTest adapter discovers and executes the tests.
+/// </summary>
+[TestClass]
+[OSCondition(OperatingSystems.Windows, IgnoreMessage = "C++/CLI requires the MSVC '/clr' toolset and is Windows-only.")]
+public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
+{
+    private const string AssetName = "CppCliMSTest";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task MSTestTestsInCppCliAssembly_AreDiscoveredAndRun_ByVSTest()
+    {
+        CancellationToken cancellationToken = TestContext.CancellationToken;
+
+        // Classic C++/CLI (.NET Framework '/clr') only needs the MSVC toolset; the dedicated C++/CLI-support
+        // component is for '/clr:netcore'. The toolset is absent on SDK-only build legs, so when it is missing
+        // we make the test inconclusive rather than fail.
+        string? vsInstallPath = await TryFindVsInstallWithCppToolsetAsync(cancellationToken);
+        if (vsInstallPath is null)
+        {
+            Assert.Inconclusive("Skipping: no Visual Studio install with the MSVC C++ toolset (Microsoft.VisualStudio.Component.VC.Tools.x86.x64) was found.");
+            return;
+        }
+
+        string msbuildExe = await FindMsbuildWithVsWhereAsync(cancellationToken);
+
+        // C++/CLI projects cannot consume managed assemblies from a NuGet PackageReference (NuGet only wires
+        // build/native assets into a vcxproj, not lib/*.dll references), so we extract the freshly-built
+        // MSTest packages and reference the assemblies via <HintPath>. This still validates the just-built
+        // framework + adapter against a managed C++/CLI test assembly.
+        using var packagesDir = new TempDirectory();
+        string frameworkNet462Dir = Path.Combine(ExtractShippingPackage(packagesDir, "MSTest.TestFramework", MSTestVersion), "lib", "net462");
+        string adapterNet462Dir = Path.Combine(ExtractShippingPackage(packagesDir, "MSTest.TestAdapter", MSTestVersion), "buildTransitive", "net462");
+        Assert.IsTrue(
+            File.Exists(Path.Combine(frameworkNet462Dir, "MSTest.TestFramework.dll")),
+            $"Expected MSTest.TestFramework.dll under '{frameworkNet462Dir}'.");
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            SourceCode.PatchCodeWithReplace("$MSTestFrameworkDir$", frameworkNet462Dir),
+            addDefaultNuGetConfigFile: false);
+
+        // The acceptance host itself runs under a code-coverage profiler; those COR_*/CORECLR_* environment
+        // variables would be inherited by the nested .NET Framework test host and break the VSTest run, so we
+        // build a clean environment (everything except the code-coverage variables) for the child processes.
+        Dictionary<string, string?> cleanEnvironment = BuildEnvironmentWithoutCodeCoverage();
+
+        // Build the C++/CLI test assembly with full Visual Studio MSBuild; the dotnet SDK muxer cannot build a vcxproj.
+        string vcxproj = Path.Combine(testAsset.TargetAssetPath, $"{AssetName}.vcxproj");
+        string binlogFile = Path.Combine(TempDirectory.TestSuiteDirectory, $"{nameof(MSTestTestsInCppCliAssembly_AreDiscoveredAndRun_ByVSTest)}.binlog");
+        using var buildCommandLine = new CommandLine();
+        int buildExitCode = await buildCommandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{msbuildExe}\" \"{vcxproj}\" /p:Configuration=Debug /p:Platform=x64 /restore:false /bl:\"{binlogFile}\"",
+            cleanEnvironment,
+            cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
+            cancellationToken: cancellationToken);
+        Assert.AreEqual(
+            0,
+            buildExitCode,
+            $"C++/CLI build failed.{Environment.NewLine}{buildCommandLine.StandardOutput}{Environment.NewLine}{buildCommandLine.ErrorOutput}");
+
+        string testDll = Path.Combine(testAsset.TargetAssetPath, "x64", "Debug", $"{AssetName}.dll");
+        Assert.IsTrue(File.Exists(testDll), $"Built C++/CLI test assembly was not found at '{testDll}'.");
+
+        // Run the managed C++/CLI assembly through VSTest using the freshly-built MSTest adapter. We use the
+        // vstest.console.exe bundled with the located VS install (rather than the Microsoft.TestPlatform NuGet
+        // package) so the test is self-contained and does not depend on that package being in the NuGet cache.
+        string vstestConsolePath = Path.Combine(vsInstallPath, "Common7", "IDE", "Extensions", "TestPlatform", "vstest.console.exe");
+        Assert.IsTrue(File.Exists(vstestConsolePath), $"vstest.console.exe was not found at '{vstestConsolePath}'.");
+        using var runCommandLine = new CommandLine();
+        int runExitCode = await runCommandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{vstestConsolePath}\" \"{testDll}\" /TestAdapterPath:\"{adapterNet462Dir}\" /Platform:x64",
+            cleanEnvironment,
+            // vstest.console.exe lives under Program Files; without a writable working directory the MSTest
+            // adapter fails creating its 'TestResults\Deploy_*' folder there. Run from the asset folder.
+            workingDirectory: testAsset.TargetAssetPath,
+            cleanDefaultEnvironmentVariableIfCustomAreProvided: true,
+            cancellationToken: cancellationToken);
+
+        string output = runCommandLine.StandardOutput;
+        Assert.AreEqual(
+            0,
+            runExitCode,
+            $"VSTest run did not succeed.{Environment.NewLine}{output}{Environment.NewLine}{runCommandLine.ErrorOutput}");
+
+        // Discovery + execution: each C++/CLI [TestMethod] surfaces (and passes) in the VSTest output.
+        Assert.Contains("Add_TwoPlusTwo_IsFour", output);
+        Assert.Contains("Strings_AreEqual", output);
+        Assert.Contains("Booleans_Work", output);
+    }
+
+    private static async Task<string?> TryFindVsInstallWithCppToolsetAsync(CancellationToken cancellationToken)
+    {
+        string vswherePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft Visual Studio",
+            "Installer",
+            "vswhere.exe");
+        if (!File.Exists(vswherePath))
+        {
+            return null;
+        }
+
+        using var commandLine = new CommandLine();
+        int exitCode = await commandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{vswherePath}\" -latest -prerelease -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath",
+            cancellationToken: cancellationToken);
+        if (exitCode != 0)
+        {
+            return null;
+        }
+
+        string installPath = commandLine.StandardOutput.Trim();
+        return string.IsNullOrEmpty(installPath) ? null : installPath;
+    }
+
+    private static string ExtractShippingPackage(TempDirectory destination, string packageId, string version)
+    {
+        string nupkg = Path.Combine(Constants.ArtifactsPackagesShipping, $"{packageId}.{version}.nupkg");
+        Assert.IsTrue(File.Exists(nupkg), $"Expected packed package '{nupkg}' was not found. Did you build with '-pack'?");
+
+        string target = Path.Combine(destination.Path, packageId);
+        ZipFile.ExtractToDirectory(nupkg, target);
+        return target;
+    }
+
+    // The code-coverage profiler environment variables the acceptance host injects; inheriting them into the
+    // nested .NET Framework VSTest host breaks the run, so they are stripped from the child process environment.
+    private static readonly string[] CodeCoverageEnvironmentVariables =
+    [
+        "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler",
+        "MicrosoftInstrumentationEngine_ConfigPath64_VanguardInstrumentationProfiler",
+        "CORECLR_PROFILER_PATH_32",
+        "CORECLR_PROFILER_PATH_64",
+        "CORECLR_ENABLE_PROFILING",
+        "CORECLR_PROFILER",
+        "COR_PROFILER_PATH_32",
+        "COR_PROFILER_PATH_64",
+        "COR_ENABLE_PROFILING",
+        "COR_PROFILER",
+        "CODE_COVERAGE_SESSION_NAME",
+        "CODE_COVERAGE_PIPE_PATH",
+        "MicrosoftInstrumentationEngine_LogLevel",
+        "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation",
+        "MicrosoftInstrumentationEngine_FileLogPath",
+    ];
+
+    private static Dictionary<string, string?> BuildEnvironmentWithoutCodeCoverage()
+    {
+        var environmentVariables = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry entry in Environment.GetEnvironmentVariables())
+        {
+            string key = (string)entry.Key;
+            if (CodeCoverageEnvironmentVariables.Contains(key, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            environmentVariables[key] = entry.Value?.ToString();
+        }
+
+        return environmentVariables;
+    }
+
+    private const string SourceCode = """
+#file CppCliMSTest.vcxproj
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B8C9F1A2-3D4E-4F5A-9B6C-7D8E9F0A1B2C}</ProjectGuid>
+    <RootNamespace>CppCliMSTest</RootNamespace>
+    <Keyword>ManagedCProj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CLRSupport>true</CLRSupport>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Tests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="MSTest.TestFramework">
+      <HintPath>$MSTestFrameworkDir$\MSTest.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestFramework.Extensions">
+      <HintPath>$MSTestFrameworkDir$\MSTest.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>
+
+#file Tests.cpp
+using namespace System;
+using namespace Microsoft::VisualStudio::TestTools::UnitTesting;
+
+[TestClass]
+public ref class CalculatorTests
+{
+public:
+    [ClassInitialize]
+    static void ClassInit(TestContext^ testContext)
+    {
+        Console::WriteLine("CalculatorTests.ClassInit called.");
+    }
+
+    [TestInitialize]
+    void MethodInit()
+    {
+        Console::WriteLine("CalculatorTests.MethodInit called.");
+    }
+
+    [TestMethod]
+    void Add_TwoPlusTwo_IsFour()
+    {
+        Assert::AreEqual(4, 2 + 2);
+    }
+
+    [TestMethod]
+    void Strings_AreEqual()
+    {
+        Assert::AreEqual(gcnew String("Hello"), gcnew String("Hello"));
+    }
+
+    [TestMethod]
+    void Booleans_Work()
+    {
+        Assert::IsTrue(1 == 1);
+        Assert::IsFalse(1 == 2);
+    }
+};
+""";
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/CppCliVSTestTests.cs
@@ -38,7 +38,14 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
             return;
         }
 
-        string msbuildExe = await FindMsbuildWithVsWhereAsync(cancellationToken);
+        // Derive MSBuild from the same VS install we validated above, so the C++ targets/toolset are
+        // guaranteed available (locating MSBuild independently could pick a different install on multi-VS machines).
+        string? msbuildExe = CppCliTestSupport.TryGetMSBuildPathFromVsInstall(vsInstallPath);
+        if (msbuildExe is null)
+        {
+            Assert.Inconclusive($"Skipping: MSBuild.exe was not found under the located Visual Studio install '{vsInstallPath}'.");
+            return;
+        }
 
         // C++/CLI projects cannot consume managed assemblies from a NuGet PackageReference (NuGet only wires
         // build/native assets into a vcxproj, not lib/*.dll references), so we extract the freshly-built
@@ -81,8 +88,15 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
         // Run the managed C++/CLI assembly through VSTest using the freshly-built MSTest adapter. We use the
         // vstest.console.exe bundled with the located VS install (rather than the Microsoft.TestPlatform NuGet
         // package) so the test is self-contained and does not depend on that package being in the NuGet cache.
+        // A VS install with the VC toolset (e.g. Build Tools) may not carry the Test Platform, so treat a
+        // missing vstest.console.exe as an environment capability gap and skip rather than fail.
         string vstestConsolePath = Path.Combine(vsInstallPath, "Common7", "IDE", "Extensions", "TestPlatform", "vstest.console.exe");
-        Assert.IsTrue(File.Exists(vstestConsolePath), $"vstest.console.exe was not found at '{vstestConsolePath}'.");
+        if (!File.Exists(vstestConsolePath))
+        {
+            Assert.Inconclusive($"Skipping: vstest.console.exe was not found under the located Visual Studio install '{vsInstallPath}'.");
+            return;
+        }
+
         using var runCommandLine = new CommandLine();
         int runExitCode = await runCommandLine.RunAsyncAndReturnExitCodeAsync(
             $"\"{vstestConsolePath}\" \"{testDll}\" /TestAdapterPath:\"{adapterNet462Dir}\" /Platform:x64",
@@ -135,7 +149,7 @@ public sealed class CppCliVSTestTests : AcceptanceTestBase<NopAssetFixture>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CharacterSet>Unicode</CharacterSet>


### PR DESCRIPTION
## Why

Some internal teams still rely on the deprecated `Microsoft::VisualStudio::CppUnitTestFramework` (CppUnit). It's VSTest-bound and aimed at managed/mixed C++, so MSTest is a plausible migration target for the C++/CLI subset of those projects. These acceptance tests guard that scenario against accidental breakage as we move toward Microsoft.Testing.Platform (MTP).

## What

Two Windows-only acceptance tests in `MSTest.Acceptance.IntegrationTests`, each building a tiny **C++/CLI managed test assembly** against the freshly-built MSTest packages and asserting the tests are discovered and executed:

- **`CppCliVSTestTests`** — runs the C++/CLI assembly through `vstest.console.exe` + the just-built MSTest adapter (the legacy, VSTest-bound path).
- **`CppCliMtpTests`** — hosts **Microsoft.Testing.Platform** from a C++/CLI `Application` with a managed `main` (`CreateBuilderAsync`/`AddMSTest`/`BuildAsync`/`RunAsync`), producing a self-contained MTP test host — no `vstest.console` needed.
- **`CppCliTestSupport`** — shared helpers (locate a VS install with the MSVC toolset via `vswhere`; build a child-process environment with the code-coverage profiler variables stripped).

## How they work

A C++/CLI `.vcxproj` cannot consume managed assemblies from a NuGet `PackageReference`, so:
- the VSTest test extracts the packed `MSTest.TestFramework`/`MSTest.TestAdapter` and references the assemblies via `<HintPath>`;
- the MTP test harvests the full MTP + MSTest `net472` runtime closure by building a generated C# `EnableMSTestRunner` project (NuGet resolves the closure into its output), then deploys it next to the C++/CLI exe.

Both build the `.vcxproj` with full Visual Studio MSBuild (the dotnet SDK muxer can't build a `.vcxproj`).

## Gating

Both are `[OSCondition(OperatingSystems.Windows)]` and **skip (`Assert.Inconclusive`)** when no Visual Studio install with the MSVC C++ toolset (`Microsoft.VisualStudio.Component.VC.Tools.x86.x64`) is present, so SDK-only build legs stay green. This is classic `/clr` (.NET Framework); `/clr:netcore` is a separate, untested axis.

## Validation

`.\build.cmd -pack` then `dotnet run --project test/IntegrationTests/MSTest.Acceptance.IntegrationTests -- --filter "FullyQualifiedName~CppCli"` → **total: 2, succeeded: 2, skipped: 0** on a VS-equipped Windows machine.

## Notes for reviewers

- These tests only execute where the C++ toolset exists; elsewhere they self-skip. Worth deciding whether CI should run a C++/CLI-capable Windows leg so they actually exercise.
- The MTP test demonstrates C++/CLI can be a first-class MTP host — a stronger, MTP-aligned migration target than the VSTest path. Happy to follow up with a small `MSTest.CppCli` helper package (header-only ergonomics layer + props/targets that deploy the closure) if there's appetite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>