### PR TITLE
Drop duplicated public color abstractions when consuming the dotnet test source share alongside MTP

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/PACKAGE.md
@@ -36,11 +36,20 @@ must have:
 - **`ImplicitUsings` enabled** — the build props supplies the extra global usings the shared source relies on
   (`System.Text`, `System.Runtime.CompilerServices`, `System.Runtime.Versioning`, …) when implicit usings are on.
 - **A `LangVersion` that supports the `field` keyword** (preview/latest).
-- **The `Microsoft.CodeAnalysis.EmbeddedAttribute` polyfill** — dotnet/sdk already defines it (for its copied IPC
-  transport); other consumers must supply a tiny internal copy.
+- **The `Microsoft.CodeAnalysis.EmbeddedAttribute` polyfill** — shipped by this package as source, so it is always
+  available (dotnet/sdk also defines its own for its copied IPC transport; the `internal sealed partial` polyfill
+  merges harmlessly).
 - **XliffTasks** (only for localized satellites) — dotnet/sdk has it via Arcade.
 
 The wire-contract source is zero-dependency and needs none of the above.
+
+> ℹ️ The terminal reporter ships a couple of small abstractions that also live in Microsoft.Testing.Platform. The
+> internal ones (`IConsole`/`IStopwatch`/`System*`) are not exported by the platform, so they never conflict. The two
+> that are *public* platform API — `IColor` and `SystemConsoleColor` — would conflict (`CS0436`) for a consumer that
+> *also* references Microsoft.Testing.Platform, so the package's `build/` props **drops** those two copies when the
+> platform is referenced and lets the reporter bind to the platform's public types. The result: a consumer that
+> references Microsoft.Testing.Platform needs **no** `NoWarn;CS0436`, and a consumer that does not keeps the copies and
+> compiles standalone.
 
 ## Scope
 

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -60,6 +60,7 @@
           AfterTargets="ResolveReferences"
           BeforeTargets="CoreCompile">
     <ItemGroup>
+      <_DotnetTestPlatformRef Remove="@(_DotnetTestPlatformRef)" />
       <_DotnetTestPlatformRef Include="@(ReferencePath)" Condition=" '%(Filename)' == 'Microsoft.Testing.Platform' " />
     </ItemGroup>
     <PropertyGroup>

--- a/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
+++ b/src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props
@@ -48,4 +48,28 @@
     <Using Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
+  <!--
+    IColor and SystemConsoleColor (shipped in contentFiles/cs/any/TerminalReporter/) are *public* API of
+    Microsoft.Testing.Platform. A consumer that references both this source package and Microsoft.Testing.Platform
+    would otherwise get CS0436 'type conflicts with imported type' for them. When the platform is referenced, drop the
+    duplicated copies so the reporter's single 'SystemConsoleColor?' use binds to the platform's public types - no
+    CS0436, no consumer-side NoWarn. A consumer that does NOT reference the platform keeps the copies and compiles
+    them standalone. Mirrors src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props.
+  -->
+  <Target Name="_RemoveDotnetTestDuplicatePublicColorAbstractions"
+          AfterTargets="ResolveReferences"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_DotnetTestPlatformRef Include="@(ReferencePath)" Condition=" '%(Filename)' == 'Microsoft.Testing.Platform' " />
+    </ItemGroup>
+    <PropertyGroup>
+      <_DotnetTestReferencesPlatform>false</_DotnetTestReferencesPlatform>
+      <_DotnetTestReferencesPlatform Condition=" '@(_DotnetTestPlatformRef)' != '' ">true</_DotnetTestReferencesPlatform>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(_DotnetTestReferencesPlatform)' == 'true' ">
+      <Compile Remove="@(Compile)"
+               Condition=" ('%(Compile.Filename)' == 'IColor' or '%(Compile.Filename)' == 'SystemConsoleColor') and ('%(Compile.NuGetPackageId)' == 'Microsoft.Testing.Platform.Internal.DotnetTest' or $([System.String]::Copy('%(Compile.Identity)').ToLowerInvariant().Contains('microsoft.testing.platform.internal.dotnettest'))) " />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
@@ -16,14 +16,21 @@
       command-line specific - the SDK has its own CLI) and TerminalResources.cs (the hand-written [Embedded]
       accessor used by in-repo IVT-linked consumers; standalone consumers compile the resx instead - see below).
 
