### PR TITLE
Add --report-azdo-groups/--report-azdo-annotations on|off toggles

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineOptions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineOptions.cs
@@ -6,8 +6,10 @@ namespace Microsoft.Testing.Extensions.Reporting;
 internal static class AzureDevOpsCommandLineOptions
 {
     public const string AzureDevOpsOptionName = "report-azdo";
+    public const string AzureDevOpsAnnotations = "report-azdo-annotations";
     public const string AzureDevOpsDemoteKnownFlaky = "report-azdo-demote-known-flaky";
     public const string AzureDevOpsFlakyHistory = "report-azdo-flaky-history";
+    public const string AzureDevOpsGroups = "report-azdo-groups";
     public const string AzureDevOpsQuarantineFile = "report-azdo-quarantine-file";
     public const string AzureDevOpsReportSeverity = "report-azdo-severity";
     public const string AzureDevOpsSlowTestHistory = "report-azdo-slow-test-history";
@@ -25,6 +27,9 @@ internal static class AzureDevOpsCommandLineOptions
     public const string AzureDevOpsUploadArtifactsModeTagsOnly = "tags-only";
     public const string PublishAzureDevOpsRunNameOptionName = "publish-azdo-run-name";
     public const string PublishAzureDevOpsTestResultsOptionName = "publish-azdo-test-results";
+
+    public const string OptionOn = "on";
+    public const string OptionOff = "off";
 
     public const int SlowTestHistoryDefaultMinSample = 10;
     public const double SlowTestHistoryDefaultMultiplier = 3.0;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
@@ -23,6 +23,12 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
 
     private static readonly string[] SeverityOptions = ["error", "warning"];
 
+    private static readonly string[] OnOffOptions =
+    [
+        AzureDevOpsCommandLineOptions.OptionOn,
+        AzureDevOpsCommandLineOptions.OptionOff,
+    ];
+
     internal const int MaxStackFrameFilterPatterns = 16;
     internal const int StackFrameFilterMatchTimeoutMs = 500;
 
@@ -55,8 +61,10 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
             AzureDevOpsResources.Description,
             [
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsOptionName, AzureDevOpsResources.OptionDescription, ArgumentArity.Zero, false),
+                new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations, AzureDevOpsResources.AnnotationsOptionDescription, ArgumentArity.ExactlyOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky, DemoteKnownFlakyOptionDescriptionFormatted, ArgumentArity.Zero, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsFlakyHistory, AzureDevOpsResources.FlakyHistoryOptionDescription, ArgumentArity.ExactlyOne, false),
+                new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsGroups, AzureDevOpsResources.GroupsOptionDescription, ArgumentArity.ExactlyOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsQuarantineFile, AzureDevOpsResources.QuarantineFileOptionDescription, ArgumentArity.ExactlyOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsReportSeverity, AzureDevOpsResources.SeverityOptionDescription, ArgumentArity.ExactlyOne, false),
                 new CommandLineOption(AzureDevOpsCommandLineOptions.AzureDevOpsSlowTestHistory, AzureDevOpsResources.SlowTestHistoryOptionDescription, ArgumentArity.ExactlyOne, false),
@@ -77,6 +85,9 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
         => commandOption.Name switch
         {
+            AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations or AzureDevOpsCommandLineOptions.AzureDevOpsGroups
+                when !OnOffOptions.Contains(arguments[0], StringComparer.OrdinalIgnoreCase)
+                => ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.InvalidOnOffValue, arguments[0])),
             AzureDevOpsCommandLineOptions.AzureDevOpsFlakyHistory => ValidateFlakyHistoryArgumentsAsync(arguments),
             AzureDevOpsCommandLineOptions.AzureDevOpsSlowTestHistory => ValidateSlowTestHistoryArgumentsAsync(arguments),
             AzureDevOpsCommandLineOptions.AzureDevOpsSlowTestHistoryMinSample => ValidateSlowTestHistoryMinSampleArgumentsAsync(arguments),
