### PR TITLE
Abstract VSTest message logging in PlatformServices (Phase 1 of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -84,9 +84,10 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
 
         try
         {
-            if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext, logger, configuration, _testSourceHandler))
+            IAdapterMessageLogger adapterLogger = logger.ToAdapterMessageLogger();
+            if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext, adapterLogger, configuration, _testSourceHandler))
             {
-                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, logger, discoverySink, discoveryContext, isMTP);
+                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, discoverySink, discoveryContext, isMTP);
             }
         }
         finally

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -139,7 +139,7 @@ internal sealed class MSTestExecutor : ITestExecutor
 
         try
         {
-            if (!MSTestDiscovererHelpers.InitializeDiscovery(from test in tests select test.Source, runContext, frameworkHandle, configuration, new TestSourceHandler()))
+            if (!MSTestDiscovererHelpers.InitializeDiscovery(from test in tests select test.Source, runContext, frameworkHandle.ToAdapterMessageLogger(), configuration, new TestSourceHandler()))
             {
                 return;
             }
@@ -183,7 +183,7 @@ internal sealed class MSTestExecutor : ITestExecutor
         try
         {
             TestSourceHandler testSourceHandler = new();
-            if (!MSTestDiscovererHelpers.InitializeDiscovery(sources, runContext, frameworkHandle, configuration, testSourceHandler))
+            if (!MSTestDiscovererHelpers.InitializeDiscovery(sources, runContext, frameworkHandle.ToAdapterMessageLogger(), configuration, testSourceHandler))
             {
                 return;
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
@@ -31,7 +30,7 @@ internal class UnitTestDiscoverer
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
     internal void DiscoverTests(
         IEnumerable<string> sources,
-        IMessageLogger logger,
+        IAdapterMessageLogger logger,
         ITestCaseDiscoverySink discoverySink,
         IDiscoveryContext discoveryContext,
         bool isMTP)
@@ -52,7 +51,7 @@ internal class UnitTestDiscoverer
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
     internal virtual void DiscoverTestsInSource(
         string source,
-        IMessageLogger logger,
+        IAdapterMessageLogger logger,
         ITestCaseDiscoverySink discoverySink,
         IDiscoveryContext? discoveryContext,
         bool isMTP)
@@ -86,7 +85,7 @@ internal class UnitTestDiscoverer
                 }
 
                 string message = string.Format(CultureInfo.CurrentCulture, Resource.DiscoveryWarning, source, warning);
-                logger.SendMessage(TestMessageLevel.Warning, message);
+                logger.SendMessage(MessageLevel.Warning, message);
             }
         }
 
@@ -109,7 +108,7 @@ internal class UnitTestDiscoverer
 
     private readonly ITestSourceHandler _testSource;
 
-    internal void SendTestCases(IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IMessageLogger logger)
+    internal void SendTestCases(IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IAdapterMessageLogger logger)
     {
         // Get filter expression and skip discovery in case filter expression has parsing error.
         ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, logger, out bool filterHasError);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
@@ -63,6 +62,8 @@ internal partial class TestExecutionManager
         }
 #endif
 
+        IAdapterMessageLogger adapterMessageLogger = frameworkHandle.ToAdapterMessageLogger();
+
         using ITestSourceHost isolationHost = PlatformServiceProvider.Instance.CreateTestSourceHost(source, runContext?.RunSettings);
         bool usesAppDomains = isolationHost is TestSourceHost { UsesAppDomain: true };
 
