### PR TITLE
docs: add missing 4.3.0/2.3.0 changelog entries (ITestFilter, ITestHostLauncher, AzDO logging, PropertyBag)

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -40,6 +40,9 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add testconfig.json JSON schema for SchemaStore publication and IDE validation by @Evangelink in [#9405](https://github.com/microsoft/testfx/pull/9405)
 * Add experimental `IBlockingDataConsumer` marker interface for synchronous inline data consumption by @Evangelink in [#9426](https://github.com/microsoft/testfx/pull/9426)
 * Add experimental `Microsoft.Testing.Extensions.VideoRecorder` extension for screen recording during test runs (requires ffmpeg; `--capture-video` opt-in) by @Evangelink in [#9377](https://github.com/microsoft/testfx/pull/9377)
+* Add experimental `ITestHostLauncher` extension point and `Microsoft.Testing.Extensions.PackagedApp` reference extension for packaged app test host deployment by @Evangelink in [#9454](https://github.com/microsoft/testfx/pull/9454)
+* Forward Azure DevOps logging commands over the dotnet test pipe for multi-assembly test runs by @Evangelink in [#9463](https://github.com/microsoft/testfx/pull/9463)
+* Add `PropertyBag.FirstOrDefault<TProperty>()` for efficient single-property lookup without per-call array allocation by @Evangelink in [#9488](https://github.com/microsoft/testfx/pull/9488)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -37,6 +37,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Add MSTEST0071 analyzer and code fix for redundant test method display name by @Evangelink in [#9272](https://github.com/microsoft/testfx/pull/9272)
 * Add [ExecutableConditionAttribute] to conditionally run tests based on tool availability by @Evangelink in [#9369](https://github.com/microsoft/testfx/pull/9369)
 * Move `orderTestsByNameInClass` testconfig.json key to `mstest:execution:orderTestsByNameInClass` (flat `mstest:orderTestsByNameInClass` still works but emits a deprecation warning) by @Evangelink in [#9430](https://github.com/microsoft/testfx/pull/9430)
+* Add experimental `ITestFilter` / `[TestFilterProviderAttribute]` for programmatic per-test filtering (before any class is loaded) by @Evangelink in [#8896](https://github.com/microsoft/testfx/pull/8896)
 
 ### Fixed
 
@@ -51,6 +52,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Flag `Assert.AreEqual(x, x)` / `AreSame(x, x)` / `AreNotEqual(x, x)` / `AreNotSame(x, x)` by @Evangelink in [#9088](https://github.com/microsoft/testfx/pull/9088)
 * Remove redundant `actual type:` line from Assert.Throws\* failure message by @Evangelink in [#9195](https://github.com/microsoft/testfx/pull/9195)
 * Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages by @Evangelink in [#9212](https://github.com/microsoft/testfx/pull/9212)
+* Fix `[ClassCleanup]` resource leak when `ITestFilter` drops the last test of an initialized class by @Evangelink in [#9503](https://github.com/microsoft/testfx/pull/9503)
 
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 


### PR DESCRIPTION
Five changelog entries missing after recent merges (2026-06-29):

**`docs/Changelog.md` (MSTest 4.3.0 UNRELEASED — Added):**
- `ITestFilter` / `[TestFilterProviderAttribute]` for programmatic per-test filtering — [`#8896`](https://github.com/microsoft/testfx/pull/8896)

**`docs/Changelog.md` (MSTest 4.3.0 UNRELEASED — Fixed):**
- Fix `[ClassCleanup]` resource leak when `ITestFilter` drops the last test of an initialized class — [`#9503`](https://github.com/microsoft/testfx/pull/9503)

**`docs/Changelog-Platform.md` (MTP 2.3.0 UNRELEASED — Added):**
- Generic `ITestHostLauncher` extension point + `Microsoft.Testing.Extensions.PackagedApp` reference extension — [`#9454`](https://github.com/microsoft/testfx/pull/9454)
- Forward Azure DevOps logging commands over the dotnet test pipe (multi-assembly) — [`#9463`](https://github.com/microsoft/testfx/pull/9463)
- `PropertyBag.FirstOrDefault<TProperty>()` (new stable public API) — [`#9488`](https://github.com/microsoft/testfx/pull/9488)




> 🤖 **Automated content by GitHub Copilot.** Posted via a maintainer's GitHub token, so it appears under their account — the account owner did **not** write or approve this content personally. Generated by the [Adhoc QA](https://github.com/microsoft/testfx/actions/runs/28426324979/agentic_workflow) workflow. · 996.9 AIC · ⌖ 24.3 AIC · ⊞ 51.3K · [◷]( · [◷](https://github.com/search?q=repo%3Amicrosoft%2Ftestfx+%22gh-aw-workflow-id%3A+adhoc-qa%22&type=pullrequests))
>
<details>
<summary>Add this agentic workflows to your repo</summary>

To install this agentic workflow, run

```
gh aw add githubnext/agentics/workflows/adhoc-qa.md@main
```
</details>


<!-- gh-aw-agentic-workflow: Adhoc QA, engine: copilot, version: 1.0.60, model: claude-sonnet-4.6, id: 28426324979, workflow_id: adhoc-qa, run: https://github.com/microsoft/testfx/actions/runs/28426324979 -->

<!-- gh-aw-workflow-id: adhoc-qa -->
<!-- gh-aw-workflow-call-id: microsoft/testfx/adhoc-qa -->