@@ -96,7 +107,15 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
         string? errorMessage = null;
         if (!commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsOptionName))
         {
-            if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky))
+            if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations))
+            {
+                errorMessage = AzureDevOpsResources.AzureDevOpsAnnotationsRequiresAzureDevOps;
+            }
+            else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsGroups))
+            {
+                errorMessage = AzureDevOpsResources.AzureDevOpsGroupsRequiresAzureDevOps;
+            }
+            else if (commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsDemoteKnownFlaky))
             {
                 errorMessage = AzureDevOpsResources.AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsConstants.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsConstants.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
@@ -34,4 +36,14 @@ internal static class AzureDevOpsConstants
             environment.GetEnvironmentVariable(TfBuildEnvironmentVariableName),
             TfBuildEnabledValue,
             StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns whether an individual <c>on|off</c> feature knob is enabled. A knob is enabled unless it
+    /// is explicitly set to <c>off</c> (case-insensitive), so every feature defaults to <c>on</c> once
+    /// the extension itself is active.
+    /// </summary>
+    public static bool IsFeatureKnobEnabled(ICommandLineOptions commandLineOptions, string knobOptionName)
+        => !(commandLineOptions.TryGetOptionArgumentList(knobOptionName, out string[]? arguments)
+            && arguments is [string value]
+            && string.Equals(value, AzureDevOpsCommandLineOptions.OptionOff, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
@@ -69,7 +69,8 @@ internal sealed class AzureDevOpsLogGroupReporter : IDataConsumer, ITestSessionL
     public Task<bool> IsEnabledAsync()
         => Task.FromResult(
             _commandLineOptions.IsOptionSet(AzureDevOpsCommandLineOptions.AzureDevOpsOptionName)
-            && AzureDevOpsConstants.IsRunningInAzureDevOps(_environment));
+            && AzureDevOpsConstants.IsRunningInAzureDevOps(_environment)
+            && AzureDevOpsConstants.IsFeatureKnobEnabled(_commandLineOptions, AzureDevOpsCommandLineOptions.AzureDevOpsGroups));
 
     // No-op: this consumer subscribes to data only to be ordered in the consumer phase at session
     // end (see the type-level remarks). It does not act on individual messages.

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsReporter.cs
@@ -109,13 +109,16 @@ internal sealed class AzureDevOpsReporter :
             EnsureEnabledConfigurationLoaded();
         }
 
+        bool annotationsEnabled = AzureDevOpsConstants.IsFeatureKnobEnabled(_commandLine, AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations);
+
         if (_logger.IsEnabled(LogLevel.Trace))
         {
             _logger.LogTrace($"{AzureDevOpsConstants.TfBuildEnvironmentVariableName} environment variable is {(isEnabledByEnvVariable ? "enabled. Will report errors to Azure DevOps, because we are running in CI." : "disabled. Will not report errors to Azure DevOps.")}");
             _logger.LogTrace($"Severity is set to '{_severity ?? "error"}', you can override it by using --report-azdo-severity parameter.");
+            _logger.LogTrace($"Failure annotations are {(annotationsEnabled ? "enabled" : "disabled")}, you can toggle them by using --report-azdo-annotations parameter.");
         }
 
-        return Task.FromResult(isEnabledByEnvVariable);
+        return Task.FromResult(isEnabledByEnvVariable && annotationsEnabled);
     }
 
     public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AnnotationsOptionDescription" xml:space="preserve">
+    <value>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</value>
+    <comment>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</comment>
+  </data>
   <data name="ArtifactUploadOptionsRequireUploadArtifacts" xml:space="preserve">
     <value>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</value>
     <comment>{Locked="--report-azdo-upload-artifact-include"}{Locked="--report-azdo-upload-artifact-exclude"}{Locked="--report-azdo-upload-artifact-name"}{Locked="--report-azdo-upload-artifacts"}{Locked="off"}</comment>
@@ -124,6 +128,10 @@
   <data name="ArtifactUploadRequiresTfBuildWarning" xml:space="preserve">
     <value>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</value>
     <comment>{Locked="TF_BUILD"}{Locked="true"}</comment>
+  </data>
+  <data name="AzureDevOpsAnnotationsRequiresAzureDevOps" xml:space="preserve">
+    <value>'--report-azdo-annotations' requires '--report-azdo' to be enabled</value>
+    <comment>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</comment>
   </data>
   <data name="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps" xml:space="preserve">
     <value>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</value>
