### PR TITLE
Dogfood Azure DevOps report history options in CI

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -152,6 +152,11 @@ extends:
                 env:
                   TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT: 5m
                   DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+                  # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
+                  # flaky-history injected by test/Directory.Build.targets) can query this pipeline's own
+                  # test-result history. Secret variables are not auto-exposed to scripts, so the explicit
+                  # mapping is required; the history service no-ops if the token or endpoints are unavailable.
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: CopyFiles@2
                 displayName: 'Copy binlogs'
@@ -245,6 +250,11 @@ extends:
                 env:
                   TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT: 5m
                   DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+                  # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
+                  # flaky-history injected by test/Directory.Build.targets) can query this pipeline's own
+                  # test-result history. Secret variables are not auto-exposed to scripts, so the explicit
+                  # mapping is required; the history service no-ops if the token or endpoints are unavailable.
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish Test Results folders'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ variables:
   #   --report-azdo-slow-test-history 30 — query the pipeline's own test history (last 30 days) and lower the
   #     per-test 'still running' threshold for historically fast tests. Mirrors the Debug path in
   #     test/Directory.Build.targets so Debug and Release dogfood the same AzDO surface.
-  #   --report-azdo-slow-test-history-min-sample 10 / --report-azdo-slow-test-history-multiplier 3 — exercise
+  #   --report-azdo-slow-test-history-min-sample 10 / --report-azdo-slow-test-history-multiplier 3.0 — exercise
   #     the slow-test-history sub-options and their 'requires report-azdo-slow-test-history' validation. Values
   #     match the extension defaults, so they don't change which tests are flagged; they only keep the option
   #     surface covered.
@@ -60,11 +60,11 @@ variables:
   #     report-azdo-demote-known-flaky option, intentionally left off so a genuine regression is never hidden).
   #   --hangdump --hangdump-timeout 15m — dump a module that hangs past 15 minutes.
   # The report-azdo history options (slow-test-history, flaky-history) authenticate via the SYSTEM_ACCESSTOKEN
-  # secret, which is intentionally NOT mapped onto these public test steps; they silently no-op without it, so
-  # here they exercise the option parsing/validation surface only. They run end-to-end where a token is present.
+  # secret. It is now mapped onto the public Test/TestRelease steps below; fork PR builds don't receive the
+  # secret so the history service silently no-ops there, while trusted-branch builds exercise it end-to-end.
   # Placeholders ({asm}/{tfm}) are resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
   - name: _ReleaseUnitTestReportArgs
-    value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-azdo-slow-test-history 30 --report-azdo-slow-test-history-min-sample 10 --report-azdo-slow-test-history-multiplier 3 --report-azdo-flaky-history 30 --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
+    value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-azdo-slow-test-history 30 --report-azdo-slow-test-history-min-sample 10 --report-azdo-slow-test-history-multiplier 3.0 --report-azdo-flaky-history 30 --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
 
 stages:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,23 @@ variables:
   #   --report-junit / --report-junit-filename "{asm}_{tfm}.xml" — JUnit XML per (assembly x TFM).
   #   --report-azdo — surfaces failed tests in the AzDO UI.
   #   --report-azdo-summary — Markdown job summary uploaded to the build's Summary tab.
+  #   --report-azdo-slow-test-history 30 — query the pipeline's own test history (last 30 days) and lower the
+  #     per-test 'still running' threshold for historically fast tests. Mirrors the Debug path in
+  #     test/Directory.Build.targets so Debug and Release dogfood the same AzDO surface.
+  #   --report-azdo-slow-test-history-min-sample 10 / --report-azdo-slow-test-history-multiplier 3 — exercise
+  #     the slow-test-history sub-options and their 'requires report-azdo-slow-test-history' validation. Values
+  #     match the extension defaults, so they don't change which tests are flagged; they only keep the option
+  #     surface covered.
+  #   --report-azdo-flaky-history 30 — query test history (last 30 days) and annotate reported failures with
+  #     flakiness context. Annotation only: it does NOT demote failures to warnings (that is the separate
+  #     report-azdo-demote-known-flaky option, intentionally left off so a genuine regression is never hidden).
   #   --hangdump --hangdump-timeout 15m — dump a module that hangs past 15 minutes.
