### PR TITLE
Abstract VSTest execution input in PlatformServices (Phase 4 of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.VSTestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
@@ -144,12 +146,26 @@ internal sealed class MSTestExecutor : ITestExecutor
                 return;
             }
 
-            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(tests, runContext, frameworkHandle, testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
+            // Convert the host test cases into the neutral model at this boundary so the execution engine runs
+            // on UnitTestElement end-to-end. Each element keeps its originating test case as an opaque handle
+            // (for full-fidelity result recording and deployment) plus the host execution-context (TCM)
+            // properties surfaced through TestContext.
+            UnitTestElement[] testElements = [.. tests.Select(ToUnitTestElement)];
+
+            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(testElements, runContext, frameworkHandle, testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
         }
         finally
         {
             await SendTelemetryAsync().ConfigureAwait(false);
         }
+    }
+
+    private static UnitTestElement ToUnitTestElement(TestCase testCase)
+    {
+        UnitTestElement testElement = testCase.ToUnitTestElementWithUpdatedSource(testCase.Source);
+        testElement.ExecutionContextProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        testElement.HostRecordingHandle = testCase;
+        return testElement;
     }
 
     internal async Task RunTestsAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration, bool isMTP)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TcmTestPropertiesProvider.cs
@@ -8,16 +8,24 @@ using TestPlatformObjectModel = Microsoft.VisualStudio.TestPlatform.ObjectModel;
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 
 /// <summary>
-/// Reads and parses the TcmTestProperties in order to populate them in TestRunParameters.
+/// Reads and parses the test-case-management (TCM) properties supplied by a host on a test case, in order to
+/// surface them to the running test through <c>TestContext</c>.
 /// </summary>