@@ -72,7 +73,7 @@ internal partial class TestExecutionManager
         }
 
         // Default test set is filtered tests based on user provided filter criteria
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, frameworkHandle.ToAdapterMessageLogger(), out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, adapterMessageLogger, out bool filterHasError);
         if (filterHasError)
         {
             // Bail out without processing everything else below.
@@ -142,8 +143,8 @@ internal partial class TestExecutionManager
         if (!MSTestSettings.CurrentSettings.DisableParallelization && sourceSettings.CanParallelizeAssembly && parallelWorkers > 0)
         {
             // Parallelization is enabled. Let's do further classification for sets.
-            frameworkHandle.SendMessage(
-                TestMessageLevel.Informational,
+            adapterMessageLogger.SendMessage(
+                MessageLevel.Informational,
                 string.Format(CultureInfo.CurrentCulture, Resource.TestParallelizationBanner, source, parallelWorkers, parallelScope));
 
             // Create test sets for execution, we can execute them in parallel based on parallel settings
@@ -248,7 +249,7 @@ internal partial class TestExecutionManager
                         PlatformServiceProvider.Instance.AdapterTraceLogger.Error("Error occurred while executing tests in parallel{0}{1}", Environment.NewLine, exceptionToString);
                     }
 
-                    frameworkHandle.SendMessage(TestMessageLevel.Error, exceptionToString);
+                    adapterMessageLogger.SendMessage(MessageLevel.Error, exceptionToString);
                     throw;
                 }
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -72,7 +72,7 @@ internal partial class TestExecutionManager
         }
 
         // Default test set is filtered tests based on user provided filter criteria
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, frameworkHandle, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, frameworkHandle.ToAdapterMessageLogger(), out bool filterHasError);
         if (filterHasError)
         {
             // Bail out without processing everything else below.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
@@ -124,12 +124,12 @@ internal partial class TestExecutionManager
 
         var tests = new List<TestCase>();
 
+        IAdapterMessageLogger logger = frameworkHandle.ToAdapterMessageLogger();
+
         // deploy everything first.
         foreach (string source in sources)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
-
-            var logger = (IMessageLogger)frameworkHandle;
 
             // discover the tests
             GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSource(source, logger, discoverySink, runContext, isMTP);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/MSTestDiscovererHelpers.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/MSTestDiscovererHelpers.cs
@@ -4,7 +4,7 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 
@@ -20,7 +20,7 @@ internal static class MSTestDiscovererHelpers
     internal static bool AreValidSources(IEnumerable<string> sources, ITestSourceHandler testSourceHandler)
         => sources.Any(source => testSourceHandler.ValidSourceExtensions.Any(extension => string.Equals(Path.GetExtension(source), extension, StringComparison.OrdinalIgnoreCase)));
 
-    internal static bool InitializeDiscovery(IEnumerable<string> sources, IDiscoveryContext? discoveryContext, IMessageLogger messageLogger, IConfiguration? configuration, ITestSourceHandler testSourceHandler)
+    internal static bool InitializeDiscovery(IEnumerable<string> sources, IDiscoveryContext? discoveryContext, IAdapterMessageLogger messageLogger, IConfiguration? configuration, ITestSourceHandler testSourceHandler)
     {
         if (!AreValidSources(sources, testSourceHandler))
         {
@@ -35,7 +35,7 @@ internal static class MSTestDiscovererHelpers
         }
         catch (AdapterSettingsException ex)
         {
-            messageLogger.SendMessage(TestMessageLevel.Error, ex.Message);
+            messageLogger.SendMessage(MessageLevel.Error, ex.Message);
             return false;
         }
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IAdapterMessageLogger.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IAdapterMessageLogger.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+/// <summary>
+/// Platform-agnostic sink for diagnostic messages (informational / warning / error) that the adapter
+/// surfaces to whichever test host is running the tests.
+/// </summary>
+/// <remarks>
+/// This abstraction lets the platform services layer report messages without taking a dependency on a
+/// specific test platform's object model. The mapping to a concrete host logger (for example the VSTest
+/// <c>IMessageLogger</c>) is provided by the adapter layer.
+/// </remarks>
+internal interface IAdapterMessageLogger
+{
+    /// <summary>
+    /// Reports a diagnostic message to the running test host.
+    /// </summary>
+    /// <param name="level">The severity of the message.</param>
+    /// <param name="message">The message text.</param>
+    void SendMessage(MessageLevel level, string message);
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -11,8 +11,8 @@ using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionSco
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
+using MessageLevel = Microsoft.VisualStudio.TestTools.UnitTesting.MessageLevel;
 using StringEx = Microsoft.VisualStudio.TestTools.UnitTesting.StringEx;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
@@ -25,7 +25,7 @@ internal sealed partial class MSTestSettings
     /// <param name="context">The discovery context.</param>
     /// <param name="logger"> The logger for messages. </param>
     /// <param name="configuration">The configuration.</param>
-    internal static void PopulateSettings(IDiscoveryContext? context, IMessageLogger? logger, IConfiguration? configuration)
+    internal static void PopulateSettings(IDiscoveryContext? context, IAdapterMessageLogger? logger, IConfiguration? configuration)
     {
 #if !WINDOWS_UWP
         if (configuration?["mstest"] is not null
@@ -62,7 +62,7 @@ internal sealed partial class MSTestSettings
 
         if (settings.RandomizeTestOrder && settings.OrderTestsByNameInClass)
         {
-            logger?.SendMessage(TestMessageLevel.Warning, Resource.RandomTestOrderAndOrderTestsByNameInClassConflict);
+            logger?.SendMessage(MessageLevel.Warning, Resource.RandomTestOrderAndOrderTestsByNameInClassConflict);
         }
 
         // Track configuration source for telemetry.
@@ -78,7 +78,7 @@ internal sealed partial class MSTestSettings
 #endif
     }
 
-    private static void SetGlobalSettings(string runsettingsXml, MSTestSettings settings, IMessageLogger? logger)
+    private static void SetGlobalSettings(string runsettingsXml, MSTestSettings settings, IAdapterMessageLogger? logger)
     {
         XElement? runConfigElement = XDocument.Parse(runsettingsXml).Element("RunSettings")?.Element("RunConfiguration");
         if (runConfigElement == null)
@@ -93,12 +93,12 @@ internal sealed partial class MSTestSettings
         }
         else if (disableParallelizationString is not null)
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, disableParallelizationString, "DisableParallelization"));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, disableParallelizationString, "DisableParallelization"));
         }
     }
 
 #if !WINDOWS_UWP
-    private static void ParseBooleanSetting(IConfiguration configuration, string key, IMessageLogger? logger, Action<bool> setSetting)
+    private static void ParseBooleanSetting(IConfiguration configuration, string key, IAdapterMessageLogger? logger, Action<bool> setSetting)
     {
         if (configuration[$"mstest:{key}"] is not string value)
         {
@@ -111,11 +111,11 @@ internal sealed partial class MSTestSettings
         }
         else
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
         }
     }
 
-    private static void ParseDebuggerLaunchModeSetting(IConfiguration configuration, string key, IMessageLogger? logger, Action<DebuggerLaunchMode> setSetting)
+    private static void ParseDebuggerLaunchModeSetting(IConfiguration configuration, string key, IAdapterMessageLogger? logger, Action<DebuggerLaunchMode> setSetting)
     {
         if (configuration[$"mstest:{key}"] is not string value)
         {
@@ -128,11 +128,11 @@ internal sealed partial class MSTestSettings
         }
         else
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
         }
     }
 
-    private static void ParseTimeoutSetting(IConfiguration configuration, string key, IMessageLogger? logger, Action<int> setSetting)
+    private static void ParseTimeoutSetting(IConfiguration configuration, string key, IAdapterMessageLogger? logger, Action<int> setSetting)
     {
         if (configuration[$"mstest:{key}"] is not string value)
         {
@@ -149,11 +149,11 @@ internal sealed partial class MSTestSettings
         }
         else
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidTimeoutValue, value, key));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidTimeoutValue, value, key));
         }
     }
 
