### PR TITLE
Polish single-assembly retry extension UX

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/ExtensionResources.resx
@@ -132,16 +132,49 @@
     <value>Percentage failed threshold is {0}% and {1}% tests failed ({2}/{3})</value>
     <comment>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</comment>
   </data>
-  <data name="MoveFiles" xml:space="preserve">
-    <value>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</value>
+  <data name="RetryArtifactsMoved" xml:space="preserve">
+    <value>Retry: moved {0} result file(s) to '{1}'</value>
+    <comment>{0} is the number of files moved. {1} is the destination result directory.</comment>
   </data>
-  <data name="MovingFileToLocation" xml:space="preserve">
-    <value>Moving file '{0}' to '{1}'</value>
-    <comment>{0} is the source file path. {1} is the destination file path.</comment>
+  <data name="RetryAttemptFailedWillRetry" xml:space="preserve">
+    <value>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</value>
+    <comment>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</comment>
+  </data>
+  <data name="RetryWaitingBeforeNextAttempt" xml:space="preserve">
+    <value>Retry: waiting {0} before attempt {1}/{2}</value>
+    <comment>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</comment>
+  </data>
+  <data name="RetrySummaryPassed" xml:space="preserve">
+    <value>Retry summary: Passed! after {0}/{1} attempts</value>
+    <comment>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</comment>
+  </data>
+  <data name="RetrySummaryPassedNoRetry" xml:space="preserve">
+    <value>Retry summary: Passed! on the first attempt (no retries needed)</value>
+    <comment>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</comment>
+  </data>
+  <data name="RetrySummaryFailed" xml:space="preserve">
+    <value>Retry summary: Failed! after {0}/{1} attempts</value>
+    <comment>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</comment>
+  </data>
+  <data name="RetrySummaryFailedLine" xml:space="preserve">
+    <value>  failed: {0}</value>
+    <comment>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</comment>
+  </data>
+  <data name="RetrySummaryFlakyLine" xml:space="preserve">
+    <value>  flaky: {0}</value>
+    <comment>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</comment>
+  </data>
+  <data name="RetrySummaryTotalLine" xml:space="preserve">
+    <value>  total: {0}</value>
+    <comment>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</comment>
+  </data>
+  <data name="RetrySummaryRetriedSuffix" xml:space="preserve">
+    <value> (+{0} retried)</value>
+    <comment>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</comment>
+  </data>
+  <data name="RetrySummaryDurationLine" xml:space="preserve">
+    <value>  duration: {0}</value>
+    <comment>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</comment>
   </data>
   <data name="RetryFailedTestsCannotStartProcessErrorMessage" xml:space="preserve">
     <value>Failed to start process '{0}'</value>
@@ -201,28 +234,6 @@ Moving last attempt asset files to the default result directory
   <data name="TestHostProcessExitedBeforeRetryCouldConnect" xml:space="preserve">
     <value>Test host process exited before the retry service could connect to it. Exit code: {0}</value>
     <comment>{0} is the test host process exit code.</comment>
