### PR TITLE
Abstract VSTest test filtering in PlatformServices (Phase 2 of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -110,8 +110,8 @@ internal class UnitTestDiscoverer
 
     internal void SendTestCases(IEnumerable<UnitTestElement> testElements, ITestCaseDiscoverySink discoverySink, IDiscoveryContext? discoveryContext, IAdapterMessageLogger logger)
     {
-        // Get filter expression and skip discovery in case filter expression has parsing error.
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(discoveryContext, logger, out bool filterHasError);
+        // Get filter and skip discovery in case filter expression has parsing error.
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(discoveryContext, logger, out bool filterHasError);
         if (filterHasError)
         {
             return;
@@ -119,15 +119,13 @@ internal class UnitTestDiscoverer
 
         foreach (UnitTestElement testElement in testElements)
         {
-            var testCase = testElement.ToTestCase();
-
-            // Filter tests based on test case filters
-            if (filterExpression != null && !filterExpression.MatchTestCase(testCase, p => _testMethodFilter.PropertyValueProvider(testCase, p)))
+            // Filter tests based on test case filters.
+            if (filter is not null && !filter.Matches(testElement))
             {
                 continue;
             }
 
-            discoverySink.SendTestCase(testCase);
+            discoverySink.SendTestCase(testElement.ToTestCase());
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -113,13 +113,19 @@ internal partial class TestExecutionManager
 
         int parallelWorkers = sourceSettings.Workers;
         ExecutionScope parallelScope = sourceSettings.Scope;
-        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filter, t, source))];
+        // Convert each test to its UnitTestElement exactly once and carry the pair through filtering and
+        // shuffling, so the surviving tests aren't converted a second time when building unitTestElements below.
+        (TestCase TestCase, UnitTestElement Element)[] testsToRunPairs =
+            [.. tests
+                .Select(test => (TestCase: test, Element: test.ToUnitTestElementWithUpdatedSource(source)))
+                .Where(pair => MatchTestFilter(filter, pair.Element))];
         if (_testOrderRandom is { } sourceRandom)
         {
-            Shuffle(sourceRandom, testsToRun);
+            Shuffle(sourceRandom, testsToRunPairs);
         }
 
-        UnitTestElement[] unitTestElements = [.. testsToRun.Select(e => e.ToUnitTestElementWithUpdatedSource(source))];
+        TestCase[] testsToRun = [.. testsToRunPairs.Select(pair => pair.TestCase)];
+        UnitTestElement[] unitTestElements = [.. testsToRunPairs.Select(pair => pair.Element)];
         // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain
         var testRunner = (UnitTestRunner)isolationHost.CreateInstanceForType(
             typeof(UnitTestRunner),

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -73,7 +73,7 @@ internal partial class TestExecutionManager
         }
 
         // Default test set is filtered tests based on user provided filter criteria
-        ITestCaseFilterExpression? filterExpression = _testMethodFilter.GetFilterExpression(runContext, adapterMessageLogger, out bool filterHasError);
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, adapterMessageLogger, out bool filterHasError);
         if (filterHasError)
         {
             // Bail out without processing everything else below.
@@ -113,7 +113,7 @@ internal partial class TestExecutionManager
 
         int parallelWorkers = sourceSettings.Workers;
         ExecutionScope parallelScope = sourceSettings.Scope;
-        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filterExpression, t, _testMethodFilter))];
+        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filter, t, source))];
         if (_testOrderRandom is { } sourceRandom)
         {
             Shuffle(sourceRandom, testsToRun);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -41,17 +41,11 @@ internal partial class TestExecutionManager
         }
     }
 