-    private static void ParseSignedIntegerSetting(IConfiguration configuration, string key, IMessageLogger? logger, Action<int> setSetting)
+    private static void ParseSignedIntegerSetting(IConfiguration configuration, string key, IAdapterMessageLogger? logger, Action<int> setSetting)
     {
         if (configuration[$"mstest:{key}"] is not string value)
         {
@@ -166,7 +166,7 @@ internal sealed partial class MSTestSettings
         }
         else
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, value, key));
         }
     }
 
@@ -176,7 +176,7 @@ internal sealed partial class MSTestSettings
     /// <param name="configuration">Configuration to load the settings from.</param>
     /// <param name="logger"> The logger for messages. </param>
     /// <param name="settings">The MSTest settings.</param>
-    internal static void SetSettingsFromConfig(IConfiguration configuration, IMessageLogger? logger, MSTestSettings settings)
+    internal static void SetSettingsFromConfig(IConfiguration configuration, IAdapterMessageLogger? logger, MSTestSettings settings)
     {
         // 'orderTestsByNameInClass' has moved under 'execution:' for consistency with the other execution settings.
         // Prefer the new 'mstest:execution:orderTestsByNameInClass' key. Only fall back to the deprecated flat
@@ -188,7 +188,7 @@ internal sealed partial class MSTestSettings
         }
         else if (configuration["mstest:orderTestsByNameInClass"] is not null)
         {
-            logger?.SendMessage(TestMessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey);
+            logger?.SendMessage(MessageLevel.Warning, Resource.DeprecatedFlatOrderTestsByNameInClassKey);
             ParseBooleanSetting(configuration, "orderTestsByNameInClass", logger, value => settings.OrderTestsByNameInClass = value);
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using DebuggerLaunchMode = Microsoft.VisualStudio.TestTools.UnitTesting.DebuggerLaunchMode;
+using MessageLevel = Microsoft.VisualStudio.TestTools.UnitTesting.MessageLevel;
 using StringEx = Microsoft.VisualStudio.TestTools.UnitTesting.StringEx;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
@@ -60,7 +61,7 @@ internal sealed partial class MSTestSettings
     }
 #endif
 
-    internal static MSTestSettings? GetSettings(string? runSettingsXml, string settingName, IMessageLogger? logger)
+    internal static MSTestSettings? GetSettings(string? runSettingsXml, string settingName, IAdapterMessageLogger? logger)
     {
         if (StringEx.IsNullOrWhiteSpace(runSettingsXml))
         {
@@ -81,7 +82,7 @@ internal sealed partial class MSTestSettings
         return !reader.EOF ? ToSettings(reader.ReadSubtree(), logger) : null;
     }
 
-    private static MSTestSettings ToSettings(XmlReader reader, IMessageLogger? logger)
+    private static MSTestSettings ToSettings(XmlReader reader, IAdapterMessageLogger? logger)
     {
         if (reader is null)
         {
@@ -108,7 +109,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, captureTraceOutput, "CaptureTraceOutput"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, captureTraceOutput, "CaptureTraceOutput"));
                         }
 
                         break;
@@ -120,7 +121,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, mapInconclusiveToFailed, "MapInconclusiveToFailed"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, mapInconclusiveToFailed, "MapInconclusiveToFailed"));
                         }
 
                         break;
@@ -132,7 +133,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, mapNotRunnableToFailed, "MapNotRunnableToFailed"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, mapNotRunnableToFailed, "MapNotRunnableToFailed"));
                         }
 
                         break;
@@ -144,7 +145,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, treatDiscoveryWarningsAsErrors, "TreatDiscoveryWarningsAsErrors"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, treatDiscoveryWarningsAsErrors, "TreatDiscoveryWarningsAsErrors"));
                         }
 
                         break;
@@ -166,7 +167,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, considerEmptyDataSourceAsInconclusive, "ConsiderEmptyDataSourceAsInconclusive"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, considerEmptyDataSourceAsInconclusive, "ConsiderEmptyDataSourceAsInconclusive"));
                         }
 
                         break;
@@ -193,7 +194,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, cooperativeCancellationTimeout, "CooperativeCancellationTimeout"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, cooperativeCancellationTimeout, "CooperativeCancellationTimeout"));
                         }
 
                         break;
@@ -205,7 +206,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, orderTestsByNameInClass, "OrderTestsByNameInClass"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, orderTestsByNameInClass, "OrderTestsByNameInClass"));
                         }
 
                         break;
@@ -217,7 +218,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomizeTestOrder, "RandomizeTestOrder"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomizeTestOrder, "RandomizeTestOrder"));
                         }
 
                         break;
@@ -229,7 +230,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomTestOrderSeed, "RandomTestOrderSeed"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, randomTestOrderSeed, "RandomTestOrderSeed"));
                         }
 
                         break;
@@ -241,7 +242,7 @@ internal sealed partial class MSTestSettings
                         }
                         else
                         {
-                            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, launchDebuggerOnAssertionFailure, "LaunchDebuggerOnAssertionFailure"));
+                            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidValue, launchDebuggerOnAssertionFailure, "LaunchDebuggerOnAssertionFailure"));
                         }
 
                         break;
@@ -256,7 +257,7 @@ internal sealed partial class MSTestSettings
         return settings;
     }
 
-    private static void ParseTimeoutSetting(string rawValue, string settingName, IMessageLogger? logger, Action<int> setSetting)
+    private static void ParseTimeoutSetting(string rawValue, string settingName, IAdapterMessageLogger? logger, Action<int> setSetting)
     {
         if (int.TryParse(rawValue, out int result) && result > 0)
         {
@@ -264,7 +265,7 @@ internal sealed partial class MSTestSettings
         }
         else
         {
-            logger?.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidTimeoutValue, rawValue, settingName));
+            logger?.SendMessage(MessageLevel.Warning, string.Format(CultureInfo.CurrentCulture, Resource.InvalidTimeoutValue, rawValue, settingName));
         }
     }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/AdapterMessageLoggerExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/AdapterMessageLoggerExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+/// <summary>
