### PR TITLE
Abstract VSTest result reporting in PlatformServices (Phase 5 of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -17,11 +18,11 @@ internal partial class TestExecutionManager
         TestTools.UnitTesting.TestResult[] unitTestResults,
         DateTimeOffset startTime,
         DateTimeOffset endTime,
-        ITestExecutionRecorder testExecutionRecorder)
+        ITestResultRecorder testResultRecorder)
     {
         if (unitTestResults.Length == 0)
         {
-            testExecutionRecorder.RecordEnd(test, TestOutcome.None);
+            testResultRecorder.RecordEmptyResult(test);
             return;
         }
 
@@ -29,39 +30,14 @@ internal partial class TestExecutionManager
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
 
-            var testResult = unitTestResult.ToTestResult(
-                test,
-                startTime,
-                endTime,
-                _environment.MachineName,
-                MSTestSettings.CurrentSettings);
-
-            testExecutionRecorder.RecordEnd(test, testResult.Outcome);
-
-            if (testResult.Outcome == TestOutcome.Failed)
-            {
-                if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsInfoEnabled)
-                {
-                    PlatformServiceProvider.Instance.AdapterTraceLogger.Info("MSTestExecutor:Test {0} failed. ErrorMessage:{1}, ErrorStackTrace:{2}.", testResult.TestCase.FullyQualifiedName, testResult.ErrorMessage, testResult.ErrorStackTrace);
-                }
-
 #if !WINDOWS_UWP && !WIN_UI
+            if (testResultRecorder.RecordResult(test, unitTestResult, startTime, endTime))
+            {
                 _hasAnyTestFailed = true;
+            }
+#else
+            testResultRecorder.RecordResult(test, unitTestResult, startTime, endTime);
 #endif
-            }
-
-            try
-            {
-                if (testResult.Outcome != TestOutcome.NotFound
-                    || !RuntimeContext.IsHotReloadEnabled)
-                {
-                    testExecutionRecorder.RecordResult(testResult);
-                }
-            }
-            catch (TestCanceledException)
-            {
-                // Ignore this exception
-            }
         }
     }
 
@@ -95,6 +71,10 @@ internal partial class TestExecutionManager
             ? new RemotingMessageLogger(testExecutionRecorder)
             : testExecutionRecorder;
 
+        // Translate the VSTest recorder into the platform-agnostic result recorder a single time for this
+        // test set. This is the boundary at which VSTest result construction is applied.
+        ITestResultRecorder testResultRecorder = testExecutionRecorder.ToTestResultRecorder(_environment.MachineName, MSTestSettings.CurrentSettings);
+
         foreach (TestCase currentTest in orderedTests)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
@@ -105,7 +85,7 @@ internal partial class TestExecutionManager
 
             UnitTestElement unitTestElement = currentTest.ToUnitTestElementWithUpdatedSource(source);
 
-            testExecutionRecorder.RecordStart(currentTest);
+            testResultRecorder.RecordStart(currentTest);
 
             DateTimeOffset startTime = DateTimeOffset.Now;
 
@@ -143,7 +123,7 @@ internal partial class TestExecutionManager
 
             DateTimeOffset endTime = DateTimeOffset.Now;
 
-            SendTestResults(currentTest, unitTestResult, startTime, endTime, testExecutionRecorder);
+            SendTestResults(currentTest, unitTestResult, startTime, endTime, testResultRecorder);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
@@ -14,8 +14,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
 /// <remarks>
 /// This abstraction lets the platform services layer report test start/end and results without taking a
 /// dependency on a specific test platform's result object model (for example the VSTest <c>TestResult</c>,