-  </data>
-  <data name="TestSuiteCompletedSuccessfully" xml:space="preserve">
-    <value>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</value>
-    <comment>{0} is the total attempt count.</comment>
-  </data>
-  <data name="TestSuiteFailed" xml:space="preserve">
-    <value>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</value>
-    <comment>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</comment>
-  </data>
-  <data name="TestSuiteFailedInAllAttempts" xml:space="preserve">
-    <value>
-=====================
-Tests suite failed in all {0} attempts
-=====================</value>
-    <comment>{0} is the total attempt count.</comment>
   </data>
   <data name="TestSuiteFailedWithWrongExitCode" xml:space="preserve">
     <value>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</value>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.cs.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Procentuální prahová hodnota selhání je {0} % a toto procento testů selhalo: {1} % ({2}/{3}).</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Přesouvání souborů prostředků posledního pokusu do výchozího adresáře výsledků
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Soubor {0} se přesouvá do umístění {1}.</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Přesouvání souborů prostředků posledního pokusu do výchozího adresáře
         <target state="translated">Možnost {0} nelze používat společně s možností {1}.</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Hostitelský proces testu byl ukončen dříve, než se k němu mohla služba opakování připojit. Ukončovací kód: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Sada testů byla úspěšně dokončena při {0} pokusech
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Sada testů selhala, celkový počet neúspěšných testů: {0}, ukončovací kód: {1}, pokus: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Sada testů selhala při všech {0} pokusech
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.de.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Der Schwellenwert für den Prozentsatz fehlgeschlagener Tests ist {0} %, und {1} % Tests mit Fehlern ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Medienobjektdateien des letzten Versuchs werden in das Standardergebnisverzeichnis verschoben.
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Die Datei "{0}" wird nach "{1}" verschoben</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Medienobjektdateien des letzten Versuchs werden in das Standardergebnisverzeichn
         <target state="translated">Optionen "{0}" und "{1}" können nicht zusammen verwendet werden</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Der Testhostprozess wurde beendet, bevor der Wiederholungsdienst eine Verbindung herstellen konnte. Exitcode: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Die Testsammlung wurde in {0} Versuchen erfolgreich abgeschlossen.
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Fehler bei der Testsammlung. Fehlerhafte Tests gesamt: {0}, Exitcode: {1}, Versuch: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Fehler bei der Testsammlung bei allen {0} Versuchen.
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.es.xlf
@@ -22,23 +22,15 @@
         <target state="translated">El umbral de porcentaje de errores es {0}% y {1}% de pruebas no superadas ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Moviendo los archivos de recursos del último intento al directorio de resultados predeterminado
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Moviendo el archivo '{0}' a '{1}'</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moviendo los archivos de recursos del último intento al directorio de resultado
         <target state="translated">Las opciones '{0}' y '{1}' no se pueden usar juntas</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">El proceso de host de prueba se cerró antes de que el servicio de reintento pudiera conectarse a él. Código de salida: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-El conjunto de pruebas se completó correctamente en {0} intentos
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Error del conjunto de pruebas, total de pruebas erróneas: {0}, código de salida: {1}, intento: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Error del conjunto de pruebas en los {0} intentos
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.fr.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Le seuil de pourcentage d’échec est {0}% et {1}% de tests ont échoué ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Déplacement des fichiers de ressources de la dernière tentative vers le répertoire de résultats par défaut
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Déplacement du fichier '{0}' vers '{1}'</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Déplacement des fichiers de ressources de la dernière tentative vers le réper
         <target state="translated">Les options «{0}» et «{1}» ne peuvent pas être utilisées ensemble</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Le processus hôte de test s’est arrêté avant que le service de nouvelle tentative puisse s’y connecter. Code de sortie : {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-La suite de tests s’est correctement terminée dans les {0} tentatives
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Échec de la suite de tests, nombre total de tests ayant échoué : {0}, code de sortie : {1}, tentative : {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Échec de la suite de tests dans toutes les {0} tentatives
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.it.xlf
@@ -22,23 +22,15 @@
         <target state="translated">La soglia percentuale di operazioni non riuscite è del {0}% e del {1}% di test non riusciti ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Spostamento dei file di asset dell'ultimo tentativo nella directory dei risultati predefinita
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Spostamento del file '{0}' in '{1}'</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Spostamento dei file di asset dell'ultimo tentativo nella directory dei risultat
         <target state="translated">Le opzioni '{0}' e '{1}' non possono essere usate insieme</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Il processo host di test è stato chiuso prima che il servizio di ripetizione potesse connettersi ad esso. Codice di uscita: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Il gruppo di test è stato completato correttamente in {0} tentativi
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Gruppo di test non riuscito, totale test non superati: {0}, codice di uscita: {1}, tentativo: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Gruppo di test non riuscito in tutti i {0} tentativi
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ja.xlf
@@ -22,23 +22,15 @@
         <target state="translated">失敗率のしきい値は {0} % で、失敗したテストは {1} % です ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-前回試行した資産ファイルを既定の結果ディレクトリに移動しています
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">ファイル '{0}' を '{1}' に移動しています</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moving last attempt asset files to the default result directory
         <target state="translated">オプション '{0}' と '{1}' を一緒に使用することはできません</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">再試行サービスが接続する前に、テスト ホスト プロセスが終了しました。終了コード: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-テスト スイートが {0} 回の試行で正常に完了しました
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-テスト スイートが失敗しました。失敗したテストの合計数: {0}、終了コード: {1}、試行: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-テスト スイートが {0} 回の試行すべてで失敗しました
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ko.xlf
@@ -22,23 +22,15 @@
         <target state="translated">실패한 임계값 백분율은 {0}%이며 {1}% 테스트에 실패했습니다({2}/{3}).</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-마지막 시도 자산 파일을 기본 결과 디렉터리로 이동
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">파일 {0}을(를) {1}(으)로 이동</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moving last attempt asset files to the default result directory
         <target state="translated">'{0}' 및 '{1}' 옵션은 함께 사용할 수 없습니다.</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">다시 시도 서비스가 연결되기 전에 테스트 호스트 프로세스가 종료되었습니다. 종료 코드: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-테스트 도구 모음이 {0} 시도에서 완료되었습니다.
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-테스트 도구 모음이 실패했습니다. 실패한 총 테스트: {0}, 종료 코드: {1}, 시도: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-테스트 도구 모음이 모든 {0} 시도에 실패했습니다
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.pl.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Wartość procentowa progu niepowodzenia wynosi {0}% i {1}% testów nie powiodło się ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Przeniesienie plików zasobów ostatniej próby do domyślnego katalogu wyników
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Przenoszenie pliku „{0}” do {1}</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Przeniesienie plików zasobów ostatniej próby do domyślnego katalogu wyników
         <target state="translated">Opcji „{0}” i „{1}” nie można używać razem</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Proces hosta testowego zakończył się, zanim usługa ponawiania próby mogła nawiązać z nim połączenie. Kod zakończenia: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Pomyślnie ukończono pakiet testów w {0} próbach
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Pakiet testów nie powiódł się, łączna liczba testów zakończonych niepowodzeniem: {0}, kod zakończenia: {1}, próba: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Pakiet testów nie powiódł się we wszystkich {0} próbach
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -22,23 +22,15 @@
         <target state="translated">O limite de porcentagem com falha é {0}% e {1}% dos testes falharam ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Movendo arquivos de ativo da última tentativa para o diretório de resultados padrão
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Movendo o arquivo ''{0}'' para ''{1}''</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Movendo arquivos de ativo da última tentativa para o diretório de resultados p
         <target state="translated">As opções ''{0}'' e ''{1}'' não podem ser usadas juntas</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">O processo de host de teste foi encerrado antes que o serviço de repetição pudesse se conectar a ele. Código de saída: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Pacote de testes concluído com êxito em {0} tentativas
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Falha no pacote de testes, total de testes com falha: {0}, código de saída: {1}, tentativa: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Falha no pacote de testes em todas as {0} tentativas
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.ru.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Пороговое значение доли неудачных тестов — {0}%, и доля неудачных тестов — {1}% ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Перемещение файлов ресурсов последней попытки в каталог результатов по умолчанию
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">Перемещение файла "{0}" в "{1}"</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moving last attempt asset files to the default result directory
         <target state="translated">Параметры "{0}" и "{1}" не могут использоваться вместе</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Тестовый хост-процесс завершился прежде, чем к нему смогла подключиться служба повторной попытки. Код выхода: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Набор тестов успешно завершен за несколько ({0}) попыток
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Сбой набора тестов. Всего неудачных тестов: {0}, код завершения: {1}, попытка: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Сбой набора тестов во всех попытках ({0})
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.tr.xlf
@@ -22,23 +22,15 @@
         <target state="translated">Başarısız olan yüzde eşiği %{0} ve başarısız %{1} ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-Son deneme varlık dosyaları, varsayılan sonuç dizinine taşınıyor
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">'{0}' dosyasını '{1}'e taşıma</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Son deneme varlık dosyaları, varsayılan sonuç dizinine taşınıyor
         <target state="translated">'{0}' ve '{1}' seçenekleri birlikte kullanılamaz</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">Yeniden deneme hizmeti ona bağlanamadan test ana makinesi işleminden çıkıldı. Çıkış kodu: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Test paketi {0} denemede de başarıyla tamamlandı
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-Test paketi başarısız oldu, toplam başarısız test: {0}, çıkış kodu: {1}, deneme: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-Test paketi tüm {0} denemede de başarısız oldu
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -22,23 +22,15 @@
         <target state="translated">失败的阈值百分比为 {0}%，有 {1}% 测试失败({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-正在将上次尝试资产文件移动到默认结果目录
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">正在将文件“{0}”移动到“{1}”</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moving last attempt asset files to the default result directory
         <target state="translated">选项“{0}”和“{1}”不能一起使用</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">测试主机进程已在重试服务可以连接到它之前退出。退出代码: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-测试套件已成功完成 {0} 次尝试
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-测试套件失败，失败的测试总数: {0}，退出代码: {1}，尝试次数: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-测试套件在所有 {0} 尝试中均失败
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -22,23 +22,15 @@
         <target state="translated">失敗的百分比閾值為 {0}%，有 {1}% 個測試失敗 ({2}/{3})</target>
         <note>{0} is the maximum failed tests percentage threshold. {1} is the actual failed tests percentage. {2} is the failed tests count. {3} is the total tests count.</note>
       </trans-unit>
-      <trans-unit id="MoveFiles">
-        <source>
-=====================
-Moving last attempt asset files to the default result directory
-=====================
-</source>
-        <target state="translated">
-=====================
-將上次嘗試的資產檔案移至預設結果目錄
-=====================
-</target>
-        <note />
+      <trans-unit id="RetryArtifactsMoved">
+        <source>Retry: moved {0} result file(s) to '{1}'</source>
+        <target state="new">Retry: moved {0} result file(s) to '{1}'</target>
+        <note>{0} is the number of files moved. {1} is the destination result directory.</note>
       </trans-unit>
-      <trans-unit id="MovingFileToLocation">
-        <source>Moving file '{0}' to '{1}'</source>
-        <target state="translated">正在將檔案 '{0}' 移至 '{1}'</target>
-        <note>{0} is the source file path. {1} is the destination file path.</note>
+      <trans-unit id="RetryAttemptFailedWillRetry">
+        <source>Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</source>
+        <target state="new">Retry: attempt {0}/{1} failed - {2} failing test(s), retrying</target>
+        <note>{0} is the current attempt number. {1} is the total number of attempts. {2} is the number of failing tests in this attempt.</note>
       </trans-unit>
       <trans-unit id="RetryExtensionNotSupportedOnBrowserErrorMessage">
         <source>The retry extension is not supported on browser platform. Browser-based tests cannot be retried due to platform limitations.</source>
@@ -115,45 +107,55 @@ Moving last attempt asset files to the default result directory
         <target state="translated">選項 '{0}' 和 '{1}' 不能同時使用</target>
         <note>{0} is the first option name. {1} is the second option name.</note>
       </trans-unit>
+      <trans-unit id="RetrySummaryDurationLine">
+        <source>  duration: {0}</source>
+        <target state="new">  duration: {0}</target>
+        <note>{0} is the total retry orchestration duration. Two leading spaces and the lowercase 'duration:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailed">
+        <source>Retry summary: Failed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Failed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Failed!' parallel to the platform 'Test run summary: Failed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFailedLine">
+        <source>  failed: {0}</source>
+        <target state="new">  failed: {0}</target>
+        <note>{0} is the number of tests still failing after the final attempt. Two leading spaces and the lowercase 'failed:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryFlakyLine">
+        <source>  flaky: {0}</source>
+        <target state="new">  flaky: {0}</target>
+        <note>{0} is the number of tests that failed at least once but eventually passed. Two leading spaces and the lowercase 'flaky:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassed">
+        <source>Retry summary: Passed! after {0}/{1} attempts</source>
+        <target state="new">Retry summary: Passed! after {0}/{1} attempts</target>
+        <note>{0} is the number of attempts used. {1} is the maximum number of attempts. Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryPassedNoRetry">
+        <source>Retry summary: Passed! on the first attempt (no retries needed)</source>
+        <target state="new">Retry summary: Passed! on the first attempt (no retries needed)</target>
+        <note>Keep 'Retry summary:' and 'Passed!' parallel to the platform 'Test run summary: Passed!' wording.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryRetriedSuffix">
+        <source> (+{0} retried)</source>
+        <target state="new"> (+{0} retried)</target>
+        <note>{0} is the number of test executions that were retried. Appended to the total line, mirroring the platform '(+N retried)' suffix.</note>
+      </trans-unit>
+      <trans-unit id="RetrySummaryTotalLine">
+        <source>  total: {0}</source>
+        <target state="new">  total: {0}</target>
+        <note>{0} is the total number of tests in the suite. Two leading spaces and the lowercase 'total:' label mirror the platform run summary.</note>
+      </trans-unit>
+      <trans-unit id="RetryWaitingBeforeNextAttempt">
+        <source>Retry: waiting {0} before attempt {1}/{2}</source>
+        <target state="new">Retry: waiting {0} before attempt {1}/{2}</target>
+        <note>{0} is the delay (e.g. '1s'). {1} is the next attempt number. {2} is the total number of attempts.</note>
+      </trans-unit>
       <trans-unit id="TestHostProcessExitedBeforeRetryCouldConnect">
         <source>Test host process exited before the retry service could connect to it. Exit code: {0}</source>
         <target state="translated">測試主機處理序在重試服務連線到它之前已結束。結束代碼: {0}</target>
         <note>{0} is the test host process exit code.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteCompletedSuccessfully">
-        <source>
-=====================
-Tests suite completed successfully in {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-測試套件已順利在 {0} 次嘗試內完成
-=====================</target>
-        <note>{0} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailed">
-        <source>
-=====================
-Tests suite failed, total failed tests: {0}, exit code: {1}, attempt: {2}/{3}
-=====================
-</source>
-        <target state="translated">
-=====================
-測試套件失敗，失敗的測試總數: {0}，結束代碼: {1}，嘗試: {2}/{3}
-=====================
-</target>
-        <note>{0} is the failed tests count. {1} is the exit code. {2} is the current attempt number. {3} is the total attempt count.</note>
-      </trans-unit>
-      <trans-unit id="TestSuiteFailedInAllAttempts">
-        <source>
-=====================
-Tests suite failed in all {0} attempts
-=====================</source>
-        <target state="translated">
-=====================
-測試套件在所有 {0} 次嘗試中都失敗
-=====================</target>
-        <note>{0} is the total attempt count.</note>
       </trans-unit>
       <trans-unit id="TestSuiteFailedWithWrongExitCode">
         <source>Test suite failed with and exit code different that 2 (failed tests). Failure related to an unexpected condition. Exit code '{0}'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -156,6 +156,15 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         string retryRootFolder = CreateRetriesDirectory(resultDirectory);
         bool retryInterrupted = false;
 
+        // Retry summary accounting (single-assembly). The orchestrator only learns each attempt's failed UID set and
+        // the total number of tests that ran, so the richer passed/skipped split stays in the per-attempt child
+        // summaries; here we reconcile the attempts into one headline (mirroring the platform run summary idiom).
+        var orchestrationStopwatch = Stopwatch.StartNew();
+        int suiteTotalTests = 0;
+        int firstAttemptFailedTests = 0;
+        int finalFailedTests = 0;
+        int retriedExecutions = 0;
+
         // Parse the delay once before the loop since command-line options don't change.
         TimeSpan? retryDelay = null;
         if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName, out string[]? retryDelayArgs)
@@ -171,7 +180,13 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
 
             if (attemptCount > 1 && retryDelay is { } delay)
             {
-                await logger.LogDebugAsync($"Waiting {delay:c} before retry attempt {attemptCount}").ConfigureAwait(false);
+                await outputDevice.DisplayAsync(
+                    this,
+                    new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryWaitingBeforeNextAttempt, FormatDelay(delay), attemptCount, userMaxRetryCount + 1))
+                    {
+                        ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGray },
+                    },
+                    cancellationToken).ConfigureAwait(false);
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
 
@@ -355,6 +370,16 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             await testHostProcess.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
             exitCodes.Add(testHostProcess.ExitCode);
+
+            int failedThisAttempt = retryFailedTestsPipeServer.FailedUID?.Count ?? 0;
+            if (attemptCount == 1)
+            {
+                // The first attempt runs the full suite, so its total is the suite size that the final summary
+                // reconciles against; its failed set is the upper bound for the "flaky" (failed-then-passed) count.
+                suiteTotalTests = retryFailedTestsPipeServer.TotalTestRan;
+                firstAttemptFailedTests = failedThisAttempt;
+            }
+
             if (testHostProcess.ExitCode != (int)ExitCode.Success)
             {
                 if (testHostProcess.ExitCode != (int)ExitCode.AtLeastOneTestFailed)
@@ -364,7 +389,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                     break;
                 }
 
-                await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailed, retryFailedTestsPipeServer.FailedUID?.Count ?? 0, testHostProcess.ExitCode, attemptCount, userMaxRetryCount + 1)), cancellationToken).ConfigureAwait(false);
+                finalFailedTests = failedThisAttempt;
 
                 // Check thresholds
                 if (attemptCount == 1)
