### PR TITLE
Add readable ToString to JSON-RPC message records

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
@@ -42,16 +42,38 @@ internal sealed record InitializeResponseArgs(int? ProcessId, ServerInfo ServerI
 internal record RequestArgsBase(Guid RunId, ICollection<TestNode>? TestNodes, string? GraphFilter);
 
 internal sealed record DiscoverRequestArgs(Guid RunId, ICollection<TestNode>? TestNodes, string? GraphFilter) :
-    RequestArgsBase(RunId, TestNodes, GraphFilter);
+    RequestArgsBase(RunId, TestNodes, GraphFilter)
+{
+    // The compiler-generated record ToString renders the TestNodes collection using its default
+    // Object.ToString (e.g. 'System.Collections.Generic.List`1[...]'), which is unreadable in the
+    // diagnostic logs. Render the members explicitly instead.
+    public override string ToString()
+        => RpcMessageFormatting.FormatRequestArgs(nameof(DiscoverRequestArgs), RunId, TestNodes, GraphFilter);
+}
 
 internal record ResponseArgsBase;
 
 internal sealed record DiscoverResponseArgs : ResponseArgsBase;
 
 internal sealed record RunRequestArgs(Guid RunId, ICollection<TestNode>? TestNodes, string? GraphFilter) :
-    RequestArgsBase(RunId, TestNodes, GraphFilter);
+    RequestArgsBase(RunId, TestNodes, GraphFilter)
+{
+    public override string ToString()
+        => RpcMessageFormatting.FormatRequestArgs(nameof(RunRequestArgs), RunId, TestNodes, GraphFilter);
+}
 
-internal sealed record RunResponseArgs(Artifact[] Artifacts) : ResponseArgsBase;
+internal sealed record RunResponseArgs(Artifact[] Artifacts) : ResponseArgsBase
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(RunResponseArgs)).Append(" { ");
+        builder.Append($"{nameof(Artifacts)} = ");
+        RpcMessageFormatting.AppendItems(builder, Artifacts);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
 
 internal sealed record Artifact(string Uri, string Producer, string Type, string DisplayName, string? Description = null);
 
@@ -81,16 +103,134 @@ internal sealed record ServerTestingCapabilities(
     bool SupportsAttachments,
     bool MultiConnectionProvider);
 
-internal sealed record TestNodeStateChangedEventArgs(Guid RunId, TestNodeUpdateMessage[]? Changes);
+internal sealed record TestNodeStateChangedEventArgs(Guid RunId, TestNodeUpdateMessage[]? Changes)
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(TestNodeStateChangedEventArgs)).Append(" { ");
+        builder.Append($"{nameof(RunId)} = ").Append(RunId);
+        builder.Append($", {nameof(Changes)} = ");
+        RpcMessageFormatting.AppendItems(builder, Changes);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
 
 internal sealed record LogEventArgs(ServerLogMessage LogMessage);
 
-internal sealed record TelemetryEventArgs(string EventName, IDictionary<string, object> Metrics);
+internal sealed record TelemetryEventArgs(string EventName, IDictionary<string, object> Metrics)
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(TelemetryEventArgs)).Append(" { ");
+        builder.Append($"{nameof(EventName)} = ").Append(EventName);
+        builder.Append($", {nameof(Metrics)} = ");
+        RpcMessageFormatting.AppendDictionary(builder, Metrics);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
 
-internal sealed record ProcessInfoArgs(string Program, string? Args, string? WorkingDirectory, IDictionary<string, string?>? EnvironmentVariables);
+internal sealed record ProcessInfoArgs(string Program, string? Args, string? WorkingDirectory, IDictionary<string, string?>? EnvironmentVariables)
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(ProcessInfoArgs)).Append(" { ");
+        builder.Append($"{nameof(Program)} = ").Append(Program);
+        builder.Append($", {nameof(Args)} = ").Append(Args);
+        builder.Append($", {nameof(WorkingDirectory)} = ").Append(WorkingDirectory);
+        builder.Append($", {nameof(EnvironmentVariables)} = ");
+        RpcMessageFormatting.AppendDictionary(builder, EnvironmentVariables);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
 
 internal sealed record AttachDebuggerInfoArgs(int ProcessId);
 