@@ -136,6 +144,10 @@
   <data name="AzureDevOpsFlakyHistoryRequiresAzureDevOps" xml:space="preserve">
     <value>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</value>
     <comment>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</comment>
+  </data>
+  <data name="AzureDevOpsGroupsRequiresAzureDevOps" xml:space="preserve">
+    <value>'--report-azdo-groups' requires '--report-azdo' to be enabled</value>
+    <comment>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</comment>
   </data>
   <data name="AzureDevOpsLivePublishingCompleteRunFailed" xml:space="preserve">
     <value>Azure DevOps live publishing failed to complete the test run.</value>
@@ -250,6 +262,10 @@
     <value>Azure DevOps flaky history for run '{0}' exceeded {1} pages or returned an unchanged continuation token. Remaining results will be ignored.</value>
     <comment>{0} is the Azure DevOps run URL. {1} is the maximum number of pages.</comment>
   </data>
+  <data name="GroupsOptionDescription" xml:space="preserve">
+    <value>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</value>
+    <comment>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</comment>
+  </data>
   <data name="InvalidArtifactUploadGlob" xml:space="preserve">
     <value>Invalid glob pattern {0}.</value>
     <comment>{0} is the invalid glob pattern.</comment>
@@ -261,6 +277,10 @@
   <data name="InvalidFlakyHistoryDays" xml:space="preserve">
     <value>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</value>
     <comment>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</comment>