@@ -409,25 +434,75 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                     }
                 }
 
+                // Only announce an attempt as "retrying" when another attempt will actually follow; the final
+                // failed attempt is reported by the summary verdict instead. Amber (not red) keeps mid-run
+                // failures visually "expected", reserving red for the give-up summary.
+                bool willRetry = attemptCount < userMaxRetryCount + 1;
+                if (willRetry)
+                {
+                    await outputDevice.DisplayAsync(
+                        this,
+                        new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryAttemptFailedWillRetry, attemptCount, userMaxRetryCount + 1, failedThisAttempt))
+                        {
+                            ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkYellow },
+                        },
+                        cancellationToken).ConfigureAwait(false);
+
+                    // Each retried attempt re-runs exactly this attempt's failed set, so its failed count is the
+                    // number of extra executions added by the retry — the platform "(+N retried)" semantics.
+                    retriedExecutions += failedThisAttempt;
+                }
+
                 finalArguments.Clear();
                 lastListOfFailedId = retryFailedTestsPipeServer.FailedUID?.ToArray();
             }
             else
             {
+                finalFailedTests = 0;
                 break;
             }
         }
 
+        orchestrationStopwatch.Stop();
+
         if (!thresholdPolicyKickedIn && !retryInterrupted)
         {
-            if (exitCodes[^1] != (int)ExitCode.Success)
+            bool runSucceeded = exitCodes[^1] == (int)ExitCode.Success;
+            int flakyTests = Math.Max(0, firstAttemptFailedTests - finalFailedTests);
+            int totalAttempts = userMaxRetryCount + 1;
+
+            // Headline verdict, colored by the FINAL outcome so a run rescued by retry reads as green.
+            if (runSucceeded)
             {
-                await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedInAllAttempts, userMaxRetryCount + 1)), cancellationToken).ConfigureAwait(false);
+                string header = attemptCount == 1
+                    ? ExtensionResources.RetrySummaryPassedNoRetry
+                    : string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryPassed, attemptCount, totalAttempts);
+                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(header) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGreen } }, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteCompletedSuccessfully, attemptCount)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGreen } }, cancellationToken).ConfigureAwait(false);
+                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailed, attemptCount, totalAttempts)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
             }