+/// <remarks>
+/// This is a translation point between the VSTest test-case object model and the neutral execution context bag
+/// consumed by the platform services engine. It runs at the adapter boundary (when a host hands the adapter
+/// concrete test cases to run) and produces a string-keyed dictionary so the engine never depends on the VSTest
+/// <c>TestProperty</c> object model. It is expected to move entirely into the adapter layer once the platform
+/// services no longer reference the VSTest object model.
+/// </remarks>
 internal static class TcmTestPropertiesProvider
 {
     /// <summary>
-    /// Gets tcm properties from test case.
+    /// Gets the host execution context properties from a test case, keyed by the host property identifier.
     /// </summary>
     /// <param name="testCase">Test case.</param>
-    /// <returns>Tcm properties.</returns>
-    public static IDictionary<TestPlatformObjectModel.TestProperty, object?>? GetTcmProperties(TestPlatformObjectModel.TestCase? testCase)
+    /// <returns>The properties, or <see langword="null"/> when the test case is null or carries no test case id.</returns>
+    public static IReadOnlyDictionary<string, object?>? GetTcmProperties(TestPlatformObjectModel.TestCase? testCase)
     {
         // Return empty properties when testCase is null or when test case id is zero.
         if (testCase == null ||
@@ -26,26 +34,26 @@ internal static class TcmTestPropertiesProvider
             return null;
         }
 
-        var tcmProperties = new Dictionary<TestPlatformObjectModel.TestProperty, object?>(capacity: 15)
+        var tcmProperties = new Dictionary<string, object?>(capacity: 15)
         {
             // Step 1: Add common properties.
-            [EngineConstants.TestRunIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestRunIdProperty, default),
-            [EngineConstants.TestPlanIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPlanIdProperty, default),
-            [EngineConstants.BuildConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.BuildConfigurationIdProperty, default),
-            [EngineConstants.BuildDirectoryProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildDirectoryProperty, default),
-            [EngineConstants.BuildFlavorProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildFlavorProperty, default),
-            [EngineConstants.BuildNumberProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildNumberProperty, default),
-            [EngineConstants.BuildPlatformProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildPlatformProperty, default),
-            [EngineConstants.BuildUriProperty] = testCase.GetPropertyValue<string>(EngineConstants.BuildUriProperty, default),
-            [EngineConstants.TfsServerCollectionUrlProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsServerCollectionUrlProperty, default),
-            [EngineConstants.TfsTeamProjectProperty] = testCase.GetPropertyValue<string>(EngineConstants.TfsTeamProjectProperty, default),
-            [EngineConstants.IsInLabEnvironmentProperty] = testCase.GetPropertyValue<bool>(EngineConstants.IsInLabEnvironmentProperty, default),
+            [EngineConstants.TestRunIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.TestRunIdProperty, default),
+            [EngineConstants.TestPlanIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.TestPlanIdProperty, default),
+            [EngineConstants.BuildConfigurationIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.BuildConfigurationIdProperty, default),
+            [EngineConstants.BuildDirectoryProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.BuildDirectoryProperty, default),
+            [EngineConstants.BuildFlavorProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.BuildFlavorProperty, default),
+            [EngineConstants.BuildNumberProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.BuildNumberProperty, default),
+            [EngineConstants.BuildPlatformProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.BuildPlatformProperty, default),
+            [EngineConstants.BuildUriProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.BuildUriProperty, default),
+            [EngineConstants.TfsServerCollectionUrlProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.TfsServerCollectionUrlProperty, default),
+            [EngineConstants.TfsTeamProjectProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.TfsTeamProjectProperty, default),
+            [EngineConstants.IsInLabEnvironmentProperty.Id] = testCase.GetPropertyValue<bool>(EngineConstants.IsInLabEnvironmentProperty, default),
 
             // Step 2: Add test case specific properties.
-            [EngineConstants.TestCaseIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestCaseIdProperty, default),
-            [EngineConstants.TestConfigurationIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestConfigurationIdProperty, default),
-            [EngineConstants.TestConfigurationNameProperty] = testCase.GetPropertyValue<string>(EngineConstants.TestConfigurationNameProperty, default),
-            [EngineConstants.TestPointIdProperty] = testCase.GetPropertyValue<int>(EngineConstants.TestPointIdProperty, default),
+            [EngineConstants.TestCaseIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.TestCaseIdProperty, default),
+            [EngineConstants.TestConfigurationIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.TestConfigurationIdProperty, default),
+            [EngineConstants.TestConfigurationNameProperty.Id] = testCase.GetPropertyValue<string>(EngineConstants.TestConfigurationNameProperty, default),
+            [EngineConstants.TestPointIdProperty.Id] = testCase.GetPropertyValue<int>(EngineConstants.TestPointIdProperty, default),
         };
 
         return tcmProperties;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestCaseDiscoverySink.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestCaseDiscoverySink.cs
@@ -3,30 +3,27 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 
 /// <summary>
-/// The test case discovery sink used internally by execution to collect the discovered tests.
+/// The discovery sink used internally by execution to collect the tests discovered from a source.
 /// </summary>
 /// <remarks>
-/// It implements the platform-agnostic <see cref="IUnitTestElementSink"/> but still materializes a VSTest
-/// <see cref="TestCase"/> for every discovered element, because the execution pipeline currently consumes
-/// <see cref="TestCase"/> instances. That materialization is expected to disappear once execution flows the
-/// neutral <see cref="UnitTestElement"/> model end-to-end.
+/// It collects the neutral <see cref="UnitTestElement"/> model directly, so the execution pipeline can flow
+/// discovered tests without round-tripping them through a VSTest <c>TestCase</c>.
 /// </remarks>
 internal sealed class TestCaseDiscoverySink : IUnitTestElementSink
 {
     /// <summary>
-    /// Gets the tests.
+    /// Gets the discovered tests.
     /// </summary>
-    public ICollection<TestCase> Tests { get; } = [];
+    public ICollection<UnitTestElement> TestElements { get; } = [];
 
     /// <summary>
-    /// Collects the discovered test, materializing it as a VSTest <see cref="TestCase"/>.
+    /// Collects the discovered test element.
     /// </summary>
     /// <param name="testElement"> The discovered test element. </param>
     public void SendTestElement(UnitTestElement testElement)
-        => Tests.Add(testElement.ToTestCase());
+        => TestElements.Add(testElement);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -23,13 +21,13 @@ internal partial class TestExecutionManager
     /// <param name="runContext">The run context.</param>
     /// <param name="frameworkHandle">Handle to record test start/end/results.</param>
     /// <param name="isDeploymentDone">Indicates if deployment is done.</param>
-    internal virtual async Task ExecuteTestsAsync(IEnumerable<TestCase> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, bool isDeploymentDone)
+    internal virtual async Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, bool isDeploymentDone)
     {
         InitializeRandomTestOrder(frameworkHandle);
 
         var testsBySource = (from test in tests
-                             group test by test.Source into testGroup
-                             select new { Source = testGroup.Key, Tests = (IEnumerable<TestCase>)testGroup }).ToArray();
+                             group test by test.TestMethod.AssemblyName into testGroup
+                             select new { Source = testGroup.Key, Tests = (IEnumerable<UnitTestElement>)testGroup }).ToArray();
 
         if (_testOrderRandom is { } random)
         {
@@ -51,7 +49,7 @@ internal partial class TestExecutionManager
     /// <param name="frameworkHandle">Handle to record test start/end/results.</param>
     /// <param name="source">The test container for the tests.</param>
     /// <param name="isDeploymentDone">Indicates if deployment is done.</param>
-    private async Task ExecuteTestsInSourceAsync(IEnumerable<TestCase> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, string source, bool isDeploymentDone)
+    private async Task ExecuteTestsInSourceAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, string source, bool isDeploymentDone)
     {
         DebugEx.Assert(!StringEx.IsNullOrEmpty(source), "Source cannot be empty");
 
@@ -113,13 +111,13 @@ internal partial class TestExecutionManager
 
         int parallelWorkers = sourceSettings.Workers;
         ExecutionScope parallelScope = sourceSettings.Scope;
-        TestCase[] testsToRun = [.. tests.Where(t => MatchTestFilter(filter, t, source))];
+        UnitTestElement[] testsToRun = [.. tests.Where(t => MatchTestFilter(filter, t, source))];
         if (_testOrderRandom is { } sourceRandom)
         {
             Shuffle(sourceRandom, testsToRun);
         }
 
-        UnitTestElement[] unitTestElements = [.. testsToRun.Select(e => e.ToUnitTestElementWithUpdatedSource(source))];
+        UnitTestElement[] unitTestElements = [.. testsToRun.Select(e => e.WithUpdatedSource(source))];
         // Create an instance of a type defined in adapter so that adapter gets loaded in the child app domain
         var testRunner = (UnitTestRunner)isolationHost.CreateInstanceForType(
             typeof(UnitTestRunner),
@@ -151,9 +149,9 @@ internal partial class TestExecutionManager
             // Parallel and not parallel sets.
             // Single-pass partition: enumerate testsToRun once via GroupBy (lazy GroupBy evaluated twice
             // — once per FirstOrDefault — caused 2 full passes over testsToRun).
-            IEnumerable<TestCase>? parallelizableTestSet = null;
-            IEnumerable<TestCase>? nonParallelizableTestSet = null;
-            foreach (IGrouping<bool, TestCase> group in testsToRun.GroupBy(t => t.GetPropertyValue(EngineConstants.DoNotParallelizeProperty, false)))
+            IEnumerable<UnitTestElement>? parallelizableTestSet = null;
+            IEnumerable<UnitTestElement>? nonParallelizableTestSet = null;
+            foreach (IGrouping<bool, UnitTestElement> group in testsToRun.GroupBy(t => t.DoNotParallelize))
             {
                 if (group.Key)
                 {
@@ -167,7 +165,7 @@ internal partial class TestExecutionManager
 
             if (parallelizableTestSet != null)
             {
-                ConcurrentQueue<IEnumerable<TestCase>>? queue = null;
+                ConcurrentQueue<IEnumerable<UnitTestElement>>? queue = null;
 
                 // Chunk the sets into further groups based on parallel level
                 switch (parallelScope)
@@ -175,13 +173,13 @@ internal partial class TestExecutionManager
                     case ExecutionScope.MethodLevel:
                         if (_testOrderRandom is { } methodRandom)
                         {
-                            IEnumerable<TestCase>[] methodChunks = [.. parallelizableTestSet.Select(t => (IEnumerable<TestCase>)[t])];
+                            IEnumerable<UnitTestElement>[] methodChunks = [.. parallelizableTestSet.Select(t => (IEnumerable<UnitTestElement>)[t])];
                             Shuffle(methodRandom, methodChunks);
-                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(methodChunks);
+                            queue = new ConcurrentQueue<IEnumerable<UnitTestElement>>(methodChunks);
                         }
                         else
                         {
-                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.Select(t => new[] { t }));
+                            queue = new ConcurrentQueue<IEnumerable<UnitTestElement>>(parallelizableTestSet.Select(t => new[] { t }));
                         }
 
                         break;
@@ -189,18 +187,18 @@ internal partial class TestExecutionManager
                     case ExecutionScope.ClassLevel:
                         if (_testOrderRandom is { } classRandom)
                         {
-                            IEnumerable<TestCase>[] classChunks =
+                            IEnumerable<UnitTestElement>[] classChunks =
                             [
                                 .. parallelizableTestSet
-                                    .GroupBy(t => t.GetPropertyValue(EngineConstants.TestClassNameProperty) as string)
-                                    .Select(g => (IEnumerable<TestCase>)g.ToArray()),
+                                    .GroupBy(t => t.TestMethod.FullClassName)
+                                    .Select(g => (IEnumerable<UnitTestElement>)g.ToArray()),
                             ];
                             Shuffle(classRandom, classChunks);
-                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(classChunks);
+                            queue = new ConcurrentQueue<IEnumerable<UnitTestElement>>(classChunks);
                         }
                         else
                         {
-                            queue = new ConcurrentQueue<IEnumerable<TestCase>>(parallelizableTestSet.GroupBy(t => t.GetPropertyValue(EngineConstants.TestClassNameProperty) as string));
+                            queue = new ConcurrentQueue<IEnumerable<UnitTestElement>>(parallelizableTestSet.GroupBy(t => t.TestMethod.FullClassName));
                         }
 
                         break;
@@ -220,7 +218,7 @@ internal partial class TestExecutionManager
                             {
                                 _testRunCancellationToken?.ThrowIfCancellationRequested();
 
-                                if (queue.TryDequeue(out IEnumerable<TestCase>? testSet))
+                                if (queue.TryDequeue(out IEnumerable<UnitTestElement>? testSet))
                                 {
                                     await ExecuteTestsWithTestRunnerAsync(testSet, frameworkHandle, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
                                 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -14,7 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 internal partial class TestExecutionManager
 {
     internal void SendTestResults(
-        TestCase test,
+        UnitTestElement test,
         TestTools.UnitTesting.TestResult[] unitTestResults,
         DateTimeOffset startTime,
         DateTimeOffset endTime,
@@ -41,10 +39,10 @@ internal partial class TestExecutionManager
         }
     }
 
-    private static bool MatchTestFilter(ITestElementFilter? filter, TestCase test, string source)
+    private static bool MatchTestFilter(ITestElementFilter? filter, UnitTestElement test, string source)
     {
         if (filter is not null
-            && !filter.Matches(test.ToUnitTestElementWithUpdatedSource(source)))
+            && !filter.Matches(test.WithUpdatedSource(source)))
         {
             // Skip test if not fitting filter criteria.
             return false;
@@ -54,15 +52,18 @@ internal partial class TestExecutionManager
     }
 
     private async Task ExecuteTestsWithTestRunnerAsync(
-        IEnumerable<TestCase> tests,
+        IEnumerable<UnitTestElement> tests,
         ITestExecutionRecorder testExecutionRecorder,
         string source,
         IDictionary<string, object> sourceLevelParameters,
         UnitTestRunner testRunner,
         bool usesAppDomains)
     {
-        IEnumerable<TestCase> orderedTests = MSTestSettings.CurrentSettings.OrderTestsByNameInClass && !MSTestSettings.CurrentSettings.RandomizeTestOrder
-            ? tests.OrderBy(t => t.GetManagedType()).ThenBy(t => t.GetManagedMethod())
+        // Ordering keys mirror the historical VSTest ManagedType/ManagedMethod test-case properties, which are
+        // only populated when the test method carries managed method metadata (see UnitTestElement.ToTestCase).
+        IEnumerable<UnitTestElement> orderedTests = MSTestSettings.CurrentSettings.OrderTestsByNameInClass && !MSTestSettings.CurrentSettings.RandomizeTestOrder
+            ? tests.OrderBy(t => t.TestMethod.HasManagedMethodAndTypeProperties ? t.TestMethod.ManagedTypeName : null)
+                .ThenBy(t => t.TestMethod.HasManagedMethodAndTypeProperties ? t.TestMethod.ManagedMethodName : null)
             : tests;
 
         // If testRunner is in a different AppDomain, we cannot pass the testExecutionRecorder directly.
@@ -75,7 +76,7 @@ internal partial class TestExecutionManager
         // test set. This is the boundary at which VSTest result construction is applied.
         ITestResultRecorder testResultRecorder = testExecutionRecorder.ToTestResultRecorder(_environment.MachineName, MSTestSettings.CurrentSettings);
 
-        foreach (TestCase currentTest in orderedTests)
+        foreach (UnitTestElement currentTest in orderedTests)
         {
             _testRunCancellationToken?.ThrowIfCancellationRequested();
             if (PlatformServiceProvider.Instance.IsGracefulStopRequested)
@@ -83,7 +84,7 @@ internal partial class TestExecutionManager
                 break;
             }
 
-            UnitTestElement unitTestElement = currentTest.ToUnitTestElementWithUpdatedSource(source);
+            UnitTestElement unitTestElement = currentTest.WithUpdatedSource(source);
 
             testResultRecorder.RecordStart(currentTest);
 
@@ -95,7 +96,7 @@ internal partial class TestExecutionManager
             }
 
             // Run single test passing test context properties to it.
-            IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(currentTest);
+            IReadOnlyDictionary<string, object?>? tcmProperties = currentTest.ExecutionContextProperties;
             Dictionary<string, object?> testContextProperties = GetTestContextProperties(tcmProperties, sourceLevelParameters, unitTestElement);
 
             TestTools.UnitTesting.TestResult[] unitTestResult;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -4,6 +4,7 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 internal partial class TestExecutionManager
 {
     internal void SendTestResults(
-        UnitTestElement test,
+        TestCase test,
         TestTools.UnitTesting.TestResult[] unitTestResults,
         DateTimeOffset startTime,
         DateTimeOffset endTime,
@@ -86,7 +87,13 @@ internal partial class TestExecutionManager
 
             UnitTestElement unitTestElement = currentTest.WithUpdatedSource(source);
 
-            testResultRecorder.RecordStart(currentTest);
+            // Obtain the host's test case for this test as an OPAQUE handle: the engine passes it verbatim to
+            // the (still VSTest-based) result recorder and reads nothing VSTest-specific off it. This preserves
+            // byte-for-byte reporting fidelity — including any host-injected (TCM / data-collector) properties —
+            // for the recorded results. Neutralizing the recorder is deferred to a later boundary phase.
+            TestCase currentTestCase = currentTest.GetOrCreateHostTestCase();
+
+            testResultRecorder.RecordStart(currentTestCase);
 
             DateTimeOffset startTime = DateTimeOffset.Now;
 
@@ -124,7 +131,7 @@ internal partial class TestExecutionManager
 
             DateTimeOffset endTime = DateTimeOffset.Now;
 
-            SendTestResults(currentTest, unitTestResult, startTime, endTime, testResultRecorder);
+            SendTestResults(currentTestCase, unitTestResult, startTime, endTime, testResultRecorder);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.TestContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.TestContext.cs
@@ -20,7 +20,7 @@ internal partial class TestExecutionManager
     /// <param name="unitTestElement">The unit test element to get properties from.</param>
     /// <returns>Test context properties.</returns>
     private static Dictionary<string, object?> GetTestContextProperties(
-        IDictionary<TestProperty, object?>? tcmProperties,
+        IReadOnlyDictionary<string, object?>? tcmProperties,
         IDictionary<string, object> sourceLevelParameters,
         UnitTestElement unitTestElement)
     {
@@ -38,9 +38,9 @@ internal partial class TestExecutionManager
         // Add tcm properties.
         if (tcmProperties is not null)
         {
-            foreach (KeyValuePair<TestProperty, object?> kvp in tcmProperties)
+            foreach (KeyValuePair<string, object?> kvp in tcmProperties)
             {
-                testContextProperties[kvp.Key.Id] = kvp.Value;
+                testContextProperties[kvp.Key] = kvp.Value;
             }
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -164,14 +164,14 @@ internal partial class TestExecutionManager
 
 #if !WINDOWS_UWP && !WIN_UI
     /// <summary>
-    /// Materializes the VSTest test cases required by the (still VSTest-based) deployment service. When an
-    /// element carries the host's original test case (tests handed to the adapter to run) that exact instance
-    /// is reused; otherwise it is materialized from the neutral element (tests discovered internally). This is
-    /// the single remaining place where execution touches the VSTest test case type, kept until the deployment
-    /// service itself is made platform-agnostic in a later phase.
+    /// Materializes the VSTest test cases required by the (still VSTest-based) deployment service. Reuses each
+    /// element's host test case when present (tests handed to the adapter to run) and otherwise materializes
+    /// and caches one (tests discovered internally), so deployment and result recording share a single test
+    /// case per test. This is the single remaining place where execution touches the VSTest test case type,
+    /// kept until the deployment service itself is made platform-agnostic in a later phase.
     /// </summary>
     private static TestCase[] ToHostTestCasesForDeployment(IEnumerable<UnitTestElement> tests)
-        => [.. tests.Select(static e => e.HostRecordingHandle as TestCase ?? e.ToTestCase())];
+        => [.. tests.Select(static e => e.GetOrCreateHostTestCase())];
 #endif
 
     internal virtual UnitTestDiscoverer GetUnitTestDiscoverer(ITestSourceHandler testSourceHandler) => new(testSourceHandler);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+#if !WINDOWS_UWP && !WIN_UI
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+#endif
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -85,7 +88,7 @@ internal partial class TestExecutionManager
     /// <param name="runContext">Context to use when executing the tests.</param>
     /// <param name="frameworkHandle">Handle to the framework to record results and to do framework operations.</param>
     /// <param name="runCancellationToken">Test run cancellation token.</param>
-    internal async Task RunTestsAsync(IEnumerable<TestCase> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, TestRunCancellationToken runCancellationToken)
+    internal async Task RunTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, TestRunCancellationToken runCancellationToken)
     {
         DebugEx.Assert(tests != null, "tests");
         DebugEx.Assert(runContext != null, "runContext");
@@ -96,7 +99,7 @@ internal partial class TestExecutionManager
         PlatformServiceProvider.Instance.TestRunCancellationToken = _testRunCancellationToken;
 
 #if !WINDOWS_UWP && !WIN_UI
-        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(tests, runContext, frameworkHandle);
+        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(ToHostTestCasesForDeployment(tests), runContext, frameworkHandle);
 #else
         const bool isDeploymentDone = false;
 #endif
@@ -122,7 +125,7 @@ internal partial class TestExecutionManager
 
         var discoverySink = new TestCaseDiscoverySink();
 
-        var tests = new List<TestCase>();
+        var tests = new List<UnitTestElement>();
 
         IAdapterMessageLogger logger = frameworkHandle.ToAdapterMessageLogger();
 
@@ -133,14 +136,14 @@ internal partial class TestExecutionManager
 
             // discover the tests
             GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSource(source, logger, discoverySink, runContext, isMTP);
-            tests.AddRange(discoverySink.Tests);
+            tests.AddRange(discoverySink.TestElements);
 
             // Clear discoverSinksTests so that it just stores test for one source at one point of time
-            discoverySink.Tests.Clear();
+            discoverySink.TestElements.Clear();
         }
 
 #if !WINDOWS_UWP && !WIN_UI
-        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(tests, runContext, frameworkHandle);
+        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(ToHostTestCasesForDeployment(tests), runContext, frameworkHandle);
 #else
         const bool isDeploymentDone = false;
 #endif
@@ -158,6 +161,18 @@ internal partial class TestExecutionManager
         }
 #endif
     }
+
+#if !WINDOWS_UWP && !WIN_UI
+    /// <summary>
+    /// Materializes the VSTest test cases required by the (still VSTest-based) deployment service. When an
+    /// element carries the host's original test case (tests handed to the adapter to run) that exact instance
+    /// is reused; otherwise it is materialized from the neutral element (tests discovered internally). This is
+    /// the single remaining place where execution touches the VSTest test case type, kept until the deployment
+    /// service itself is made platform-agnostic in a later phase.
+    /// </summary>
+    private static TestCase[] ToHostTestCasesForDeployment(IEnumerable<UnitTestElement> tests)
+        => [.. tests.Select(static e => e.HostRecordingHandle as TestCase ?? e.ToTestCase())];
+#endif
 
     internal virtual UnitTestDiscoverer GetUnitTestDiscoverer(ITestSourceHandler testSourceHandler) => new(testSourceHandler);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 
 using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
 
@@ -22,24 +22,24 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
 internal interface ITestResultRecorder
 {
     /// <summary>
-    /// Signals that execution of the given test case has started.
+    /// Signals that execution of the given test has started.
     /// </summary>
-    /// <param name="testCase">The test case whose execution is starting.</param>
-    void RecordStart(TestCase testCase);
+    /// <param name="testElement">The test whose execution is starting.</param>
+    void RecordStart(UnitTestElement testElement);
 
     /// <summary>
-    /// Signals that execution of the given test case ended without producing any result.
+    /// Signals that execution of the given test ended without producing any result.
     /// </summary>
-    /// <param name="testCase">The test case whose execution ended.</param>
-    void RecordEmptyResult(TestCase testCase);
+    /// <param name="testElement">The test whose execution ended.</param>
+    void RecordEmptyResult(UnitTestElement testElement);
 
     /// <summary>
-    /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test case to the test host.
+    /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test to the test host.
     /// </summary>
-    /// <param name="testCase">The test case the result belongs to.</param>
+    /// <param name="testElement">The test the result belongs to.</param>
     /// <param name="unitTestResult">The framework result produced by executing the test.</param>
     /// <param name="startTime">The time at which the test started executing.</param>
     /// <param name="endTime">The time at which the test finished executing.</param>
     /// <returns><see langword="true"/> if the result was reported as a failure; otherwise, <see langword="false"/>.</returns>
-    bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
+    bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
 
@@ -17,29 +17,31 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
 /// <c>TestOutcome</c> and attachment types). The concrete recorder is provided at the platform boundary by a
 /// wrapper over the host's result recorder (currently <c>TestResultRecorderExtensions</c>, which wraps the
 /// VSTest <c>ITestExecutionRecorder</c>), and is expected to move fully out of the platform services layer in
-/// a later phase.
+/// a later phase. The execution engine passes the test's <c>TestCase</c> as an opaque handle to this recorder
+/// (it reads nothing VSTest-specific off it); reporting fidelity — including host-injected properties — is the
+/// recorder's responsibility.
 /// </remarks>
 internal interface ITestResultRecorder
 {
     /// <summary>
-    /// Signals that execution of the given test has started.
+    /// Signals that execution of the given test case has started.
     /// </summary>
-    /// <param name="testElement">The test whose execution is starting.</param>
-    void RecordStart(UnitTestElement testElement);
+    /// <param name="testCase">The test case whose execution is starting.</param>
+    void RecordStart(TestCase testCase);
 
     /// <summary>
-    /// Signals that execution of the given test ended without producing any result.
+    /// Signals that execution of the given test case ended without producing any result.
     /// </summary>
-    /// <param name="testElement">The test whose execution ended.</param>
-    void RecordEmptyResult(UnitTestElement testElement);
+    /// <param name="testCase">The test case whose execution ended.</param>
+    void RecordEmptyResult(TestCase testCase);
 
     /// <summary>
-    /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test to the test host.
+    /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test case to the test host.
     /// </summary>
-    /// <param name="testElement">The test the result belongs to.</param>
+    /// <param name="testCase">The test case the result belongs to.</param>
     /// <param name="unitTestResult">The framework result produced by executing the test.</param>
     /// <param name="startTime">The time at which the test started executing.</param>
     /// <param name="endTime">The time at which the test finished executing.</param>
     /// <returns><see langword="true"/> if the result was reported as a failure; otherwise, <see langword="false"/>.</returns>
-    bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
+    bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -135,7 +135,23 @@ internal sealed class TestMethod : ITestMethod
 
     internal TestMethod Clone() => (TestMethod)MemberwiseClone();
 
+    // NOTE: This method has a latent bug (it assigns AssemblyName/MethodInfo on `this` instead of on the
+    // returned clone), tracked by https://github.com/microsoft/testfx/issues/9573. It is intentionally left
+    // untouched here so the existing ToTestCase / test-case filter bridge callers keep their exact current
+    // behavior; the execution engine uses the correct CloneWithSource below instead. The two are unified once
+    // #9573 is addressed.
     internal TestMethod CloneWithUpdatedSource(string source)
+    {
+        var clone = (TestMethod)MemberwiseClone();
+        AssemblyName = source;
+        MethodInfo = null;
+        return clone;
+    }
+
+    // Correct counterpart of CloneWithUpdatedSource: assigns the updated source and clears the cached
+    // MethodInfo on the returned clone (leaving `this` untouched). Used by the execution engine's source
+    // resolution. See https://github.com/microsoft/testfx/issues/9573.
+    internal TestMethod CloneWithSource(string source)
     {
         var clone = (TestMethod)MemberwiseClone();
         clone.AssemblyName = source;

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -138,8 +138,8 @@ internal sealed class TestMethod : ITestMethod
     internal TestMethod CloneWithUpdatedSource(string source)
     {
         var clone = (TestMethod)MemberwiseClone();
-        AssemblyName = source;
-        MethodInfo = null;
+        clone.AssemblyName = source;
+        clone.MethodInfo = null;
         return clone;
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -132,10 +132,24 @@ internal sealed class UnitTestElement
         return clone;
     }
 
+    // Legacy source-updating clone used only by the ToTestCase / test-case filter bridge
+    // (TestCaseExtensions.ToUnitTestElementWithUpdatedSource). It delegates to the buggy
+    // TestMethod.CloneWithUpdatedSource and is retained to preserve that path's exact current behavior; the
+    // execution engine uses WithUpdatedSource / CloneWithSource instead. Tracked by
+    // https://github.com/microsoft/testfx/issues/9573.
     internal UnitTestElement CloneWithUpdatedSource(string source)
     {
         var clone = (UnitTestElement)MemberwiseClone();
         clone.TestMethod = TestMethod.CloneWithUpdatedSource(source);
+        return clone;
+    }
+
+    // Correct source-updating clone: the returned clone (only) targets the new source. Used by the execution
+    // engine via WithUpdatedSource. See https://github.com/microsoft/testfx/issues/9573.
+    internal UnitTestElement CloneWithSource(string source)
+    {
+        var clone = (UnitTestElement)MemberwiseClone();
+        clone.TestMethod = TestMethod.CloneWithSource(source);
         return clone;
     }
 
@@ -149,7 +163,7 @@ internal sealed class UnitTestElement
     /// <param name="source">The (possibly deployment-relocated) source of the test.</param>
     /// <returns>An element whose <see cref="ObjectModel.TestMethod.AssemblyName"/> is <paramref name="source"/>.</returns>
     internal UnitTestElement WithUpdatedSource(string source)
-        => TestMethod.AssemblyName == source ? this : CloneWithUpdatedSource(source);
+        => TestMethod.AssemblyName == source ? this : CloneWithSource(source);
 
     /// <summary>
     /// Convert the UnitTestElement instance to an Object Model testCase instance.

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -95,17 +95,35 @@ internal sealed class UnitTestElement
     internal IReadOnlyDictionary<string, object?>? ExecutionContextProperties { get; set; }
 
     /// <summary>
-    /// Gets or sets an opaque handle to the host's original representation of this test, used only to report
-    /// its lifecycle and results back to the host with full fidelity (preserving any host-injected data that
-    /// the neutral model does not otherwise carry). It is set at the platform boundary by the adapter and is
-    /// <see langword="null"/> for tests discovered internally by the platform services. The platform services
-    /// engine treats it as opaque; only the result-recording bridge interprets it.
+    /// Gets or sets the host's test case for this test, used to report its lifecycle and results back to the
+    /// host with full fidelity (preserving any host-injected data — such as test-case-management properties —
+    /// that the neutral model does not otherwise carry) and to describe it to the (still VSTest-based)
+    /// deployment service. For tests handed to the adapter by a host it is that original test case; for tests
+    /// discovered internally by the platform services it is <see langword="null"/> until materialized on
+    /// demand by <see cref="GetOrCreateHostTestCase"/>. The platform services engine treats it as opaque; only
+    /// the result-recording bridge and the deployment boundary interpret it.
     /// </summary>
 #if NETFRAMEWORK
-    // Result recording happens on the source-processing side; the isolation host copy never reads it.
+    // Result recording and deployment happen on the source-processing side; the isolation host copy never reads it.
     [field: NonSerialized]
 #endif
     internal object? HostRecordingHandle { get; set; }
+
+    /// <summary>
+    /// Returns the host test case for this test, reusing the host-provided one when present and otherwise
+    /// materializing a single VSTest test case on demand and caching it (so deployment, test-start and every
+    /// reported result share one instance, matching the historical "one test case per discovered test").
+    /// </summary>
+    internal TestCase GetOrCreateHostTestCase()
+    {
+        if (HostRecordingHandle is not TestCase testCase)
+        {
+            testCase = ToTestCase();
+            HostRecordingHandle = testCase;
+        }
+
+        return testCase;
+    }
 
     internal UnitTestElement Clone()
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -96,12 +96,13 @@ internal sealed class UnitTestElement
 
     /// <summary>
     /// Gets or sets the host's test case for this test, used to report its lifecycle and results back to the
-    /// host with full fidelity (preserving any host-injected data — such as test-case-management properties —
-    /// that the neutral model does not otherwise carry) and to describe it to the (still VSTest-based)
-    /// deployment service. For tests handed to the adapter by a host it is that original test case; for tests
-    /// discovered internally by the platform services it is <see langword="null"/> until materialized on
-    /// demand by <see cref="GetOrCreateHostTestCase"/>. The platform services engine treats it as opaque; only
-    /// the result-recording bridge and the deployment boundary interpret it.
+    /// host with full fidelity (preserving any host-injected data — such as test-case-management or
+    /// data-collector properties — that the neutral model does not otherwise carry) and to describe it to the
+    /// (still VSTest-based) deployment service. For tests handed to the adapter by a host it is that original
+    /// test case; for tests discovered internally by the platform services it is <see langword="null"/> until
+    /// materialized on demand by <see cref="GetOrCreateHostTestCase"/>. The execution engine treats it as an
+    /// opaque handle — it reads nothing VSTest-specific off it and only threads it into the result recorder and
+    /// the deployment boundary.
     /// </summary>
 #if NETFRAMEWORK
     // Result recording and deployment happen on the source-processing side; the isolation host copy never reads it.

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -81,6 +81,32 @@ internal sealed class UnitTestElement
     /// </summary>
     internal string[]? WorkItemIds { get; set; }
 
+    /// <summary>
+    /// Gets or sets host-provided execution context properties (for example the values historically read
+    /// from a test-case-management host: run id, plan id, build configuration, test point id, ...) that are
+    /// surfaced to the running test through <c>TestContext</c>. Keyed by the host property identifier so the
+    /// platform services layer does not depend on a specific test platform's property object model. This is
+    /// only populated when a host supplies such values (for internally discovered tests it stays null).
+    /// </summary>
+#if NETFRAMEWORK
+    // Consumed on the source-processing side before execution; the isolation host copy never reads it.
+    [field: NonSerialized]
+#endif
+    internal IReadOnlyDictionary<string, object?>? ExecutionContextProperties { get; set; }
+
+    /// <summary>
+    /// Gets or sets an opaque handle to the host's original representation of this test, used only to report
+    /// its lifecycle and results back to the host with full fidelity (preserving any host-injected data that
+    /// the neutral model does not otherwise carry). It is set at the platform boundary by the adapter and is
+    /// <see langword="null"/> for tests discovered internally by the platform services. The platform services
+    /// engine treats it as opaque; only the result-recording bridge interprets it.
+    /// </summary>
+#if NETFRAMEWORK
+    // Result recording happens on the source-processing side; the isolation host copy never reads it.
+    [field: NonSerialized]
+#endif
+    internal object? HostRecordingHandle { get; set; }
+
     internal UnitTestElement Clone()
     {
         var clone = (UnitTestElement)MemberwiseClone();
@@ -94,6 +120,18 @@ internal sealed class UnitTestElement
         clone.TestMethod = TestMethod.CloneWithUpdatedSource(source);
         return clone;
     }
+
+    /// <summary>
+    /// Returns this element when it already targets <paramref name="source"/>, otherwise a clone whose test
+    /// method points at <paramref name="source"/>. This mirrors the source resolution the adapter previously
+    /// performed while converting a host test case, so a deployed source (relocated to the deployment
+    /// directory) is honored without reloading the assembly from its original location (see
+    /// https://github.com/microsoft/testfx/issues/6713).
+    /// </summary>
+    /// <param name="source">The (possibly deployment-relocated) source of the test.</param>
+    /// <returns>An element whose <see cref="ObjectModel.TestMethod.AssemblyName"/> is <paramref name="source"/>.</returns>
+    internal UnitTestElement WithUpdatedSource(string source)
+        => TestMethod.AssemblyName == source ? this : CloneWithUpdatedSource(source);
 
     /// <summary>
     /// Convert the UnitTestElement instance to an Object Model testCase instance.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
-using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -47,15 +46,14 @@ internal static class TestResultRecorderExtensions
             _settings = settings;
         }
 
-        public void RecordStart(UnitTestElement testElement)
-            => _testExecutionRecorder.RecordStart(ResolveTestCase(testElement));
+        public void RecordStart(TestCase testCase)
+            => _testExecutionRecorder.RecordStart(testCase);
 
-        public void RecordEmptyResult(UnitTestElement testElement)
-            => _testExecutionRecorder.RecordEnd(ResolveTestCase(testElement), TestOutcome.None);
+        public void RecordEmptyResult(TestCase testCase)
+            => _testExecutionRecorder.RecordEnd(testCase, TestOutcome.None);
 
-        public bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+        public bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
         {
-            TestCase testCase = ResolveTestCase(testElement);
             var testResult = unitTestResult.ToTestResult(testCase, startTime, endTime, _computerName, _settings);
 
             _testExecutionRecorder.RecordEnd(testCase, testResult.Outcome);
@@ -84,15 +82,5 @@ internal static class TestResultRecorderExtensions
             // observed as part of reporting the result.
             return isFailed;
         }
-
-        /// <summary>
-        /// Resolves the VSTest <see cref="TestCase"/> to record against. When the element carries the host's
-        /// original representation (tests handed to the adapter to run), that exact test case is reused so all
-        /// host-injected data (including test-case-management properties) is preserved with full fidelity;
-        /// otherwise a single test case is materialized from the neutral element and reused (tests discovered
-        /// internally).
-        /// </summary>
-        private static TestCase ResolveTestCase(UnitTestElement testElement)
-            => testElement.GetOrCreateHostTestCase();
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
@@ -4,6 +4,7 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -46,14 +47,15 @@ internal static class TestResultRecorderExtensions
             _settings = settings;
         }
 
-        public void RecordStart(TestCase testCase)
-            => _testExecutionRecorder.RecordStart(testCase);
+        public void RecordStart(UnitTestElement testElement)
+            => _testExecutionRecorder.RecordStart(ResolveTestCase(testElement));
 
-        public void RecordEmptyResult(TestCase testCase)
-            => _testExecutionRecorder.RecordEnd(testCase, TestOutcome.None);
+        public void RecordEmptyResult(UnitTestElement testElement)
+            => _testExecutionRecorder.RecordEnd(ResolveTestCase(testElement), TestOutcome.None);
 
-        public bool RecordResult(TestCase testCase, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+        public bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
         {
+            TestCase testCase = ResolveTestCase(testElement);
             var testResult = unitTestResult.ToTestResult(testCase, startTime, endTime, _computerName, _settings);
 
             _testExecutionRecorder.RecordEnd(testCase, testResult.Outcome);
@@ -82,5 +84,14 @@ internal static class TestResultRecorderExtensions
             // observed as part of reporting the result.
             return isFailed;
         }
+
+        /// <summary>
+        /// Resolves the VSTest <see cref="TestCase"/> to record against. When the element carries the host's
+        /// original representation (tests handed to the adapter to run), that exact test case is reused so all
+        /// host-injected data (including test-case-management properties) is preserved with full fidelity;
+        /// otherwise the test case is materialized from the neutral element (tests discovered internally).
+        /// </summary>
+        private static TestCase ResolveTestCase(UnitTestElement testElement)
+            => testElement.HostRecordingHandle as TestCase ?? testElement.ToTestCase();
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestResultRecorderExtensions.cs
@@ -89,9 +89,10 @@ internal static class TestResultRecorderExtensions
         /// Resolves the VSTest <see cref="TestCase"/> to record against. When the element carries the host's
         /// original representation (tests handed to the adapter to run), that exact test case is reused so all
         /// host-injected data (including test-case-management properties) is preserved with full fidelity;
-        /// otherwise the test case is materialized from the neutral element (tests discovered internally).
+        /// otherwise a single test case is materialized from the neutral element and reused (tests discovered
+        /// internally).
         /// </summary>
         private static TestCase ResolveTestCase(UnitTestElement testElement)
-            => testElement.HostRecordingHandle as TestCase ?? testElement.ToTestCase();
+            => testElement.GetOrCreateHostTestCase();
     }
 }

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -7,6 +7,8 @@ using DiscoveryAndExecutionTests.Utilities;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
@@ -37,7 +39,7 @@ public abstract partial class CLITestBase
         var testExecutionManager = new TestExecutionManager();
         var frameworkHandle = new InternalFrameworkHandle();
 
-        await testExecutionManager.ExecuteTestsAsync(testCases, null, frameworkHandle, false);
+        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), null, frameworkHandle, false);
         return frameworkHandle.GetFlattenedTestResults();
     }
 
@@ -49,9 +51,21 @@ public abstract partial class CLITestBase
         string runSettingsXml = GetRunSettingsXml(string.Empty);
         var runContext = new InternalRunContext(runSettingsXml, testCaseFilter);
 
-        await testExecutionManager.ExecuteTestsAsync(testCases, runContext, frameworkHandle, false);
+        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), runContext, frameworkHandle, false);
         return frameworkHandle.GetFlattenedTestResults();
     }
+
+    // Mirrors the adapter's execution boundary (see MSTestExecutor): each host test case becomes a neutral
+    // UnitTestElement carrying its execution-context (TCM) properties and the originating test case as an
+    // opaque recording handle, so results are recorded against the exact same TestCase instances.
+    private static IEnumerable<UnitTestElement> ToUnitTestElements(IEnumerable<TestCase> testCases)
+        => testCases.Select(static testCase =>
+        {
+            UnitTestElement element = testCase.ToUnitTestElementWithUpdatedSource(testCase.Source);
+            element.ExecutionContextProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+            element.HostRecordingHandle = testCase;
+            return element;
+        });
 
     #region Helper classes
     private class InternalLogger : IMessageLogger

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TcmTestPropertiesProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -34,7 +34,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
 
     public void GetTcmPropertiesShouldReturnEmptyDictionaryIfTestCaseIsNull()
     {
-        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
+        IReadOnlyDictionary<string, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(null);
         tcmProperties.Should().BeNull();
     }
 
@@ -61,7 +61,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        IReadOnlyDictionary<string, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
         tcmProperties.Should().BeNull();
     }
 
@@ -88,7 +88,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
         ];
         SetTestCaseProperties(testCase, propertiesValue);
 
-        IDictionary<TestProperty, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        IReadOnlyDictionary<string, object?>? tcmProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
 
         VerifyTcmProperties(tcmProperties, testCase);
     }
@@ -116,7 +116,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IReadOnlyDictionary<string, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -140,7 +140,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IReadOnlyDictionary<string, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
     }
 
