### PR TITLE
Prefer TestMethodIdentifierProperty in AzureDevOps TestNodeIdentity

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestNodeIdentity.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestNodeIdentity.cs
@@ -31,7 +31,7 @@ internal static class TestNodeIdentity
         // Walk the PropertyBag once with the zero-allocation struct enumerator, avoiding the LINQ
         // iterator/boxed-enumerator allocations that OfType<T>().FirstOrDefault(...) would incur.
         // Short-circuit as soon as the preferred TestMethodIdentifierProperty is found; otherwise
-        // remember the VSTest fully-qualified name as a fallback.
+        // remember the first VSTest fully-qualified name as a fallback.
         string? fullyQualifiedName = null;
         using PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
@@ -41,7 +41,7 @@ internal static class TestNodeIdentity
                 case TestMethodIdentifierProperty testMethodIdentifier:
                     return FormatFullyQualifiedName(testMethodIdentifier);
 
-                case SerializableKeyValuePairStringProperty { Key: FullyQualifiedNamePropertyKey } kvp:
+                case SerializableKeyValuePairStringProperty { Key: FullyQualifiedNamePropertyKey } kvp when fullyQualifiedName is null:
                     fullyQualifiedName = kvp.Value;
                     break;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestNodeIdentity.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/TestNodeIdentity.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.Extensions.Messages;
 
 namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
@@ -11,24 +12,46 @@ internal static class TestNodeIdentity
 
     /// <summary>
     /// Resolves the stable test name used to match a <see cref="TestNode"/> against Azure DevOps history
-    /// (which keys results by <c>AutomatedTestName</c>). Falls back to the display name when the
-    /// fully-qualified name property is unavailable.
+    /// (which keys results by <c>AutomatedTestName</c>, i.e. the fully-qualified <c>Namespace.Type.Method</c>).
     /// </summary>
+    /// <remarks>
+    /// The identity is resolved in the same priority order used by the TRX and VSTest-bridge converters:
+    /// <list type="number">
+    /// <item><description><see cref="TestMethodIdentifierProperty"/> — the canonical, ECMA-335 compliant identity added by
+    /// frameworks running natively on the platform. This is the property that maps to Azure DevOps' <c>AutomatedTestName</c>.</description></item>
+    /// <item><description>The non-standard <c>vstest.TestCase.FullyQualifiedName</c> property (only present for tests flowing
+    /// through the VSTest bridge in server mode).</description></item>
+    /// <item><description>The display name, as a last resort.</description></item>
+    /// </list>
+    /// In practice a given <see cref="TestNode"/> carries at most one of the first two properties, so the walk order does
+    /// not matter; we still prefer <see cref="TestMethodIdentifierProperty"/> when both are somehow present.
+    /// </remarks>
     public static string GetTestName(TestNode testNode)
     {
-        // Walk the PropertyBag once with the zero-allocation struct enumerator and short-circuit
-        // on the first matching key, avoiding the LINQ iterator/boxed-enumerator allocations that
-        // OfType<T>().FirstOrDefault(...) would incur.
+        // Walk the PropertyBag once with the zero-allocation struct enumerator, avoiding the LINQ
+        // iterator/boxed-enumerator allocations that OfType<T>().FirstOrDefault(...) would incur.
+        // Short-circuit as soon as the preferred TestMethodIdentifierProperty is found; otherwise
+        // remember the VSTest fully-qualified name as a fallback.
+        string? fullyQualifiedName = null;
         using PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
         {
-            if (enumerator.Current is SerializableKeyValuePairStringProperty kvp
-                && kvp.Key == FullyQualifiedNamePropertyKey)
+            switch (enumerator.Current)
             {
-                return kvp.Value;
+                case TestMethodIdentifierProperty testMethodIdentifier:
+                    return FormatFullyQualifiedName(testMethodIdentifier);
+
+                case SerializableKeyValuePairStringProperty { Key: FullyQualifiedNamePropertyKey } kvp:
+                    fullyQualifiedName = kvp.Value;
+                    break;
             }
         }
 
-        return testNode.DisplayName;
+        return fullyQualifiedName ?? testNode.DisplayName;
     }