-    private static bool MatchTestFilter(ITestElementFilter? filter, TestCase test, string source)
-    {
-        if (filter is not null
-            && !filter.Matches(test.ToUnitTestElementWithUpdatedSource(source)))
-        {
-            // Skip test if not fitting filter criteria.
-            return false;
-        }
-
-        return true;
-    }
+    // Takes the already-converted UnitTestElement (rather than reconstructing one from the TestCase) so the
+    // caller can convert each test exactly once and reuse that element both for filtering and downstream.
+    private static bool MatchTestFilter(ITestElementFilter? filter, UnitTestElement testElement)
+        // Keep the test when there is no filter or when the element satisfies the filter criteria.
+        => filter is null || filter.Matches(testElement);
 
     private async Task ExecuteTestsWithTestRunnerAsync(
         IEnumerable<TestCase> tests,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -41,10 +41,10 @@ internal partial class TestExecutionManager
         }
     }
 
-    private static bool MatchTestFilter(ITestCaseFilterExpression? filterExpression, TestCase test, TestMethodFilter testMethodFilter)
+    private static bool MatchTestFilter(ITestElementFilter? filter, TestCase test, string source)
     {
-        if (filterExpression != null
-            && !filterExpression.MatchTestCase(test, p => testMethodFilter.PropertyValueProvider(test, p)))
+        if (filter is not null
+            && !filter.Matches(test.ToUnitTestElementWithUpdatedSource(source)))
         {
             // Skip test if not fitting filter criteria.
             return false;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilter.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+/// <summary>
+/// Platform-agnostic predicate that decides whether a discovered or executed <see cref="UnitTestElement"/>
+/// should be included in the current test run, based on the user-provided test-case filter.
+/// </summary>
+/// <remarks>
+/// This abstraction lets the platform services discovery and execution pipelines apply filtering over the
+/// neutral <see cref="UnitTestElement"/> model without taking a dependency on a specific test platform's
+/// filter object model (for example the VSTest <c>ITestCaseFilterExpression</c>, <c>TestProperty</c> and
+/// <c>IRunContext.GetTestCaseFilter</c> types). The concrete filter is produced at the platform boundary by a
+/// wrapper that parses the host's filter (currently <c>TestMethodFilter</c>, which wraps the VSTest filter
+/// expression), and is expected to move fully out of the platform services layer in a later phase.
+/// A <see langword="null"/> filter means "no filter" and every element is included.
+/// </remarks>
+internal interface ITestElementFilter
+{
+    /// <summary>
+    /// Determines whether the given <paramref name="testElement"/> matches the filter and should be included.
+    /// </summary>
+    /// <param name="testElement">The test element to evaluate.</param>
+    /// <returns><see langword="true"/> if the element matches the filter; otherwise, <see langword="false"/>.</returns>
+    bool Matches(UnitTestElement testElement);
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -55,6 +56,24 @@ internal sealed class TestMethodFilter
         }
 
         return filter;
+    }
+
+    /// <summary>
+    /// Builds a platform-agnostic <see cref="ITestElementFilter"/> for the properties supported by the adapter.
+    /// </summary>
+    /// <param name="context">The current context of the run.</param>
+    /// <param name="logger">Handler to report test messages/start/end and results.</param>
+    /// <param name="filterHasError">Indicates that the filter is unsupported/has an error.</param>
+    /// <returns>
+    /// A filter that evaluates <see cref="UnitTestElement"/> instances, or <see langword="null"/> when no
+    /// filter applies (in which case every element is included).
+    /// </returns>
+    internal ITestElementFilter? GetTestElementFilter(IDiscoveryContext? context, IAdapterMessageLogger logger, out bool filterHasError)
+    {
+        ITestCaseFilterExpression? filterExpression = GetFilterExpression(context, logger, out filterHasError);
+        return filterExpression is null
+            ? null
+            : new TestElementFilter(this, filterExpression);
     }
 
     /// <summary>
@@ -138,5 +157,28 @@ internal sealed class TestMethodFilter
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Platform-agnostic filter that evaluates a <see cref="UnitTestElement"/> against a VSTest
+    /// <see cref="ITestCaseFilterExpression"/>. This is the single point where the neutral element model is
+    /// translated to the VSTest test case in order to reuse the host's filter matching.
+    /// </summary>
+    private sealed class TestElementFilter : ITestElementFilter
+    {
+        private readonly TestMethodFilter _testMethodFilter;
+        private readonly ITestCaseFilterExpression _filterExpression;
+
+        public TestElementFilter(TestMethodFilter testMethodFilter, ITestCaseFilterExpression filterExpression)
+        {
+            _testMethodFilter = testMethodFilter;
+            _filterExpression = filterExpression;
+        }
+
+        public bool Matches(UnitTestElement testElement)
+        {
+            var testCase = testElement.ToTestCase();
+            return _filterExpression.MatchTestCase(testCase, propertyName => _testMethodFilter.PropertyValueProvider(testCase, propertyName));
+        }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/TestMethodFilter.cs
@@ -31,7 +31,7 @@ internal sealed class TestMethodFilter
     /// Returns ITestCaseFilterExpression for TestProperties supported by adapter.
     /// </summary>
     /// <param name="context">The current context of the run.</param>
-    /// <param name="logger">Handler to report test messages/start/end and results.</param>
+    /// <param name="logger">Logger used to report diagnostic messages (for example, filter parse errors).</param>
     /// <param name="filterHasError">Indicates that the filter is unsupported/has an error.</param>
     /// <returns>A filter expression.</returns>
     internal ITestCaseFilterExpression? GetFilterExpression(IDiscoveryContext? context, IAdapterMessageLogger logger, out bool filterHasError)
@@ -62,7 +62,7 @@ internal sealed class TestMethodFilter
     /// Builds a platform-agnostic <see cref="ITestElementFilter"/> for the properties supported by the adapter.
     /// </summary>
     /// <param name="context">The current context of the run.</param>
-    /// <param name="logger">Handler to report test messages/start/end and results.</param>
+    /// <param name="logger">Logger used to report diagnostic messages (for example, filter parse errors).</param>
     /// <param name="filterHasError">Indicates that the filter is unsupported/has an error.</param>
     /// <returns>
     /// A filter that evaluates <see cref="UnitTestElement"/> instances, or <see langword="null"/> when no

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/ServerControlMessageSerializer.cs
@@ -55,7 +55,7 @@ internal sealed class ServerControlMessageSerializer : NamedPipeSerializer<Serve
 
     protected override void SerializeCore(ServerControlMessage objectToSerialize, Stream stream)
     {
-        RoslynDebug.Assert(stream.CanSeek, "We expect a seekable stream.");
+        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
 
         // Kind is always written (it is a non-nullable byte).
         WriteUShort(stream, 1);

--- a/test/IntegrationTests/MSTest.IntegrationTests/TestCaseFilteringTests.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/TestCaseFilteringTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.MSTestV2.CLIAutomation;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using TestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
+namespace MSTest.IntegrationTests;
+
+/// <summary>
+/// Regression guard for the platform-agnostic filtering refactor (neutral <c>ITestElementFilter</c>).
+/// Filtering is now expressed over the neutral <c>UnitTestElement</c>: discovery matches
+/// <c>element.ToTestCase()</c>, and execution matches
+/// <c>incomingTestCase.ToUnitTestElementWithUpdatedSource(source).ToTestCase()</c>. These tests lock the
+/// end-to-end discover-then-run behavior for <c>FullyQualifiedName</c> and <c>Id</c> filters — the two
+/// properties most sensitive to the <c>TestCase</c> ↔ <c>UnitTestElement</c> round-trip that the refactor
+/// re-routes — so a future change cannot silently break <c>--filter</c>.
+/// </summary>
+[TestClass]
+public class TestCaseFilteringTests : CLITestBase
+{
+    private const string TestAsset = "DiscoverInternalsProject";
+
+    // A non-parameterized test with a stable, filter-safe fully qualified name (no filter operator chars).
+    private const string TargetDisplayName = "TopLevelInternalClass_TestMethod1";
+
+    [TestMethod]
+    public void FilterByFullyQualifiedNameSelectsExactlyTheMatchingTestDuringDiscovery()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        TestCase target = GetTargetTestCase(assemblyPath);
+
+        ImmutableArray<TestCase> filtered = DiscoverTests(assemblyPath, $"FullyQualifiedName={target.FullyQualifiedName}");
+
+        Assert.HasCount(1, filtered);
+        Assert.AreEqual(target.FullyQualifiedName, filtered[0].FullyQualifiedName);
+        Assert.AreEqual(target.Id, filtered[0].Id);
+    }
+
+    [TestMethod]
+    public void FilterByIdSelectsExactlyTheMatchingTestDuringDiscovery()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        TestCase target = GetTargetTestCase(assemblyPath);
+
+        ImmutableArray<TestCase> filtered = DiscoverTests(assemblyPath, $"Id={target.Id}");
+
+        Assert.HasCount(1, filtered);
+        Assert.AreEqual(target.FullyQualifiedName, filtered[0].FullyQualifiedName);
+        Assert.AreEqual(target.Id, filtered[0].Id);
+    }
+
+    [TestMethod]
+    public async Task FilterByFullyQualifiedNameSelectsExactlyTheMatchingTestDuringExecution()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        ImmutableArray<TestCase> allTests = DiscoverTests(assemblyPath);
+        TestCase target = allTests.First(t => t.DisplayName == TargetDisplayName);
+
+        SimulateCrossProcessTestCases(allTests);
+
+        ImmutableArray<TestResult> results = await RunTestsAsync(allTests, $"FullyQualifiedName={target.FullyQualifiedName}");
+
+        // HasCount(1) is the load-bearing assertion: it fails if the filter is ignored (all tests run) or if
+        // the FQN no longer matches after reconstruction (no test runs). The outcome check proves the target
+        // was actually executed via the reconstructed element, not merely selected.
+        Assert.HasCount(1, results);
+        Assert.AreEqual(target.FullyQualifiedName, results[0].TestCase.FullyQualifiedName);
+        Assert.AreEqual(TestOutcome.Passed, results[0].Outcome);
+    }
+
+    [TestMethod]
+    public async Task FilterByIdSelectsExactlyTheMatchingTestDuringExecution()
+    {
+        string assemblyPath = GetAssetFullPath(TestAsset);
+        ImmutableArray<TestCase> allTests = DiscoverTests(assemblyPath);
+        Guid targetId = allTests.First(t => t.DisplayName == TargetDisplayName).Id;
+
+        SimulateCrossProcessTestCases(allTests);
+
+        ImmutableArray<TestResult> results = await RunTestsAsync(allTests, $"Id={targetId}");
+
+        // HasCount(1) is the load-bearing assertion: filtering by Id after the TestCase -> UnitTestElement ->
+        // TestCase reconstruction must still recompute the same Id and select exactly the target. The outcome
+        // check proves the target was actually executed via the reconstructed element.
+        Assert.HasCount(1, results);
+        Assert.AreEqual(targetId, results[0].TestCase.Id);
+        Assert.AreEqual(TestOutcome.Passed, results[0].Outcome);
+    }
+
+    private static TestCase GetTargetTestCase(string assemblyPath)
+        => DiscoverTests(assemblyPath).First(t => t.DisplayName == TargetDisplayName);
+
+    // Clears LocalExtensionData so the execution pipeline rebuilds the UnitTestElement (and its regenerated
+    // TestCase/Id) from the test-case properties, mirroring the out-of-proc VSTest path where deserialized
+    // test cases carry no LocalExtensionData. This is the round-trip the filtering refactor must preserve.
+    private static void SimulateCrossProcessTestCases(ImmutableArray<TestCase> testCases)
+    {
+        foreach (TestCase testCase in testCases)
+        {
+            testCase.LocalExtensionData = null;
+        }
+    }
+}

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -41,6 +41,18 @@ public abstract partial class CLITestBase
         return frameworkHandle.GetFlattenedTestResults();
     }
 
