### PR TITLE
Abstract VSTest test filtering in PlatformServices (Phase 2 of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -110,8 +110,8 @@ internal class UnitTestDiscoverer
 
     internal void SendTestCases(IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IAdapterMessageLogger logger)
     {
-        // Get filter expression and skip discovery in case filter expression has parsing error.
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, logger, out bool filterHasError);
+        // Get filter and skip discovery in case filter expression has parsing error.
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(discoveryContext, logger, out bool filterHasError);
         if (filterHasError)
         {
             return;
@@ -119,15 +119,13 @@ internal class UnitTestDiscoverer
 
         foreach (UnitTestElement testElement in testElements)
         {
-            var testCase = testElement.ToTestCase();
-
-            // Filter tests based on test case filters
-            if (filterExpression != null && !filterExpression.MatchTestCase(testCase, p => _testMethodFilter.PropertyValueProvider(testCase, p)))
+            // Filter tests based on test case filters.
+            if (filter is not null && !filter.Matches(testElement))
             {
                 continue;
             }
 
-            discoverySink.SendTestCase(testCase);
+            discoverySink.SendTestCase(testElement.ToTestCase());
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -73,7 +73,7 @@ internal partial class TestExecutionManager
         }
 
         // Default test set is filtered tests based on user provided filter criteria
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, adapterMessageLogger, out bool filterHasError);
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, adapterMessageLogger, out bool filterHasError);
         if (filterHasError)
         {
             // Bail out without processing everything else below.
@@ -113,7 +113,7 @@ internal partial class TestExecutionManager
 
         int parallelWorkers = sourceSettings.Workers;
         ExecutionScope parallelScope = sourceSettings.Scope;
-        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filterExpression, t, _testMethodFilter))];
+        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filter, t, source))];
         if (_testOrderRandom is { } sourceRandom)
         {
             Shuffle(sourceRandom, testsToRun);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -41,10 +41,10 @@ internal partial class TestExecutionManager
         }
     }
 