+/// Bridges a VSTest <see cref="IMessageLogger"/> to the platform-agnostic <see cref="IAdapterMessageLogger"/>.
+/// </summary>
+/// <remarks>
+/// This is the single translation point between the VSTest object model and the platform services
+/// message-logging abstraction. It is expected to move entirely into the adapter layer once the
+/// execution pipeline no longer flows VSTest handles through the platform services (see the tracking
+/// issue linked in the pull request that removes the VSTest object model from platform services).
+/// </remarks>
+internal static class AdapterMessageLoggerExtensions
+{
+    /// <summary>
+    /// Wraps a VSTest <see cref="IMessageLogger"/> as an <see cref="IAdapterMessageLogger"/>.
+    /// </summary>
+    /// <param name="messageLogger">The host message logger to wrap.</param>
+    /// <returns>A platform-agnostic logger that forwards to <paramref name="messageLogger"/>.</returns>
+    public static IAdapterMessageLogger ToAdapterMessageLogger(this IMessageLogger messageLogger)
+        => new HostMessageLogger(messageLogger);
+
+    private sealed class HostMessageLogger : IAdapterMessageLogger
+    {
+        private readonly IMessageLogger _messageLogger;
+
+        public HostMessageLogger(IMessageLogger messageLogger)
+            => _messageLogger = messageLogger;
+
+        public void SendMessage(MessageLevel level, string message)
+            => _messageLogger.SendMessage(level.ToTestMessageLevel(), message);
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/AdapterMessageLoggerExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/AdapterMessageLoggerExtensions.cs
@@ -23,8 +23,8 @@ internal static class AdapterMessageLoggerExtensions
     /// </summary>
     /// <param name="messageLogger">The host message logger to wrap.</param>
     /// <returns>A platform-agnostic logger that forwards to <paramref name="messageLogger"/>.</returns>
-    public static IAdapterMessageLogger ToAdapterMessageLogger(this IMessageLogger messageLogger)
-        => new HostMessageLogger(messageLogger);
+    internal static IAdapterMessageLogger ToAdapterMessageLogger(this IMessageLogger messageLogger)
+        => new HostMessageLogger(messageLogger ?? throw new ArgumentNullException(nameof(messageLogger)));
 
     private sealed class HostMessageLogger : IAdapterMessageLogger
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
@@ -33,7 +33,7 @@ internal sealed class TestMethodFilter
     /// <param name="logger">Handler to report test messages/start/end and results.</param>
     /// <param name="filterHasError">Indicates that the filter is unsupported/has an error.</param>
     /// <returns>A filter expression.</returns>
-    internal ITestCaseFilterExpression? GetFilterExpression(IDiscoveryContext? context, IMessageLogger logger, out bool filterHasError)
+    internal ITestCaseFilterExpression? GetFilterExpression(IDiscoveryContext? context, IAdapterMessageLogger logger, out bool filterHasError)
     {
         filterHasError = false;
         if (context == null)
@@ -51,7 +51,7 @@ internal sealed class TestMethodFilter
         catch (TestPlatformFormatException ex)
         {
             filterHasError = true;
-            logger.SendMessage(TestMessageLevel.Error, ex.Message);
+            logger.SendMessage(MessageLevel.Error, ex.Message);
         }
 
         return filter;
@@ -118,7 +118,7 @@ internal sealed class TestMethodFilter
     /// <param name="logger">The logger to log exception messages too.</param>
     /// <returns>Filter expression.</returns>
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:'target parameter' argument does not satisfy 'DynamicallyAccessedMembersAttribute' in call to target method.", Justification = "GetTestCaseFilter is part of the VSTest discovery contract on the concrete DiscoveryContext type; the runtime guarantees the method exists on supported hosts.")]
-    private ITestCaseFilterExpression? GetTestCaseFilterFromDiscoveryContext(IDiscoveryContext context, IMessageLogger logger)
+    private ITestCaseFilterExpression? GetTestCaseFilterFromDiscoveryContext(IDiscoveryContext context, IAdapterMessageLogger logger)
     {
         try
         {
@@ -134,7 +134,7 @@ internal sealed class TestMethodFilter
         }
         catch (Exception ex)
         {
-            logger.SendMessage(TestMessageLevel.Warning, ex.Message);
+            logger.SendMessage(MessageLevel.Warning, ex.Message);
         }
 
         return null;

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -27,7 +27,7 @@ public abstract partial class CLITestBase
         string runSettingsXml = GetRunSettingsXml(string.Empty);
         var context = new InternalDiscoveryContext(runSettingsXml, testCaseFilter);
 
-        unitTestDiscoverer.DiscoverTestsInSource(assemblyPath, logger, sink, context, false);
+        unitTestDiscoverer.DiscoverTestsInSource(assemblyPath, logger.ToAdapterMessageLogger(), sink, context, false);
 
         return sink.DiscoveredTests;
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/AssemblyEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/AssemblyEnumeratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;
@@ -9,6 +9,7 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -64,7 +65,7 @@ public class AssemblyEnumeratorTests : TestContainer
                 actualReader.ReadInnerXml();
             });
         var mockMessageLogger = new Mock<IMessageLogger>();
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, mockMessageLogger.Object);
+        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, mockMessageLogger.Object.ToAdapterMessageLogger());
         adapterSettings.Should().NotBeNull();
 
         // Constructor has the side effect of populating the passed settings to MSTestSettings.CurrentSettings

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/TypeEnumeratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -120,7 +121,7 @@ public partial class TypeEnumeratorTests : TestContainer
         mockRunContext.Setup(dc => dc.RunSettings).Returns(mockRunSettings.Object);
         mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
 