-internal sealed record class TestsAttachments(RunTestAttachment[] Attachments);
+internal sealed record class TestsAttachments(RunTestAttachment[] Attachments)
+{
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(TestsAttachments)).Append(" { ");
+        builder.Append($"{nameof(Attachments)} = ");
+        RpcMessageFormatting.AppendItems(builder, Attachments);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
 
 internal sealed record class RunTestAttachment(string? Uri, string? Producer, string? Type, string? DisplayName, string? Description);
+
+/// <summary>
+/// Helpers to render JSON-RPC message members that hold collections or dictionaries. The compiler-generated
+/// record <see cref="object.ToString"/> would otherwise print these members using the default
+/// <see cref="object.ToString"/> (e.g. <c>System.Collections.Generic.List`1[...]</c>), which is unreadable
+/// when the messages are dumped to the diagnostic logs.
+/// </summary>
+internal static class RpcMessageFormatting
+{
+    public static string FormatRequestArgs(string typeName, Guid runId, ICollection<TestNode>? testNodes, string? graphFilter)
+    {
+        var builder = new StringBuilder();
+        builder.Append(typeName).Append(" { ");
+        builder.Append("RunId = ").Append(runId);
+        builder.Append(", TestNodes = ");
+        AppendItems(builder, testNodes);
+        builder.Append(", GraphFilter = ").Append(graphFilter);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+
+    public static void AppendItems<T>(StringBuilder builder, IEnumerable<T>? items)
+    {
+        if (items is null)
+        {
+            builder.Append("<null>");
+            return;
+        }
+
+        builder.Append('[');
+        bool first = true;
+        foreach (T item in items)
+        {
+            if (!first)
+            {
+                builder.Append(", ");
+            }
+
+            first = false;
+            builder.Append(item);
+        }
+
+        builder.Append(']');
+    }
+
+    public static void AppendDictionary<TValue>(StringBuilder builder, IDictionary<string, TValue>? dictionary)
+    {
+        if (dictionary is null)
+        {
+            builder.Append("<null>");
+            return;
+        }
+
+        builder.Append('[');
+        bool first = true;
+        foreach (KeyValuePair<string, TValue> pair in dictionary)
+        {
+            if (!first)
+            {
+                builder.Append(", ");
+            }
+
+            first = false;
+            builder.Append(pair.Key).Append(" = ").Append(pair.Value);
+        }
+
+        builder.Append(']');
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
@@ -140,8 +140,10 @@ internal sealed record ProcessInfoArgs(string Program, string? Args, string? Wor
         var builder = new StringBuilder();
         builder.Append(nameof(ProcessInfoArgs)).Append(" { ");
         builder.Append($"{nameof(Program)} = ").Append(Program);
-        builder.Append($", {nameof(Args)} = ").Append(Args);
-        builder.Append($", {nameof(WorkingDirectory)} = ").Append(WorkingDirectory);
+        builder.Append($", {nameof(Args)} = ");
+        RpcMessageFormatting.AppendValue(builder, Args);
+        builder.Append($", {nameof(WorkingDirectory)} = ");
+        RpcMessageFormatting.AppendValue(builder, WorkingDirectory);
         builder.Append($", {nameof(EnvironmentVariables)} = ");
         RpcMessageFormatting.AppendDictionary(builder, EnvironmentVariables);
         builder.Append(" }");
@@ -181,9 +183,23 @@ internal static class RpcMessageFormatting
         builder.Append("RunId = ").Append(runId);
         builder.Append(", TestNodes = ");
         AppendItems(builder, testNodes);
-        builder.Append(", GraphFilter = ").Append(graphFilter);
+        builder.Append(", GraphFilter = ");
+        AppendValue(builder, graphFilter);
         builder.Append(" }");
         return builder.ToString();
+    }
+
+    // Appends a value, rendering null explicitly as "<null>" so that a null value is not
+    // confused with an empty string in the diagnostic logs.
+    public static void AppendValue<T>(StringBuilder builder, T value)
+    {
+        if (value is null)
+        {
+            builder.Append("<null>");
+            return;
+        }
+
+        builder.Append(value);
     }
 
     public static void AppendItems<T>(StringBuilder builder, IEnumerable<T>? items)
@@ -204,7 +220,7 @@ internal static class RpcMessageFormatting
             }
 
             first = false;
-            builder.Append(item);
+            AppendValue(builder, item);
         }
 
         builder.Append(']');
@@ -228,7 +244,8 @@ internal static class RpcMessageFormatting
             }
 
             first = false;
