### PR TITLE
Add server-initiated session cancellation to the dotnet test IPC protocol (#8691)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Extensions.TestHost;
@@ -59,6 +60,13 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
                 RoslynDebug.Assert(PushOnlyProtocol is not null);
 
                 bool isValidProtocol = await PushOnlyProtocol.IsCompatibleProtocolAsync(hostType).ConfigureAwait(false);
+
+                if (isValidProtocol && PushOnlyProtocol.IsServerControlChannelSupported)
+                {
+                    // Start listening for server-initiated signals (e.g. session cancellation) before running tests
+                    // so a signal that arrives mid-run is observed. React by stopping gracefully where possible.
+                    await PushOnlyProtocol.StartServerControlChannelAsync(RequestGracefulSessionStopAsync).ConfigureAwait(false);
+                }
 
                 exitCode = isValidProtocol
                     ? await RunTestAppAsync(platformOTelService, testApplicationCancellationToken, alreadyDisposed).ConfigureAwait(false)
@@ -125,6 +133,25 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
         // this path. This method only covers the test host and test host controller roles.
         string hostType = HostType;
         return hostType;
+    }
+
+    // Reaction to a server-initiated session cancellation coming over the reverse control pipe. Prefer a graceful
+    // stop so the framework stops scheduling new tests but still emits trx/logs/artifacts for whatever completed
+    // (mirroring the local '--maximum-failed-tests' behavior). Fall back to hard cancellation when the running
+    // framework has no graceful-stop capability (e.g. the test host controller), which is the only lever left.
+    private async Task RequestGracefulSessionStopAsync(CancellationToken cancellationToken)
+    {
+        IGracefulStopTestExecutionCapability? capability =
+            ServiceProvider.GetService<ITestFrameworkCapabilities>()?.GetCapability<IGracefulStopTestExecutionCapability>();
+
+        if (capability is not null)
+        {
+            await capability.StopTestExecutionAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            ServiceProvider.GetTestApplicationCancellationTokenSource().Cancel();
+        }
     }
 
     private async Task<int> RunTestAppAsync(IPlatformOpenTelemetryService? platformOTelService, CancellationToken testApplicationCancellationToken, List<object> alreadyDisposed)

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostOchestratorHost.cs
@@ -46,6 +46,17 @@ internal sealed class TestHostOrchestratorHost(TestHostOrchestratorConfiguration
             {
                 return (int)ExitCode.IncompatibleProtocolVersion;
             }
+
+            if (pushOnlyProtocol.IsServerControlChannelSupported)
+            {
+                // The orchestrator has no graceful-stop capability of its own; a server-initiated cancel maps to
+                // cancelling the application token, which propagates to the orchestrated test host processes.
+                await pushOnlyProtocol.StartServerControlChannelAsync(_ =>
+                {
+                    applicationCancellationToken.Cancel();
+                    return Task.CompletedTask;
+                }).ConfigureAwait(false);
+            }
         }
 
         int exitCode;

--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeClient.cs
@@ -23,6 +23,7 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
     private readonly NamedPipeClientStream _namedPipeClientStream;
     private readonly SemaphoreSlim _lock = new(1, 1);
     private readonly IEnvironment _environment;
+    private readonly bool _exitProcessOnConnectionLoss;
 
     private bool _disposed;
 
@@ -32,6 +33,25 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
     }
 
     public NamedPipeClient(string name, IEnvironment environment)
