### PR TITLE
[test-improver] test: add edge case tests for UseAttributeOnTestMethodAnalyzer (MSTEST0007)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseAttributeOnTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseAttributeOnTestMethodAnalyzerTests.cs
@@ -240,7 +240,7 @@ public sealed class UseAttributeOnTestMethodAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenMethodIsMarkedWithDataTestMethodAndTestAttribute_NoDiagnosticAsync()
+    public async Task WhenMethodIsMarkedWithDataTestMethodAndOwnerAttribute_NoDiagnosticAsync()
     {
         // DataTestMethod inherits TestMethodAttribute — the analyzer exits early on any
         // method decorated with a TestMethod subclass, including the standard DataTestMethod.

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseAttributeOnTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseAttributeOnTestMethodAnalyzerTests.cs
@@ -238,4 +238,64 @@ public sealed class UseAttributeOnTestMethodAnalyzerTests
             VerifyCS.Diagnostic(UseAttributeOnTestMethodAnalyzer.ConditionBaseRule).WithLocation(0).WithArguments("IgnoreAttribute"),
             fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenMethodIsMarkedWithDataTestMethodAndTestAttribute_NoDiagnosticAsync()
+    {
+        // DataTestMethod inherits TestMethodAttribute — the analyzer exits early on any
+        // method decorated with a TestMethod subclass, including the standard DataTestMethod.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DataTestMethod]
+                [Owner("owner")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodIsMarkedWithOSConditionAttributeButNotWithTestMethod_DiagnosticAsync()
+    {
+        // OSConditionAttribute inherits ConditionBaseAttribute — the analyzer fires
+        // ConditionBaseRule and includes the concrete attribute class name in the message.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [{|#0:OSCondition(OperatingSystems.Windows)|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [OSCondition(OperatingSystems.Windows)]
+                [TestMethod]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(UseAttributeOnTestMethodAnalyzer.ConditionBaseRule).WithLocation(0).WithArguments("OSConditionAttribute"),
+            fixedCode);
+    }
 }


### PR DESCRIPTION
## Goal and Rationale

`UseAttributeOnTestMethodAnalyzer` (MSTEST0007) had 37 test cases via 11 test methods (several using `DynamicData`), but two distinct code paths in the analyzer's logic were not covered:

| Untested path | Guard |
|---|---|
| Standard `[DataTestMethod]` causes early-return (no diagnostic) | `methodAttribute.AttributeClass.Inherits(testMethodAttributeSymbol)` early-return — previously only tested with a custom `MyCustomTestMethodAttribute` |
| Non-`[Ignore]` `ConditionBase` subclass fires `ConditionBaseRule` with the concrete class name | `ReferenceEquals(attribute.Rule, ConditionBaseRule)` → `attribute.AttributeData.AttributeClass.Name` — previously only `[Ignore]` was tested |

## Approach

Added two `[TestMethod]` entries to `UseAttributeOnTestMethodAnalyzerTests.cs`:

| Test | What it covers |
|---|---|
| `WhenMethodIsMarkedWithDataTestMethodAndTestAttribute_NoDiagnosticAsync` | `[DataTestMethod]` + `[Owner("owner")]` → no diagnostic. Validates that the standard `DataTestMethodAttribute` (which inherits `TestMethodAttribute`) also causes early-return in the analyzer, not just user-defined subclasses. |
| `WhenMethodIsMarkedWithOSConditionAttributeButNotWithTestMethod_DiagnosticAsync` | `[OSCondition(OperatingSystems.Windows)]` on a method with no `[TestMethod]` → `ConditionBaseRule` with argument `"OSConditionAttribute"`. Validates the `ConditionBaseRule` branch for a non-`[Ignore]` subclass of `ConditionBaseAttribute`. |

## Coverage Impact

| | Before | After |
|---|---|---|
| Tests in `UseAttributeOnTestMethodAnalyzerTests` | 37 | 39 |

## Trade-offs

Purely additive — no production code changes, no new dependencies.

## Test Status

All 39/39 tests pass (`net8.0`, `Debug`):

```
Test run summary: Passed!
  total: 39
  failed: 0
  succeeded: 39
  duration: 7s 251ms
```

## Reproducibility

```bash
.dotnet/dotnet test test/UnitTests/MSTest.Analyzers.UnitTests/MSTest.Analyzers.UnitTests.csproj \
  -f net8.0 --no-build -c Debug \
  --filter "FullyQualifiedName~UseAttributeOnTestMethodAnalyzerTests"
```




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Test Improver](https://github.com/microsoft/testfx/actions/runs/28408908117/agentic_workflow) workflow. · 2K AIC · ⌖ 25.1 AIC · ⊞ 58.2K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+test-improver%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/test-improver.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Test Improver, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28408908117, workflow_id: test-improver, run: https://github.com/microsoft/testfx/actions/runs/28408908117 -->

<!-- gh-aw-workflow-id: test-improver -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/test-improver -->