+
+            if (!runSucceeded && finalFailedTests > 0)
+            {
+                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailedLine, finalFailedTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
+            }
+
+            // "flaky" = failed at least once but eventually passed — the headline value of the retry feature.
+            if (flakyTests > 0)
+            {
+                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFlakyLine, flakyTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkYellow } }, cancellationToken).ConfigureAwait(false);
+            }
+
+            string totalLine = string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryTotalLine, suiteTotalTests);
+            if (retriedExecutions > 0)
+            {
+                totalLine += string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryRetriedSuffix, retriedExecutions);
+            }
+
+            await outputDevice.DisplayAsync(this, new TextOutputDeviceData(totalLine), cancellationToken).ConfigureAwait(false);
+            await outputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryDurationLine, FormatDuration(orchestrationStopwatch.Elapsed))), cancellationToken).ConfigureAwait(false);
         }
 
         ApplicationStateGuard.Ensure(currentTryResultFolder is not null);
@@ -435,9 +510,8 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         string[] filesToMove = _fileSystem.GetFiles(currentTryResultFolder, "*.*", SearchOption.AllDirectories);
         if (filesToMove.Length > 0)
         {
-            await outputDevice.DisplayAsync(this, new TextOutputDeviceData(ExtensionResources.MoveFiles), cancellationToken).ConfigureAwait(false);
-
-            // Move last attempt assets
+            // Move last attempt assets. The per-file detail is demoted to a debug log; the user-facing output is a
+            // single collapsed line so a large artifact set no longer spams the console.
             foreach (string file in filesToMove)
             {
                 string finalFileLocation = file.Replace(currentTryResultFolder, resultDirectory);
@@ -445,7 +519,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 // Create the directory if missing
                 fileSystem.CreateDirectory(Path.GetDirectoryName(finalFileLocation)!);
 
-                await outputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.MovingFileToLocation, file, finalFileLocation)), cancellationToken).ConfigureAwait(false);
+                logger.LogDebug($"Moving file '{file}' to '{finalFileLocation}'");
 #if NETCOREAPP
                 fileSystem.MoveFile(file, finalFileLocation, overwrite: true);
 #else