+  # The report-azdo history options (slow-test-history, flaky-history) authenticate via the SYSTEM_ACCESSTOKEN
+  # secret, which is intentionally NOT mapped onto these public test steps; they silently no-op without it, so
+  # here they exercise the option parsing/validation surface only. They run end-to-end where a token is present.
   # Placeholders ({asm}/{tfm}) are resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
   - name: _ReleaseUnitTestReportArgs
-    value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
+    value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-azdo-slow-test-history 30 --report-azdo-slow-test-history-min-sample 10 --report-azdo-slow-test-history-multiplier 3 --report-azdo-flaky-history 30 --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
 
 stages:
 
@@ -194,6 +207,13 @@ stages:
             name: Test
             displayName: Test
             condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
+            env:
+              # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
+              # flaky-history injected by test/Directory.Build.targets) can query this pipeline's own
+              # test-result history. Secret variables are not auto-exposed to scripts, so the explicit mapping
+              # is required. Fork PR builds don't receive the secret, so the history service simply no-ops
+              # there; trusted branch builds exercise it end-to-end.
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
           # Integration tests are redundant in Release—they spawn child processes that already cover
           # both Debug and Release configurations. Use --test-modules to run only unit tests.
@@ -219,6 +239,13 @@ stages:
             name: TestRelease
             displayName: Test (unit tests only)
             condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+            env:
+              # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
+              # flaky-history in $(_ReleaseUnitTestReportArgs)) can query this pipeline's own test-result
+              # history. Secret variables are not auto-exposed to scripts, so the explicit mapping is required.
+              # Fork PR builds don't receive the secret, so the history service simply no-ops there; trusted
+              # branch builds exercise it end-to-end.
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -24,6 +24,12 @@ steps:
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
+  env:
+    # Expose the build's OAuth token so the report-azdo history options (slow-test-history / flaky-history
+    # injected by test/Directory.Build.targets) can query this pipeline's own test-result history. Secret
+    # variables are not auto-exposed to scripts, so the explicit mapping is required. Fork PR builds don't
+    # receive the secret, so the history service simply no-ops there; trusted branch builds run it end-to-end.
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 # Integration tests are redundant in Release—they spawn child processes that already cover
 # both Debug and Release configurations. Use --test-modules to run only unit tests.
@@ -48,6 +54,12 @@ steps:
   name: TestRelease
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))
+  env:
+    # Expose the build's OAuth token so the report-azdo history options (slow-test-history / flaky-history in
+    # $(_ReleaseUnitTestReportArgs)) can query this pipeline's own test-result history. Secret variables are
+    # not auto-exposed to scripts, so the explicit mapping is required. Fork PR builds don't receive the
+    # secret, so the history service simply no-ops there; trusted branch builds run it end-to-end.
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Test Results folders'

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -26,6 +26,20 @@
          lines with historical p95/p99. It requires the report-azdo option (added above) and the OAuth access
          token, and silently no-ops when TF_BUILD is not 'true' or no token is available, so gate it on $(TF_BUILD). -->
     <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history 30</TestingPlatformCommandLineArguments>