-        MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
         SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
 
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
@@ -150,7 +151,7 @@ public partial class TypeEnumeratorTests : TestContainer
         mockRunContext.Setup(dc => dc.RunSettings).Returns(mockRunSettings.Object);
         mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
 
-        MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(mockRunContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
         SetupTestClassAndTestMethods(isValidTestClass: true, isValidTestMethod: true);
         TypeEnumerator typeEnumerator = GetTypeEnumeratorInstance(typeof(DummyDerivedTestClass), Assembly.GetExecutingAssembly().FullName!);
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -80,7 +80,7 @@ public class UnitTestDiscovererTests : TestContainer
                 .Returns(false);
         }
 
-        Action act = () => _unitTestDiscoverer.DiscoverTests(sources, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
+        Action act = () => _unitTestDiscoverer.DiscoverTests(sources, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
         act.Should().Throw<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, sources[0]));
     }
@@ -93,7 +93,7 @@ public class UnitTestDiscovererTests : TestContainer
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.DoesFileExist(Source))
             .Returns(false);
 
-        Action act = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
+        Action act = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
         act.Should().Throw<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, Source));
     }
@@ -122,10 +122,10 @@ public class UnitTestDiscovererTests : TestContainer
               </MSTestV2>
             </RunSettings>
             """);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
+        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.AtLeastOnce);
@@ -157,10 +157,10 @@ public class UnitTestDiscovererTests : TestContainer
             """;
 
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(settingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        Action action = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
+        Action action = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
 
         // Assert
         action.Should().Throw<MSTestException>()
@@ -195,11 +195,11 @@ public class UnitTestDiscovererTests : TestContainer
               </MSTestV2>
             </RunSettings>
             """);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act & Assert
         // Should not throw an exception
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
+        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, false);
 
         // Verify warning message was sent to logger (not error)
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.AtLeastOnce);
@@ -209,7 +209,7 @@ public class UnitTestDiscovererTests : TestContainer
     public void SendTestCasesShouldNotSendAnyTestCasesIfThereAreNoTestElements()
     {
         // There is a null check for testElements in the code flow before this function call. So not adding a unit test for that.
-        _unitTestDiscoverer.SendTestCases(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.Never);
@@ -221,7 +221,7 @@ public class UnitTestDiscovererTests : TestContainer
         var test2 = new UnitTestElement(CreateTestMethod("M2", "C", "A", displayName: null));
         var testElements = new List<UnitTestElement> { test1, test2 };
 
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, _mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -240,7 +240,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -259,7 +259,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -278,7 +278,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -297,7 +297,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object);
+        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object, discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Never);
@@ -325,7 +325,7 @@ internal class TestableUnitTestDiscoverer(ITestSourceHandler? testSourceHandler 
 {
     internal override void DiscoverTestsInSource(
         string source,
-        IMessageLogger logger,
+        IAdapterMessageLogger logger,
         ITestCaseDiscoverySink discoverySink,
         IDiscoveryContext? discoveryContext,
         bool isMTP)

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -461,7 +461,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
@@ -498,7 +498,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
@@ -535,7 +535,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
@@ -570,7 +570,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
             testablePlatformService.SetupMockReflectionOperations();
 
@@ -629,7 +629,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
             testablePlatformService.SetupMockReflectionOperations();
 
@@ -696,7 +696,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
@@ -730,7 +730,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
             testablePlatformService.SetupMockReflectionOperations();
 
@@ -802,7 +802,7 @@ public class TestExecutionManagerTests : TestContainer
 
         try
         {
-            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+            MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
             await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassWithDoNotParallelizeMethods.ThreadApartmentStates.Count.Should().Be(1);
@@ -842,7 +842,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         var firstHandle = new TestableFrameworkHandle();
         var firstManager = new TestExecutionManager(EnvironmentWrapper.Instance, task => task());
@@ -885,7 +885,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -89,7 +89,7 @@ public class TestMethodFilterTests : TestContainer
     public void GetFilterExpressionForNullRunContextReturnsNull()
     {
         TestableTestExecutionRecorder recorder = new();
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(null, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(null, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().BeNull();
         filterHasError.Should().BeFalse();
@@ -100,7 +100,7 @@ public class TestMethodFilterTests : TestContainer
         TestableTestExecutionRecorder recorder = new();
         var dummyFilterExpression = new TestableTestCaseFilterExpression();
         TestableRunContext runContext = new(() => dummyFilterExpression);
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().Be(dummyFilterExpression);
         filterHasError.Should().BeFalse();
@@ -114,7 +114,7 @@ public class TestMethodFilterTests : TestContainer
         TestableTestExecutionRecorder recorder = new();
         var dummyFilterExpression = new TestableTestCaseFilterExpression();
         TestableDiscoveryContextWithGetTestCaseFilter discoveryContext = new(() => dummyFilterExpression);
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().Be(dummyFilterExpression);
         filterHasError.Should().BeFalse();
@@ -127,7 +127,7 @@ public class TestMethodFilterTests : TestContainer
     {
         TestableTestExecutionRecorder recorder = new();
         TestableDiscoveryContextWithoutGetTestCaseFilter discoveryContext = new();
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().BeNull();
         filterHasError.Should().BeFalse();
@@ -137,7 +137,7 @@ public class TestMethodFilterTests : TestContainer
     {
         TestableTestExecutionRecorder recorder = new();
         TestableRunContext runContext = new(() => throw new TestPlatformFormatException("DummyException"));
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().BeNull();
         filterHasError.Should().BeTrue();
@@ -152,7 +152,7 @@ public class TestMethodFilterTests : TestContainer
     {
         TestableTestExecutionRecorder recorder = new();
         TestableDiscoveryContextWithGetTestCaseFilter discoveryContext = new(() => throw new TestPlatformFormatException("DummyException"));
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder, out bool filterHasError);
+        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
 
         filterExpression.Should().BeNull();
         filterHasError.Should().BeTrue();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TypeCacheTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -817,7 +818,7 @@ public class TypeCacheTests : TestContainer
             </RunSettings>
             """;
 
-        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         settings.Should().NotBeNull();
         MSTestSettings.PopulateSettings(settings);
 
@@ -841,7 +842,7 @@ public class TypeCacheTests : TestContainer
             </RunSettings>
             """;
 
-        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         settings.Should().NotBeNull();
         MSTestSettings.PopulateSettings(settings);
 
@@ -870,7 +871,7 @@ public class TypeCacheTests : TestContainer
             </RunSettings>
             """;
 
-        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         settings.Should().NotBeNull();
         MSTestSettings.PopulateSettings(settings);
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -65,7 +66,7 @@ public sealed class UnitTestRunnerTests : TestContainer
                 actualReader.ReadInnerXml();
             });
 
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         adapterSettings.Should().NotBeNull();
         var assemblyEnumerator = new UnitTestRunner(adapterSettings, []);
 