@@ -453,6 +527,14 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 fileSystem.DeleteFile(file);
 #endif
             }
+
+            await outputDevice.DisplayAsync(
+                this,
+                new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryArtifactsMoved, filesToMove.Length, resultDirectory))
+                {
+                    ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGray },
+                },
+                cancellationToken).ConfigureAwait(false);
         }
 
         return exitCodes[^1];
@@ -513,4 +595,21 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             }
         }
     }
+
+    // Renders a retry delay the same way the --retry-failed-tests-delay option accepts it (e.g. '500ms', '1s')
+    // so the displayed wait is consistent with how the user configured it.
+    private static string FormatDelay(TimeSpan delay)
+        => delay.TotalMilliseconds < 1000
+            ? string.Format(CultureInfo.CurrentCulture, "{0}ms", (int)delay.TotalMilliseconds)
+            : delay.TotalSeconds < 60 && delay.Milliseconds == 0
+                ? string.Format(CultureInfo.CurrentCulture, "{0}s", (int)delay.TotalSeconds)
+                : delay.ToString("c", CultureInfo.CurrentCulture);
+
+    // Compact, human-friendly duration for the retry summary (milliseconds / seconds / minutes-seconds).
+    private static string FormatDuration(TimeSpan duration)
+        => duration.TotalSeconds < 1
+            ? string.Format(CultureInfo.CurrentCulture, "{0}ms", (int)duration.TotalMilliseconds)
+            : duration.TotalMinutes < 1
+                ? string.Format(CultureInfo.CurrentCulture, "{0:0.000}s", duration.TotalSeconds)
+                : string.Format(CultureInfo.CurrentCulture, "{0}m {1:00}s", (int)duration.TotalMinutes, duration.Seconds);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -596,20 +596,22 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         }
     }
 