@@ -167,7 +167,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             345
         ];
         SetTestCaseProperties(testCase1, propertiesValue1);
-        IDictionary<TestProperty, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
+        IReadOnlyDictionary<string, object?>? tcmProperties1 = TcmTestPropertiesProvider.GetTcmProperties(testCase1);
         VerifyTcmProperties(tcmProperties1, testCase1);
 
         // Verify 2nd call.
@@ -191,7 +191,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             346
         ];
         SetTestCaseProperties(testCase2, propertiesValue2);
-        IDictionary<TestProperty, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
+        IReadOnlyDictionary<string, object?>? tcmProperties2 = TcmTestPropertiesProvider.GetTcmProperties(testCase2);
         VerifyTcmProperties(tcmProperties2, testCase2);
 
         // Verify 3rd call.
@@ -215,7 +215,7 @@ public class TcmTestPropertiesProviderTests : TestContainer
             347
         ];
         SetTestCaseProperties(testCase3, propertiesValue3);
-        IDictionary<TestProperty, object?>? tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
+        IReadOnlyDictionary<string, object?>? tcmProperties3 = TcmTestPropertiesProvider.GetTcmProperties(testCase3);
         VerifyTcmProperties(tcmProperties3, testCase3);
     }
 
@@ -232,12 +232,12 @@ public class TcmTestPropertiesProviderTests : TestContainer
         }
     }
 