@@ -449,7 +450,7 @@ public sealed class UnitTestRunnerTests : TestContainer
                 actualReader.ReadInnerXml();
             });
 
-        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         settings.Should().NotBeNull();
         return settings;
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/UnitTestOutcomeHelperTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/UnitTestOutcomeHelperTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -28,7 +29,7 @@ public class UnitTestOutcomeHelperTests : TestContainer
             </RunSettings>
             """;
         var mockMessageLogger = new Mock<IMessageLogger>();
-        _adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, mockMessageLogger.Object)!;
+        _adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, mockMessageLogger.Object.ToAdapterMessageLogger())!;
     }
 
     public void UniTestHelperToTestOutcomeForUnitTestOutcomePassedShouldReturnTestOutcomePassed()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -117,7 +117,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(13));
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'CooperativeCancellationTimeout', setting will be ignored."), Times.Once);
@@ -719,7 +719,7 @@ public class MSTestSettingsTests : TestContainer
                 actualReader.ReadInnerXml();
             });
 
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         _testablePlatformServiceProvider.MockSettingsProvider.Verify(sp => sp.Load(It.IsAny<XmlReader>()), Times.Once);
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
@@ -57,7 +58,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.MapInconclusiveToFailed.Should().BeFalse();
     }
@@ -72,7 +73,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
     }
@@ -88,7 +89,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.MapInconclusiveToFailed.Should().BeTrue();
     }
@@ -116,7 +117,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(13));
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'CooperativeCancellationTimeout', setting will be ignored."), Times.Once);
@@ -146,7 +147,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(0);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '0' for runsettings entry 'TestTimeout'. The timeout must be a strictly positive integer (in milliseconds); a value of 0 or less is not allowed. Omit the entry to use the default (no timeout). The setting will be ignored."), Times.Once);
@@ -163,7 +164,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.MapNotRunnableToFailed.Should().BeTrue();
     }
@@ -178,7 +179,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
     }
@@ -194,7 +195,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.CaptureDebugTraces.Should().BeFalse();
     }
@@ -210,7 +211,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(4000);
     }
@@ -225,7 +226,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(0);
     }
@@ -240,7 +241,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TreatDiscoveryWarningsAsErrors.Should().BeTrue();
     }
@@ -256,7 +257,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TreatDiscoveryWarningsAsErrors.Should().BeTrue();
     }
@@ -271,7 +272,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.HasValue.Should().BeFalse();
         adapterSettings.ParallelizationScope.HasValue.Should().BeFalse();
@@ -287,7 +288,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.RandomizeTestOrder.Should().BeFalse();
         adapterSettings.RandomTestOrderSeed.Should().BeNull();
@@ -305,7 +306,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.RandomizeTestOrder.Should().BeTrue();
         adapterSettings.RandomTestOrderSeed.Should().Be(42);
@@ -322,7 +323,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.RandomTestOrderSeed.Should().Be(-7);
     }
@@ -338,7 +339,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.RandomizeTestOrder.Should().BeFalse();
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'notabool' for runsettings entry 'RandomizeTestOrder', setting will be ignored."), Times.Once);
@@ -355,7 +356,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.RandomTestOrderSeed.Should().BeNull();
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value 'notanint' for runsettings entry 'RandomTestOrderSeed', setting will be ignored."), Times.Once);
@@ -375,7 +376,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings.CurrentSettings.RandomizeTestOrder.Should().BeTrue();
         MSTestSettings.CurrentSettings.OrderTestsByNameInClass.Should().BeTrue();
@@ -399,7 +400,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings.CurrentSettings.RandomizeTestOrder.Should().BeTrue();
         MSTestSettings.CurrentSettings.OrderTestsByNameInClass.Should().BeFalse();
@@ -419,7 +420,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         AdapterSettingsException exception = act.Should().Throw<AdapterSettingsException>().Which;
 
         exception.Message.Should().Contain("Invalid value 'GoneFishing' specified for 'Workers'. The value should be a non-negative integer.");
@@ -438,7 +439,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         AdapterSettingsException exception = act.Should().Throw<AdapterSettingsException>().Which;
         exception.Message.Should().Contain("Invalid value '-1' specified for 'Workers'. The value should be a non-negative integer.");
     }
@@ -456,7 +457,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.Should().Be(2);
     }
@@ -474,7 +475,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.Should().Be(Environment.ProcessorCount);
     }
@@ -491,7 +492,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.Should().Be(Environment.ProcessorCount);
         adapterSettings.ParallelizationScope.Should().Be(ExecutionScope.ClassLevel);
@@ -508,7 +509,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.Should().Be(Environment.ProcessorCount);
         adapterSettings.ParallelizationScope.Should().Be(ExecutionScope.ClassLevel);
@@ -528,7 +529,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationWorkers.Should().Be(127);
         adapterSettings.ParallelizationScope.Should().Be(ExecutionScope.MethodLevel);
@@ -547,7 +548,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         AdapterSettingsException exception = act.Should().Throw<AdapterSettingsException>().Which;
         exception.Message.Should().Contain("Invalid value 'JustParallelizeWillYou' specified for 'Scope'. Supported scopes are ClassLevel, MethodLevel.");
     }
@@ -565,7 +566,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.ParallelizationScope.Should().Be(ExecutionScope.MethodLevel);
     }
@@ -583,7 +584,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object);
+        Action act = () => MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger());
         AdapterSettingsException exception = act.Should().Throw<AdapterSettingsException>().Which;
         exception.Message.Should().Contain("MSTestAdapter encountered an unexpected element 'Hola' in its settings 'Parallelize'. Remove this element and try again.");
     }
@@ -601,7 +602,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(12);
     }
@@ -621,7 +622,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(12);
         adapterSettings.ParallelizationWorkers.Should().Be(127);
@@ -640,7 +641,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         adapterSettings.TestTimeout.Should().Be(12);
     }
@@ -655,7 +656,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings.CurrentSettings.DisableParallelization.Should().BeFalse();
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Never);
@@ -674,7 +675,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings.CurrentSettings.DisableParallelization.Should().BeTrue();
     }
@@ -692,7 +693,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'DisableParallelization', setting will be ignored."), Times.Once);
     }
 
@@ -718,7 +719,7 @@ public class MSTestSettingsTests : TestContainer
                 actualReader.ReadInnerXml();
             });
 
-        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        var adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         _testablePlatformServiceProvider.MockSettingsProvider.Verify(sp => sp.Load(It.IsAny<XmlReader>()), Times.Once);
     }
 
@@ -744,7 +745,7 @@ public class MSTestSettingsTests : TestContainer
                 observedXml = actualReader.ReadOuterXml();
             });
 
-        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         (expectedRunSettingXml == observedXml).Should().BeTrue();
     }
 
@@ -791,7 +792,7 @@ public class MSTestSettingsTests : TestContainer
                 }
             });
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         // Assert.
         dummyPlatformSpecificSetting.Should().BeTrue();
@@ -844,7 +845,7 @@ public class MSTestSettingsTests : TestContainer
                 }
             });
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         // Assert.
         dummyPlatformSpecificSetting.Should().BeTrue();
@@ -893,7 +894,7 @@ public class MSTestSettingsTests : TestContainer
                 }
             });
 
-        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         outOfScopeCall.Should().BeFalse();
@@ -944,7 +945,7 @@ public class MSTestSettingsTests : TestContainer
                 }
             });
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         // Assert.
         dummyPlatformSpecificSetting.Should().BeTrue();
@@ -980,7 +981,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
         MSTestSettings adapterSettings2 = MSTestSettings.CurrentSettings;
@@ -1009,7 +1010,7 @@ public class MSTestSettingsTests : TestContainer
             </RunSettings>
             """;
 