+  </data>
+  <data name="InvalidOnOffValue" xml:space="preserve">
+    <value>Invalid value '{0}'. Valid values are 'on' and 'off'.</value>
+    <comment>{Locked="on"}{Locked="off"}</comment>
   </data>
   <data name="InvalidSeverity" xml:space="preserve">
     <value>Invalid option {0}.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">Parametry --report-azdo-upload-artifact-include, --report-azdo-upload-artifact-exclude a --report-azdo-upload-artifact-name vyžadují, aby parametr --report-azdo-upload-artifacts byl nastavený na jinou hodnotu než off.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Bylo vyžádáno nahrání artefaktu Azure DevOps, ale TF_BUILD není nastavené na hodnotu true. Nahrání artefaktu Azure DevOps a značek buildu se přeskočí.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">Aby bylo možné použít parametr ---report-azdo-flaky-history, musí být povolený parametr --report-azdo.</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Historie nestability Azure DevOps vrátila {0} spuštění. Prověří se jenom první(ch) {1} spuštění.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Neplatný vzor glob {0}</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Neplatná hodnota {0} pro --report-azdo-flaky-history Zadejte celé číslo mezi 1 a 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">„--report-azdo-upload-artifact-include“, „--report-azdo-upload-artifact-exclude“, und „--report-azdo-upload-artifact-name“ erfordern, dass „--report-azdo-upload-artifacts“ auf einen anderen Wert als „off“ festgelegt werden.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Azure DevOps-Artefaktupload wurde angefordert, aber TF_BUILD ist nicht auf „true“ festgelegt. Azure DevOps Artefaktupload und Buildtags werden übersprungen.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">Für „--report-azdo-flaky-history“ muss „--report-azdo“ aktiviert sein.</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Der unzuverlässige Azure DevOps-Verlauf hat {0} Ausführungen zurückgegeben. Nur die ersten {1} Ausführungen werden überprüft.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Ungültiges Globmuster „{0}“.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Ungültiger Wert „{0}“ für „--report-azdo-flaky-history“. Geben Sie eine ganze Zahl zwischen 1 und 90 an.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">"--report-azdo-upload-artifact-include", "--report-azdo-upload-artifact-exclude" y "--report-azdo-upload-artifact-name" requieren que "--report-azdo-upload-artifacts" esté establecido en un valor distinto de "off".</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Se solicitó la carga de artefactos de Azure DevOps, pero TF_BUILD no está establecido en "true"; se omite la carga de artefactos y las etiquetas de compilación de Azure DevOps.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-flaky-history" requiere que se habilite "--report-azdo"</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps devolvió {0} ejecuciones del historial de inestabilidad. Solo se inspeccionarán las primeras {1} ejecuciones.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Patrón global no válido {0}.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Valor no válido "{0}" para "--report-azdo-flaky-history". Proporcione un entero entre 1 y 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">« --report-azdo-upload-artifact-include », « --report-azdo-upload-artifact-exclude » et « --report-azdo-upload-artifact-name » nécessitent que « --report-azdo-upload-artifacts » soit défini sur une valeur autre que « off ».</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Le chargement d’artefacts Azure DevOps a été demandé, mais TF_BUILD n’est pas défini sur « true ». Le chargement d’artefacts Azure DevOps et l’ajout de balises de build sont ignorés.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">« --report-azdo-flaky-history » nécessite l’activation de « --report-azdo »</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">L’historique des échecs intermittents Azure DevOps a renvoyé {0} exécutions. Seules les {1} premières exécutions seront examinées.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Modèle Glob {0} non valide.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Valeur non valide « {0} » pour « --report-azdo-flaky-history ». Indiquez un nombre entier entre 1 et 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude' e '--report-azdo-upload-artifact-name' richiedono che '--report-azdo-upload-artifacts' sia impostato su un valore diverso da 'off'.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">È stato richiesto il caricamento degli artefatti di Azure DevOps, ma TF_BUILD non è impostato su "true"; il caricamento degli artefatti e i tag di build di Azure DevOps verranno ignorati.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history' richiede l'autenticazione di '--report-azdo'</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">La cronologia degli elementi instabili di Azure DevOps ha restituito {0} esecuzioni. Verranno esaminate solo le prime {1} esecuzioni.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Il modello GLOB {0} non è valido.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Valore non valido '{0}' per '--report-azdo-flaky-history'. Specifica un numero intero compreso tra 1 e 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include'、'--report-azdo-upload-artifact-exclude'、および '--report-azdo-upload-artifact-name' では、'--report-azdo-upload-artifacts' を 'off' 以外の値に設定する必要があります。</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Azure DevOps の成果物のアップロードが要求されましたが、TF_BUILD が 'true' に設定されていないため、Azure DevOps の成果物のアップロードとビルド タグをスキップします。</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history' では '--report-azdo' を有効にする必要があります</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps の flaky 履歴が {0} 件の実行を返しました。最初の {1} 件の実行のみが検査されます。</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">glob パターン {0} が無効です。</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">'--report-azdo-flaky-history' の値 '{0}' が無効です。1 から 90 までの整数を入力してください。</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', '--report-azdo-upload-artifact-name'을 사용하려면 '--report-azdo-upload-artifacts'를 'off' 이외의 값으로 설정해야 합니다.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Azure DevOps 아티팩트 업로드가 요청되었지만 TF_BUILD가 'true'로 설정되지 않았습니다. Azure DevOps 아티팩트 업로드와 빌드 태그를 건너뜁니다.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history'를 사용하려면 '--report-azdo'가 활성화되어 있어야 합니다.</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps 불안정성 기록이 {0}회 반환되었습니다. 첫 {1}회 실행만 검사합니다.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">GLOB 패턴 {0}이(가) 잘못되었습니다.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">'--report-azdo-flaky-history'의 값 '{0}'이(가) 잘못되었습니다. 1에서 90 사이의 정수를 입력하세요.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">„--report-azdo-upload-artifact-include”, „--report-azdo-upload-artifact-exclude” i „--report-azdo-upload-artifact-name” wymagają ustawienia wartości „--report-azdo-upload-artifacts” na wartość inną niż „off”.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Zażądano przekazania artefaktu usługi Azure DevOps, ale TF_BUILD nie jest ustawiona na wartość „true”; pomijanie przekazywania artefaktu usługi Azure DevOps i tagów kompilacji.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">Element „--report-azdo-flaky-history” wymaga włączenia opcji „--report-azdo”</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Niestabilna historia usługi Azure DevOps zwróciła następującą liczbę przebiegów: {0}. Tylko pierwsze przebiegi ({1}) zostaną poddane inspekcji.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Nieprawidłowy wzorzec globalny „{0}”.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Nieprawidłowa wartość „{0}” dla „--report-azdo-flaky-history”. Podaj liczbę całkowitą z zakresu od 1 do 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', e '--report-azdo-upload-artifact-name' requerem que '--report-azdo-upload-artifacts' esteja definido com um valor diferente de 'off'.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">A solicitação de upload de artefatos do Azure DevOps foi feita, mas TF_BUILD não está definido como 'true'; ignorando o upload de artefatos e as marcas de compilação do Azure DevOps.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history' requer que '--report-azdo' esteja habilitado</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">O histórico de instabilidade recorrente do Azure DevOps retornou {0} execuções. Somente as primeiras {1} execuções serão inspecionadas.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Padrão glob inválido {0}.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Valor inválido '{0}' para '--report-azdo-flaky-history'. Forneça um inteiro entre 1 e 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">"--report-azdo-upload-artifact-include", "--report-azdo-upload-artifact-exclude" и "--report-azdo-upload-artifact-name" требуют, чтобы для "--report-azdo-upload-artifacts" было настроено значение, отличное от "off".</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Запрошена отправка артефактов Azure DevOps, но для TF_BUILD не настроено значение "true"; отправка артефактов Azure DevOps и теги сборки пропускаются.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-flaky-history" требует включения "--report-azdo"</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Журнал ненадежных экземпляров Azure DevOps вернул несколько ({0}) выполнений. Будут проверены только первые несколько ({1}) выполнений.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">Недопустимая стандартная маска {0}.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">Недопустимое значение "{0}" для "--report-azdo-flaky-history". Укажите целое число в диапазоне от 1 до 90.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude' ve '--report-azdo-upload-artifact-name', '--report-azdo-upload-artifacts' seçeneğinin 'off' dışındaki bir değere ayarlanmasını gerektirir.</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">Azure DevOps yapıtı karşıya yükleme istendi, ancak TF_BUILD 'true' olarak ayarlanmadı; Azure DevOps yapıtı karşıya yükleme ve derleme etiketleri atlanıyor.</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history' öğesi '--report-azdo' öğesinin etkinleştirilmesini gerektirir</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps güvenilir olmayan geçmişi {0} çalıştırma döndürdü. Yalnızca ilk {1} çalıştırma incelenecek.</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">{0} glob deseni geçersiz.</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">'--report-azdo-flaky-history' için geçersiz değer '{0}'. 1 ile 90 arasında bir tamsayı belirtin.</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">"--report-azdo-upload-artifact-include"、"--report-azdo-upload-artifact-exclude" 和 "--report-azdo-upload-artifact-name" 要求 "--report-azdo-upload-artifacts" 设置为非 "off" 的值。</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">已请求上传 Azure DevOps 项目，但 TF_BUILD 未设置为 "true"；正在跳过 Azure DevOps 项目上传和生成标记。</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">"--report-azdo-flaky-history" 要求启用 "--report-azdo"</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps 不可靠历史记录返回 {0} 次运行。仅检查前 {1} 次运行。</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">glob 模式 {0} 无效。</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">"--report-azdo-flaky-history" 的值“{0}”无效。请提供 1 到 90 之间的整数。</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../AzureDevOpsResources.resx">
     <body>