-    private void VerifyTcmProperties(IDictionary<TestProperty, object?>? tcmProperties, TestCase testCase)
+    private void VerifyTcmProperties(IReadOnlyDictionary<string, object?>? tcmProperties, TestCase testCase)
     {
         tcmProperties.Should().NotBeNull();
         foreach (TestProperty property in _tcmKnownProperties)
         {
-            testCase.GetPropertyValue(property)!.Equals(tcmProperties[property]).Should().BeTrue();
+            testCase.GetPropertyValue(property)!.Equals(tcmProperties[property.Id]).Should().BeTrue();
         }
     }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
@@ -18,22 +18,22 @@ public class TestCaseDiscoverySinkTests : TestContainer
 
     public void TestCaseDiscoverySinkConstructorShouldInitializeTests()
     {
-        _testCaseDiscoverySink.Tests.Should().NotBeNull();
-        _testCaseDiscoverySink.Tests.Count.Should().Be(0);
+        _testCaseDiscoverySink.TestElements.Should().NotBeNull();
+        _testCaseDiscoverySink.TestElements.Count.Should().Be(0);
     }
 
-    public void SendTestElementShouldAddTheMaterializedTestCaseToTests()
+    public void SendTestElementShouldAddTheTestElement()
     {
         var testElement = new UnitTestElement(new TestMethod("M", "C", "A", displayName: null));
 
         _testCaseDiscoverySink.SendTestElement(testElement);
 
-        _testCaseDiscoverySink.Tests.Should().NotBeNull();
-        _testCaseDiscoverySink.Tests.Count.Should().Be(1);
-        _testCaseDiscoverySink.Tests.ToArray()[0].FullyQualifiedName.Should().Be("C.M");
+        _testCaseDiscoverySink.TestElements.Should().NotBeNull();
+        _testCaseDiscoverySink.TestElements.Count.Should().Be(1);
+        _testCaseDiscoverySink.TestElements.ToArray()[0].Should().BeSameAs(testElement);
     }
 
