### PR TITLE
Bump BannedApiAnalyzers/PublicApiAnalyzers to 5.6.0 (fixes #9560 build)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,11 +22,11 @@
     <MicrosoftCodeAnalysisVersion>3.11.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionForTests>4.10.0</MicrosoftCodeAnalysisVersionForTests>
     <MicrosoftCodeAnalysisVersionForSourceGen>4.8.0</MicrosoftCodeAnalysisVersionForSourceGen>
-    <!-- Microsoft.CodeAnalysis.PublicApiAnalyzers / .BannedApiAnalyzers pinned to a daily build (5.5.x).
-         The last stable release (3.3.4, 2022) lacks newer RS0017/RS0026/RS0036 fixes that testfx's
-         public-API surface tracking depends on. Promote back to the next stable 5.x once one ships.
+    <!-- Microsoft.CodeAnalysis.PublicApiAnalyzers / .BannedApiAnalyzers.
+         Kept on a 5.x release for the RS0017/RS0026/RS0036 fixes that testfx's public-API
+         surface tracking depends on (the old 3.3.4 stable from 2022 lacks them).
          Tracking context: https://github.com/microsoft/testfx/issues/9091 (Task 5). -->
-    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.5.0-2.26224.1</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.6.0</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- UWP and WinUI dependencies -->
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.14</MicrosoftNETCoreUniversalWindowsPlatformVersion>

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Shipped.txt
@@ -78,12 +78,12 @@ Microsoft.Testing.Platform.Builder.ITestApplication.RunAsync() -> System.Threadi
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.BuildAsync() -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Builder.ITestApplication!>!
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.CommandLine.get -> Microsoft.Testing.Platform.CommandLine.ICommandLineManager!
-Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.Configuration.get -> Microsoft.Testing.Platform.Configurations.IConfigurationManager!
-Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.Logging.get -> Microsoft.Testing.Platform.Logging.ILoggingManager!
+[TPEXP]Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.Configuration.get -> Microsoft.Testing.Platform.Configurations.IConfigurationManager!
+[TPEXP]Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.Logging.get -> Microsoft.Testing.Platform.Logging.ILoggingManager!
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.RegisterTestFramework(System.Func<System.IServiceProvider!, Microsoft.Testing.Platform.Capabilities.TestFramework.ITestFrameworkCapabilities!>! capabilitiesFactory, System.Func<Microsoft.Testing.Platform.Capabilities.TestFramework.ITestFrameworkCapabilities!, System.IServiceProvider!, Microsoft.Testing.Platform.Extensions.TestFramework.ITestFramework!>! frameworkFactory) -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.TestHost.get -> Microsoft.Testing.Platform.TestHost.ITestHostManager!
 Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.TestHostControllers.get -> Microsoft.Testing.Platform.TestHostControllers.ITestHostControllersManager!
-Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.TestHostOrchestrator.get -> Microsoft.Testing.Platform.TestHostOrchestrator.ITestHostOrchestratorManager!
+[TPEXP]Microsoft.Testing.Platform.Builder.ITestApplicationBuilder.TestHostOrchestrator.get -> Microsoft.Testing.Platform.TestHostOrchestrator.ITestHostOrchestratorManager!
 Microsoft.Testing.Platform.Builder.TestApplication
 Microsoft.Testing.Platform.Builder.TestApplication.Dispose() -> void
 Microsoft.Testing.Platform.Builder.TestApplication.RunAsync() -> System.Threading.Tasks.Task<int>!

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
@@ -55,7 +55,7 @@ internal sealed class ServerControlMessageSerializer : NamedPipeSerializer<Serve
 
     protected override void SerializeCore(ServerControlMessage objectToSerialize, Stream stream)
     {
-        RoslynDebug.Assert(stream.CanSeek, "We expect a seekable stream.");
+        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
 
         // Kind is always written (it is a non-nullable byte).
         WriteUShort(stream, 1);

--- a/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/TestFramework/TestFramework.Extensions/PublicAPI/PublicAPI.Shipped.txt
@@ -20,7 +20,7 @@ Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestDisplayName.set -> 
 Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestException.get -> System.Exception?
 Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestException.set -> void
 Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.TestRunCount.get -> int
-static Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Current.get -> Microsoft.VisualStudio.TestTools.UnitTesting.TestContext?
+[MSTESTEXP]static Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.Current.get -> Microsoft.VisualStudio.TestTools.UnitTesting.TestContext?
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CancellationTokenSource.get -> System.Threading.CancellationTokenSource!
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CancellationTokenSource.set -> void
 virtual Microsoft.VisualStudio.TestTools.UnitTesting.TestContext.CurrentTestOutcome.get -> Microsoft.VisualStudio.TestTools.UnitTesting.UnitTestOutcome


### PR DESCRIPTION
Supersedes the dependabot bump in #9560, which failed to build on all platforms.

## Problem

#9560 promotes `Microsoft.CodeAnalysis.PublicApiAnalyzers` / `.BannedApiAnalyzers` from the pinned daily build `5.5.0-2.26224.1` to stable `5.6.0` (the version variable is shared, so both analyzers move together). The build then fails with `RS0016`/`RS0017` on four members:

- `TestContext.Current` (`[Experimental("MSTESTEXP")]`)
- `ITestApplicationBuilder.Configuration` / `.Logging` / `.TestHostOrchestrator` (`[Experimental("TPEXP")]`)

`5.6.0` now correctly requires the experimental-diagnostic prefix (`[TPEXP]` / `[MSTESTEXP]`) on the **getters** of `[Experimental]` members in the `PublicAPI.*.txt` files. The previous daily build did not, so the entries were unprefixed.

## Fix

- Prefix the four affected shipped `PublicAPI.Shipped.txt` entries with `[TPEXP]` / `[MSTESTEXP]` to match the analyzer's expected public-API name.
- Apply the `5.6.0` version bump and refresh the now-stale pinning comment.

Full `build.cmd` (Debug) passes with 0 warnings / 0 errors.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>