+      <trans-unit id="AnnotationsOptionDescription">
+        <source>Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="ArtifactUploadOptionsRequireUploadArtifacts">
         <source>'--report-azdo-upload-artifact-include', '--report-azdo-upload-artifact-exclude', and '--report-azdo-upload-artifact-name' require '--report-azdo-upload-artifacts' to be set to a value other than 'off'.</source>
         <target state="translated">'--report-azdo-upload-artifact-include'、'--report-azdo-upload-artifact-exclude' 和 '--report-azdo-upload-artifact-name' 需要將 '--report-azdo-upload-artifacts' 設定為 'off' 以外的值。</target>
@@ -11,6 +16,11 @@
         <source>Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags.</source>
         <target state="translated">已要求 Azure DevOps 成品上傳，但 TF_BUILD 未設定為 'true'；將略過 Azure DevOps 成品上傳和組建標籤。</target>
         <note>{Locked="TF_BUILD"}{Locked="true"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsAnnotationsRequiresAzureDevOps">
+        <source>'--report-azdo-annotations' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-annotations' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-annotations"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsDemoteKnownFlakyRequiresAzureDevOps">
         <source>'--report-azdo-demote-known-flaky' requires '--report-azdo' to be enabled</source>
@@ -26,6 +36,11 @@
         <source>'--report-azdo-flaky-history' requires '--report-azdo' to be enabled</source>
         <target state="translated">'--report-azdo-flaky-history' 需要啟用 '--report-azdo'</target>
         <note>{Locked="--report-azdo-flaky-history"}{Locked="--report-azdo"}</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsGroupsRequiresAzureDevOps">
+        <source>'--report-azdo-groups' requires '--report-azdo' to be enabled</source>
+        <target state="new">'--report-azdo-groups' requires '--report-azdo' to be enabled</target>
+        <note>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
@@ -197,6 +212,11 @@
         <target state="translated">Azure DevOps 不穩定歷程記錄傳回 {0} 次執行。只會檢查前 {1} 次執行。</target>
         <note>{0} is the number of runs returned. {1} is the maximum number of runs to inspect.</note>
       </trans-unit>
+      <trans-unit id="GroupsOptionDescription">
+        <source>Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</source>
+        <target state="new">Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.</target>
+        <note>{Locked="on"}{Locked="off"}{Locked="--report-azdo"}</note>
+      </trans-unit>
       <trans-unit id="InvalidArtifactUploadGlob">
         <source>Invalid glob pattern {0}.</source>
         <target state="translated">無效的 glob 模式 {0}。</target>
@@ -211,6 +231,11 @@
         <source>Invalid value '{0}' for '--report-azdo-flaky-history'. Provide an integer between 1 and 90.</source>
         <target state="translated">'--report-azdo-flaky-history' 的值 '{0}' 無效。提供 1 到 90 之間的整數。</target>
         <note>{0} is the invalid value. {Locked="--report-azdo-flaky-history"}</note>
+      </trans-unit>
+      <trans-unit id="InvalidOnOffValue">
+        <source>Invalid value '{0}'. Valid values are 'on' and 'off'.</source>
+        <target state="new">Invalid value '{0}'. Valid values are 'on' and 'off'.</target>
+        <note>{Locked="on"}{Locked="off"}</note>
       </trans-unit>
       <trans-unit id="InvalidSeverity">
         <source>Invalid option {0}.</source>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -133,10 +133,14 @@ Extension options:
         Publish test results live to the Azure DevOps Tests tab.
     --report-azdo
         Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.
+    --report-azdo-annotations
+        Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.
     --report-azdo-demote-known-flaky
         Demote failures with an Azure DevOps flaky history of at least 25% in the selected window to warnings.
     --report-azdo-flaky-history
         Query Azure DevOps test result history for the past N days (1-90) and annotate reported failures with flakiness context.
+    --report-azdo-groups
+        Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.
     --report-azdo-quarantine-file
         Path to a text file that lists quarantined test fully qualified names or glob patterns. Matching failures are reported as warnings.
     --report-azdo-severity
@@ -409,6 +413,10 @@ Registered command line providers:
         Arity: 0
         Hidden: False
         Description: Enable Azure DevOps report generator to write errors to the output in a way that Azure DevOps understands.
+      --report-azdo-annotations
+        Arity: 1
+        Hidden: False
+        Description: Enable or disable Azure DevOps failure annotations ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.
       --report-azdo-demote-known-flaky
         Arity: 0
         Hidden: False
@@ -417,6 +425,10 @@ Registered command line providers:
         Arity: 1
         Hidden: False
         Description: Query Azure DevOps test result history for the past N days (1-90) and annotate reported failures with flakiness context.
+      --report-azdo-groups
+        Arity: 1
+        Hidden: False
+        Description: Enable or disable per-assembly Azure DevOps log groups ('on' or 'off'). Defaults to 'on'. Requires '--report-azdo'.
       --report-azdo-quarantine-file
         Arity: 1
         Hidden: False

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsCommandLineProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsCommandLineProviderTests.cs
@@ -106,6 +106,72 @@ public sealed class AzureDevOpsCommandLineProviderTests
     }
 
     [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_ReturnsInvalid_WhenAnnotationsIsUsedWithoutAzureDevOpsAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        ValidationResult validationResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations] = ["off"],