+    internal static async Task<ImmutableArray<TestResult>> RunTestsAsync(IEnumerable<TestCase> testCases, string? testCaseFilter)
+    {
+        var testExecutionManager = new TestExecutionManager();
+        var frameworkHandle = new InternalFrameworkHandle();
+
+        string runSettingsXml = GetRunSettingsXml(string.Empty);
+        var runContext = new InternalRunContext(runSettingsXml, testCaseFilter);
+
+        await testExecutionManager.ExecuteTestsAsync(testCases, runContext, frameworkHandle, false);
+        return frameworkHandle.GetFlattenedTestResults();
+    }
+
     #region Helper classes
     private class InternalLogger : IMessageLogger
     {
@@ -73,15 +85,46 @@ public abstract partial class CLITestBase
         public IRunSettings? RunSettings { get; }
 
         public ITestCaseFilterExpression? GetTestCaseFilter(IEnumerable<string> supportedProperties, Func<string, TestProperty> propertyProvider) => _filter;
+    }
 
-        private class InternalRunSettings : IRunSettings
+    private sealed class InternalRunContext : IRunContext
+    {
+        private readonly ITestCaseFilterExpression? _filter;
+
+        public InternalRunContext(string runSettings, string? testCaseFilter)
         {
-            public InternalRunSettings(string runSettings) => SettingsXml = runSettings;
+            RunSettings = new InternalRunSettings(runSettings);
 
-            public string SettingsXml { get; }
-
-            public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
+            if (testCaseFilter != null)
+            {
+                _filter = TestCaseFilterFactory.ParseTestFilter(testCaseFilter);
+            }
         }
+
+        public IRunSettings? RunSettings { get; }
+
+        public bool KeepAlive => false;
+
+        public bool InIsolation => false;
+
+        public bool IsDataCollectionEnabled => false;
+
+        public bool IsBeingDebugged => false;
+
+        public string? TestRunDirectory => null;
+
+        public string? SolutionDirectory => null;
+
+        public ITestCaseFilterExpression? GetTestCaseFilter(IEnumerable<string>? supportedProperties, Func<string, TestProperty?> propertyProvider) => _filter;
+    }
+
+    private sealed class InternalRunSettings : IRunSettings
+    {
+        public InternalRunSettings(string runSettings) => SettingsXml = runSettings;
+
+        public string SettingsXml { get; }
+
+        public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
     }
 
     private sealed class InternalFrameworkHandle : IFrameworkHandle

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
@@ -4,7 +4,9 @@
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
@@ -160,6 +162,55 @@ public class TestMethodFilterTests : TestContainer
         recorder.TestMessageLevel.Should().Be(TestMessageLevel.Error);
     }
 