-    public void SendTestElementShouldAddEachTestCaseInOrder()
+    public void SendTestElementShouldAddEachTestElementInOrder()
     {
         var testElement1 = new UnitTestElement(new TestMethod("M1", "C", "A", displayName: null));
         var testElement2 = new UnitTestElement(new TestMethod("M2", "C", "A", displayName: null));
@@ -41,8 +41,8 @@ public class TestCaseDiscoverySinkTests : TestContainer
         _testCaseDiscoverySink.SendTestElement(testElement1);
         _testCaseDiscoverySink.SendTestElement(testElement2);
 
-        _testCaseDiscoverySink.Tests.Count.Should().Be(2);
-        _testCaseDiscoverySink.Tests.ToArray()[0].FullyQualifiedName.Should().Be("C.M1");
-        _testCaseDiscoverySink.Tests.ToArray()[1].FullyQualifiedName.Should().Be("C.M2");
+        _testCaseDiscoverySink.TestElements.Count.Should().Be(2);
+        _testCaseDiscoverySink.TestElements.ToArray()[0].Should().BeSameAs(testElement1);
+        _testCaseDiscoverySink.TestElements.ToArray()[1].Should().BeSameAs(testElement2);
     }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -5,6 +5,7 @@ using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
@@ -92,7 +93,7 @@ public class TestExecutionManagerTests : TestContainer
         // Causing the FilterExpressionError
         _runContext = new TestableRunContextTestExecutionTests(() => throw new TestPlatformFormatException());
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, _cancellationToken);
 
         // No Results
         _frameworkHandle.TestCaseStartList.Count.Should().Be(0);