-      The reporter + rendering + state types are [Microsoft.CodeAnalysis.Embedded], so a consumer that also
-      references Microsoft.Testing.Platform never sees them as conflicting types. The small platform abstractions
-      in this set (IConsole/IStopwatch/IColor/SystemConsole/SystemConsoleColor/SystemStopwatch) are NOT embedded -
-      they are foundational, platform-wide types used far beyond the terminal. A consumer that compiles this
-      contract AND references Microsoft.Testing.Platform will therefore get benign CS0436 conflict warnings for
-      those types (the compiler uses the locally-compiled copy); such consumers should suppress CS0436 (the
-      in-repo standalone test does). A consumer that does NOT reference Microsoft.Testing.Platform - the real
-      target, e.g. dotnet/sdk's 'dotnet test' - sees no conflict at all.
+      The reporter + rendering + state types are [Microsoft.CodeAnalysis.Embedded], so they are NOT exported by
+      Microsoft.Testing.Platform; a consumer that also references the platform compiles its own (single-source)
+      copy and never sees a conflict. The small internal platform abstractions in this set (IConsole/IStopwatch/
+      SystemConsole/SystemStopwatch + RoslynString/ApplicationStateGuard/StackTraceHelper/TargetFrameworkParser/
+      TestRunSummaryHelper/ZeroTestsPolicy) are 'internal' and not exported either (no InternalsVisibleTo to an
+      external consumer), so they also never conflict.
+
+      The exception is IColor and SystemConsoleColor: those two ARE shipped *public* API of Microsoft.Testing.Platform
+      (Microsoft.Testing.Platform.OutputDevice.FormattedTextOutputDeviceData.Fore/BackgroundColor), so a consumer that
+      ALSO references the platform would get CS0436 'conflicts with imported type' for them. They are public API, so
+      they cannot be made [Embedded]/internal in the platform. Instead, when the consumer references
+      Microsoft.Testing.Platform we DROP the duplicated copies (see the _RemoveTerminalReporter* target below) and let
+      the single reporter use of 'SystemConsoleColor?' (TerminalTestReporter.Messaging.cs) bind to the platform's
+      public types - no CS0436 and no consumer-side NoWarn. A consumer that does NOT reference the platform keeps the
+      copies and compiles standalone. The NuGet source package applies the same drop in its build/ props.
 
     USAGE
       Import this file from any project that needs the reporter source. Microsoft.Testing.Platform itself does
@@ -58,8 +65,14 @@
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\System\IStopwatch.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\System\SystemConsole.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\System\SystemStopwatch.cs" />
-    <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\IColor.cs" />
-    <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\SystemConsoleColor.cs" />
+    <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\IColor.cs">
+      <!-- Public API of Microsoft.Testing.Platform; dropped (not compiled) when the consumer references the platform. -->
+      <PlatformPublicColorAbstraction>true</PlatformPublicColorAbstraction>
+    </TerminalReporterContractSource>
+    <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\SystemConsoleColor.cs">
+      <!-- Public API of Microsoft.Testing.Platform; dropped (not compiled) when the consumer references the platform. -->
+      <PlatformPublicColorAbstraction>true</PlatformPublicColorAbstraction>
+    </TerminalReporterContractSource>
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\TargetFrameworkParser.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\OutputDevice\TestRunSummaryHelper.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\CommandLine\ZeroTestsPolicy.cs" />
@@ -76,5 +89,29 @@
          Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources so the reporter source resolves it. -->
     <EmbeddedResource Include="@(TerminalReporterContractResource)" GenerateSource="true" />
   </ItemGroup>