+        : this(name, environment, exitProcessOnConnectionLoss: true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NamedPipeClient"/> class connecting to the named pipe
+    /// <paramref name="name"/>.
+    /// </summary>
+    /// <param name="name">The OS-level named pipe name to connect to.</param>
+    /// <param name="environment">The environment abstraction used for process-exit on connection loss.</param>
+    /// <param name="exitProcessOnConnectionLoss">
+    /// When <see langword="true"/> (the default) a lost connection - the server disconnecting while we write a
+    /// request or before it sends a response - terminates the process via <see cref="IEnvironment.Exit(int)"/>.
+    /// This is the right behavior for the primary data pipe: if we cannot talk to the host there is no way to
+    /// recover. Set it to <see langword="false"/> for auxiliary channels (e.g. the reverse server-control pipe)
+    /// where a dropped connection should surface as an exception the caller can handle cooperatively rather than
+    /// killing the whole test host.
+    /// </param>
+    public NamedPipeClient(string name, IEnvironment environment, bool exitProcessOnConnectionLoss)
     {
         if (name is null)
         {
@@ -41,6 +61,7 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
         _namedPipeClientStream = new(".", name, PipeDirection.InOut, AsyncCurrentUserPipeOptions);
         PipeName = name;
         _environment = environment;
+        _exitProcessOnConnectionLoss = exitProcessOnConnectionLoss;
     }
 
     public string PipeName { get; }
@@ -69,6 +90,12 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                 // The server disconnected while we were writing the request. Mirror the read-EOF handling
                 // below: if we cannot deliver the request there's no way to recover, so exit abnormally
                 // instead of surfacing a raw IPC error to the caller.
+                if (!_exitProcessOnConnectionLoss)
+                {
+                    // Auxiliary channel: let the caller observe the disconnect and react cooperatively.
+                    throw;
+                }
+
                 _environment.Exit((int)ExitCode.GenericFailure);
                 throw;
             }
@@ -83,6 +110,13 @@ internal sealed class NamedPipeClient : NamedPipeBase, IClient
                 // This is especially important for 'dotnet test', where the user can simply kill the dotnet.exe process themselves.
                 // In that case, we want the MTP process to also die.
                 // Exit code 1 indicates abnormal termination due to IPC connection loss.
+                if (!_exitProcessOnConnectionLoss)
+                {
+                    // Auxiliary channel (e.g. the reverse server-control pipe): a dropped connection means the
+                    // peer went away. Surface it as an exception so the caller can react (e.g. treat "host gone"
+                    // as a cooperative cancel) instead of killing the whole test host.
+                    throw new IOException($"Pipe '{PipeName}' was closed by the server before a response was received.");
+                }
 
                 // Surface a diagnostic on stderr so the user has a chance to understand why this process is exiting.
                 // We deliberately use Console.Error (and not stdout) to avoid corrupting any machine-readable output

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/RegisterSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/RegisterSerializers.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Testing.Platform.IPC.Serializers;
  * TestInProgressMessagesSerializer: 10
  * AzureDevOpsLogMessageSerializer: 11
  * DisplayMessageSerializer: 12
+ * WaitForServerControlRequestSerializer: 13
+ * ServerControlMessageSerializer: 14
 */
 
 [Embedded]
@@ -41,5 +43,7 @@ internal static class RegisterSerializers
         namedPipeBase.RegisterSerializer(new TestInProgressMessagesSerializer(), typeof(TestInProgressMessages));
         namedPipeBase.RegisterSerializer(new AzureDevOpsLogMessageSerializer(), typeof(AzureDevOpsLogMessage));
         namedPipeBase.RegisterSerializer(new DisplayMessageSerializer(), typeof(DisplayMessage));
+        namedPipeBase.RegisterSerializer(new WaitForServerControlRequestSerializer(), typeof(WaitForServerControlRequest));
+        namedPipeBase.RegisterSerializer(new ServerControlMessageSerializer(), typeof(ServerControlMessage));
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -217,15 +217,19 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
     /// The reaction to a server-initiated cancel. It receives the test application cancellation token.
     /// </param>
     /// <remarks>
-    /// This is best-effort: if the control pipe cannot be established the test run continues unaffected (the
-    /// feature simply stays off). Callers should only invoke this after a successful handshake and when
-    /// <see cref="IsServerControlChannelSupported"/> is <see langword="true"/>.
+    /// Both the connect and the long-poll run entirely on a background task, so test start is never blocked on
+    /// this auxiliary channel. This is best-effort: if the control pipe cannot be established the test run
+    /// continues unaffected (the feature simply stays off). Callers should only invoke this after a successful
+    /// handshake and when <see cref="IsServerControlChannelSupported"/> is <see langword="true"/>. It is invoked
+    /// once per connection on the awaited run path (before the test run starts), so the control-channel fields
+    /// below are written here and only read later during exit/dispose - the single-threaded lifecycle makes the
+    /// plain fields safe without extra synchronization.
     /// </remarks>
-    public async Task StartServerControlChannelAsync(Func<CancellationToken, Task> onCancelSessionRequestedAsync)
+    public Task StartServerControlChannelAsync(Func<CancellationToken, Task> onCancelSessionRequestedAsync)
     {
         if (!IsServerControlChannelSupported || RoslynString.IsNullOrEmpty(_serverControlPipeName) || _serverControlPipeClient is not null)
         {
-            return;
+            return Task.CompletedTask;
         }
 
         _serverControlListenerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.CancellationToken);
@@ -234,25 +238,33 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
         // turns it into a cooperative cancel instead.
         var controlClient = new NamedPipeClient(_serverControlPipeName, _environment, exitProcessOnConnectionLoss: false);
         controlClient.RegisterAllSerializers();
+        _serverControlPipeClient = controlClient;
 
+        // Connect AND listen on a background task: we deliberately do not await the connect on the run path so a
+        // slow/absent control server can never delay (or fail) test execution start.
+        _serverControlListenerTask = Task.Run(
+            () => ConnectAndListenForServerControlAsync(controlClient, onCancelSessionRequestedAsync, _serverControlListenerCts.Token));
+        return Task.CompletedTask;
+    }
+
+    private async Task ConnectAndListenForServerControlAsync(NamedPipeClient controlClient, Func<CancellationToken, Task> onCancelSessionRequestedAsync, CancellationToken cancellationToken)
+    {
         try
         {
-            // Bound the connect so a misbehaving SDK that advertises a pipe it never listens on cannot hang the run.
-            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(_serverControlListenerCts.Token);
+            // Bound the connect so a misbehaving SDK that advertises a pipe it never listens on cannot leave this
+            // task parked forever holding resources.
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             connectCts.CancelAfter(TimeSpan.FromSeconds(30));
             await controlClient.ConnectAsync(connectCts.Token).ConfigureAwait(false);
         }
         catch (Exception)
         {
             // Best-effort: failing to establish the control channel degrades to "no server-initiated cancel"
-            // rather than breaking the test run.
-            controlClient.Dispose();
+            // rather than affecting the test run.
             return;
         }
 
-        _serverControlPipeClient = controlClient;
-        _serverControlListenerTask = Task.Run(
-            () => ListenForServerControlAsync(controlClient, onCancelSessionRequestedAsync, _serverControlListenerCts.Token));
+        await ListenForServerControlAsync(controlClient, onCancelSessionRequestedAsync, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task ListenForServerControlAsync(NamedPipeClient controlClient, Func<CancellationToken, Task> onCancelSessionRequestedAsync, CancellationToken cancellationToken)
@@ -280,12 +292,14 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
         catch (Exception) when (!cancellationToken.IsCancellationRequested)
         {
             // The control pipe dropped while the session was still live => the host went away. Treat it as a
-            // cooperative cancel so we still try to wind down and report whatever completed.
+            // cooperative cancel so we still try to wind down and report whatever completed. NOTE: this makes it a
+            // protocol requirement that the SDK keep the control pipe open until the data session ends - an early
+            // close for any reason is interpreted here as a cancel.
             await RequestCancelOnceAsync(onCancelSessionRequestedAsync).ConfigureAwait(false);
         }
         catch (Exception)
         {
-            // Cancellation raced with a pipe error; ignore.
+            // Cancellation raced with a pipe error (e.g. the stream was disposed during teardown); ignore.
         }
     }
 
@@ -312,17 +326,16 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 #pragma warning restore VSTHRD103
 #endif
 
+        // Cancelling the token is enough to abort an in-flight named-pipe read on modern .NET, but on .NET
+        // Framework cancellation of an already-parked overlapped read is not reliable - disposing the stream is
+        // what forces it to unblock. We cancelled first (above) so the listener treats the resulting failure as
+        // shutdown rather than "host gone => cancel".
+        _serverControlPipeClient?.Dispose();
+
         if (_serverControlListenerTask is { } listenerTask)
         {
-            try
-            {
-                await listenerTask.ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // The listener swallows its own expected exceptions; anything reaching here happened during
-                // shutdown and must not fail the exit path.
-            }
+            // Bounded wait so a stuck listener can never hang the exit path on any target framework.
+            await Task.WhenAny(listenerTask, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
         }
     }
 
@@ -330,11 +343,14 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
     {
         _serverControlListenerCts?.Cancel();
 
+        // Disposing the pipe client forces a parked read to abort even where token cancellation alone would not.
+        _serverControlPipeClient?.Dispose();
+
         if (_serverControlListenerTask is { } listenerTask)
         {
             try
             {
-                // Bounded wait: cancelling the linked token unblocks the parked read quickly. Never hang exit.
+                // Bounded wait: the cancel + dispose above unblock the parked read quickly. Never hang exit.
                 listenerTask.Wait(TimeSpan.FromSeconds(5));
             }
             catch (Exception)
@@ -343,7 +359,6 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             }
         }
 
-        _serverControlPipeClient?.Dispose();
         _serverControlListenerCts?.Dispose();
         _dotnetTestPipeClient?.Dispose();
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -23,6 +23,12 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
 
     private NamedPipeClient? _dotnetTestPipeClient;
 
+    private NamedPipeClient? _serverControlPipeClient;
+    private Task? _serverControlListenerTask;
+    private CancellationTokenSource? _serverControlListenerCts;
+    private string? _serverControlPipeName;
+    private int _cancelRequested;
+
     public static string InstanceId { get; } = Guid.NewGuid().ToString("N");
 
     public DotnetTestConnection(CommandLineHandler commandLineHandler, IEnvironment environment, ITestApplicationModuleInfo testApplicationModuleInfo, ITestApplicationCancellationTokenSource cancellationTokenSource)
@@ -97,6 +103,12 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
     // so an older SDK (<= 1.2.0) never receives an unknown message id.
     public bool IsDisplayMessageForwardingSupported { get; private set; }
 
+    // True once the SDK advertised a reverse "server control" pipe name in its handshake reply. When set, the
+    // test host opens a NamedPipeClient to that pipe and parks a long-poll so the SDK can push a
+    // ServerControlMessage (e.g. CancelSession) at any time. The feature is gated on the presence of the handshake
+    // property (a capability), not on the negotiated version string, so an older SDK simply never enables it.
+    public bool IsServerControlChannelSupported { get; private set; }
+
     public async Task<bool> IsCompatibleProtocolAsync(string hostType, IReadOnlyDictionary<byte, string>? additionalHandshakeProperties = null)
     {
         RoslynDebug.Assert(_dotnetTestPipeClient is not null);
@@ -131,6 +143,13 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
         IsIDE = response.Properties?.TryGetValue(HandshakeMessagePropertyNames.IsIDE, out string? isIDEValue) == true &&
             bool.TryParse(isIDEValue, out bool isIDE) &&
             isIDE;
+
+        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.ServerControlPipeName, out string? serverControlPipeName) == true &&
+            !RoslynString.IsNullOrEmpty(serverControlPipeName))
+        {
+            _serverControlPipeName = serverControlPipeName;
+            IsServerControlChannelSupported = true;
+        }
 
         if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.SupportedProtocolVersions, out string? protocolVersion) is true)
         {
@@ -186,7 +205,146 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
         }
     }
 