-    // Renders a retry delay the same way the --retry-failed-tests-delay option accepts it (e.g. '500ms', '1s')
-    // so the displayed wait is consistent with how the user configured it.
+    // Renders a retry delay the same way the --retry-failed-tests-delay option accepts it (e.g. '500ms', '1s',
+    // '1500ms') so the displayed wait is consistent with how the user configured it. The output is always a single
+    // value + unit that TimeSpanParser round-trips, and uses InvariantCulture so it never varies by locale.
     private static string FormatDelay(TimeSpan delay)
         => delay.TotalMilliseconds < 1000
-            ? string.Format(CultureInfo.CurrentCulture, "{0}ms", (int)delay.TotalMilliseconds)
-            : delay.TotalSeconds < 60 && delay.Milliseconds == 0
-                ? string.Format(CultureInfo.CurrentCulture, "{0}s", (int)delay.TotalSeconds)
-                : delay.ToString("c", CultureInfo.CurrentCulture);
+            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)delay.TotalMilliseconds)
+            : delay.Milliseconds == 0
+                ? string.Format(CultureInfo.InvariantCulture, "{0}s", (long)delay.TotalSeconds)
+                : string.Format(CultureInfo.InvariantCulture, "{0}ms", (long)delay.TotalMilliseconds);
 
-    // Compact, human-friendly duration for the retry summary (milliseconds / seconds / minutes-seconds).
+    // Compact, human-friendly duration for the retry summary, mirroring the platform terminal style
+    // (e.g. '240ms', '1s 240ms', '2m 03s'). InvariantCulture keeps the numeric separators stable across locales.
     private static string FormatDuration(TimeSpan duration)
         => duration.TotalSeconds < 1