+
+  <!--
+    IColor and SystemConsoleColor are shipped *public* API of Microsoft.Testing.Platform. When the consumer of this
+    contract ALSO references Microsoft.Testing.Platform, compiling local copies would raise CS0436 (conflicts with the
+    imported public types). Drop the local copies in that case so the reporter's single 'SystemConsoleColor?' use
+    binds to the platform's public types instead - no CS0436, no NoWarn. A consumer that does NOT reference the
+    platform keeps the copies and compiles standalone. The NuGet source package applies the same drop in its build/
+    props for external consumers.
+  -->
+  <Target Name="_RemoveTerminalReporterDuplicatePublicColorAbstractions"
+          AfterTargets="ResolveReferences"
+          BeforeTargets="CoreCompile"
+          Condition=" '$(TerminalReporterContractCompile)' != 'false' ">
+    <ItemGroup>
+      <_TerminalReporterPlatformRef Include="@(ReferencePath)" Condition=" '%(Filename)' == 'Microsoft.Testing.Platform' " />
+    </ItemGroup>
+    <PropertyGroup>
+      <_TerminalReporterReferencesPlatform>false</_TerminalReporterReferencesPlatform>
+      <_TerminalReporterReferencesPlatform Condition=" '@(_TerminalReporterPlatformRef)' != '' ">true</_TerminalReporterReferencesPlatform>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(_TerminalReporterReferencesPlatform)' == 'true' ">
+      <Compile Remove="@(Compile)" Condition=" '%(Compile.PlatformPublicColorAbstraction)' == 'true' " />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
@@ -24,7 +24,7 @@
       external consumer), so they also never conflict.
 
       The exception is IColor and SystemConsoleColor: those two ARE shipped *public* API of Microsoft.Testing.Platform
-      (Microsoft.Testing.Platform.OutputDevice.FormattedTextOutputDeviceData.Fore/BackgroundColor), so a consumer that
+      (Microsoft.Testing.Platform.OutputDevice.FormattedTextOutputDeviceData.ForegroundColor/BackgroundColor), so a consumer that
       ALSO references the platform would get CS0436 'conflicts with imported type' for them. They are public API, so
       they cannot be made [Embedded]/internal in the platform. Instead, when the consumer references
       Microsoft.Testing.Platform we DROP the duplicated copies (see the _RemoveTerminalReporter* target below) and let
@@ -103,6 +103,7 @@
           BeforeTargets="CoreCompile"
           Condition=" '$(TerminalReporterContractCompile)' != 'false' ">
     <ItemGroup>
+      <_TerminalReporterPlatformRef Remove="@(_TerminalReporterPlatformRef)" />
       <_TerminalReporterPlatformRef Include="@(ReferencePath)" Condition=" '%(Filename)' == 'Microsoft.Testing.Platform' " />
     </ItemGroup>
     <PropertyGroup>

--- a/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj
@@ -4,14 +4,6 @@
     <TargetFrameworks>$(SupportedNetFrameworks)</TargetFrameworks>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
-    <!--
-      No NoWarn;CS0436 needed: this project compiles its OWN copy of the shared reporter source while also
-      transitively referencing Microsoft.Testing.Platform via the MSTest runner. The only public types that would
-      otherwise conflict - IColor and SystemConsoleColor (public API of Microsoft.Testing.Platform) - are dropped by
-      TerminalReporterContract.props when the platform is referenced, so the reporter binds to the platform's public
-      copies. The remaining shared abstractions are internal and not exported (no InternalsVisibleTo here), so they
-      never conflict.
-    -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj
@@ -5,12 +5,13 @@
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
     <!--
