### PR TITLE
[efficiency-improver] perf: cache MethodInfo.GetParameters() to avoid per-row array allocations in data-driven tests

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/AssemblyEnumerator.cs
@@ -289,12 +289,14 @@ internal class AssemblyEnumerator
 
         var discoveredTests = new List<UnitTestElement>();
         bool dataSourceHasData = false;
+        // PERF: Hoist outside the loop — MethodInfo.GetParameters() returns a fresh array copy on each
+        // call (CLR safety guarantee), so calling it per row allocates N identical arrays for N data rows.
+        ParameterInfo[] parameters = methodInfo.GetParameters();
 
         foreach (object?[] dataOrTestDataRow in dataEnumerable)
         {
             dataSourceHasData = true;
             object?[] d = dataOrTestDataRow;
-            ParameterInfo[] parameters = methodInfo.GetParameters();
 
             // The effective ignore message for this row is the row-level ignore message (from
             // TestDataRow<T>), falling back to the whole-source ignore message. It must be

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -63,8 +63,14 @@ internal partial class TestMethodInfo : ITestMethod
     /// <remarks>
     /// Lazy-cached: <c>MethodInfo.GetParameters()</c> returns a fresh array copy on every call
     /// (CLR safety guarantee), so caching avoids N redundant copies for data-driven tests with N rows.
+    /// This cached array is shared across internal call sites and MUST NOT be mutated. The explicit
+    /// <see cref="ITestMethod.ParameterTypes"/> implementation hands external consumers a fresh copy to
+    /// preserve the previous "fresh array per call" behavior and protect the cache from mutation.
     /// </remarks>
     public ParameterInfo[] ParameterTypes => field ??= MethodInfo.GetParameters();
+
+    /// <inheritdoc />
+    ParameterInfo[] ITestMethod.ParameterTypes => (ParameterInfo[])ParameterTypes.Clone();
 
     /// <summary>
     /// Gets the return type of the test method.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -60,7 +60,11 @@ internal partial class TestMethodInfo : ITestMethod
     /// <summary>
     /// Gets the parameter types of the test method.
     /// </summary>
-    public ParameterInfo[] ParameterTypes => MethodInfo.GetParameters();
+    /// <remarks>
+    /// Lazy-cached: <c>MethodInfo.GetParameters()</c> returns a fresh array copy on every call
+    /// (CLR safety guarantee), so caching avoids N redundant copies for data-driven tests with N rows.
+    /// </remarks>
+    public ParameterInfo[] ParameterTypes => field ??= MethodInfo.GetParameters();
 
     /// <summary>
     /// Gets the return type of the test method.


### PR DESCRIPTION
## Goal

Eliminate redundant `ParameterInfo[]` heap allocations in the data-driven test execution and discovery paths.

## Focus Area

**Code-Level Efficiency** — reducing unnecessary object creation that causes GC pressure.

## Background

`MethodInfo.GetParameters()` is a CLR-mandated copy-on-every-call API: the runtime keeps an internal `ParameterInfo[]` but returns a **fresh copy** to each caller to prevent external mutation of internal reflection state. This means every call allocates a new array on the heap, even when the method signature hasn't changed.

Two separate call sites in the MSTest adapter were calling `GetParameters()` repeatedly for the same method while iterating over data rows:

### 1. `AssemblyEnumerator.TryUnfoldITestDataSource` (discovery path)

```csharp
foreach (object?[] dataOrTestDataRow in dataEnumerable)
{
    ParameterInfo[] parameters = methodInfo.GetParameters();  // ← inside the loop
    ...
```

For a test with N data rows, this allocates N identical `ParameterInfo[]` objects during test discovery.

### 2. `TestMethodInfo.ParameterTypes` (execution path)

```csharp
public ParameterInfo[] ParameterTypes => MethodInfo.GetParameters();  // ← eager, no cache
```

In `TestMethodRunner.ExecuteTestWithDataSourceAsync`, `ParameterTypes` is accessed up to 3 times per data row:

```csharp
TestDataSourceHelpers.TryHandleITestDataRow(data, _testMethodInfo.ParameterTypes, ...)    // row × 1
TestDataSourceHelpers.IsDataConsideredSingleArgumentValue(data, _testMethodInfo.ParameterTypes) // row × 1
TestDataSourceHelpers.TryHandleTupleDataSource(data[0], _testMethodInfo.ParameterTypes, ...)  // row × 1
```

## Fix

**`AssemblyEnumerator.cs`**: hoist `GetParameters()` above the `foreach` — one call before the loop, reused across all rows.

**`TestMethodInfo.cs`**: use the C# 14 `field` keyword to lazily cache the result once per `TestMethodInfo` instance (the backing `MethodInfo` is `get`-only and set once in the constructor, so the cache is valid for the lifetime of the object):

```csharp
public ParameterInfo[] ParameterTypes => field ??= MethodInfo.GetParameters();
```

## Energy Efficiency Evidence

| Metric | Before | After |
|--------|--------|-------|
| `ParameterInfo[]` allocs — discovery (N rows) | N arrays | 1 array |
| `ParameterInfo[]` allocs — execution (N rows) | up to 3N arrays | 1 array |

**Proxy metric**: heap allocation count. Fewer short-lived heap objects → fewer GC mark/sweep cycles → fewer CPU cycles spent collecting garbage → lower energy per test run.

For a data-driven test with 100 rows, this reduces `ParameterInfo[]` allocations from ~400 to 1.

**Green Software Foundation — Hardware Efficiency**: making better use of already-allocated memory by reusing a cached value rather than churning through repeated identical allocations improves work-per-watt.

## Trade-offs

None significant. The `field` keyword lazy-initialisation is a one-liner that's idiomatic C# 14. The hoisted `GetParameters()` call is straightforward. `MethodInfo` is get-only on `TestMethodInfo`, so the cached value is permanently valid.

## Reproducibility

Any test suite with `[DynamicData]` or custom `ITestDataSource` test methods will exercise both paths. Run `./build.sh -pack -test -integrationTest` to exercise acceptance tests that use data-driven tests.

## Test Status

`./build.sh -test` — all unit tests pass (net8.0 + net9.0).




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Efficiency Improver](https://github.com/microsoft/testfx/actions/runs/28405553132/agentic_workflow) workflow. · 4.4K AIC · ⌖ 40.1 AIC · ⊞ 58.8K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+efficiency-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/efficiency-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Efficiency Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28405553132, workflow_id: efficiency-improver, run: https://github.com/microsoft/testfx/actions/runs/28405553132 -->

<!-- gh-aw-workflow-id: efficiency-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/efficiency-improver -->