-            ? string.Format(CultureInfo.CurrentCulture, "{0}ms", (int)duration.TotalMilliseconds)
+            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds)
             : duration.TotalMinutes < 1
-                ? string.Format(CultureInfo.CurrentCulture, "{0:0.000}s", duration.TotalSeconds)
-                : string.Format(CultureInfo.CurrentCulture, "{0}m {1:00}s", (int)duration.TotalMinutes, duration.Seconds);
+                ? string.Format(CultureInfo.InvariantCulture, "{0}s {1:000}ms", duration.Seconds, duration.Milliseconds)
+                : string.Format(CultureInfo.InvariantCulture, "{0}m {1:00}s", (int)duration.TotalMinutes, duration.Seconds);
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/JUnitReportTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/JUnitReportTests.cs
@@ -191,7 +191,7 @@ public sealed class JUnitReportMTPRetryExtensionTests : AcceptanceTestBase<JUnit
 
         // Test fails the first time then passes on retry — orchestrator should succeed.
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
 
         // Each attempt is a separate test-host child process and produces its own JUnit XML file.
         string[] junitFiles = Directory.GetFiles(resultDirectory, "*.xml", SearchOption.AllDirectories);

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -41,7 +41,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         if (!failOnly)
         {
             testHostResult.AssertExitCodeIs(ExitCode.Success);
-            testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+            testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
 
@@ -57,12 +57,12 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         else
         {
             testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
-            testHostResult.AssertOutputContains("Tests suite failed in all 4 attempts");
-            testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 1/4");
-            testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 2/4");
-            testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 3/4");
-            testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 4/4");
-            testHostResult.AssertOutputDoesNotContain("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 5/4");
+            testHostResult.AssertOutputContains("Retry summary: Failed! after 4/4 attempts");
+            testHostResult.AssertOutputContains("Retry: attempt 1/4 failed - 1 failing test(s), retrying");
+            testHostResult.AssertOutputContains("Retry: attempt 2/4 failed - 1 failing test(s), retrying");
+            testHostResult.AssertOutputContains("Retry: attempt 3/4 failed - 1 failing test(s), retrying");
+            // The final (4th) attempt is reported by the summary verdict, not by an amber "retrying" line.
+            testHostResult.AssertOutputDoesNotContain("Retry: attempt 4/4 failed");
             testHostResult.AssertOutputContains("Failed! -");
         }
     }
@@ -89,7 +89,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
     }
 
     [TestMethod]
@@ -129,7 +129,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         else
         {
             testHostResult.AssertExitCodeIs(ExitCode.Success);
-            testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+            testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
         }
@@ -161,7 +161,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         else
         {
             testHostResult.AssertExitCodeIs(ExitCode.Success);
-            testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+            testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
         }
@@ -225,7 +225,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             Assert.Contains("Test run summary: Passed!", logFileContents);
             Assert.Contains("total: 3", logFileContents);
             Assert.Contains("succeeded: 3", logFileContents);
-            Assert.Contains("Tests suite completed successfully in 1 attempts", logFileContents);
+            Assert.Contains("Retry summary: Passed! on the first attempt (no retries needed)", logFileContents);
         }
     }
 
@@ -249,8 +249,8 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
-        testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 1/4");
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
+        testHostResult.AssertOutputContains("Retry: attempt 1/4 failed - 1 failing test(s), retrying");
 
         // Verify that the retry attempt only ran the failed test (UID 1).
         // The TRX in the top-level results directory (not under Retries/) is from the last attempt.
@@ -286,8 +286,8 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
-        testHostResult.AssertOutputContains("Tests suite failed, total failed tests: 1, exit code: 2, attempt: 1/4");
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
+        testHostResult.AssertOutputContains("Retry: attempt 1/4 failed - 1 failing test(s), retrying");
 
         // Verify that the first attempt honored the treenode-filter.
         string[] retryTrxFiles = Directory.GetFiles(Path.Combine(resultDirectory, "Retries"), "*.trx", SearchOption.AllDirectories);
@@ -337,7 +337,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        testHostResult.AssertOutputContains("Tests suite completed successfully in 2 attempts");
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
         testHostResult.AssertOutputDoesNotContain("Minimum expected tests policy violation");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -42,6 +42,8 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         {
             testHostResult.AssertExitCodeIs(ExitCode.Success);
             testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
+            testHostResult.AssertOutputContains("  flaky: 1");
+            testHostResult.AssertOutputContains("  total: 3 (+1 retried)");
             testHostResult.AssertOutputContains("Failed! -");
             testHostResult.AssertOutputContains("Passed! -");
 
@@ -63,6 +65,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             testHostResult.AssertOutputContains("Retry: attempt 3/4 failed - 1 failing test(s), retrying");
             // The final (4th) attempt is reported by the summary verdict, not by an amber "retrying" line.
             testHostResult.AssertOutputDoesNotContain("Retry: attempt 4/4 failed");
+            testHostResult.AssertOutputContains("  failed: 1");
             testHostResult.AssertOutputContains("Failed! -");
         }
     }