-      CS0436: this project compiles its OWN copy of the shared reporter source (incl. small abstractions like
-      IColor/SystemConsoleColor that are NOT [Embedded]), while also transitively referencing
-      Microsoft.Testing.Platform via the MSTest runner. The compiler correctly uses the locally-defined copy; the
-      conflict warning is expected and benign for an independent source consumer, so we suppress it here.
+      No NoWarn;CS0436 needed: this project compiles its OWN copy of the shared reporter source while also
+      transitively referencing Microsoft.Testing.Platform via the MSTest runner. The only public types that would
+      otherwise conflict - IColor and SystemConsoleColor (public API of Microsoft.Testing.Platform) - are dropped by
+      TerminalReporterContract.props when the platform is referenced, so the reporter binds to the platform's public
+      copies. The remaining shared abstractions are internal and not exported (no InternalsVisibleTo here), so they
+      never conflict.
     -->
-    <NoWarn>$(NoWarn);CS0436</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Context

Follow-up to the dotnet/sdk work in [dotnet/sdk#54959](https://github.com/dotnet/sdk/pull/54959), which consumes the source-only `Microsoft.Testing.Platform.Internal.DotnetTest` package. That PR had to add `NoWarn;CS0436` to `dotnet.csproj` because the shared terminal-reporter source ships a few small abstractions that also exist in `Microsoft.Testing.Platform`, and a consumer that references both gets `CS0436` "type conflicts with imported type".

Pushing a blanket `NoWarn` onto every consumer is the weaker design. This PR removes the need for it on the testfx side.

## Findings (what the build actually showed)

I first tried conditional `[Microsoft.CodeAnalysis.Embedded]` on the six abstractions, but building the in-repo contract consumer (which compiles the shared source **and** references MTP) revealed:

1. **Only two types actually conflict: `IColor` and `SystemConsoleColor`.** The four `internal` ones (`IConsole`/`IStopwatch`/`SystemConsole`/`SystemStopwatch`) never did — MTP doesn't export internals to an external consumer (no `InternalsVisibleTo` to the SDK). So the original blanket `NoWarn;CS0436` "for six abstractions" was overbroad.
2. **`[Embedded]` can't fix the two that remain.** `[Embedded]` suppresses conflicts from the **producer** side (MTP not exporting the type — that's how the reporter types avoid `CS0436`). But `IColor`/`SystemConsoleColor` are **shipped public API** of MTP (`FormattedTextOutputDeviceData.ForegroundColor`/`BackgroundColor`), so they cannot be made embedded/internal in the platform.

## Fix

The reporter's only use of these is a single `SystemConsoleColor?` parameter (`TerminalTestReporter.Messaging.cs`). So: **when the consumer references `Microsoft.Testing.Platform`, drop the duplicated `IColor`/`SystemConsoleColor` copies** and let the reporter bind to the platform's public types — no `CS0436`, no consumer-side `NoWarn`. A platform-free standalone consumer keeps the copies and compiles them itself.

Implemented as an MSBuild target (detect MTP in `@(ReferencePath)`, remove the two `Compile` items) in both:
- `src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props` (in-repo consumers)
- `src/Platform/Microsoft.Testing.Platform.Internal.DotnetTest/build/Microsoft.Testing.Platform.Internal.DotnetTest.props` (external consumers, e.g. dotnet/sdk)

No `Microsoft.Testing.Platform` `.cs` source was changed. Removed the now-unneeded `NoWarn;CS0436` from the in-repo contract test and updated `PACKAGE.md`.

## Validation

- The in-repo contract test (`Microsoft.Testing.Platform.TerminalReporterContract.UnitTests`) — an independent consumer that references MTP — builds **0 warnings / 0 errors** with the `NoWarn` removed; tests pass on `net8.0` and `net9.0`.
- Packed the source package and confirmed it ships `IColor.cs`/`SystemConsoleColor.cs` at `contentFiles/cs/any/TerminalReporter/` with `buildAction=Compile`, matching the package-side removal condition.
- **Not yet run:** a full dotnet/sdk consume (couldn't replicate the SDK's XliffTasks/global-usings prerequisites locally) — same remaining gap as dotnet/sdk#54959's own "Gap 5".

## Downstream effect

Once dotnet/sdk picks up a testfx build containing this change, the `NoWarn;CS0436` added to `src/Cli/dotnet/dotnet.csproj` in dotnet/sdk#54959 can be deleted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>