+        })).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.AreEqual(AzureDevOpsResources.AzureDevOpsAnnotationsRequiresAzureDevOps, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_ReturnsInvalid_WhenGroupsIsUsedWithoutAzureDevOpsAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        ValidationResult validationResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsGroups] = ["off"],
+        })).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+        Assert.AreEqual(AzureDevOpsResources.AzureDevOpsGroupsRequiresAzureDevOps, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsInvalid_WhenGroupsValueIsNotOnOrOffAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsGroups);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["maybe"]).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsValid_WhenGroupsValueIsOffAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsGroups);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["off"]).ConfigureAwait(false);
+
+        Assert.IsTrue(validationResult.IsValid, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsInvalid_WhenAnnotationsValueIsNotOnOrOffAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["maybe"]).ConfigureAwait(false);
+
+        Assert.IsFalse(validationResult.IsValid);
+    }
+
+    [TestMethod]
+    public async Task ValidateOptionArgumentsAsync_ReturnsValid_WhenAnnotationsValueIsOnAsync()
+    {
+        AzureDevOpsCommandLineProvider provider = new();
+        CommandLineOption option = provider.GetCommandLineOptions().Single(o => o.Name == AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations);
+        ValidationResult validationResult = await provider.ValidateOptionArgumentsAsync(option, ["on"]).ConfigureAwait(false);
+
+        Assert.IsTrue(validationResult.IsValid, validationResult.ErrorMessage);
+    }
+
+    [TestMethod]
     public async Task ValidateOptionArgumentsAsync_ReturnsInvalid_WhenStackFrameFilterRegexIsInvalidAsync()
     {
         AzureDevOpsCommandLineProvider provider = new();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsConstantsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsConstantsTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport;
+using Microsoft.Testing.Extensions.Reporting;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
 using Microsoft.Testing.Platform.Helpers;
 
 using Moq;
@@ -66,5 +68,38 @@ public sealed class AzureDevOpsConstantsTests
 
         Assert.IsTrue(AzureDevOpsConstants.IsRunningInAzureDevOps(environmentMock.Object));
         environmentMock.Verify(e => e.GetEnvironmentVariable("TF_BUILD"), Times.Once);
+    }
+
+    [TestMethod]
+    public void IsFeatureKnobEnabled_ReturnsTrue_WhenKnobNotSet()
+    {
+        TestCommandLineOptions options = new([]);
+        Assert.IsTrue(AzureDevOpsConstants.IsFeatureKnobEnabled(options, AzureDevOpsCommandLineOptions.AzureDevOpsGroups));
+    }
+
+    [TestMethod]
+    [DataRow("on")]
+    [DataRow("On")]
+    [DataRow("anything")]
+    public void IsFeatureKnobEnabled_ReturnsTrue_WhenKnobIsNotOff(string value)
+    {
+        TestCommandLineOptions options = new(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsGroups] = [value],
+        });
+        Assert.IsTrue(AzureDevOpsConstants.IsFeatureKnobEnabled(options, AzureDevOpsCommandLineOptions.AzureDevOpsGroups));
+    }
+
+    [TestMethod]
+    [DataRow("off")]
+    [DataRow("OFF")]
+    [DataRow("Off")]
+    public void IsFeatureKnobEnabled_ReturnsFalse_WhenKnobIsOff(string value)
+    {
+        TestCommandLineOptions options = new(new Dictionary<string, string[]>
+        {
+            [AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations] = [value],
+        });
+        Assert.IsFalse(AzureDevOpsConstants.IsFeatureKnobEnabled(options, AzureDevOpsCommandLineOptions.AzureDevOpsAnnotations));
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLogGroupReporterTests.cs
@@ -59,6 +59,20 @@ public sealed class AzureDevOpsLogGroupReporterTests
     }
 
     [TestMethod]