-        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object);
+        var settings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsName, _mockMessageLogger.Object.ToAdapterMessageLogger());
         settings.Should().NotBeNull();
         MSTestSettings.PopulateSettings(settings);
 
@@ -1021,7 +1022,7 @@ public class MSTestSettingsTests : TestContainer
 
     public void PopulateSettingsShouldInitializeDefaultAdapterSettingsWhenDiscoveryContextIsNull()
     {
-        MSTestSettings.PopulateSettings(null, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(null, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
@@ -1032,7 +1033,7 @@ public class MSTestSettingsTests : TestContainer
 
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsIsNull()
     {
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
@@ -1044,7 +1045,7 @@ public class MSTestSettingsTests : TestContainer
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsXmlIsEmpty()
     {
         _mockDiscoveryContext.Setup(md => md.RunSettings!.SettingsXml).Returns(string.Empty);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
         adapterSettings.CaptureDebugTraces.Should().BeTrue();
@@ -1066,7 +1067,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
 
@@ -1091,7 +1092,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
 
@@ -1117,7 +1118,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
 
@@ -1146,7 +1147,7 @@ public class MSTestSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         MSTestSettings adapterSettings = MSTestSettings.CurrentSettings;
 
@@ -1185,7 +1186,7 @@ public class MSTestSettingsTests : TestContainer
                   .Returns((string key) => configDictionary.TryGetValue(key, out string? value) ? value : null);
 
         var settings = new MSTestSettings();
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.Exactly(12));
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '3' for runsettings entry 'timeout:useCooperativeCancellation', setting will be ignored."), Times.Once);
@@ -1216,7 +1217,7 @@ public class MSTestSettingsTests : TestContainer
                   .Returns((string key) => configDictionary.TryGetValue(key, out string? value) ? value : null);
 
         var settings = new MSTestSettings();
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         settings.TestTimeout.Should().Be(0);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, "Invalid value '0' for runsettings entry 'timeout:test'. The timeout must be a strictly positive integer (in milliseconds); a value of 0 or less is not allowed. Omit the entry to use the default (no timeout). The setting will be ignored."), Times.Once);
@@ -1255,7 +1256,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
@@ -1296,7 +1297,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
@@ -1318,7 +1319,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
@@ -1342,7 +1343,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.OrderTestsByNameInClass.Should().BeTrue();
@@ -1370,7 +1371,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.DisableParallelization.Should().Be(!parallelismEnabled);
@@ -1390,7 +1391,7 @@ public class MSTestSettingsTests : TestContainer
         var settings = new MSTestSettings();
 
         // Act
-        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object, settings);
+        MSTestSettings.SetSettingsFromConfig(mockConfig.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), settings);
 
         // Assert
         settings.ParallelizationScope.Should().Be(ExecutionScope.MethodLevel);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestResultTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestResultTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -28,7 +29,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Passed, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Passed);