+    public void GetTestElementFilterForNullContextReturnsNull()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(null, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeFalse();
+    }
+
+    public void GetTestElementFilterForContextWithoutFilterReturnsNull()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        TestableDiscoveryContextWithoutGetTestCaseFilter discoveryContext = new();
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(discoveryContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeFalse();
+    }
+
+    public void GetTestElementFilterMatchesElementsUsingUnderlyingFilterExpression()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        MatchingTestCaseFilterExpression matchingFilterExpression = new(testCase => testCase.DisplayName == "M1");
+        TestableRunContext runContext = new(() => matchingFilterExpression);
+
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().NotBeNull();
+        filterHasError.Should().BeFalse();
+
+        var matching = new UnitTestElement(new TestMethod("M1", "C", "A", displayName: "M1"));
+        var nonMatching = new UnitTestElement(new TestMethod("M2", "C", "A", displayName: "M2"));
+
+        filter!.Matches(matching).Should().BeTrue();
+        filter.Matches(nonMatching).Should().BeFalse();
+    }
+
+    public void GetTestElementFilterForFilterErrorReturnsNullWithFilterHasErrorTrue()
+    {
+        TestableTestExecutionRecorder recorder = new();
+        TestableRunContext runContext = new(() => throw new TestPlatformFormatException("DummyException"));
+        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, recorder.ToAdapterMessageLogger(), out bool filterHasError);
+
+        filter.Should().BeNull();
+        filterHasError.Should().BeTrue();
+        recorder.Message.Should().Be("DummyException");
+        recorder.TestMessageLevel.Should().Be(TestMessageLevel.Error);
+    }
+
     [DummyTestClass]
     internal class DummyTestClassWithTestMethods
     {
@@ -230,6 +281,17 @@ public class TestMethodFilterTests : TestContainer
         public string TestCaseFilterValue => null!;
 
         public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => throw new NotImplementedException();
+    }
+
+    private sealed class MatchingTestCaseFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly Func<TestCase, bool> _matchTestCase;
+
+        public MatchingTestCaseFilterExpression(Func<TestCase, bool> matchTestCase) => _matchTestCase = matchTestCase;
+
+        public string TestCaseFilterValue => null!;
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => _matchTestCase(testCase);
     }
 
     private class DummyTestClassAttribute : TestClassAttribute;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodFilterTests.cs