-    private static bool MatchTestFilter(ITestCaseFilterExpression? filterExpression, TestCase test, TestMethodFilter testMethodFilter)
+    private static bool MatchTestFilter(ITestElementFilter? filter, TestCase test, string source)
     {
-        if (filterExpression != null
-            && !filterExpression.MatchTestCase(test, p => testMethodFilter.PropertyValueProvider(test, p)))
+        if (filter is not null
+            && !filter.Matches(test.ToUnitTestElementWithUpdatedSource(source)))
         {
             // Skip test if not fitting filter criteria.
             return false;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilter.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+/// <summary>
+/// Platform-agnostic predicate that decides whether a discovered or executed <see cref="UnitTestElement"/>
+/// should be included in the current test run, based on the user-provided test-case filter.
+/// </summary>
+/// <remarks>
+/// This abstraction lets the platform services discovery and execution pipelines apply filtering over the
+/// neutral <see cref="UnitTestElement"/> model without taking a dependency on a specific test platform's
+/// filter object model (for example the VSTest <c>ITestCaseFilterExpression</c>, <c>TestProperty</c> and
+/// <c>IRunContext.GetTestCaseFilter</c> types). The concrete filter is produced at the platform boundary by a
+/// wrapper that parses the host's filter (currently <c>TestMethodFilter</c>, which wraps the VSTest filter
+/// expression), and is expected to move fully out of the platform services layer in a later phase.
+/// A <see langword="null"/> filter means "no filter" and every element is included.
+/// </remarks>
+internal interface ITestElementFilter
+{
+    /// <summary>
+    /// Determines whether the given <paramref name="testElement"/> matches the filter and should be included.
+    /// </summary>
+    /// <param name="testElement">The test element to evaluate.</param>
+    /// <returns><see langword="true"/> if the element matches the filter; otherwise, <see langword="false"/>.</returns>
+    bool Matches(UnitTestElement testElement);
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -55,6 +56,24 @@ internal sealed class TestMethodFilter
         }
 
         return filter;
+    }
+
+    /// <summary>
+    /// Builds a platform-agnostic <see cref="ITestElementFilter"/> for the properties supported by the adapter.
+    /// </summary>
+    /// <param name="context">The current context of the run.</param>
+    /// <param name="logger">Handler to report test messages/start/end and results.</param>
+    /// <param name="filterHasError">Indicates that the filter is unsupported/has an error.</param>
+    /// <returns>
+    /// A filter that evaluates <see cref="UnitTestElement"/> instances, or <see langword="null"/> when no
+    /// filter applies (in which case every element is included).
+    /// </returns>
+    internal ITestElementFilter? GetTestElementFilter(IDiscoveryContext? context, IAdapterMessageLogger logger, out bool filterHasError)
+    {
+        ITestCaseFilterExpression? filterExpression = GetFilterExpression(context, logger, out filterHasError);
+        return filterExpression is null
+            ? null
+            : new TestElementFilter(this, filterExpression);
     }
 
     /// <summary>
@@ -138,5 +157,28 @@ internal sealed class TestMethodFilter
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Platform-agnostic filter that evaluates a <see cref="UnitTestElement"/> against a VSTest
+    /// <see cref="ITestCaseFilterExpression"/>. This is the single point where the neutral element model is
+    /// translated to the VSTest test case in order to reuse the host's filter matching.
+    /// </summary>
+    private sealed class TestElementFilter : ITestElementFilter
+    {
+        private readonly TestMethodFilter _testMethodFilter;
+        private readonly ITestCaseFilterExpression _filterExpression;
+
+        public TestElementFilter(TestMethodFilter testMethodFilter, ITestCaseFilterExpression filterExpression)
+        {
+            _testMethodFilter = testMethodFilter;
+            _filterExpression = filterExpression;
+        }
+
+        public bool Matches(UnitTestElement testElement)
+        {
+            var testCase = testElement.ToTestCase();
+            return _filterExpression.MatchTestCase(testCase, propertyName => _testMethodFilter.PropertyValueProvider(testCase, propertyName));
+        }
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestCaseFilteringTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestCaseFilteringTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.MSTestV2.CLIAutomation;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
+namespace MSTest.IntegrationTests;
+
+/// <summary>
+/// Regression guard for the platform-agnostic filtering refactor (neutral <c>ITestElementFilter</c>).
+/// Filtering is now expressed over the neutral <c>UnitTestElement</c>: discovery matches
+/// <c>element.ToTestCase()</c>, and execution matches
+/// <c>incomingTestCase.ToUnitTestElementWithUpdatedSource(source).ToTestCase()</c>. These tests lock the
+/// end-to-end discover-then-run behavior for <c>FullyQualifiedName</c> and <c>Id</c> filters — the two
+/// properties most sensitive to the <c>TestCase</c> ↔ <c>UnitTestElement</c> round-trip that the refactor
+/// re-routes — so a future change cannot silently break <c>--filter</c>.
+/// </summary>
+[TestClass]
+public class TestCaseFilteringTests : CLITestBase
+{
+    private const string TestAsset = "DiscoverInternalsProject";
+
+    // A non-parameterized test with a stable, filter-safe fully qualified name (no filter operator chars).
+    private const string TargetDisplayName = "TopLevelInternalClass_TestMethod1";
+
+    [TestMethod]
+    public void FilterByFullyQualifiedNameSelectsExactlyTheMatchingTestDuringDiscovery()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        TestCase target = GetTargetTestCase(assemblyPath);
+
+        ImmutableArray<TestCase> filtered = DiscoverTests(assemblyPath, $"FullyQualifiedName={target.FullyQualifiedName}");
+
+        Assert.HasCount(1, filtered);
+        Assert.AreEqual(target.FullyQualifiedName, filtered[0].FullyQualifiedName);
+        Assert.AreEqual(target.Id, filtered[0].Id);
+    }
+
+    [TestMethod]
+    public void FilterByIdSelectsExactlyTheMatchingTestDuringDiscovery()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        TestCase target = GetTargetTestCase(assemblyPath);
+
+        ImmutableArray<TestCase> filtered = DiscoverTests(assemblyPath, $"Id={target.Id}");
+
+        Assert.HasCount(1, filtered);
+        Assert.AreEqual(target.FullyQualifiedName, filtered[0].FullyQualifiedName);
+        Assert.AreEqual(target.Id, filtered[0].Id);
+    }
+
+    [TestMethod]
+    public async Task FilterByFullyQualifiedNameSelectsExactlyTheMatchingTestDuringExecution()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        ImmutableArray<TestCase> allTests = DiscoverTests(assemblyPath);
+        TestCase target = allTests.First(t => t.DisplayName == TargetDisplayName);
+
+        SimulateCrossProcessTestCases(allTests);
+
+        ImmutableArray<TestResult> results = await RunTestsAsync(allTests, $"FullyQualifiedName={target.FullyQualifiedName}");
+
+        // HasCount(1) is the load-bearing assertion: it fails if the filter is ignored (all tests run) or if
+        // the FQN no longer matches after reconstruction (no test runs). The outcome check proves the target
+        // was actually executed via the reconstructed element, not merely selected.
+        Assert.HasCount(1, results);
+        Assert.AreEqual(target.FullyQualifiedName, results[0].TestCase.FullyQualifiedName);
+        Assert.AreEqual(TestOutcome.Passed, results[0].Outcome);
+    }
+
+    [TestMethod]
+    public async Task FilterByIdSelectsExactlyTheMatchingTestDuringExecution()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        ImmutableArray<TestCase> allTests = DiscoverTests(assemblyPath);
+        Guid targetId = allTests.First(t => t.DisplayName == TargetDisplayName).Id;
+
+        SimulateCrossProcessTestCases(allTests);
+
+        ImmutableArray<TestResult> results = await RunTestsAsync(allTests, $"Id={targetId}");
+
+        // HasCount(1) is the load-bearing assertion: filtering by Id after the TestCase -> UnitTestElement ->
+        // TestCase reconstruction must still recompute the same Id and select exactly the target. The outcome
+        // check proves the target was actually executed via the reconstructed element.
+        Assert.HasCount(1, results);
+        Assert.AreEqual(targetId, results[0].TestCase.Id);
+        Assert.AreEqual(TestOutcome.Passed, results[0].Outcome);
+    }
+
+    private static TestCase GetTargetTestCase(string assemblyPath)
+        => DiscoverTests(assemblyPath).First(t => t.DisplayName == TargetDisplayName);
+
+    // Clears LocalExtensionData so the execution pipeline rebuilds the UnitTestElement (and its regenerated
+    // TestCase/Id) from the test-case properties, mirroring the out-of-proc VSTest path where deserialized
+    // test cases carry no LocalExtensionData. This is the round-trip the filtering refactor must preserve.
+    private static void SimulateCrossProcessTestCases(ImmutableArray<TestCase> testCases)
+    {
+        foreach (TestCase testCase in testCases)
+        {
+            testCase.LocalExtensionData = null;
+        }
+    }
+}

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -41,6 +41,18 @@ public abstract partial class CLITestBase
         return frameworkHandle.GetFlattenedTestResults();
     }
 