@@ -44,7 +45,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Failed, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
@@ -60,7 +61,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Error, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
@@ -77,7 +78,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.None);
@@ -93,7 +94,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
@@ -109,7 +110,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Timeout, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
@@ -125,7 +126,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Ignored, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Skipped);
@@ -141,7 +142,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Skipped);
@@ -158,7 +159,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.Inconclusive, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
@@ -174,7 +175,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotFound, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.NotFound);
@@ -190,7 +191,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
 
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.InProgress, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.None);
@@ -207,7 +208,7 @@ public class UnitTestResultTests : TestContainer
             </RunSettings>
             """;
 
-        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object)!;
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
         var resultOutcome = UnitTestOutcomeHelper.ToTestOutcome(UnitTestOutcome.NotRunnable, adapterSettings);
         resultOutcome.Should().Be(TestOutcome.Failed);
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/RunConfigurationSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/RunConfigurationSettingsTests.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -60,7 +61,7 @@ public class RunConfigurationSettingsTests : TestContainer
 
     public void PopulateSettingsShouldInitializeDefaultConfigurationSettingsWhenDiscoveryContextIsNull()
     {
-        MSTestSettings.PopulateSettings(null, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(null, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
         settings.ExecutionApartmentState.Should().BeNull();
@@ -68,7 +69,7 @@ public class RunConfigurationSettingsTests : TestContainer
 
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsIsNull()
     {
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
         settings.ExecutionApartmentState.Should().BeNull();
@@ -77,7 +78,7 @@ public class RunConfigurationSettingsTests : TestContainer
     public void PopulateSettingsShouldInitializeDefaultSettingsWhenRunSettingsXmlIsEmpty()
     {
         _mockDiscoveryContext.Setup(md => md.RunSettings!.SettingsXml).Returns(string.Empty);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
         settings.ExecutionApartmentState.Should().BeNull();
@@ -96,7 +97,7 @@ public class RunConfigurationSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
         settings.Should().NotBeNull();
@@ -119,7 +120,7 @@ public class RunConfigurationSettingsTests : TestContainer
 
         _mockDiscoveryContext.Setup(dc => dc.RunSettings).Returns(_mockRunSettings.Object);
         _mockRunSettings.Setup(rs => rs.SettingsXml).Returns(runSettingsXml);
-        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object, null);
+        MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         RunConfigurationSettings settings = MSTestSettings.RunConfigurationSettings;
         settings.Should().NotBeNull();


### PR DESCRIPTION
## Why

This is the first, self-contained slice of a larger effort to make **`MSTestAdapter.PlatformServices`** platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.TestPlatform.ObjectModel`). The end goal is for the VSTest coupling to live only in the adapter layer (`MSTest.TestAdapter`), so the platform-services engine can eventually be driven by an MTP-native adapter without round-tripping through the VSTest bridge.

The full phased plan (0–8) is tracked separately; this PR delivers **Phase 0 + Phase 1 (message logging)** only, to keep the change reviewable.

## What

Introduces a platform-agnostic message-logging abstraction and migrates the *standalone* logger role in PlatformServices off VSTest types. The VSTest connection is now made **at the adapter boundary**.

- **New neutral abstraction** (functional, non-VSTest naming):
  - `IAdapterMessageLogger` — `SendMessage(MessageLevel, string)`, reusing the existing neutral `MessageLevel` enum from `TestFramework.Extensions`.
  - `AdapterMessageLoggerExtensions.ToAdapterMessageLogger(this IMessageLogger)` — the single VSTest → neutral bridge (internal `HostMessageLogger`, maps via the pre-existing `ToTestMessageLevel()`).
- **Migrated to the neutral logger** (`IMessageLogger`/`TestMessageLevel` → `IAdapterMessageLogger`/`MessageLevel`): `MSTestDiscovererHelpers`, `MSTestSettings.Configuration`, `MSTestSettings.RunSettingsXml`, `UnitTestDiscoverer`, `TestMethodFilter`.
- **Adapter boundary wraps** via `frameworkHandle.ToAdapterMessageLogger()` in `MSTestDiscoverer` / `MSTestExecutor`, plus the two execution sites that reuse the framework handle as a logger.

### Deliberately out of scope
The recorder's *dual* logger role (`IFrameworkHandle` / `ITestExecutionRecorder.SendMessage`) is intentionally left for the later recorder phase, since there the logger and the recorder are the same object. The `ToAdapterMessageLogger` bridge stays in PlatformServices as a temporary translation point until that phase.

## No behavior change

This is a pure refactor. The `MessageLevel` ↔ `TestMessageLevel` mapping is 1:1, and no message levels or paths were dropped. Tests keep their `Mock<IMessageLogger>` and wrap with `.ToAdapterMessageLogger()` at migrated call sites, so the existing `Verify(... TestMessageLevel ...)` assertions still exercise the mapping end-to-end.

## Verification

- Full Debug `src` build green across all TFMs (net462, net8.0, net9.0, UWP, WinUI).
- `MSTestAdapter.PlatformServices.UnitTests`: **889 passed**.
- `MSTestAdapter.UnitTests`: **21 passed**.
- Reviewed with the expert MSTest reviewer agent (two passes); all findings addressed.