@@ -108,7 +109,7 @@ public class TestExecutionManagerTests : TestContainer
 
         _runContext = new TestableRunContextTestExecutionTests(() => new TestableTestCaseFilterExpression(p => p.DisplayName == "PassingTest"));
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, _cancellationToken);
 
         // FailingTest should be skipped because it does not match the filter criteria.
         List<string> expectedTestCaseStartList = ["PassingTest"];
@@ -125,7 +126,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "PassingTest");
         Microsoft.VisualStudio.TestTools.UnitTesting.TestResult[] unitTestResults = [];
 
-        _testExecutionManager.SendTestResults(testCase, unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
+        _testExecutionManager.SendTestResults(ToUnitTestElement(testCase), unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
 
         _frameworkHandle.TestCaseEndList.Should().Equal("PassingTest:None");
         _frameworkHandle.ResultsList.Should().BeEmpty();
@@ -136,7 +137,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "IgnoredTest");
         TestCase[] tests = [testCase];
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, _cancellationToken);
 
         _frameworkHandle.TestCaseStartList[0].Should().Be("IgnoredTest");
         _frameworkHandle.TestCaseEndList[0].Should().Be("IgnoredTest:Skipped");
@@ -149,7 +150,7 @@ public class TestExecutionManagerTests : TestContainer
 
         TestCase[] tests = [testCase];
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         List<string> expectedTestCaseStartList = ["PassingTest"];
         List<string> expectedTestCaseEndList = ["PassingTest:Passed"];