-    public Task OnExitAsync() => Task.CompletedTask;
+    /// <summary>
+    /// Opens the reverse "server control" pipe the SDK advertised during the handshake and parks a long-poll
+    /// <see cref="WaitForServerControlRequest"/> on it. The SDK completes that request with a
+    /// <see cref="ServerControlMessage"/> whenever it wants to signal the test host (today only
+    /// <see cref="ServerControlKinds.CancelSession"/>). On cancel - or when the control pipe drops, which means
+    /// the host went away - <paramref name="onCancelSessionRequestedAsync"/> is invoked exactly once so the caller
+    /// can stop the run cooperatively (preferring a graceful stop so trx/artifacts are still produced).
+    /// </summary>
+    /// <param name="onCancelSessionRequestedAsync">
+    /// The reaction to a server-initiated cancel. It receives the test application cancellation token.
+    /// </param>
+    /// <remarks>
+    /// This is best-effort: if the control pipe cannot be established the test run continues unaffected (the
+    /// feature simply stays off). Callers should only invoke this after a successful handshake and when
+    /// <see cref="IsServerControlChannelSupported"/> is <see langword="true"/>.
+    /// </remarks>
+    public async Task StartServerControlChannelAsync(Func<CancellationToken, Task> onCancelSessionRequestedAsync)
+    {
+        if (!IsServerControlChannelSupported || RoslynString.IsNullOrEmpty(_serverControlPipeName) || _serverControlPipeClient is not null)
+        {
+            return;
+        }
 
-    public void Dispose() => _dotnetTestPipeClient?.Dispose();
+        _serverControlListenerCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationTokenSource.CancellationToken);
+
+        // exitProcessOnConnectionLoss: false - a dropped control pipe must not kill the test host; the listener
+        // turns it into a cooperative cancel instead.
+        var controlClient = new NamedPipeClient(_serverControlPipeName, _environment, exitProcessOnConnectionLoss: false);
+        controlClient.RegisterAllSerializers();
+
+        try
+        {
+            // Bound the connect so a misbehaving SDK that advertises a pipe it never listens on cannot hang the run.
+            using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(_serverControlListenerCts.Token);
+            connectCts.CancelAfter(TimeSpan.FromSeconds(30));
+            await controlClient.ConnectAsync(connectCts.Token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Best-effort: failing to establish the control channel degrades to "no server-initiated cancel"
+            // rather than breaking the test run.
+            controlClient.Dispose();
+            return;
+        }
+
+        _serverControlPipeClient = controlClient;
+        _serverControlListenerTask = Task.Run(
+            () => ListenForServerControlAsync(controlClient, onCancelSessionRequestedAsync, _serverControlListenerCts.Token));
+    }
+
+    private async Task ListenForServerControlAsync(NamedPipeClient controlClient, Func<CancellationToken, Task> onCancelSessionRequestedAsync, CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                ServerControlMessage message = await controlClient.RequestReplyAsync<WaitForServerControlRequest, ServerControlMessage>(
+                    WaitForServerControlRequest.CachedInstance, cancellationToken).ConfigureAwait(false);
+
+                if (message.Kind == ServerControlKinds.CancelSession)
+                {
+                    await RequestCancelOnceAsync(onCancelSessionRequestedAsync).ConfigureAwait(false);
+                    return;
+                }
+
+                // Unknown control kind (forward-compat): ignore it and keep parking for the next signal.
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // We are shutting down (dispose or app cancellation) - nothing to do.
+        }
+        catch (Exception) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The control pipe dropped while the session was still live => the host went away. Treat it as a
+            // cooperative cancel so we still try to wind down and report whatever completed.
+            await RequestCancelOnceAsync(onCancelSessionRequestedAsync).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Cancellation raced with a pipe error; ignore.
+        }
+    }
+
+    private async Task RequestCancelOnceAsync(Func<CancellationToken, Task> onCancelSessionRequestedAsync)
+    {
+        if (Interlocked.Exchange(ref _cancelRequested, 1) != 0)
+        {
+            return;
+        }
+
+        await onCancelSessionRequestedAsync(_cancellationTokenSource.CancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task OnExitAsync()
+    {
+#if NET
+        if (_serverControlListenerCts is { } cts)
+        {
+            await cts.CancelAsync().ConfigureAwait(false);
+        }
+#else
+#pragma warning disable VSTHRD103 // CancellationTokenSource.CancelAsync is not available on this target framework.
+        _serverControlListenerCts?.Cancel();
+#pragma warning restore VSTHRD103
+#endif
+
+        if (_serverControlListenerTask is { } listenerTask)
+        {
+            try
+            {
+                await listenerTask.ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // The listener swallows its own expected exceptions; anything reaching here happened during
+                // shutdown and must not fail the exit path.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _serverControlListenerCts?.Cancel();
+
+        if (_serverControlListenerTask is { } listenerTask)
+        {
+            try
+            {
+                // Bounded wait: cancelling the linked token unblocks the parked read quickly. Never hang exit.
+                listenerTask.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception)
+            {
+                // Best-effort shutdown.
+            }
+        }
+
+        _serverControlPipeClient?.Dispose();
+        _serverControlListenerCts?.Dispose();
+        _dotnetTestPipeClient?.Dispose();
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -144,7 +144,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             bool.TryParse(isIDEValue, out bool isIDE) &&
             isIDE;
 
-        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.ServerControlPipeName, out string? serverControlPipeName) == true &&
+        if (response.Properties?.TryGetValue(HandshakeMessagePropertyNames.ServerControlPipeName, out string? serverControlPipeName) is true &&
             !RoslynString.IsNullOrEmpty(serverControlPipeName))
         {
             _serverControlPipeName = serverControlPipeName;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -68,6 +68,15 @@ internal static class HandshakeMessagePropertyNames
     // NamedPipeClient to that pipe and parks a long-poll WaitForServerControlRequest so the SDK can
     // push a ServerControlMessage (e.g. CancelSession) at any time - even while the test host is
     // otherwise silent. An older SDK never sends this property, so the feature stays disabled.
+    //
+    // SDK-side contract (duplicated by hand in dotnet/sdk - keep in sync):
+    //   * Every process that performs the handshake and receives this property (test host, test host
+    //     controller, orchestrator) opens its own client to the advertised name, so the SDK must be able to
+    //     accept one control connection per connecting process (e.g. one server instance per process, or a
+    //     distinct pipe name advertised per handshake reply).
+    //   * The SDK MUST keep the control pipe open for the whole data session. The test host treats an early
+    //     pipe drop as "host gone => cancel", so closing the control pipe before the data session ends would be
+    //     interpreted as a cancellation.
     internal const byte ServerControlPipeName = 12;
 }
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -61,6 +61,23 @@ internal static class HandshakeMessagePropertyNames
     // dotnet test in the SDK) can understand why an orchestrator is participating
     // in the run. The value is the orchestrator extension Uid.
     internal const byte OrchestratorFeature = 11;
+
+    // Carries the OS-level name of the reverse "server control" pipe. Only ever sent by the SDK
+    // (dotnet test) in its handshake reply. Its presence is the capability signal for
+    // server-initiated session cancellation: when the test host sees a non-empty value it opens a
+    // NamedPipeClient to that pipe and parks a long-poll WaitForServerControlRequest so the SDK can
+    // push a ServerControlMessage (e.g. CancelSession) at any time - even while the test host is
+    // otherwise silent. An older SDK never sends this property, so the feature stays disabled.
+    internal const byte ServerControlPipeName = 12;
+}
+
+[Embedded]
+internal static class ServerControlKinds
+{
+    // The kind of a ServerControlMessage the SDK pushes to the test host over the reverse control pipe.
+    // Values must stay stable (they flow over IPC to dotnet test). Reserve additional values for future
+    // signals (drain, pause, ...).
+    internal const byte CancelSession = 1;
 }
 
 [Embedded]
@@ -128,5 +145,12 @@ internal static class ProtocolConstants
     // output (the SDK suppresses its TerminalTestReporter to avoid colliding with the host output it expected
     // before this change). Users must update to an SDK that negotiates 1.1.0 to see live output via the SDK's
     // TerminalTestReporter.
-    internal const string SupportedVersions = "1.0.0;1.1.0;1.2.0;1.3.0";
+    // 1.4.0 adds the reverse "server control" channel used for server-initiated session cancellation. When the
+    // SDK advertises a ServerControlPipeName in its handshake reply, the test host opens a NamedPipeClient to that
+    // pipe and parks a long-poll WaitForServerControlRequest; the SDK completes it with a ServerControlMessage
+    // (e.g. CancelSession) whenever it wants the test host to stop cooperatively (global --maximum-failed-tests,
+    // --timeout, ...). The feature is gated on the presence of the handshake property (a capability), not on this
+    // version string, so an older SDK that never advertises the pipe leaves the feature disabled. The version is
+    // still bumped so the negotiated-version state advances in lockstep.
+    internal const string SupportedVersions = "1.0.0;1.1.0;1.2.0;1.3.0;1.4.0";
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/ServerControlMessage.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/ServerControlMessage.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.IPC.Models;
+
+// The SDK's reply to a parked WaitForServerControlRequest on the reverse "server control" pipe. Kind is one of
+// ServerControlKinds (e.g. CancelSession); on CancelSession the test host stops scheduling new tests and stops the
+// current run cooperatively (preferring a graceful stop so trx/artifacts are still produced). Introduced with
+// protocol version 1.4.0; the SDK only creates the control pipe when it advertises ServerControlPipeName, so an
+// older SDK never sends this message.
+internal sealed record ServerControlMessage(byte Kind) : IResponse;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/WaitForServerControlRequest.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/WaitForServerControlRequest.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.IPC.Models;
+
+// Sent once by the test host on the reverse "server control" pipe (see HandshakeMessagePropertyNames.
+// ServerControlPipeName). The test host parks this long-poll request and the SDK completes it with a
+// ServerControlMessage whenever it wants to push a control signal (e.g. CancelSession). Introduced with
+// protocol version 1.4.0; the request carries no payload.
+internal sealed class WaitForServerControlRequest : IRequest
+{
+    public static readonly WaitForServerControlRequest CachedInstance = new();
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -197,3 +197,17 @@ internal static class DisplayMessageFieldsId
     public const ushort Level = 3;
     public const ushort Text = 4;
 }
+
+[Embedded]
+internal static class WaitForServerControlRequestFieldsId
+{
+    public const int MessagesSerializerId = 13;
+}
+
+[Embedded]
+internal static class ServerControlMessageFieldsId
+{
+    public const int MessagesSerializerId = 14;
+
+    public const ushort Kind = 1;
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC.Models;
+
+namespace Microsoft.Testing.Platform.IPC.Serializers;
+
+/*
+    |---FieldCount---| 2 bytes
+
+    |---Kind Id---| (2 bytes)
+    |---Kind Size---| (4 bytes)
+    |---Kind Value---| (1 byte)
+*/
+
+internal sealed class ServerControlMessageSerializer : NamedPipeSerializer<ServerControlMessage>, INamedPipeSerializer
+{
+    public override int Id => ServerControlMessageFieldsId.MessagesSerializerId;
+
+    protected override ServerControlMessage DeserializeCore(Stream stream)
+    {
+        byte kind = 0;
+
+        ushort fieldCount = ReadUShort(stream);
+
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
+            switch (fieldId)
+            {
+                case ServerControlMessageFieldsId.Kind:
+                    kind = ReadByte(stream);
+
+                    // Kind is a single byte today, but honor the declared field size so that a future
+                    // protocol revision that widens it (or a frame that reports a different size) does not
+                    // leave extra bytes unread and misalign the remaining fields.
+                    if (fieldSize > 1)
+                    {
+                        SetPosition(stream, stream.Position + (fieldSize - 1));
+                    }
+
+                    break;
+
+                default:
+                    // If we don't recognize the field id, skip the payload corresponding to that field.
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
+            }
+        }
+
+        return new(kind);
+    }
+
+    protected override void SerializeCore(ServerControlMessage objectToSerialize, Stream stream)
+    {
+        RoslynDebug.Assert(stream.CanSeek, "We expect a seekable stream.");
+
+        // Kind is always written (it is a non-nullable byte).
+        WriteUShort(stream, 1);
+        WriteField(stream, ServerControlMessageFieldsId.Kind, objectToSerialize.Kind);
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/WaitForServerControlRequestSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/WaitForServerControlRequestSerializer.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC.Models;
+
+namespace Microsoft.Testing.Platform.IPC.Serializers;
+
+internal sealed class WaitForServerControlRequestSerializer : NamedPipeSerializer<WaitForServerControlRequest>, INamedPipeSerializer
+{
+    public override int Id => WaitForServerControlRequestFieldsId.MessagesSerializerId;
+
+    protected override WaitForServerControlRequest DeserializeCore(Stream _)
+        => WaitForServerControlRequest.CachedInstance;
+
+    protected override void SerializeCore(WaitForServerControlRequest _, Stream __)
+    {
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/IPushOnlyProtocol.cs
@@ -7,11 +7,20 @@ internal interface IPushOnlyProtocol : IDisposable
 {
     bool IsServerMode { get; }
 
+    // True once the SDK advertised a reverse "server control" pipe during the handshake, meaning it can push
+    // server-initiated signals (e.g. session cancellation) to the test host. Only meaningful after a successful
+    // IsCompatibleProtocolAsync call.
+    bool IsServerControlChannelSupported { get; }
+
     Task AfterCommonServiceSetupAsync();
 
     Task HelpInvokedAsync();
 
     Task<bool> IsCompatibleProtocolAsync(string testHostType, IReadOnlyDictionary<byte, string>? additionalHandshakeProperties = null);
+
+    // Opens the reverse "server control" channel (when supported) and parks a long-poll on it. The provided
+    // reaction runs exactly once when the SDK signals a session cancellation (or when the control pipe drops).
+    Task StartServerControlChannelAsync(Func<CancellationToken, Task> onCancelSessionRequestedAsync);
 
     Task<IPushOnlyProtocolConsumer> GetDataConsumerAsync();
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -25,11 +25,12 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
 
     public TestContext TestContext { get; set; } = null!;
 
-    // The test host (testfx) now advertises protocol 1.0.0, 1.1.0, 1.2.0 and 1.3.0. The 1.1.0 bump signalled
+    // The test host (testfx) now advertises protocol 1.0.0, 1.1.0, 1.2.0, 1.3.0 and 1.4.0. The 1.1.0 bump signalled
     // that TerminalOutputDevice is no longer plugged in under the pipe protocol (microsoft/testfx#7161
     // and dotnet/sdk#51615); 1.2.0 added AzureDevOpsLogMessage forwarding; 1.3.0 added generic DisplayMessage
-    // (warning/error) forwarding. This mirrors ProtocolConstants.SupportedVersions on the host side.
-    private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0;1.2.0;1.3.0";
+    // (warning/error) forwarding; 1.4.0 added the reverse server-control channel (server-initiated cancellation).
+    // This mirrors ProtocolConstants.SupportedVersions on the host side.
+    private const string HostAdvertisedProtocolVersions = "1.0.0;1.1.0;1.2.0;1.3.0;1.4.0";
 
     [TestMethod]
     public async Task DotnetTestPipe_TestAppAdvertisesAllSupportedVersions_NegotiatesDownToV100WithOldSdk()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -42,6 +42,8 @@ internal static class DotnetTestPipeProtocol
         public const int TestInProgressMessages = 10;
         public const int AzureDevOpsLogMessage = 11;
         public const int DisplayMessage = 12;
+        public const int WaitForServerControlRequest = 13;
+        public const int ServerControlMessage = 14;
     }
 
     public static class HandshakeProperties
@@ -58,6 +60,12 @@ internal static class DotnetTestPipeProtocol
         public const byte IsIDE = 9;
         public const byte ExecutionMode = 10;
         public const byte OrchestratorFeature = 11;
+        public const byte ServerControlPipeName = 12;
+    }
+
+    public static class ServerControlKinds
+    {
+        public const byte CancelSession = 1;
     }
 
     public static class SessionEventTypes
@@ -194,6 +202,24 @@ internal static class DotnetTestPipeProtocol
             stream.WriteByte(kvp.Key);
             WriteLengthPrefixedString(stream, kvp.Value);
         }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Encodes the body of a <see cref="SerializerIds.ServerControlMessage"/> frame. Mirrors
+    /// <c>ServerControlMessageSerializer</c>: a field-tagged object with a single <c>Kind</c> field (id 1)
+    /// carrying one byte (<see cref="ServerControlKinds"/>).
+    /// </summary>
+    public static byte[] EncodeServerControlMessageBody(byte kind)
+    {
+        const ushort kindFieldId = 1;
+
+        using MemoryStream stream = new();
+        WriteUShort(stream, 1); // field count
+        WriteUShort(stream, kindFieldId);
+        WriteInt(stream, sizeof(byte)); // field size
+        stream.WriteByte(kind);
 
         return stream.ToArray();
     }
@@ -541,6 +567,13 @@ internal static class DotnetTestPipeProtocol
     private static void WriteUShort(Stream stream, ushort value)
     {
         Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        BitConverter.TryWriteBytes(bytes, value);
+        stream.Write(bytes);
+    }
+
+    private static void WriteInt(Stream stream, int value)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
         BitConverter.TryWriteBytes(bytes, value);
         stream.Write(bytes);
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeServerCancellationTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeServerCancellationTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests.DotnetTestPipe;
+
+/// <summary>
+/// End-to-end tests for server-initiated session cancellation over the <c>--server dotnettestcli</c> pipe
+/// protocol (issue https://github.com/microsoft/testfx/issues/8691).
+/// <para>
+/// The fake SDK advertises a reverse "server control" pipe in its handshake reply. The test app connects back to
+/// it and parks a long-poll; the SDK completes that long-poll with a <c>CancelSession</c> message while the app is
+/// blocked inside a running test. The app is expected to react by stopping <b>gracefully</b> - it still emits its
+/// test results and <c>TestSessionEnd</c> and exits cleanly, rather than being killed.
+/// </para>
+/// </summary>
+[TestClass]
+public sealed class DotnetTestPipeServerCancellationTests : AcceptanceTestBase<DotnetTestPipeServerCancellationTests.TestAssetFixture>
+{
+    private const string AssetName = "DotnetTestPipeServerCancellationTest";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task DotnetTestPipe_ServerCancelSession_StopsGracefullyAndStillReports()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        // The fake SDK advertises the reverse control pipe and, once the app connects and parks, pushes a
+        // CancelSession. The advertised protocol version must include 1.4.0 so the negotiation succeeds; the
+        // feature itself is gated on the ServerControlPipeName property, not the version string.
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            environmentVariables: new Dictionary<string, string?> { ["SERVERCANCEL_WAIT"] = "1" },
+            supportedProtocolVersions: "1.0.0;1.1.0;1.2.0;1.3.0;1.4.0",
+            advertiseServerControlPipe: true,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsTrue(result.ServerControlPipeConnected, "The test app should have connected back to the reverse server-control pipe.");
+        Assert.IsTrue(result.ServerCancelSent, "The fake SDK should have pushed a CancelSession over the control pipe.");
+
+        // Reporting must survive the cancel: the app publishes a passed result only AFTER it observes the cancel,
+        // so seeing a TestResult frame proves the graceful path kept the reporting pipeline alive.
+        Assert.IsNotEmpty(
+            result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.TestResultMessages).ToList(),
+            "Expected a TestResult message after the server-initiated cancel (reporting should survive a graceful stop).");
+
+        // TestSessionEnd must still be emitted - the app wound down cleanly instead of being killed.
+        byte[] sessionEventTypes =
+        [
+            .. result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.TestSessionEvent)
+                .Select(m => DotnetTestPipeProtocol.DecodeTestSessionEventBody(m.Body).SessionType)
+                .Where(t => t.HasValue)
+                .Select(t => t!.Value)
+        ];
+
+        Assert.Contains(
+            DotnetTestPipeProtocol.SessionEventTypes.TestSessionEnd,
+            sessionEventTypes,
+            $"Expected a TestSessionEnd event after cancel; got [{string.Join(", ", sessionEventTypes)}].");
+
+        Assert.AreEqual(
+            0,
+            result.TestHostResult.ExitCode,
+            $"A graceful server-initiated cancel that still reports a passing test should exit cleanly.{Environment.NewLine}" +
+            $"stdout:{Environment.NewLine}{result.TestHostResult.StandardOutput}{Environment.NewLine}" +
+            $"stderr:{Environment.NewLine}{result.TestHostResult.StandardError}");
+    }
+
+    [TestMethod]
+    public async Task DotnetTestPipe_NoServerControlPipeAdvertised_AppNeverConnectsBack()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        // An SDK that does not advertise the control pipe (the old-SDK / opted-out case) must not cause the app
+        // to open any control channel; the feature stays off and the app finishes on its own fallback timeout.
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            supportedProtocolVersions: "1.0.0;1.1.0;1.2.0;1.3.0;1.4.0",
+            advertiseServerControlPipe: false,
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.IsFalse(result.ServerControlPipeConnected, "No control pipe was advertised, so the app must not connect back.");
+        Assert.IsFalse(result.ServerCancelSent, "No control pipe was advertised, so no cancel could be sent.");
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string AssetCode = """
+#file DotnetTestPipeServerCancellationTest.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <OutputType>Exe</OutputType>
+        <UseAppHost>true</UseAppHost>
+        <LangVersion>preview</LangVersion>
+        <!-- IGracefulStopTestExecutionCapability is [Experimental("TPEXP")]; this asset intentionally uses it. -->
+        <NoWarn>$(NoWarn);TPEXP</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+    </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        var framework = new DummyTestFramework();
+        builder.RegisterTestFramework(
+            _ => new TestFrameworkCapabilities(framework.GracefulStopCapability),
+            (_, __) => framework);
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+// A graceful-stop capability whose StopTestExecutionAsync unblocks the running test. The platform resolves this
+// capability when it receives a server-initiated CancelSession over the reverse control pipe.
+public sealed class DummyGracefulStopCapability : IGracefulStopTestExecutionCapability
+{
+    private readonly TaskCompletionSource _requested = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task Requested => _requested.Task;
+
+    public Task StopTestExecutionAsync(CancellationToken cancellationToken)
+    {
+        _requested.TrySetResult();
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class DummyTestFramework : ITestFramework, IDataProducer
+{
+    public DummyGracefulStopCapability GracefulStopCapability { get; } = new();
+
+    public string Uid => nameof(DummyTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DummyTestFramework);
+    public string Description => nameof(DummyTestFramework);
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        // Only the cancellation scenario asks us to park (via an env var) so the negative test finishes fast.
+        if (Environment.GetEnvironmentVariable("SERVERCANCEL_WAIT") == "1")
+        {
+            // Park until the SDK asks us to stop (via the reverse control pipe -> graceful stop) or the whole
+            // application is cancelled. A generous fallback timeout keeps the process from hanging forever if no
+            // signal ever arrives (the test assertions then fail loudly rather than the run deadlocking).
+            Task requested = GracefulStopCapability.Requested;
+            Task timeout = Task.Delay(TimeSpan.FromSeconds(60));
+            await Task.WhenAny(requested, timeout);
+        }
+
+        // Reporting must survive the cancel: publish a passed result AFTER we observed the stop request so the
+        // harness can prove the graceful path kept the reporting pipeline alive.
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid,
+            new TestNode() { Uid = "1", DisplayName = "CancelledButReported", Properties = new(PassedTestNodeStateProperty.CachedInstance) }));
+        context.Complete();
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            AssetCode
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
@@ -33,6 +33,7 @@ internal static class FakeDotnetTestSdk
         Dictionary<string, string?>? environmentVariables = null,
         string supportedProtocolVersions = DefaultSupportedProtocolVersions,
         bool isIde = false,
+        bool advertiseServerControlPipe = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(testHost);
@@ -49,10 +50,22 @@ internal static class FakeDotnetTestSdk
         // path (matching what NamedPipeServer.GetPipeName produces with Path.Combine("/tmp", name)).
         using NamedPipeServerStream stream = new(osPipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, options);
 
+        // Optional reverse "server control" pipe: when advertised, the test app connects back and parks a
+        // WaitForServerControlRequest that we complete with a CancelSession, exercising server-initiated
+        // session cancellation (issue #8691).
+        string? controlOsPipeName = null;
+        NamedPipeServerStream? controlStream = null;
+        if (advertiseServerControlPipe)
+        {
+            controlOsPipeName = DotnetTestPipeProtocol.GetPipeName(Guid.NewGuid().ToString("N"));
+            controlStream = new(controlOsPipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, options);
+        }
+
         List<RawMessage> received = [];
         Dictionary<byte, string>? receivedHandshake = null;
         Dictionary<byte, string>? sentHandshakeReply = null;
         string? negotiatedVersion = null;
+        var controlObservations = new ServerControlObservations();
 
         string pipeArgs = $"--server dotnettestcli --dotnet-test-pipe {osPipeName}";
         string finalArgs = extraArguments is null ? pipeArgs : $"{pipeArgs} {extraArguments}";
@@ -60,6 +73,11 @@ internal static class FakeDotnetTestSdk
 
         // Wait for the test app to connect.
         await stream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        // Accept the control connection and push the cancel signal concurrently with the data read loop.
+        Task? controlTask = controlStream is null
+            ? null
+            : Task.Run(() => DriveServerControlAsync(controlStream, controlObservations, cancellationToken), cancellationToken);
 
         // Read frames until the peer disconnects.
         while (true)
@@ -77,7 +95,7 @@ internal static class FakeDotnetTestSdk
                 receivedHandshake = DotnetTestPipeProtocol.DecodeHandshakeBody(frame.Body);
                 string selected = SelectHighestMutuallySupportedVersion(receivedHandshake, supportedProtocolVersions);
                 negotiatedVersion = selected;
-                sentHandshakeReply = BuildSdkHandshakeReply(selected, isIde);
+                sentHandshakeReply = BuildSdkHandshakeReply(selected, isIde, controlOsPipeName);
                 byte[] replyBody = DotnetTestPipeProtocol.EncodeHandshakeBody(sentHandshakeReply);
                 await DotnetTestPipeProtocol.WriteFrameAsync(stream, DotnetTestPipeProtocol.SerializerIds.HandshakeMessage, replyBody, cancellationToken).ConfigureAwait(false);
             }
@@ -90,12 +108,60 @@ internal static class FakeDotnetTestSdk
 
         TestHostResult hostResult = await hostRun.ConfigureAwait(false);
 
+        if (controlTask is not null)
+        {
+            try
+            {
+                await controlTask.WaitAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Best-effort: the control interaction is observed via controlObservations; don't let its
+                // teardown fail the harness.
+            }
+        }
+
+        if (controlStream is not null)
+        {
+            await controlStream.DisposeAsync().ConfigureAwait(false);
+        }
+
         return new FakeDotnetTestSdkResult(
             hostResult,
             received,
             receivedHandshake,
             sentHandshakeReply,
-            negotiatedVersion);
+            negotiatedVersion,
+            controlObservations.Connected,
+            controlObservations.CancelSent);
+    }
+
+    /// <summary>
+    /// Accepts the reverse control-pipe connection, reads the single parked
+    /// <see cref="DotnetTestPipeProtocol.SerializerIds.WaitForServerControlRequest"/>, and completes it with a
+    /// <see cref="DotnetTestPipeProtocol.ServerControlKinds.CancelSession"/> message.
+    /// </summary>
+    private static async Task DriveServerControlAsync(NamedPipeServerStream controlStream, ServerControlObservations observations, CancellationToken cancellationToken)
+    {
+        await controlStream.WaitForConnectionAsync(cancellationToken).ConfigureAwait(false);
+        observations.Connected = true;
+
+        RawMessage? request = await DotnetTestPipeProtocol.ReadFrameAsync(controlStream, cancellationToken).ConfigureAwait(false);
+        if (request is null || request.SerializerId != DotnetTestPipeProtocol.SerializerIds.WaitForServerControlRequest)
+        {
+            return;
+        }
+
+        byte[] body = DotnetTestPipeProtocol.EncodeServerControlMessageBody(DotnetTestPipeProtocol.ServerControlKinds.CancelSession);
+        await DotnetTestPipeProtocol.WriteFrameAsync(controlStream, DotnetTestPipeProtocol.SerializerIds.ServerControlMessage, body, cancellationToken).ConfigureAwait(false);
+        observations.CancelSent = true;
+    }
+
+    private sealed class ServerControlObservations
+    {
+        public bool Connected { get; set; }
+
+        public bool CancelSent { get; set; }
     }
 
     /// <summary>
@@ -141,7 +207,7 @@ internal static class FakeDotnetTestSdk
         return best ?? string.Empty;
     }
 
-    private static Dictionary<byte, string> BuildSdkHandshakeReply(string selectedVersion, bool isIde)
+    private static Dictionary<byte, string> BuildSdkHandshakeReply(string selectedVersion, bool isIde, string? serverControlPipeName = null)
     {
         Dictionary<byte, string> properties = new(capacity: 6)
         {
@@ -155,6 +221,11 @@ internal static class FakeDotnetTestSdk
         if (isIde)
         {
             properties.Add(DotnetTestPipeProtocol.HandshakeProperties.IsIDE, bool.TrueString);
+        }
+
+        if (!string.IsNullOrEmpty(serverControlPipeName))
+        {
+            properties.Add(DotnetTestPipeProtocol.HandshakeProperties.ServerControlPipeName, serverControlPipeName);
         }
 
         return properties;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdk.cs
@@ -52,14 +52,12 @@ internal static class FakeDotnetTestSdk
 
         // Optional reverse "server control" pipe: when advertised, the test app connects back and parks a
         // WaitForServerControlRequest that we complete with a CancelSession, exercising server-initiated
-        // session cancellation (issue #8691).
-        string? controlOsPipeName = null;
-        NamedPipeServerStream? controlStream = null;
-        if (advertiseServerControlPipe)
-        {
-            controlOsPipeName = DotnetTestPipeProtocol.GetPipeName(Guid.NewGuid().ToString("N"));
-            controlStream = new(controlOsPipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, options);
-        }
+        // session cancellation (issue #8691). Declared with 'await using' so the OS handle is released reliably
+        // on every exit path (including exceptions), and remains a no-op when the feature is not advertised.
+        string? controlOsPipeName = advertiseServerControlPipe ? DotnetTestPipeProtocol.GetPipeName(Guid.NewGuid().ToString("N")) : null;
+        await using NamedPipeServerStream? controlStream = controlOsPipeName is null
+            ? null
+            : new(controlOsPipeName, PipeDirection.InOut, maxNumberOfServerInstances: 1, PipeTransmissionMode.Byte, options);
 
         List<RawMessage> received = [];
         Dictionary<byte, string>? receivedHandshake = null;
@@ -119,11 +117,6 @@ internal static class FakeDotnetTestSdk
                 // Best-effort: the control interaction is observed via controlObservations; don't let its
                 // teardown fail the harness.
             }
-        }
-
-        if (controlStream is not null)
-        {
-            await controlStream.DisposeAsync().ConfigureAwait(false);
         }
 
         return new FakeDotnetTestSdkResult(

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdkResult.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/FakeDotnetTestSdkResult.cs
@@ -16,13 +16,17 @@ internal sealed class FakeDotnetTestSdkResult
         IReadOnlyList<RawMessage> receivedMessages,
         Dictionary<byte, string>? receivedHandshake,
         Dictionary<byte, string>? sentHandshakeReply,
-        string? negotiatedProtocolVersion)
+        string? negotiatedProtocolVersion,
+        bool serverControlPipeConnected = false,
+        bool serverCancelSent = false)
     {
         TestHostResult = testHostResult;
         ReceivedMessages = receivedMessages;
         ReceivedHandshake = receivedHandshake;
         SentHandshakeReply = sentHandshakeReply;
         NegotiatedProtocolVersion = negotiatedProtocolVersion;
+        ServerControlPipeConnected = serverControlPipeConnected;
+        ServerCancelSent = serverCancelSent;
     }
 
     /// <summary>The process-level result: exit code, captured stdout, captured stderr.</summary>
@@ -40,6 +44,12 @@ internal sealed class FakeDotnetTestSdkResult
 
     /// <summary>The version the fake SDK selected from the test app's advertised list, or null/empty if none.</summary>
     public string? NegotiatedProtocolVersion { get; }
+
+    /// <summary>True when the test app connected back to the reverse server-control pipe the SDK advertised.</summary>
+    public bool ServerControlPipeConnected { get; }
+
+    /// <summary>True when the fake SDK pushed a CancelSession control message to the test app.</summary>
+    public bool ServerCancelSent { get; }
 
     /// <summary>Returns all frames whose serializer ID matches <paramref name="serializerId"/>.</summary>
     public IEnumerable<RawMessage> MessagesWithSerializerId(int serializerId)

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
@@ -39,6 +39,8 @@ public sealed class DotnetTestProtocolContractTests
             [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
             [AzureDevOpsLogMessageFieldsId.MessagesSerializerId] = nameof(AzureDevOpsLogMessageFieldsId),
             [DisplayMessageFieldsId.MessagesSerializerId] = nameof(DisplayMessageFieldsId),
+            [WaitForServerControlRequestFieldsId.MessagesSerializerId] = nameof(WaitForServerControlRequestFieldsId),
+            [ServerControlMessageFieldsId.MessagesSerializerId] = nameof(ServerControlMessageFieldsId),
         };
 
         Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
@@ -55,6 +57,8 @@ public sealed class DotnetTestProtocolContractTests
         Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
         Assert.AreEqual(nameof(AzureDevOpsLogMessageFieldsId), serializerIds[11]);
         Assert.AreEqual(nameof(DisplayMessageFieldsId), serializerIds[12]);
+        Assert.AreEqual(nameof(WaitForServerControlRequestFieldsId), serializerIds[13]);
+        Assert.AreEqual(nameof(ServerControlMessageFieldsId), serializerIds[14]);
     }
 
     [TestMethod]
@@ -73,6 +77,8 @@ public sealed class DotnetTestProtocolContractTests
             [HandshakeMessagePropertyNames.InstanceId] = nameof(HandshakeMessagePropertyNames.InstanceId),
             [HandshakeMessagePropertyNames.IsIDE] = nameof(HandshakeMessagePropertyNames.IsIDE),
             [HandshakeMessagePropertyNames.ExecutionMode] = nameof(HandshakeMessagePropertyNames.ExecutionMode),
+            [HandshakeMessagePropertyNames.OrchestratorFeature] = nameof(HandshakeMessagePropertyNames.OrchestratorFeature),
+            [HandshakeMessagePropertyNames.ServerControlPipeName] = nameof(HandshakeMessagePropertyNames.ServerControlPipeName),
         };
 
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.PID), properties[0]);
@@ -86,6 +92,8 @@ public sealed class DotnetTestProtocolContractTests
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.InstanceId), properties[8]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.IsIDE), properties[9]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionMode), properties[10]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.OrchestratorFeature), properties[11]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ServerControlPipeName), properties[12]);
     }
 
     [TestMethod]
@@ -142,6 +150,6 @@ public sealed class DotnetTestProtocolContractTests
         // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
         // constant as "always true" (MSTEST0032).
         string[] versions = [ProtocolConstants.SupportedVersions];
-        Assert.AreEqual("1.0.0;1.1.0;1.2.0;1.3.0", versions[0]);
+        Assert.AreEqual("1.0.0;1.1.0;1.2.0;1.3.0;1.4.0", versions[0]);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -86,6 +86,39 @@ public sealed class ProtocolTests
     }
 
     [TestMethod]
+    public void ServerControlMessageSerializeDeserialize()
+    {
+        object serializer = new ServerControlMessageSerializer();
+        var message = new ServerControlMessage(ServerControlKinds.CancelSession);
+
+        ServerControlMessage actual = RoundTrip(serializer, message);
+
+        Assert.AreEqual(ServerControlKinds.CancelSession, actual.Kind);
+    }
+
+    [TestMethod]
+    public void ServerControlMessageSerializeDeserialize_UnknownKindIsPreserved()
+    {
+        object serializer = new ServerControlMessageSerializer();
+        // A forward-compat kind the current host does not recognize must still round-trip its byte value.
+        var message = new ServerControlMessage(42);
+
+        ServerControlMessage actual = RoundTrip(serializer, message);
+
+        Assert.AreEqual((byte)42, actual.Kind);
+    }
+
+    [TestMethod]
+    public void WaitForServerControlRequestSerializeDeserialize()
+    {
+        object serializer = new WaitForServerControlRequestSerializer();
+
+        WaitForServerControlRequest actual = RoundTrip(serializer, WaitForServerControlRequest.CachedInstance);
+
+        Assert.IsNotNull(actual);
+    }
+
+    [TestMethod]
     public void DiscoveredTestMessagesSerializeDeserialize()
     {
         object serializer = new DiscoveredTestMessagesSerializer();
@@ -230,6 +263,7 @@ public sealed class ProtocolTests
             { HandshakeMessagePropertyNames.IsIDE, nameof(HandshakeMessagePropertyNames.IsIDE) },
             { HandshakeMessagePropertyNames.ExecutionMode, nameof(HandshakeMessagePropertyNames.ExecutionMode) },
             { HandshakeMessagePropertyNames.OrchestratorFeature, nameof(HandshakeMessagePropertyNames.OrchestratorFeature) },
+            { HandshakeMessagePropertyNames.ServerControlPipeName, nameof(HandshakeMessagePropertyNames.ServerControlPipeName) },
         };
 
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.PID), properties[0]);
@@ -244,6 +278,7 @@ public sealed class ProtocolTests
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.IsIDE), properties[9]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionMode), properties[10]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.OrchestratorFeature), properties[11]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ServerControlPipeName), properties[12]);
     }
 
     // The HandshakeMessageExecutionModes string values flow over IPC to
@@ -416,6 +451,8 @@ public sealed class ProtocolTests
             [TestInProgressMessagesFieldsId.MessagesSerializerId] = nameof(TestInProgressMessagesFieldsId),
             [AzureDevOpsLogMessageFieldsId.MessagesSerializerId] = nameof(AzureDevOpsLogMessageFieldsId),
             [DisplayMessageFieldsId.MessagesSerializerId] = nameof(DisplayMessageFieldsId),
+            [WaitForServerControlRequestFieldsId.MessagesSerializerId] = nameof(WaitForServerControlRequestFieldsId),
+            [ServerControlMessageFieldsId.MessagesSerializerId] = nameof(ServerControlMessageFieldsId),
         };
 
         Assert.AreEqual(nameof(VoidResponseFieldsId), serializerIds[0]);
@@ -432,6 +469,8 @@ public sealed class ProtocolTests
         Assert.AreEqual(nameof(TestInProgressMessagesFieldsId), serializerIds[10]);
         Assert.AreEqual(nameof(AzureDevOpsLogMessageFieldsId), serializerIds[11]);
         Assert.AreEqual(nameof(DisplayMessageFieldsId), serializerIds[12]);
+        Assert.AreEqual(nameof(WaitForServerControlRequestFieldsId), serializerIds[13]);
+        Assert.AreEqual(nameof(ServerControlMessageFieldsId), serializerIds[14]);
     }
 
     // The SessionEventTypes byte values flow over IPC to dotnet test in the dotnet/sdk repository.
@@ -487,6 +526,6 @@ public sealed class ProtocolTests
         // Indirect through a collection so the MSTest analyzer does not flag the comparison of a compile-time
         // constant as "always true" (MSTEST0032).
         string[] versions = [ProtocolConstants.SupportedVersions];
-        Assert.AreEqual("1.0.0;1.1.0;1.2.0;1.3.0", versions[0]);
+        Assert.AreEqual("1.0.0;1.1.0;1.2.0;1.3.0;1.4.0", versions[0]);
     }
 }


### PR DESCRIPTION
Closes #8691.

Implements the RFC's recommended **Option B** — a reverse "server control" pipe — so `dotnet test`-level features (global `--maximum-failed-tests`, `--timeout`, graceful Ctrl+C drain) can ask a Microsoft.Testing.Platform test app to stop **cooperatively** instead of only letting it run to completion or `Process.Kill`-ing it.

## How it works

```mermaid
sequenceDiagram
    participant SDK as dotnet test (SDK)
    participant App as MTP test app
    App->>SDK: Handshake (advertises 1.4.0)
    SDK-->>App: Handshake reply (ServerControlPipeName=<pipe>)
    App->>SDK: WaitForServerControlRequest (parks on control pipe)
    Note over SDK: global budget reached
    SDK-->>App: ServerControlMessage(CancelSession)
    App->>App: IGracefulStopTestExecutionCapability.StopTestExecutionAsync()
    App->>SDK: final results + TestSessionEnd (data pipe)
    App-->>SDK: exit
```

- The SDK advertises a control-pipe name in its handshake reply. Its **presence is the capability signal** (no separate boolean), gated per-connection — an older SDK never advertises it, so the feature stays off.
- The test host opens a second `NamedPipeClient` and parks a long-poll `WaitForServerControlRequest`; the SDK completes it with a `ServerControlMessage`. This is a true server push, so it works even when the app is silent/hung — the crux for `--timeout`.
- On `CancelSession` the host stops **gracefully** via `IGracefulStopTestExecutionCapability` (the same path `--maximum-failed-tests` uses), so trx/logs/artifacts for anything that completed are still emitted. It falls back to hard token cancellation only when the running framework has no graceful-stop capability.
- The connect + long-poll run entirely on a background task, so test start is never blocked on the auxiliary channel. A dropped control pipe is treated as "host went away → cancel"; the new `NamedPipeClient.exitProcessOnConnectionLoss` flag keeps that from killing the host (the shared data-pipe behavior is unchanged). On exit the parked read is force-aborted (dispose-before-await), so shutdown can't hang — including on .NET Framework where cancelling an in-flight named-pipe read is unreliable.

## Protocol changes (mirror in dotnet/sdk in lockstep)
- `ProtocolConstants` bumped to add **1.4.0**.
- Handshake property `ServerControlPipeName = 12`.
- Serializers `WaitForServerControlRequest = 13`, `ServerControlMessage = 14` (`Kind` byte, `CancelSession = 1`). Note the RFC's "id 11 is next free" was stale — 11/12 are already `AzureDevOpsLogMessage`/`DisplayMessage`.
- The `ServerControlPipeName` doc spells out the SDK-side contract: accept one control connection per connecting process, and keep the pipe open until the data session ends (an early drop is read as cancel).

## Notes vs. the RFC
- The version-negotiation "latent bug" is already effectively fixed in the current tree (the SDK returns a single negotiated version and the host tracks per-connection capability), so it's out of scope here.
- The reaction is a **graceful stop**, not `CancellationTokenSource.Cancel()` as the RFC sketched, precisely so reporting survives.

## Tests
- Contract + round-trip unit tests for the two new serializers, plus id/property/version stability (`ProtocolTests`, `DotnetTestProtocolContractTests`).
- End-to-end acceptance tests (`DotnetTestPipeServerCancellationTests`): a graceful server-initiated cancel still reports a result + `TestSessionEnd` and exits cleanly; an SDK that doesn't advertise the pipe is a no-op.
- Extended the `FakeDotnetTestSdk` harness to stand up the control pipe and push `CancelSession`.

All 13 DotnetTestPipe acceptance tests, the protocol unit tests, and the contract tests pass; the strict `-pack` build is green.

An expert review pass was run and its findings addressed (background connect, force-abort-on-exit, protocol-contract docs) in the second commit.

⚠️ The protocol files are duplicated in dotnet/sdk — a matching PR must land there in coordination.