### PR TITLE
Register AzureFoundry, PackagedApp, Telemetry and VideoRecorder extensions to HelpInfo tests

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -89,6 +89,18 @@ Options:
         Specifies how a run that executed no tests is treated.
         Valid values are 'allow-skipped' (the default) which counts skipped tests as run, so only a run where no test was found at all fails with exit code 8, and 'strict' which treats skipped tests as not run, so a run where every test was skipped (or no test was found) fails with exit code 8.
 Extension options:
+    --capture-video
+        Record the screen during the test run. Optionally specify when to keep the video: 'on-failure' (default, keep only failing tests' footage) or 'always'.
+    --capture-video-args
+        Extra arguments passed to the underlying recorder (currently ffmpeg), as output/encoding options. Requires --capture-video. Because the value usually starts with '-', use the '=' delimiter so it is not parsed as a separate option, e.g. --capture-video-args="-vf scale=1280:-1".
+    --capture-video-chapters
+        Whether the per-session video includes one chapter bookmark per test: 'on' (default) or 'off'. Only applies with --capture-video-granularity session. Requires --capture-video.
+    --capture-video-granularity
+        How recordings are split: 'test' (default, one video per test) or 'session' (one chaptered video for the whole run). Requires --capture-video.
+    --capture-video-max-duration
+        Limit retained footage to roughly the last N seconds (a rolling buffer) to bound disk usage on long runs. Older footage that no running test needs is pruned. Requires --capture-video.
+    --capture-video-source
+        What to capture: 'screen' (default, the full screen) or 'window' (only the current process window; Windows only, falls back to full screen elsewhere). Requires --capture-video.
     --crash-report
         [Linux/macOS only] Generate a JSON crash report when the test process crashes. Combine with '--crashdump' to also generate a dump file. Requires .NET 7+ when used alone; .NET 6+ when combined with '--crashdump'. This runtime requirement is not enforced by the tool: on unsupported runtimes no crash report will be emitted. Not supported on Windows due to a .NET runtime limitation (dotnet/runtime#80191); use '--crash-report-if-supported' to silently skip the option there.
     --crash-report-if-supported
@@ -625,6 +637,35 @@ Registered command line providers:
         Description: The name of the generated TRX report. May include a relative or absolute path; relative paths are resolved against the test results directory and missing directories are created.
         Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
         Example: MyReport_{tfm}.trx
+  VideoRecorderCommandLineProvider
+    Name: Video recorder
+    Version: *
+    Description: Command-line options for the video recorder extension.
+    Options:
+      --capture-video
+        Arity: 0..1
+        Hidden: False
+        Description: Record the screen during the test run. Optionally specify when to keep the video: 'on-failure' (default, keep only failing tests' footage) or 'always'.
+      --capture-video-args
+        Arity: 1
+        Hidden: False
+        Description: Extra arguments passed to the underlying recorder (currently ffmpeg), as output/encoding options. Requires --capture-video. Because the value usually starts with '-', use the '=' delimiter so it is not parsed as a separate option, e.g. --capture-video-args="-vf scale=1280:-1".
+      --capture-video-chapters
+        Arity: 1
+        Hidden: False
+        Description: Whether the per-session video includes one chapter bookmark per test: 'on' (default) or 'off'. Only applies with --capture-video-granularity session. Requires --capture-video.
+      --capture-video-granularity
+        Arity: 1
+        Hidden: False
+        Description: How recordings are split: 'test' (default, one video per test) or 'session' (one chaptered video for the whole run). Requires --capture-video.
+      --capture-video-max-duration
+        Arity: 1
+        Hidden: False
+        Description: Limit retained footage to roughly the last N seconds (a rolling buffer) to bound disk usage on long runs. Older footage that no running test needs is pruned. Requires --capture-video.
+      --capture-video-source
+        Arity: 1
+        Hidden: False
+        Description: What to capture: 'screen' (default, the full screen) or 'window' (only the current process window; Windows only, falls back to full screen elsewhere). Requires --capture-video.
 Registered tools:
   TrxCompareTool
     Command: ms-trxcompare
@@ -673,14 +714,19 @@ Registered tools:
     <ItemGroup>
         <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.AzureFoundry" Version="$MicrosoftTestingExtensionsAzureFoundryVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.CtrfReport" Version="$MicrosoftTestingExtensionsCtrfReportVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.HangDump" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.HotReload" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.HtmlReport" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.JUnitReport" Version="$MicrosoftTestingExtensionsJUnitReportVersion$" />
+        <!-- PackagedApp ships only for .NET (no netstandard2.0 / net462 asset), so exclude it on .NET Framework. -->
+        <PackageReference Include="Microsoft.Testing.Extensions.PackagedApp" Version="$MicrosoftTestingExtensionsPackagedAppVersion$" Condition=" '$(TargetFramework)' != 'net462' " />
         <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.Telemetry" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.VideoRecorder" Version="$MicrosoftTestingExtensionsVideoRecorderVersion$" />
     </ItemGroup>
 </Project>
 
@@ -736,7 +782,10 @@ public class DummyTestFramework : ITestFramework
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MicrosoftTestingExtensionsCtrfReportVersion$", MicrosoftTestingExtensionsCtrfReportVersion)
-                .PatchCodeWithReplace("$MicrosoftTestingExtensionsJUnitReportVersion$", MicrosoftTestingExtensionsJUnitReportVersion));
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsJUnitReportVersion$", MicrosoftTestingExtensionsJUnitReportVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsPackagedAppVersion$", MicrosoftTestingExtensionsPackagedAppVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsVideoRecorderVersion$", MicrosoftTestingExtensionsVideoRecorderVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsAzureFoundryVersion$", MicrosoftTestingExtensionsAzureFoundryVersion));
     }
 
     public TestContext TestContext { get; set; }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -22,6 +22,7 @@ public abstract class AcceptanceTestBase
         MicrosoftTestingExtensionsJUnitReportVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Extensions.JUnitReport.");
         MicrosoftTestingExtensionsPackagedAppVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Extensions.PackagedApp.");
         MicrosoftTestingExtensionsVideoRecorderVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Extensions.VideoRecorder.");