+    internal static async Task<ImmutableArray<TestResult>> RunTestsAsync(IEnumerable<TestCase> testCases, string? testCaseFilter)
+    {
+        var testExecutionManager = new TestExecutionManager();
+        var frameworkHandle = new InternalFrameworkHandle();
+
+        string runSettingsXml = GetRunSettingsXml(string.Empty);
+        var runContext = new InternalRunContext(runSettingsXml, testCaseFilter);
+
+        await testExecutionManager.ExecuteTestsAsync(testCases, runContext, frameworkHandle, false);
+        return frameworkHandle.GetFlattenedTestResults();
+    }
+
     #region Helper classes
     private class InternalLogger : IMessageLogger
     {
@@ -73,15 +85,46 @@ public abstract partial class CLITestBase
         public IRunSettings? RunSettings { get; }
 
         public ITestCaseFilterExpression? GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider) => _filter;
+    }
 
-        private class InternalRunSettings : IRunSettings
+    private sealed class InternalRunContext : IRunContext
+    {
+        private readonly ITestCaseFilterExpression? _filter;
+
+        public InternalRunContext(string runSettings, string? testCaseFilter)
         {
-            public InternalRunSettings(string runSettings) => SettingsXml = runSettings;
+            RunSettings = new InternalRunSettings(runSettings);
 
-            public string SettingsXml { get; }
-
-            public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
+            if (testCaseFilter != null)
+            {
+                _filter = TestCaseFilterFactory.ParseTestFilter(testCaseFilter);
+            }
         }
+
+        public IRunSettings? RunSettings { get; }
+
+        public bool KeepAlive => false;
+
+        public bool InIsolation => false;
+
+        public bool IsDataCollectionEnabled => false;
+
+        public bool IsBeingDebugged => false;
+
+        public string? TestRunDirectory => null;
+
+        public string? SolutionDirectory => null;
+
+        public ITestCaseFilterExpression? GetTestCaseFilter(IEnumerable<string>? supportedProperties, Func<string, TestProperty?> propertyProvider) => _filter;
+    }
+
+    private sealed class InternalRunSettings : IRunSettings
+    {
+        public InternalRunSettings(string runSettings) => SettingsXml = runSettings;
+
+        public string SettingsXml { get; }
+
+        public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
     }
 
     private sealed class InternalFrameworkHandle : IFrameworkHandle

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
@@ -4,7 +4,9 @@
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -160,6 +162,55 @@ public class TestMethodFilterTests : TestContainer
         recorder.TestMessageLevel.Should().Be(TestMessageLevel.Error);
     }
 