@@ -278,7 +278,7 @@ public class TestMethodFilterTests : TestContainer
 
     private sealed class TestableTestCaseFilterExpression : ITestCaseFilterExpression
     {
-        public string TestCaseFilterValue => null!;
+        public string TestCaseFilterValue => string.Empty;
 
         public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => throw new NotImplementedException();
     }
@@ -289,7 +289,7 @@ public class TestMethodFilterTests : TestContainer
 
         public MatchingTestCaseFilterExpression(Func<TestCase, bool> matchTestCase) => _matchTestCase = matchTestCase;
 
-        public string TestCaseFilterValue => null!;
+        public string TestCaseFilterValue => string.Empty;
 
         public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider) => _matchTestCase(testCase);
     }


### PR DESCRIPTION
## Why

Continues the effort to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model. Phase 1 (message logging, #9548) and Phase 5 (result reporting, #9550) have merged to `main`; this brings **Phase 2 (test filtering)** to `main`.

This is the same change previously reviewed and approved as #9555 (which merged into the integration branch `dev/amauryleve/vstest-decoupling-base`). It is re-based cleanly onto current `main` here as a standalone, Phase-2-only PR now that its prerequisites have landed.

## What

- Introduces a neutral `ITestElementFilter { bool Matches(UnitTestElement testElement); }` in `PlatformServices/Interfaces` (`null` = include all).
- Keeps `TestMethodFilter` as the single VSTest translation bridge in PlatformServices (consistent with the Phase 1/5 bridges): it now exposes `GetTestElementFilter(...)` wrapping the parsed `ITestCaseFilterExpression` in a private `TestElementFilter` that reuses `element.ToTestCase()` + `MatchTestCase` + `PropertyValueProvider`.
- Routes BOTH consumers through the neutral filter: `UnitTestDiscoverer.SendTestCases` and `TestExecutionManager` (`MatchTestFilter` + `ExecuteTestsInSourceAsync`). Neither consumer references `ITestCaseFilterExpression` / `MatchTestCase` / `TestProperty` anymore.
- `filterHasError` bail-outs preserved byte-for-byte (discovery still enumerates + logs warnings before bailing; execution still early-bails before creating the isolation `UnitTestRunner`).

## No behavior change

Pure refactor. Filter parse errors, the supported-property set, the discovery-context vs run-context code paths, and every match result stay identical. Execution still filters on `TestCase` then converts survivors to `UnitTestElement` at the same logical point (unchanged surviving set / order / grouping).

Includes an out-of-proc `--filter` regression guard (`TestCaseFilteringTests.cs`) that nulls `TestCase.LocalExtensionData` to force the `TestCase → UnitTestElement → TestCase` reconstruction path and asserts filtering by both `FullyQualifiedName` and `Id` selects exactly the expected test(s) on discovery and execution.

## Remaining move-to-adapter work (future phase)

`TestMethodFilter` (the VSTest filter parser) intentionally remains the lone VSTest filter bridge in PlatformServices for now; physically relocating it to `MSTest.TestAdapter` is entangled with per-side `filterHasError` semantics and is deferred to a later phase.

## Verification

- `.\build.cmd -c Debug` green across all TFMs; PlatformServices + adapter unit-test projects green; the 4 filtering regression tests pass.
- Cherry-picked cleanly onto current `main` (which already has Phase 1 + Phase 5); PlatformServices and its unit-test project rebuild with 0 errors on the new base.