@@ -224,6 +227,8 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             string logFileContents = File.ReadAllText(logFile);
             Assert.Contains("Test run summary: Passed!", logFileContents);
             Assert.Contains("total: 3", logFileContents);
+            // Zero-retry runs must not advertise a retried suffix on the total line.
+            Assert.DoesNotContain("retried)", logFileContents);
             Assert.Contains("succeeded: 3", logFileContents);
             Assert.Contains("Retry summary: Passed! on the first attempt (no retries needed)", logFileContents);
         }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryWithMaxFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryWithMaxFailedTestsTests.cs
@@ -35,11 +35,11 @@ public class RetryWithMaxFailedTestsTests : AcceptanceTestBase<RetryWithMaxFaile
         // The child must have produced the standard max-failed-tests stop diagnostic.
         testHostResult.AssertOutputContains("Test session is aborting due to reaching failures ('2') specified by the '--maximum-failed-tests' option.");
 
-        // The retry orchestrator must NOT launch a second attempt. The TestSuiteFailed
-        // diagnostic for attempt 2 must therefore never appear.
-        testHostResult.AssertOutputDoesNotContain("attempt: 2/");
-        testHostResult.AssertOutputDoesNotContain("Tests suite failed in all");
-        testHostResult.AssertOutputDoesNotContain("Tests suite completed successfully");
+        // The retry orchestrator must NOT launch a second attempt, and because the child stopped with an
+        // unexpected exit code the orchestrator bails out before printing any retry summary verdict.
+        testHostResult.AssertOutputDoesNotContain("Retry: attempt 2/");
+        testHostResult.AssertOutputDoesNotContain("Retry summary: Failed!");
+        testHostResult.AssertOutputDoesNotContain("Retry summary: Passed!");
 
         // TODO(https://github.com/microsoft/testfx/issues/6914): the retry orchestrator
         // emits "Test suite failed with and exit code different that 2 (failed tests)..."


### PR DESCRIPTION
## Problem

The standalone `Microsoft.Testing.Extensions.Retry` orchestrator (single-assembly retry) prints output that clashes badly with the polished MTP summary it sits next to:

- ASCII `=====` banners, no indentation, no colorized counts.
- Every attempt prints a red `Failed!` — a run that ultimately **passes after retry** still shows scary red summaries, with the green truth buried at the bottom.
- N independent per-attempt summaries with no run-level reconciliation.
- One `Moving file X to Y` line per artifact — pure noise.

Notably, the polished reporter **already** has first-class retry rendering (`(+N retried)`, the `r` glyph) — but only for the `dotnet test` multi-process orchestrator. The standalone path fell back to banners. This PR makes single-assembly retry render in the same idiom.

## New UX

**Mid-run** (amber — a failure about to be retried is *expected*, not alarming):
```
Retry: attempt 1/4 failed - 1 failing test(s), retrying
Retry: waiting 1s before attempt 2/4
```

**Final summary** (colored by the *final* outcome, so retry-rescued runs read green):
```
Retry summary: Passed! after 2/4 attempts
  flaky: 1
  total: 3 (+1 retried)
  duration: 1s 240ms
Retry: moved 4 result file(s) to '<dir>'
```

- Final failure → red `Retry summary: Failed! after 4/4 attempts` with `failed: N`.
- First-attempt success → `Retry summary: Passed! on the first attempt (no retries needed)`.
- `flaky: N` (failed-then-passed) surfaces the headline value of the feature.
- `total: N (+R retried)` reuses the platform's existing retried vocabulary.
- Per-file move detail demoted to `LogDebug`; one collapsed line remains.

The threshold-policy ("policy kicked in") and unexpected-exit-code paths keep their existing messages.

## Changes

- `RetryOrchestrator.cs` — stopwatch, per-attempt stat capture, new per-attempt + summary rendering, amber-not-red mid-run, collapsed artifact move, `FormatDelay`/`FormatDuration` helpers.
- `Resources/ExtensionResources.resx` — removed 5 obsolete banner strings, added 10 polished ones; regenerated all `*.xlf` via `UpdateXlf`.
- Updated acceptance assertions in `RetryFailedTestsTests`, `RetryWithMaxFailedTestsTests`, `JUnitReportTests`.

## Validation

- `build.cmd -pack -c Debug` — clean (0 warnings, 0 errors).
- Acceptance suites pass: `RetryFailedTestsTests` (31), `RetryWithMaxFailedTestsTests` (1), `JUnitReportMTPRetryExtensionTests` (1).

## Follow-up

`dotnet test` cross-assembly already renders `(+N retried)` / the `r` glyph; a natural follow-up is to surface the same `flaky:` line there (the terminal reporter already tracks `RetriedFailedTests`).