+
+    private static string FormatFullyQualifiedName(TestMethodIdentifierProperty testMethodIdentifier)
+        => RoslynString.IsNullOrEmpty(testMethodIdentifier.Namespace)
+            ? $"{testMethodIdentifier.TypeName}.{testMethodIdentifier.MethodName}"
+            : $"{testMethodIdentifier.Namespace}.{testMethodIdentifier.TypeName}.{testMethodIdentifier.MethodName}";
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestNodeIdentityTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestNodeIdentityTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport;
+using Microsoft.Testing.Platform.Extensions.Messages;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class AzureDevOpsTestNodeIdentityTests
+{
+    [TestMethod]
+    public void GetTestName_WhenTestMethodIdentifierPropertyPresent_ReturnsFullyQualifiedName()
+    {
+        TestNode testNode = CreateNode(
+            displayName: "My display name",
+            new TestMethodIdentifierProperty("Assembly", "My.Namespace", "MyType", "MyMethod", 0, [], "System.Void"));
+
+        Assert.AreEqual("My.Namespace.MyType.MyMethod", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    [TestMethod]
+    public void GetTestName_WhenTestMethodIdentifierPropertyHasEmptyNamespace_OmitsLeadingDot()
+    {
+        TestNode testNode = CreateNode(
+            displayName: "My display name",
+            new TestMethodIdentifierProperty("Assembly", string.Empty, "MyType", "MyMethod", 0, [], "System.Void"));
+
+        Assert.AreEqual("MyType.MyMethod", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    [TestMethod]
+    public void GetTestName_WhenTestMethodIdentifierPropertyPresent_IsPreferredOverVSTestFullyQualifiedName()
+    {
+        TestNode testNode = CreateNode(
+            displayName: "My display name",
+            new SerializableKeyValuePairStringProperty("vstest.TestCase.FullyQualifiedName", "Some.Vstest.Fqn"),
+            new TestMethodIdentifierProperty("Assembly", "My.Namespace", "MyType", "MyMethod", 0, [], "System.Void"));
+
+        Assert.AreEqual("My.Namespace.MyType.MyMethod", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    [TestMethod]
+    public void GetTestName_WhenOnlyVSTestFullyQualifiedNamePresent_ReturnsIt()
+    {
+        TestNode testNode = CreateNode(
+            displayName: "My display name",
+            new SerializableKeyValuePairStringProperty("vstest.TestCase.FullyQualifiedName", "My.Namespace.MyType.MyMethod"));
+
+        Assert.AreEqual("My.Namespace.MyType.MyMethod", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    [TestMethod]
+    public void GetTestName_WhenNoIdentityProperty_FallsBackToDisplayName()
+    {
+        TestNode testNode = CreateNode(displayName: "My display name");
+
+        Assert.AreEqual("My display name", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    [TestMethod]
+    public void GetTestName_IgnoresUnrelatedSerializableProperties()
+    {
+        TestNode testNode = CreateNode(
+            displayName: "My display name",
+            new SerializableKeyValuePairStringProperty("vstest.TestCase.Id", "some-guid"));
+
+        Assert.AreEqual("My display name", TestNodeIdentity.GetTestName(testNode));
+    }
+
+    private static TestNode CreateNode(string displayName, params IProperty[] properties)
+    {
+        PropertyBag propertyBag = new();
+        foreach (IProperty property in properties)
+        {
+            propertyBag.Add(property);
+        }
+
+        return new TestNode
+        {
+            Uid = "uid",
+            DisplayName = displayName,
+            Properties = propertyBag,
+        };
+    }
+}


### PR DESCRIPTION
## Problem

`TestNodeIdentity.GetTestName` (in `Microsoft.Testing.Extensions.AzureDevOpsReport`) only checked the non-standard `vstest.TestCase.FullyQualifiedName` property and otherwise returned `TestNode.DisplayName`.

That property is:
- **absent for tests running natively on the platform** — those carry their identity in `TestMethodIdentifierProperty`, not the `vstest.*` string property; and
- **gated behind server mode + VSTest-provider support** (`ShouldAddVSTestProviderProperties`), so it's not even present for typical VSTest-bridge CLI runs.

In those common cases `GetTestName` silently fell back to `DisplayName`, which does **not** equal Azure DevOps' `AutomatedTestName` (they differ notably for parameterized/data-driven tests). This broke:
- slow-test history/threshold matching in `AzureDevOpsSlowTestReporter`, and
- the test name shown in `AzureDevOpsReporter` error logging.

## Fix

Resolve the identity in the same priority order already used by the TRX and VSTest-bridge converters (`TrxReportEngine.Results.cs`, `ObjectModelConverters.cs`), which treat `TestMethodIdentifierProperty` as canonical and the VSTest FQN as a non-standard fallback:

1. `TestMethodIdentifierProperty` → formatted as `Namespace.Type.Method` (matches how ADO derives `AutomatedTestName`)
2. `vstest.TestCase.FullyQualifiedName`
3. `DisplayName` (last resort)

The two properties are effectively mutually exclusive, so walk order doesn't strictly matter — but `TestMethodIdentifierProperty` is preferred and short-circuits when found. The single-pass zero-allocation struct enumerator is preserved.

> Note: frameworks that don't emit `TestMethodIdentifierProperty` (e.g. NUnit — same caveat is called out in `TrxReportEngine.Results.cs`) still fall back to `DisplayName`, matching historical behavior.

## Tests

Added `AzureDevOpsTestNodeIdentityTests` covering: TMIP present, TMIP with empty namespace, TMIP preferred over VSTest FQN, VSTest-FQN-only, no identity → DisplayName, and unrelated `vstest.*` properties ignored. All Extensions unit tests pass on net8.0/net9.0/net462/net472.