+    <!-- Dogfood the report-azdo-slow-test-history sub-options so their wiring and the
+         'requires report-azdo-slow-test-history' validation cross-check stay covered in CI. The values match
+         the extension defaults (min-sample 10, multiplier 3.0), so they don't change which tests get flagged
+         as slow; they only keep the option surface exercised. They require report-azdo-slow-test-history
+         (added above, also TF_BUILD-gated), so gate them on $(TF_BUILD) too. -->
+    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history-min-sample 10</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history-multiplier 3</TestingPlatformCommandLineArguments>
+    <!-- Dogfood the Azure DevOps flaky-history annotator (pairs with report-azdo above). It queries the
+         pipeline's own test history for the last 30 days and decorates reported failures with flakiness
+         context. It only annotates: it never demotes a failure to a warning (that is the separate
+         report-azdo-demote-known-flaky option, intentionally left off so a genuine regression is never
+         hidden). Like report-azdo-slow-test-history it silently no-ops without TF_BUILD or an OAuth access
+         token, so gate it on $(TF_BUILD). -->
+    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-flaky-history 30</TestingPlatformCommandLineArguments>
     <!-- Dogfood the JUnit report extension (Microsoft.Testing.Extensions.JUnitReport). The .xml files end up in
          $(ResultsDirectory) (Arcade default) alongside the TRX files so they are picked up by the AzDO
          PublishTestResults task and any external JUnit consumer. -->

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -32,7 +32,7 @@
          as slow; they only keep the option surface exercised. They require report-azdo-slow-test-history
          (added above, also TF_BUILD-gated), so gate them on $(TF_BUILD) too. -->
     <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history-min-sample 10</TestingPlatformCommandLineArguments>
-    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history-multiplier 3</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-slow-test-history-multiplier 3.0</TestingPlatformCommandLineArguments>
     <!-- Dogfood the Azure DevOps flaky-history annotator (pairs with report-azdo above). It queries the
          pipeline's own test history for the last 30 days and decorates reported failures with flakiness
          context. It only annotates: it never demotes a failure to a warning (that is the separate


### PR DESCRIPTION
## What

Exercises more of the `report-azdo` extension surface in our own CI, and makes the history-backed options actually run end-to-end on both pipelines.

### Option set
- Adds `--report-azdo-flaky-history 30`, `--report-azdo-slow-test-history-min-sample 10`, and `--report-azdo-slow-test-history-multiplier 3`.
- `test/Directory.Build.targets` (Debug `dotnet test` + official `Test.cmd` path, `TF_BUILD`-gated) and the `_ReleaseUnitTestReportArgs` variable in `azure-pipelines.yml` (Release `--test-modules` path) now inject the same set, and Release gains `--report-azdo-slow-test-history 30` so Debug and Release dogfood an identical AzDO surface on every OS.

### Token mapping (the reason they now actually run)
The history-backed options authenticate via the `SYSTEM_ACCESSTOKEN` secret, which is **not** auto-exposed to scripts — so today they no-op everywhere. This PR maps `SYSTEM_ACCESSTOKEN: $(System.AccessToken)` onto **every test step on both pipelines**:
- Public: `azure-pipelines.yml` (Windows Debug + Release) and `eng/pipelines/steps/test-non-windows.yml` (Linux/macOS Debug + Release).
- Official: `azure-pipelines-official.yml` (Windows + Linux test steps).

The env propagates to the spawned test-host processes that read it.

## Why it's safe
- **Safe-by-default on public PRs:** fork PR builds don't receive the secret, so the history service silently no-ops — no token exposure to untrusted PR code. Trusted branch and official builds get the token and exercise the feature for real.
- **No failure-hiding:** `flaky-history` only *annotates* reported failures. `--report-azdo-demote-known-flaky` (which demotes failures to warnings) is intentionally left off so a genuine regression is never hidden.
- The slow-test sub-option values match the extension defaults, so they don't change which tests get flagged; they keep the option plumbing and the `requires report-azdo-slow-test-history` validation covered.

## Not included (deliberately)
`--report-azdo-demote-known-flaky` (hides failures), `--report-azdo-quarantine-file` (needs a tracked file), `--report-azdo-severity`, `--report-azdo-stackframe-filter` (needs a repo-specific regex), `--report-azdo-upload-artifacts*` (duplicates the existing `PublishBuildArtifacts` of TestResults), and `--publish-azdo-test-results` (overlaps the existing TRX/JUnit + `PublishTestResults` flow).

## Validation
- All three YAML files parse; `test/Directory.Build.targets` is valid XML.
- AzDO option validation cross-checks satisfied (`flaky-history` → `report-azdo`; slow-test sub-options → `slow-test-history`, co-gated so they co-occur).
- No `--help`/`--info` acceptance changes needed — the provider's registered options are unchanged; this only changes which arguments our own CI passes.

Config-only change.