+    public void GetTestElementFilterForNullContextReturnsNull()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(null, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeFalse();
+    }
+
+    public void GetTestElementFilterForContextWithoutFilterReturnsNull()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        TestableDiscoveryContextWithoutGetTestCaseFilter discoveryContext = new();
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(discoveryContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeFalse();
+    }
+
+    public void GetTestElementFilterMatchesElementsUsingUnderlyingFilterExpression()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        MatchingTestCaseFilterExpression matchingFilterExpression = new(testCase => testCase.DisplayName == "M1");
+        TestableRunContext runContext = new(() => matchingFilterExpression);
+
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().NotBeNull();
+        filterHasError.Should().BeFalse();
+
+        var matching = new UnitTestElement(new TestMethod("M1", "C", "A", displayName: "M1"));
+        var nonMatching = new UnitTestElement(new TestMethod("M2", "C", "A", displayName: "M2"));
+
+        filter!.Matches(matching).Should().BeTrue();
+        filter.Matches(nonMatching).Should().BeFalse();
+    }
+
+    public void GetTestElementFilterForFilterErrorReturnsNullWithFilterHasErrorTrue()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        TestableRunContext runContext = new(() => throw new TestPlatformFormatException("DummyException"));
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeTrue();
+        recorder.Message.Should().Be("DummyException");
+        recorder.TestMessageLevel.Should().Be(TestMessageLevel.Error);
+    }
+
     [DummyTestClass]
     internal class DummyTestClassWithTestMethods
     {
@@ -230,6 +281,17 @@ public class TestMethodFilterTests : TestContainer
         public string TestCaseFilterValue => null!;
 
         public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => throw new NotImplementedException();
+    }
+
+    private sealed class MatchingTestCaseFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly Func<TestCase, bool> _matchTestCase;
+
+        public MatchingTestCaseFilterExpression(Func<TestCase, bool> matchTestCase) => _matchTestCase = matchTestCase;
+
+        public string TestCaseFilterValue => null!;
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => _matchTestCase(testCase);
     }
 
     private class DummyTestClassAttribute : TestClassAttribute;


### PR DESCRIPTION
## Why