-            builder.Append(pair.Key).Append(" = ").Append(pair.Value);
+            builder.Append(pair.Key).Append(" = ");
+            AppendValue(builder, pair.Value);
         }
 
         builder.Append(']');

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/RpcMessagesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/RpcMessagesTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.ServerMode;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class RpcMessagesTests
+{
+    private static TestNode CreateTestNode(string uid, string displayName)
+        => new() { Uid = new TestNodeUid(uid), DisplayName = displayName };
+
+    [TestMethod]
+    public void RunRequestArgs_ToString_RendersTestNodesReadably()
+    {
+        RunRequestArgs args = new(Guid.Empty, [CreateTestNode("uid1", "Test1"), CreateTestNode("uid2", "Test2")], GraphFilter: null);
+
+        string result = args.ToString();
+
+        Assert.StartsWith("RunRequestArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("Test1", result);
+        Assert.Contains("Test2", result);
+    }
+
+    [TestMethod]
+    public void DiscoverRequestArgs_ToString_RendersTestNodesReadably()
+    {
+        DiscoverRequestArgs args = new(Guid.Empty, [CreateTestNode("uid1", "Test1")], GraphFilter: "filter");
+
+        string result = args.ToString();
+
+        Assert.StartsWith("DiscoverRequestArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("Test1", result);
+        Assert.Contains("filter", result);
+    }
+
+    [TestMethod]
+    public void RequestArgs_ToString_WithNullTestNodes_RendersNull()
+    {
+        RunRequestArgs args = new(Guid.Empty, TestNodes: null, GraphFilter: null);
+
+        string result = args.ToString();
+
+        Assert.Contains("TestNodes = <null>", result);
+        AssertNoDefaultCollectionToString(result);
+    }
+
+    [TestMethod]
+    public void RunResponseArgs_ToString_RendersArtifactsReadably()
+    {
+        RunResponseArgs args = new([new Artifact("uri", "producer", "type", "MyArtifact")]);
+
+        string result = args.ToString();
+
+        Assert.StartsWith("RunResponseArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("MyArtifact", result);
+    }
+
+    [TestMethod]
+    public void TestNodeStateChangedEventArgs_ToString_RendersChangesReadably()
+    {
+        TestNodeUpdateMessage change = new(new SessionUid("session"), CreateTestNode("uid1", "ChangedTest"));
+        TestNodeStateChangedEventArgs args = new(Guid.Empty, [change]);
+
+        string result = args.ToString();
+
+        Assert.StartsWith("TestNodeStateChangedEventArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("ChangedTest", result);
+    }
+
+    [TestMethod]
+    public void TelemetryEventArgs_ToString_RendersMetricsReadably()
+    {
+        TelemetryEventArgs args = new("my-event", new Dictionary<string, object> { ["metric1"] = 42 });
+
+        string result = args.ToString();
+
+        Assert.StartsWith("TelemetryEventArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("my-event", result);
+        Assert.Contains("metric1 = 42", result);
+    }
+
+    [TestMethod]
+    public void ProcessInfoArgs_ToString_RendersEnvironmentVariablesReadably()
+    {
+        ProcessInfoArgs args = new("program.exe", "--flag", "C:\\work", new Dictionary<string, string?> { ["VAR"] = "value" });
+
+        string result = args.ToString();
+
+        Assert.StartsWith("ProcessInfoArgs {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("VAR = value", result);
+    }
+
+    [TestMethod]
+    public void TestsAttachments_ToString_RendersAttachmentsReadably()
+    {
+        TestsAttachments args = new([new RunTestAttachment("uri", "producer", "type", "MyAttachment", "desc")]);
+
+        string result = args.ToString();
+
+        Assert.StartsWith("TestsAttachments {", result);
+        AssertNoDefaultCollectionToString(result);
+        Assert.Contains("MyAttachment", result);
+    }
+
+    private static void AssertNoDefaultCollectionToString(string value)
+    {
+        Assert.DoesNotContain("System.Collections", value);
+        Assert.DoesNotContain("System.String[]", value);
+        Assert.DoesNotContain("`1[", value);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/RpcMessagesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/RpcMessagesTests.cs
@@ -47,7 +47,30 @@ public sealed class RpcMessagesTests
         string result = args.ToString();
 
         Assert.Contains("TestNodes = <null>", result);
+        Assert.Contains("GraphFilter = <null>", result);
         AssertNoDefaultCollectionToString(result);
+    }
+
+    [TestMethod]
+    public void ProcessInfoArgs_ToString_WithNullMembers_RendersNull()
+    {
+        ProcessInfoArgs args = new("program.exe", Args: null, WorkingDirectory: null, EnvironmentVariables: null);
+
+        string result = args.ToString();
+
+        Assert.Contains("Args = <null>", result);
+        Assert.Contains("WorkingDirectory = <null>", result);
+        Assert.Contains("EnvironmentVariables = <null>", result);
+    }
+
+    [TestMethod]
+    public void ProcessInfoArgs_ToString_WithNullEnvironmentVariableValue_RendersNull()
+    {
+        ProcessInfoArgs args = new("program.exe", "--flag", "C:\\work", new Dictionary<string, string?> { ["VAR"] = null });
+
+        string result = args.ToString();
+
+        Assert.Contains("VAR = <null>", result);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Problem

Some types were printed with the default `Object.ToString` in the diagnostic logs, making them hard to read.

After confirming (via a full trace-diagnostic run of the unit-test suite — 1272 tests, 2545 data pushes) that the main message-bus log path is already clean — every `IData`/`IProperty` type has a hand-written `ToString` — the remaining offender is the JSON-RPC layer.

The `RpcMessage` records in `RpcMessages.cs` are logged via `PassiveNode`'s `_logger.LogTraceAsync(message.ToString())`, but they rely on the **compiler-generated record `ToString`**, which renders collection/dictionary members using the default `Object.ToString`:

```
RunRequestArgs { RunId = …, TestNodes = System.Collections.Generic.List`1[…], GraphFilter =  }
RunResponseArgs { Artifacts = System.String[] }
```

This is the same class of problem previously addressed for `IData` objects in #2142 and #3857.

## Fix

Added explicit, readable `ToString` overrides (matching the established repo pattern) to the RPC message records whose members are collections/dictionaries, via a small shared `RpcMessageFormatting` helper:

- `DiscoverRequestArgs`
- `RunRequestArgs`
- `RunResponseArgs`
- `TestNodeStateChangedEventArgs`
- `TelemetryEventArgs`
- `ProcessInfoArgs`
- `TestsAttachments`

All of these types are `internal`, so there is no public-API surface change. JSON serialization is untouched.

## Verification

- `Microsoft.Testing.Platform` builds clean on net8.0/net9.0/netstandard2.0 (0 warnings).
- Added `RpcMessagesTests.cs` (8 tests) asserting the output is readable and contains no `System.Collections` / `` `1[ `` / `System.String[]` — all pass.
- 58 existing server-mode/serialization tests still pass.