-/// <c>TestOutcome</c> and attachment types). The mapping to a concrete host recorder (for example the
-/// VSTest <c>ITestExecutionRecorder</c>) is provided by the adapter layer.
+/// <c>TestOutcome</c> and attachment types). The concrete recorder is provided at the platform boundary by a
+/// wrapper over the host's result recorder (currently <c>TestResultRecorderExtensions</c>, which wraps the
+/// VSTest <c>ITestExecutionRecorder</c>), and is expected to move fully out of the platform services layer in
+/// a later phase.
 /// </remarks>
 internal interface ITestResultRecorder
 {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+/// <summary>
+/// Platform-agnostic sink for reporting the lifecycle and results of test execution to whichever
+/// test host is running the tests.
+/// </summary>
+/// <remarks>
+/// This abstraction lets the platform services layer report test start/end and results without taking a
+/// dependency on a specific test platform's result object model (for example the VSTest <c>TestResult</c>,
+/// <c>TestOutcome</c> and attachment types). The mapping to a concrete host recorder (for example the
+/// VSTest <c>ITestExecutionRecorder</c>) is provided by the adapter layer.
+/// </remarks>
+internal interface ITestResultRecorder
+{
+    /// <summary>
+    /// Signals that execution of the given test case has started.
+    /// </summary>
+    /// <param name="testCase">The test case whose execution is starting.</param>
+    void RecordStart(TestCase testCase);
+
+    /// <summary>
+    /// Signals that execution of the given test case ended without producing any result.
+    /// </summary>
+    /// <param name="testCase">The test case whose execution ended.</param>
+    void RecordEmptyResult(TestCase testCase);
+
+    /// <summary>
+    /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test case to the test host.
+    /// </summary>
+    /// <param name="testCase">The test case the result belongs to.</param>
+    /// <param name="unitTestResult">The framework result produced by executing the test.</param>
+    /// <param name="startTime">The time at which the test started executing.</param>
+    /// <param name="endTime">The time at which the test finished executing.</param>
+    /// <returns><see langword="true"/> if the result was reported as a failure; otherwise, <see langword="false"/>.</returns>
+    bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+/// <summary>
+/// Bridges a VSTest <see cref="ITestExecutionRecorder"/> to the platform-agnostic <see cref="ITestResultRecorder"/>.
+/// </summary>
+/// <remarks>
+/// This is the single translation point between the VSTest result object model (<c>TestResult</c>,
+/// <c>TestOutcome</c>, attachments, ...) and the platform services result-reporting abstraction. It is
+/// expected to move entirely into the adapter layer once the execution pipeline no longer flows VSTest
+/// recorders through the platform services.
+/// </remarks>
+internal static class TestResultRecorderExtensions
+{
+    /// <summary>
+    /// Wraps a VSTest <see cref="ITestExecutionRecorder"/> as an <see cref="ITestResultRecorder"/>.
+    /// </summary>
+    /// <param name="testExecutionRecorder">The host recorder to wrap.</param>
+    /// <param name="computerName">The computer name stamped on reported results.</param>
+    /// <param name="settings">The current MSTest settings used to map framework outcomes to host outcomes.</param>
+    /// <returns>A platform-agnostic recorder that forwards to <paramref name="testExecutionRecorder"/>.</returns>
+    public static ITestResultRecorder ToTestResultRecorder(this ITestExecutionRecorder testExecutionRecorder, string computerName, MSTestSettings settings)
+        => new HostTestResultRecorder(testExecutionRecorder, computerName, settings);
+
+    private sealed class HostTestResultRecorder : ITestResultRecorder
+    {
+        private readonly ITestExecutionRecorder _testExecutionRecorder;
+        private readonly string _computerName;
+        private readonly MSTestSettings _settings;
+
+        public HostTestResultRecorder(ITestExecutionRecorder testExecutionRecorder, string computerName, MSTestSettings settings)
+        {
+            _testExecutionRecorder = testExecutionRecorder;
+            _computerName = computerName;
+            _settings = settings;
+        }
+
+        public void RecordStart(TestCase testCase)
+            => _testExecutionRecorder.RecordStart(testCase);
+
+        public void RecordEmptyResult(TestCase testCase)
+            => _testExecutionRecorder.RecordEnd(testCase, TestOutcome.None);
+
+        public bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+        {
+            var testResult = unitTestResult.ToTestResult(testCase, startTime, endTime, _computerName, _settings);
+
+            _testExecutionRecorder.RecordEnd(testCase, testResult.Outcome);
+
+            bool isFailed = testResult.Outcome == TestOutcome.Failed;
+            if (isFailed && PlatformServiceProvider.Instance.AdapterTraceLogger.IsInfoEnabled)
+            {
+                PlatformServiceProvider.Instance.AdapterTraceLogger.Info("MSTestExecutor:Test {0} failed. ErrorMessage:{1}, ErrorStackTrace:{2}.", testResult.TestCase.FullyQualifiedName, testResult.ErrorMessage, testResult.ErrorStackTrace);
+            }
+
+            try
+            {
+                if (testResult.Outcome != TestOutcome.NotFound
+                    || !RuntimeContext.IsHotReloadEnabled)
+                {
+                    _testExecutionRecorder.RecordResult(testResult);
+                }
+            }
+            catch (TestCanceledException)
+            {
+                // Ignore this exception
+            }
+
+            // A failure is reported only once RecordResult has completed (a swallowed TestCanceledException
+            // still counts as completed). This mirrors the original inline flow where the failure was
+            // observed as part of reporting the result.
+            return isFailed;
+        }
+    }
+}

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -125,7 +125,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "PassingTest");
         Microsoft.VisualStudio.TestTools.UnitTesting.TestResult[] unitTestResults = [];
 
-        _testExecutionManager.SendTestResults(testCase, unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle);
+        _testExecutionManager.SendTestResults(testCase, unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
 
         _frameworkHandle.TestCaseEndList.Should().Equal("PassingTest:None");
         _frameworkHandle.ResultsList.Should().BeEmpty();


### PR DESCRIPTION
## Why

Part of the multi-PR effort to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.VisualStudio.TestPlatform.ObjectModel.*`). The VSTest coupling is being concentrated into small adapter-facing bridges so it can later be lifted entirely out of PlatformServices.

**Phase 5** targets the execution *result / output* path: the VSTest result-side types (`TestResult`, `TestOutcome`, `TestResultMessage`, `AttachmentSet`, `UriDataAttachment`) and the recorder role used to report results.

## What

- **New neutral abstraction** `ITestResultRecorder` (`Interfaces/ITestResultRecorder.cs`, namespace `…PlatformServices.Interface`): a functional, platform-agnostic sink with `RecordStart` / `RecordEmptyResult` / `RecordResult(TestCase, framework TestResult, start, end)`. It carries no VSTest result-type naming and reuses the framework `TestResult`.
- **Single VSTest translation point** `HostTestResultRecorder` behind `TestResultRecorderExtensions.ToTestResultRecorder(this ITestExecutionRecorder, computerName, settings)` (`Services/TestResultRecorderExtensions.cs`, namespace `…PlatformServices`). This bridge is the only place that builds a VSTest `TestResult`/`TestOutcome`, records attachments/messages, and calls the VSTest recorder — mirroring the Phase 1 `IAdapterMessageLogger` + `AdapterMessageLoggerExtensions` pattern.
- `Execution/TestExecutionManager.Runner.cs` now reports start/empty/result through `ITestResultRecorder`, so it no longer constructs any VSTest result-side type. The VSTest recorder is wrapped once at the boundary (inside `ExecuteTestsWithTestRunnerAsync`) to avoid touching Phase 1 files.
- `TestResultExtensions.ToTestResult` and `UnitTestOutcomeHelper.ToTestOutcome` are **unchanged** (still directly unit-tested) and are now invoked from the bridge.

## No behavior change

This is a pure refactor. The `UnitTestOutcome` → VSTest `TestOutcome` mapping and the assembled `TestResult` (messages, attachments, error info, timings) are byte-for-byte equivalent, and every branch of the original `SendTestResults` flow is preserved: empty-results → `RecordEnd(None)`; per result → `RecordEnd(mapped)`, trace on `Failed`, `_hasAnyTestFailed` (under `#if !WINDOWS_UWP && !WIN_UI`), and the guarded `RecordResult` inside `try/catch(TestCanceledException)` with the `NotFound` + hot-reload skip.

## Verification

- `build.cmd -c Debug` green across all TFMs (net462, net8.0, net9.0, UWP, WinUI); analyzers-as-errors clean.
- `MSTestAdapter.PlatformServices.UnitTests` (net8.0): 889 passed.
- `MSTestAdapter.UnitTests` (net8.0): 21 passed.
- `expert-reviewer` confirmed byte-for-byte equivalence of the refactored flow.

## Relationship to other PRs

Independent of and parallel to #9548 (Phase 1). The diff is disjoint from Phase 1's production files. One Phase-1 **test** file (`TestExecutionManagerTests.cs`) is touched by a single line — the direct `SendTestResults` call now wraps `_frameworkHandle.ToTestResultRecorder(...)`; this hunk is far from Phase 1's edits and should not conflict.