Part of the multi-PR effort to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.TestPlatform.ObjectModel`). This is **Phase 2: test filtering**.

Today the PlatformServices discovery and execution pipelines filter tests using the VSTest filter object model directly: `ITestCaseFilterExpression`, `TestProperty`, `IRunContext.GetTestCaseFilter`, and `ITestCaseFilterExpression.MatchTestCase`. This phase decouples the filtering **consumers** from those types so filtering is expressed as a neutral predicate over the neutral `UnitTestElement` model.

## What

- **New neutral abstraction** `ITestElementFilter { bool Matches(UnitTestElement testElement); }` in `Interfaces/ITestElementFilter.cs` (namespace `…PlatformServices.Interface`). A `null` filter means "no filter" → every element is included. The name is deliberately functional and carries no VSTest/TestCase/ObjectModel naming.
- **`TestMethodFilter` stays as the single VSTest translation bridge** (mirroring how Phase 1/5 left their `AdapterMessageLoggerExtensions` / `TestResultRecorderExtensions` bridges in PlatformServices). It gains `GetTestElementFilter(IDiscoveryContext?, IAdapterMessageLogger, out bool filterHasError)`, which parses the VSTest filter exactly as before via the existing `GetFilterExpression` and wraps the result in a private `TestElementFilter : ITestElementFilter`. That wrapper is the lone place that translates the neutral element to a VSTest `TestCase` (`element.ToTestCase()`) and reuses `ITestCaseFilterExpression.MatchTestCase` + `PropertyValueProvider`.
- **Consumers routed through the neutral filter**:
  - Discovery: `UnitTestDiscoverer.SendTestCases` now uses `ITestElementFilter?` + `filter.Matches(element)`.
  - Execution: `TestExecutionManager.MatchTestFilter` / `ExecuteTestsInSourceAsync` now use `ITestElementFilter?` + `filter.Matches(test.ToUnitTestElementWithUpdatedSource(source))`.
  Neither consumer references `ITestCaseFilterExpression` / `MatchTestCase` / `TestProperty` anymore.
- Unit tests added in `TestMethodFilterTests.cs` for the new wrapper (null context, no-filter context, match/non-match, parse-error → `filterHasError`).

## No behavior change

Pure refactor. The supported-property set, the discovery-context vs run-context code paths, the parse-error handling, and the `filterHasError` bail-out semantics are preserved exactly:
- Discovery still enumerates the assembly and logs warnings **before** bailing on a filter parse error.
- Execution still early-bails **before** creating the isolation `UnitTestRunner`.

**One transparent nuance** (surfaced during review): in the out-of-proc VSTest path, execution now evaluates the filter against `TestCase → UnitTestElement → TestCase`, i.e. the *same* reconstruction that produces the executed element, instead of the raw incoming `TestCase`. For every test discovered by this adapter the round-trip is identical for all supported filter properties (`FullyQualifiedName`, `DisplayName`, `Id`, `TestCategory`, `Priority`, `ClassName`, traits), so results are unchanged in practice — the only theoretical divergence would be a foreign/older-hash `Id` or a non-standard fully-qualified name, which the same-adapter discover→execute flow does not produce. Reusing `ToTestCase()` as the single translation point was pre-approved, and the behavior is now locked by the out-of-proc `--filter` regression guard described under Verification.

## Remaining work (future phase)

- Physically move `TestMethodFilter` (the VSTest parser) up into the adapter layer (`MSTest.TestAdapter`), building the filter at the adapter boundary and passing `ITestElementFilter?` into the PlatformServices entry points. That was intentionally deferred here because preserving the *different* per-side `filterHasError` semantics byte-for-byte would require threading a nullable filter + error flag through many discovery/execution signatures — an awkward change for a transitional step.
- Let the filter operate on `UnitTestElement` end-to-end to avoid the transitional double `ToTestCase()` conversion in filtered discovery.

## Verification

- `.\build.cmd -c Debug` — green across all TFMs (net462, net8.0, net9.0, UWP, WinUI), 0 warnings / 0 errors.
- `MSTestAdapter.PlatformServices.UnitTests` (net8.0): 893 passed.
- `MSTestAdapter.UnitTests` (net8.0): 21 passed.
- **Out-of-proc `--filter` regression guard added** — new `MSTest.IntegrationTests/TestCaseFilteringTests` discovers then runs the `DiscoverInternalsProject` asset and asserts that filtering by both `FullyQualifiedName` and `Id` selects exactly the target test, in **discovery and execution**. The execution tests clear `TestCase.LocalExtensionData` to force the out-of-proc `TestCase → UnitTestElement → TestCase` reconstruction path this PR re-routes, so a future change cannot silently break `--filter`. All 4 pass; full `MSTest.IntegrationTests` suite green (47 passed, 1 pre-existing skip).
- Ran the `expert-reviewer` agent on both the refactor and the regression guard; no blocking/major findings.

## ⚠️ Stacked PR

This is a **stacked PR** on top of:
- #9548 — Phase 1 (message-logging abstraction)
- #9550 — Phase 5 (result-recorder abstraction)

Its base branch is `dev/amauryleve/vstest-decoupling-base`, an integration branch that combines #9548 + #9550 (filtering touches `TestMethodFilter.cs` from Phase 1 and `TestExecutionManager.Runner.cs` from Phase 5). Until those merge, this PR's diff will include their changes. **Please review/merge this after #9548 and #9550.**

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>