+    public async Task IsEnabledAsync_ReturnsFalse_WhenGroupsExplicitlyOffAsync()
+    {
+        AzureDevOpsLogGroupReporter reporter = CreateReporter(enabled: true, tfBuild: true, groups: ["off"]);
+        Assert.IsFalse(await reporter.IsEnabledAsync());
+    }
+
+    [TestMethod]
+    public async Task IsEnabledAsync_ReturnsTrue_WhenGroupsExplicitlyOnAsync()
+    {
+        AzureDevOpsLogGroupReporter reporter = CreateReporter(enabled: true, tfBuild: true, groups: ["on"]);
+        Assert.IsTrue(await reporter.IsEnabledAsync());
+    }
+
+    [TestMethod]
     public async Task SessionStarting_EmitsGroupHeaderWithAssemblyAndTfmAsync()
     {
         AzureDevOpsLogGroupReporter reporter = CreateReporter(enabled: true, tfBuild: true);
@@ -121,11 +135,16 @@ public sealed class AzureDevOpsLogGroupReporterTests
                 Properties = new PropertyBag(state),
             });
 
-    private AzureDevOpsLogGroupReporter CreateReporter(bool enabled, bool tfBuild)
+    private AzureDevOpsLogGroupReporter CreateReporter(bool enabled, bool tfBuild, string[]? groups = null)
     {
         Dictionary<string, string[]> options = enabled
             ? new Dictionary<string, string[]> { [AzureDevOpsCommandLineOptions.AzureDevOpsOptionName] = [] }
             : [];
+        if (groups is not null)
+        {
+            options[AzureDevOpsCommandLineOptions.AzureDevOpsGroups] = groups;
+        }
+
         _ = _environmentMock.Setup(e => e.GetEnvironmentVariable(AzureDevOpsConstants.TfBuildEnvironmentVariableName))
             .Returns(tfBuild ? AzureDevOpsConstants.TfBuildEnabledValue : null);
         return new AzureDevOpsLogGroupReporter(


### PR DESCRIPTION
## Summary

The `Microsoft.Testing.Extensions.AzureDevOpsReport` extension's **per-assembly log groups** and **failure annotations** were unconditionally on once `--report-azdo` was set (on an Azure DevOps agent), with **no way to disable them individually**. This adds two additive `on|off` knobs (default `on`), mirroring the `GitHubActionsReport` per-feature toggle scheme, so each feature can be turned off without affecting the rest of the extension.

This is a **non-breaking, additive** change: the new options don't exist today, and every feature still defaults to `on`, so existing behavior is unchanged.

## New options

| Option | Description | Default |
|---|---|---|
| `--report-azdo-groups on\|off` | Per-assembly Azure DevOps log groups | on |
| `--report-azdo-annotations on\|off` | Azure DevOps failure annotations (`##vso[task.logissue]`) | on |

Both require `--report-azdo` and only take effect on an Azure DevOps agent (`TF_BUILD=true`), consistent with the extension's existing activation model.

## Changes

- **`AzureDevOpsConstants.IsFeatureKnobEnabled`** — shared helper (mirrors `GitHubActionsFeature.IsKnobEnabled`): a knob is enabled unless explicitly set to `off`.
- Gated `AzureDevOpsLogGroupReporter.IsEnabledAsync` on the groups knob and `AzureDevOpsReporter.IsEnabledAsync` on the annotations knob.
- Registered the two options with `on|off` argument validation and requires-`--report-azdo` checks, consistent with the existing sub-options.
- Added `.resx` strings and regenerated the `.xlf` files for all locales via `UpdateXlf`.
- Updated the `--help`/`--info` expectations in `HelpInfoAllExtensionsTests`.
- Added unit tests for the option validation, the toggle helper, and log-group gating.

## Context

This came out of a review of #9541 (the new GitHubActionsReport extension). GH ships uniform `--report-gh-<feature> on|off` knobs from day one; AzDO lacked any off switch for its always-on features. This closes that gap for the two boolean features while intentionally leaving the genuinely multi-valued options (`--report-azdo-upload-artifacts` mode, `--report-azdo-summary` path, publish flags) as-is.

## Testing

- Built the extension and unit-test projects (0 errors).
- All AzureDevOps unit tests pass, including the new validation/gating/helper tests.
- Note: `HelpInfoAllExtensionsTests` is an acceptance test that requires `build.cmd -pack` to run end-to-end; its expectations were updated to exactly match the resx text and arity and should be confirmed in CI.