@@ -166,7 +167,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase failingTestCase = GetTestCase(typeof(DummyTestClass), "FailingTest");
         TestCase[] tests = [testCase, failingTestCase];
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, _cancellationToken);
 
         List<string> expectedTestCaseStartList = ["PassingTest", "FailingTest"];
         List<string> expectedTestCaseEndList = ["PassingTest:Passed", "FailingTest:Failed"];
@@ -186,7 +187,7 @@ public class TestExecutionManagerTests : TestContainer
 
         // Cancel the test run
         _cancellationToken.Cancel();
-        Func<Task> func = () => _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, _cancellationToken);
+        Func<Task> func = () => _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, _cancellationToken);
         await func.Should().ThrowAsync<OperationCanceledException>();
 
         // No Results
@@ -204,10 +205,10 @@ public class TestExecutionManagerTests : TestContainer
         // Setup mocks.
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
         testablePlatformService.MockTestDeployment.Setup(
-            td => td.Deploy(tests, _runContext, _frameworkHandle)).Callback(() => SetCaller("Deploy"));
+            td => td.Deploy(It.Is<IEnumerable<TestCase>>(t => t.SequenceEqual(tests)), _runContext, _frameworkHandle)).Callback(() => SetCaller("Deploy"));
 
         await _testExecutionManager.RunTestsAsync(
-            tests,
+            ToUnitTestElements(tests),
             _runContext,
             _frameworkHandle,
             new TestRunCancellationToken());
@@ -230,7 +231,7 @@ public class TestExecutionManagerTests : TestContainer
             td => td.Cleanup()).Callback(() => SetCaller("Cleanup"));
 #endif
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         _callers[0].Should().Be("LoadAssembly", "Cleanup should be called after execution.");
 
@@ -247,7 +248,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase[] tests = [testCase, failingTestCase];
 
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         testablePlatformService.MockTestDeployment.Verify(td => td.Cleanup(), Times.Never);
     }
@@ -262,11 +263,11 @@ public class TestExecutionManagerTests : TestContainer
 
         // Setup mocks.
         testablePlatformService.MockTestDeployment.Setup(
-            td => td.Deploy(tests, _runContext, _frameworkHandle)).Returns(true);
+            td => td.Deploy(It.Is<IEnumerable<TestCase>>(t => t.SequenceEqual(tests)), _runContext, _frameworkHandle)).Returns(true);
         testablePlatformService.MockTestDeployment.Setup(td => td.GetDeploymentDirectory())
             .Returns(@"C:\temp");
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         testablePlatformService.MockFileOperations.Verify(
             fo => fo.LoadAssembly(It.Is<string>(s => s.StartsWith("C:\\temp"))),
@@ -292,7 +293,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         DummyTestClass.TestContextProperties!.Contains(
             new KeyValuePair<string, object>("webAppUrl", "http://localhost")).Should().BeTrue();
@@ -314,7 +315,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         VerifyTcmProperties(DummyTestClass.TestContextProperties, testCase);
     }
@@ -327,7 +328,7 @@ public class TestExecutionManagerTests : TestContainer
         // Setup mocks.
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         testablePlatformService.MockSettingsProvider.Verify(sp => sp.GetProperties(It.IsAny<string>()), Times.Once);
     }
@@ -351,7 +352,7 @@ public class TestExecutionManagerTests : TestContainer
             """);
 
         // Trigger First Run
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         // Update runsettings to have different values for similar keys
         _runContext.MockRunSettings.Setup(rs => rs.SettingsXml).Returns(
@@ -368,7 +369,7 @@ public class TestExecutionManagerTests : TestContainer
             """);
 
         // Trigger another Run
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         "http://updatedLocalHost".Equals(DummyTestClass.TestContextProperties!["webAppUrl"]).Should().BeTrue();
     }
@@ -462,7 +463,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
             DummyTestClassForParallelize2.ThreadIds.Count.Should().Be(1);
@@ -499,7 +500,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
 
@@ -536,7 +537,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
             DummyTestClassForParallelize2.ThreadIds.Count.Should().Be(1);
@@ -599,7 +600,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
         }
@@ -658,7 +659,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
         }
@@ -697,7 +698,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
             DummyTestClassWithDoNotParallelizeMethods.ParallelizableTestsThreadIds.Count.Should().BeOneOf(1, 2);
@@ -763,7 +764,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
 
@@ -803,7 +804,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
             DummyTestClassWithDoNotParallelizeMethods.ThreadApartmentStates.Count.Should().Be(1);
             DummyTestClassWithDoNotParallelizeMethods.ThreadApartmentStates.ToArray()[0].Should().Be(Thread.CurrentThread.GetApartmentState());
@@ -846,11 +847,11 @@ public class TestExecutionManagerTests : TestContainer
 
         var firstHandle = new TestableFrameworkHandle();
         var firstManager = new TestExecutionManager(EnvironmentWrapper.Instance, task => task());
-        await firstManager.RunTestsAsync(BuildTests(), _runContext, firstHandle, new TestRunCancellationToken());
+        await firstManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, firstHandle, new TestRunCancellationToken());
 
         var secondHandle = new TestableFrameworkHandle();
         var secondManager = new TestExecutionManager(EnvironmentWrapper.Instance, task => task());
-        await secondManager.RunTestsAsync(BuildTests(), _runContext, secondHandle, new TestRunCancellationToken());
+        await secondManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, secondHandle, new TestRunCancellationToken());
 
         // Same seed must produce the same order across separate runs.
         firstHandle.TestCaseStartList.Should().Equal(secondHandle.TestCaseStartList);
@@ -887,7 +888,7 @@ public class TestExecutionManagerTests : TestContainer
 
         MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
-        await _testExecutionManager.RunTestsAsync(tests, _runContext, _frameworkHandle, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, new TestRunCancellationToken());
 
         _frameworkHandle.TestCaseStartList.Should().Equal("TestA", "TestB", "TestC");
     }
@@ -902,6 +903,21 @@ public class TestExecutionManagerTests : TestContainer
         var testMethod = new TestMethod(methodInfo.Name, hierarchyValues: null, methodInfo.Name, typeOfClass.FullName!, Assembly.GetExecutingAssembly().Location, displayName: null, null);
         UnitTestElement element = new(testMethod);
         return element.ToTestCase();
+    }
+
+    // Mirrors the conversion the adapter performs at the execution boundary (see MSTestExecutor): each host
+    // test case becomes a neutral UnitTestElement carrying the host execution-context (TCM) properties and the
+    // originating test case as an opaque recording handle, so recorded results are reported against the exact
+    // same TestCase instances the tests build (keeping the framework-handle Verify assertions meaningful).
+    private static UnitTestElement[] ToUnitTestElements(params TestCase[] tests)
+        => [.. tests.Select(ToUnitTestElement)];
+
+    private static UnitTestElement ToUnitTestElement(TestCase testCase)
+    {
+        UnitTestElement element = testCase.ToUnitTestElementWithUpdatedSource(testCase.Source);
+        element.ExecutionContextProperties = TcmTestPropertiesProvider.GetTcmProperties(testCase);
+        element.HostRecordingHandle = testCase;
+        return element;
     }
 
     private TestablePlatformServiceProvider SetupTestablePlatformService()
@@ -1248,9 +1264,9 @@ internal sealed class TestableTestCaseFilterExpression : ITestCaseFilterExpressi
 
 internal class TestableTestExecutionManager : TestExecutionManager
 {
-    internal Action<IEnumerable<TestCase>, IRunContext?, IFrameworkHandle, bool> ExecuteTestsWrapper { get; set; } = null!;
+    internal Action<IEnumerable<UnitTestElement>, IRunContext?, IFrameworkHandle, bool> ExecuteTestsWrapper { get; set; } = null!;
 
-    internal override Task ExecuteTestsAsync(IEnumerable<TestCase> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, bool isDeploymentDone)
+    internal override Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, bool isDeploymentDone)
     {
         ExecuteTestsWrapper?.Invoke(tests, runContext, frameworkHandle, isDeploymentDone);
         return Task.CompletedTask;

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -126,7 +126,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "PassingTest");
         Microsoft.VisualStudio.TestTools.UnitTesting.TestResult[] unitTestResults = [];
 
