### PR TITLE
Drop Microsoft.NET.Test.Sdk from the MSTest metapackage

### DIFF
--- a/src/Package/MSTest/MSTest.csproj
+++ b/src/Package/MSTest/MSTest.csproj
@@ -49,15 +49,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Microsoft.NET.Test.Sdk package is referenced by build system, so omitting it. -->
-    <!-- VSTest is packaging props/targets in build directory of the NuGet package instead of buildTransitive -->
-    <!-- To ensure that this flows to consumers of MSTest metapackage, we set PrivateAssets to none (by default, PrivateAssets includes "build") -->
-    <!-- If VSTest moves from build to buildTransitive, the PrivateAssets here can/should be removed. -->
-    <!-- Currently, VSTest isn't able to move from build to buildTransitive -->
-    <!-- See: https://github.com/microsoft/vstest/pull/3879, -->
-    <!--      https://github.com/microsoft/vstest/issues/4098 -->
-    <!--      https://github.com/microsoft/vstest/pull/4104 -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="$(MicrosoftNETTestSdkVersion)" Condition="'$(TargetFramework)' != '$(UwpMinimum)'" PrivateAssets="none" />
+    <!--
+      Microsoft.NET.Test.Sdk (the classic VSTest runner, which drags in Microsoft.TestPlatform.TestHost and the
+      rest of the VSTest execution stack) is intentionally NOT referenced. MSTest runs as a
+      Microsoft.Testing.Platform (MTP) application and does not need the VSTest testhost/runner. Dropping it keeps
+      the MSTest package's only VSTest-lineage dependency down to Microsoft.TestPlatform.ObjectModel, which flows
+      transitively through Microsoft.Testing.Extensions.VSTestBridge (plus the source-only, non-flowing
+      Microsoft.TestPlatform.Filter.Source). MTP build integration is provided by Microsoft.Testing.Platform.MSBuild
+      (flowed via MSTest.TestAdapter), not by Microsoft.NET.Test.Sdk. -->
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
   </ItemGroup>
 


### PR DESCRIPTION
**Draft / illustrative — companion to microsoft/vstest#16201. Not meant to merge as-is.**

MSTest already runs as a Microsoft.Testing.Platform (MTP) app, so it doesn't need the classic VSTest runner. The `Microsoft.NET.Test.Sdk` reference in the MSTest metapackage drags in `Microsoft.TestPlatform.TestHost` and the rest of the VSTest execution stack. Dropping it leaves `Microsoft.TestPlatform.ObjectModel` as the only VSTest-lineage package MSTest brings in — and that flows transitively through `Microsoft.Testing.Extensions.VSTestBridge` (alongside the source-only, non-flowing `Microsoft.TestPlatform.Filter.Source`). Build integration still comes from `Microsoft.Testing.Platform.MSBuild` via `MSTest.TestAdapter`.

Why bother: on the vstest side I taught `vstest.console`/`datacollector` to run pure-MTP apps directly over the MTP protocol — including in a single mixed run next to a classic vstest-based project, with TRX + coverage. This testfx draft is the other half of that picture: proof that MSTest could shed its vstest deps and still be driven by vstest in a mixed run. You don't need to do both — the point is that the migration can be incremental. Port some tests to MTP, then all of them, then move the infra (reporting, CI) off vstest when it's convenient — instead of replacing test infra, reporting, and every test in one shot. And no dynamic code loading.

**Known limitation (coverage).** The vstest "Code Coverage" datacollector binaries ship in `Microsoft.CodeCoverage` and normally reach vstest.console through `Microsoft.NET.Test.Sdk` (`Microsoft.CodeCoverage.props` sets `TraceDataCollectorDirectoryPath`, which the SDK's VSTest task forwards as `VSTestTraceDataCollectorDirectoryPath`). A metapackage without Test.Sdk won't restore those DLLs, so vstest-datacollector coverage on such a project needs another source for them — the project references `Microsoft.CodeCoverage`, or vstest bundles the collector in its runner. Pinned for a design discussion with the owner of code coverage. MTP-native coverage is unaffected: the metapackage still references `Microsoft.Testing.Extensions.CodeCoverage`.

Verified on the base it was authored against — restore graph `net462;net8.0;net9.0;uap10.0` plus a real packed nuspec: no Test.Sdk, no TestHost, ObjectModel only. The metapackage region is unchanged on `main`, so it cherry-picks clean.

Co-authored with GitHub Copilot.