+        MicrosoftTestingExtensionsAzureFoundryVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesNonShipping, "Microsoft.Testing.Extensions.AzureFoundry.");
     }
 
     internal static string RID { get; }
@@ -50,6 +51,8 @@ public abstract class AcceptanceTestBase
     public static string MicrosoftTestingExtensionsPackagedAppVersion { get; private set; }
 
     public static string MicrosoftTestingExtensionsVideoRecorderVersion { get; private set; }
+
+    public static string MicrosoftTestingExtensionsAzureFoundryVersion { get; private set; }
 
     private static string ExtractVersionFromPackage(string rootFolder, string packagePrefixName)
     {


### PR DESCRIPTION
## Summary

Registers four more platform extensions in the `HelpInfoAllExtensionsTests` acceptance test asset so the `--help`/`-?`/`--info` output assertions cover them:

- `Microsoft.Testing.Extensions.AzureFoundry`
- `Microsoft.Testing.Extensions.PackagedApp`
- `Microsoft.Testing.Extensions.Telemetry`
- `Microsoft.Testing.Extensions.VideoRecorder`

## Changes

- **`AcceptanceTestBase.cs`** — added `MicrosoftTestingExtensionsAzureFoundryVersion`, extracted from the **NonShipping** packages folder (AzureFoundry sets `IsShipping=false`; the other three are Shipping).
- **`HelpInfoAllExtensionsTests.cs`** — added the four `PackageReference`s (plus version-token patches) to the generated test asset and updated the expected `--help` / `--info` wildcard patterns.

## Notes

- Only **VideoRecorder** surfaces in the help/info output — it registers a command-line provider, contributing six `--capture-video*` options to the `--help` *Extension options* section and a `VideoRecorderCommandLineProvider` block to `--info`. AzureFoundry (chat-client provider), PackagedApp (test-host launcher), and Telemetry (telemetry collector) register silently and are exercised via the `ExitCode.Success` assertion.
- **PackagedApp ships only for .NET** (`net8.0;net9.0`, no `netstandard2.0`/`net462` asset), so it is referenced with `Condition=" '$(TargetFramework)' != 'net462' "` to keep the `net462` host restorable. The other three cover all TFMs via `netstandard2.0`.
- Expected text was captured from a real `--help`/`--info` run after `build.cmd -pack`.
- The `-?` short-name test needed no change (it only asserts the header lines).

## Testing

`HelpInfoAllExtensionsTests` — 9/9 passing (3 methods × net462, net8.0, net10.0).