-        _testExecutionManager.SendTestResults(ToUnitTestElement(testCase), unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
+        _testExecutionManager.SendTestResults(testCase, unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
 
         _frameworkHandle.TestCaseEndList.Should().Equal("PassingTest:None");
         _frameworkHandle.ResultsList.Should().BeEmpty();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -33,6 +33,44 @@ public class UnitTestElementTests : TestContainer
 
     #endregion
 
+    #region Source resolution / host test case tests
+
+    public void WithUpdatedSourceShouldReturnSameInstanceWhenSourceUnchanged()
+        => _unitTestElement.WithUpdatedSource("A").Should().BeSameAs(_unitTestElement);
+
+    public void WithUpdatedSourceShouldReturnCloneWithNewSourceAndLeaveOriginalUnchanged()
+    {
+        UnitTestElement clone = _unitTestElement.WithUpdatedSource("B");
+
+        clone.Should().NotBeSameAs(_unitTestElement);
+        clone.TestMethod.AssemblyName.Should().Be("B");
+        // The original element (and its test method) must not be mutated by the clone.
+        _unitTestElement.TestMethod.AssemblyName.Should().Be("A");
+        clone.TestMethod.Should().NotBeSameAs(_testMethod);
+    }
+
+    public void GetOrCreateHostTestCaseShouldReturnHostHandleWhenPresent()
+    {
+        var hostTestCase = new TestCase("C.M", EngineConstants.ExecutorUri, "A");
+        _unitTestElement.HostRecordingHandle = hostTestCase;
+
+        _unitTestElement.GetOrCreateHostTestCase().Should().BeSameAs(hostTestCase);
+    }
+
+    public void GetOrCreateHostTestCaseShouldMaterializeAndCacheWhenNoHandle()
+    {
+        _unitTestElement.HostRecordingHandle.Should().BeNull();
+
+        TestCase materialized = _unitTestElement.GetOrCreateHostTestCase();
+
+        materialized.Should().NotBeNull();
+        // Subsequent calls (deployment, test-start, each reported result) reuse the same instance.
+        _unitTestElement.GetOrCreateHostTestCase().Should().BeSameAs(materialized);
+        _unitTestElement.HostRecordingHandle.Should().BeSameAs(materialized);
+    }
+
+    #endregion
+
     #region ToTestCase tests
 
     public void ToTestCaseShouldSetFullyQualifiedName()


### PR DESCRIPTION
## Why

Part of the multi-PR effort to make `src/Adapter/MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.TestPlatform.ObjectModel`). VSTest coupling moves **up** into the adapter layer (`src/Adapter/MSTest.TestAdapter`); the platform-services engine stops **reading** VSTest-specific data off the test.

This is **Phase 4 (execution input)**: it makes the execution **engine** (`TestExecutionManager` + partials) operate on the neutral `UnitTestElement` model for everything that reads test metadata.

## What

- **Boundary conversion.** `TestCase` → `UnitTestElement` now happens at the adapter boundary (`MSTestExecutor`, and the unit/integration test harnesses). Each element carries:
  - a neutral, string-keyed `ExecutionContextProperties` bag holding the host execution-context (a.k.a. TCM) properties. `TcmTestPropertiesProvider.GetTcmProperties` now returns `IReadOnlyDictionary<string, object?>` keyed by property id — lossless because `GetTestContextProperties` only ever consumed `TestProperty.Id`.
  - an opaque, `[NonSerialized]` `HostRecordingHandle` holding the originating VSTest `TestCase`.
- **Neutral reads.** `RunTestsAsync` (tests overload), `ExecuteTestsAsync`, `ExecuteTestsInSourceAsync`, `ExecuteTestsWithTestRunnerAsync`, and `MatchTestFilter` no longer **read** VSTest test-case properties. Filtering, parallelization grouping (`element.DoNotParallelize` / `element.TestMethod.FullClassName`), ordering (managed type/method gated by `HasManagedMethodAndTypeProperties`, matching the old `GetManagedType()`/`GetManagedMethod()` semantics), source resolution (`UnitTestElement.WithUpdatedSource`), and TCM→`TestContext` (the neutral bag) all run off the neutral model.
- **Internal discovery.** `TestCaseDiscoverySink` now collects `UnitTestElement` directly (no `TestCase` round-trip).

## VSTest `TestCase` remaining — as an opaque handle only

The engine still hands the test's `TestCase` to **two boundary services** — the result **recorder** (`ITestResultRecorder`, unchanged from Phase 5) and the **deployment** service (`ITestDeployment`, `TestCase`-based) — but treats it as an **opaque handle**: it obtains it via `UnitTestElement.GetOrCreateHostTestCase()` (the host's original test case when present, else a single cached materialized one) and reads nothing VSTest-specific off it. This deliberately keeps recorded results **byte-for-byte identical to baseline**: the unchanged recorder receives the exact same `TestCase` the engine passed before this change, so TRX/TCM association and any host/data-collector-injected properties are preserved. This is **not** "100% `TestCase`-free" — see remaining work.

## No behavior change

Pure refactor: the executed test set, order, parallelization grouping, TCM/TRX properties, and recorded results (fields, Id, outcome, messages, attachments, timings) are preserved for both the `RunTestsAsync(tests)` and `RunTestsAsync(sources)` paths. The filter `Id` is filename-based (source-path-independent), so source resolution does not affect the filtered set.

### Source resolution and a tracked latent bug

Correct element-based source resolution is required for the deployment path (issue #6713 — the executed assembly must load from the deployment directory). `TestMethod.CloneWithUpdatedSource` has a **latent bug**: it assigns `AssemblyName`/`MethodInfo` on `this` instead of the returned clone, tolerated only by the current call order. Rather than change that shared primitive here, this PR **leaves the buggy method untouched** for the existing `ToTestCase`/test-case-filter bridge callers and adds a new, correct `CloneWithSource` that the neutral engine uses via `WithUpdatedSource`. The bug is tracked by #9573 and referenced in comments next to both coexisting clone methods. Correct deployment-directory loading is verified by `RunTestsForTestShouldLoadSourceFromDeploymentDirectoryIfDeployed`.

## Remaining work (later phases)

Neutralizing the two boundary services — so the engine no longer holds a `TestCase` handle at all — is deferred and is the prerequisite for **Phase 7** (cutting the `Microsoft.TestPlatform.ObjectModel` dependency from PlatformServices):
- The **result recorder** neutralization (moving the `element → TestCase` reconstruction, incl. the host-handle / TCM / data-collector fidelity, out of the engine) — a dedicated recorder piece.
- **Deployment** (`ITestDeployment.Deploy`, which also flows `IFrameworkHandle`) — folds into the deployment/contexts phase (**Phase 6**).
- The single VSTest **bridges** that stay in `PlatformServices` for now: `TestResultRecorderExtensions`, `UnitTestElementSinkExtensions`, `TcmTestPropertiesProvider`, `TestCaseExtensions`/`UnitTestElement.ToTestCase`.
- Unifying the two clone methods once #9573 is addressed.

## Verification

- `build.cmd -c Debug` green across all TFMs (net462, net8.0, net9.0, UWP, WinUI).
- `MSTestAdapter.PlatformServices.UnitTests` (897) and `MSTestAdapter.UnitTests` (21) green; the deployment-directory test passes explicitly. Recorded-result fidelity is covered by `MSTestExecutorTests` (asserts `RecordStart` against the original host `TestCase`) and the integration harness's recorded-result assertions — the recorder is unchanged and receives the same `TestCase` as baseline.
- `MSTest.IntegrationTests` (discover→run harness) green — the only failing test seen was `OutputIsNotMixedWhenTestsRunInParallel`, a known `[CICondition(ConditionMode.Exclude)]` timing-flaky parallelism assertion unrelated to this change.

## Stacked PR

Base = `dev/amauryleve/vstest-decoupling-base` (the accumulation base that already contains Phase 2 #9555 and Phase 3 #9566). Phase 1 + Phase 5 are already on `main`. This should be reviewed/merged after the earlier phases reach `main`.