### PR TITLE
Neutralize deployment input in PlatformServices (Phase 6a of platform-agnostic effort)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Deployment/DeploymentContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Deployment/DeploymentContext.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP && !WIN_UI
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
+
+/// <summary>
+/// Platform-agnostic inputs the deployment pipeline needs from the running test host: the test-run/results
+/// directory and the run settings XML. This lets the platform services deployment layer run without taking a
+/// dependency on a specific test platform's run-context object model (for example the VSTest
+/// <c>IRunContext</c> / <c>IRunSettings</c> types). It is populated at the adapter boundary.
+/// </summary>
+internal sealed class DeploymentContext
+{
+    public DeploymentContext(string? testRunDirectory, string? runSettingsXml)
+    {
+        TestRunDirectory = testRunDirectory;
+        RunSettingsXml = runSettingsXml;
+    }
+
+    /// <summary>
+    /// Gets the host-provided test-run directory (the root under which results/deployment directories are
+    /// created), or <see langword="null"/> to fall back to a temp directory.
+    /// </summary>
+    public string? TestRunDirectory { get; }
+
+    /// <summary>
+    /// Gets the run settings XML supplied by the host, or <see langword="null"/> when none was provided.
+    /// </summary>
+    public string? RunSettingsXml { get; }
+}
+
+#endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -3,11 +3,11 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+#if !WINDOWS_UWP && !WIN_UI
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
+#endif
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-#if !WINDOWS_UWP && !WIN_UI
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-#endif
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -99,7 +99,7 @@ internal partial class TestExecutionManager
         PlatformServiceProvider.Instance.TestRunCancellationToken = _testRunCancellationToken;
 
 #if !WINDOWS_UWP && !WIN_UI
-        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(ToHostTestCasesForDeployment(tests), runContext, frameworkHandle);
+        bool isDeploymentDone = Deploy(tests, runContext, frameworkHandle);
 #else
         const bool isDeploymentDone = false;
 #endif
@@ -143,7 +143,7 @@ internal partial class TestExecutionManager
         }
 
 #if !WINDOWS_UWP && !WIN_UI
-        bool isDeploymentDone = PlatformServiceProvider.Instance.TestDeployment.Deploy(ToHostTestCasesForDeployment(tests), runContext, frameworkHandle);
+        bool isDeploymentDone = Deploy(tests, runContext, frameworkHandle);
 #else
         const bool isDeploymentDone = false;
 #endif
@@ -164,14 +164,15 @@ internal partial class TestExecutionManager
 
 #if !WINDOWS_UWP && !WIN_UI
     /// <summary>
-    /// Materializes the VSTest test cases required by the (still VSTest-based) deployment service. Reuses each
-    /// element's host test case when present (tests handed to the adapter to run) and otherwise materializes
-    /// and caches one (tests discovered internally), so deployment and result recording share a single test
-    /// case per test. This is the single remaining place where execution touches the VSTest test case type,
-    /// kept until the deployment service itself is made platform-agnostic in a later phase.
+    /// Runs deployment for the given tests via the platform-agnostic deployment service, translating the host
+    /// run context into the neutral <see cref="DeploymentContext"/> at this call site. This is the single place
+    /// execution reads the VSTest run context for deployment (removed once the run context itself is neutralized).
     /// </summary>
-    private static TestCase[] ToHostTestCasesForDeployment(IEnumerable<UnitTestElement> tests)
-        => [.. tests.Select(static e => e.GetOrCreateHostTestCase())];
+    private static bool Deploy(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle)
+    {
+        var deploymentContext = new DeploymentContext(runContext?.TestRunDirectory, runContext?.RunSettings?.SettingsXml);
+        return PlatformServiceProvider.Instance.TestDeployment.Deploy(tests, deploymentContext, frameworkHandle.ToAdapterMessageLogger());
+    }
 #endif
 
     internal virtual UnitTestDiscoverer GetUnitTestDiscoverer(ITestSourceHandler testSourceHandler) => new(testSourceHandler);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDeployment.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestDeployment.cs
@@ -3,8 +3,8 @@
 
 #if !WINDOWS_UWP && !WIN_UI
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 
@@ -14,13 +14,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Int
 internal interface ITestDeployment
 {
     /// <summary>
-    /// Deploy deployment items for the specified test cases.
+    /// Deploy deployment items for the specified tests.
     /// </summary>
-    /// <param name="testCases"> The test cases. </param>
-    /// <param name="runContext"> The run context. </param>
-    /// <param name="frameworkHandle"> The framework handle. </param>
+    /// <param name="testElements"> The tests. </param>
+    /// <param name="deploymentContext"> The host deployment inputs (test-run directory, run settings XML). </param>
+    /// <param name="messageLogger"> The logger used to surface deployment warnings. </param>
     /// <returns> True if deployment is done. </returns>
-    bool Deploy(IEnumerable<TestCase> testCases, IRunContext? runContext, IFrameworkHandle frameworkHandle);
+    bool Deploy(IEnumerable<UnitTestElement> testElements, DeploymentContext deploymentContext, IAdapterMessageLogger messageLogger);
 
     /// <summary>
     /// Gets the set of deployment items on a method and its corresponding class.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
@@ -4,12 +4,14 @@
 #if !WINDOWS_UWP && !WIN_UI
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 #if NETFRAMEWORK
+// SuspendCodeCoverage (used below to pause dynamic code coverage while deployment copies files) is a VSTest
+// object-model type. Its neutralization is deferred to a later platform-services decoupling step; the rest of
+// the deployment input is already platform-agnostic.
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 #endif
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -104,13 +106,13 @@ internal sealed class TestDeployment : ITestDeployment
     /// <summary>
     /// Deploy files related to the list of tests specified.
     /// </summary>
-    /// <param name="testCases"> The tests. </param>
-    /// <param name="runContext"> The run context. </param>
-    /// <param name="frameworkHandle"> The framework handle. </param>
+    /// <param name="testElements"> The tests. </param>
+    /// <param name="deploymentContext"> The host deployment inputs. </param>
+    /// <param name="messageLogger"> The logger used to surface deployment warnings. </param>
     /// <returns> Return true if deployment is done. </returns>
-    public bool Deploy(IEnumerable<TestCase> testCases, IRunContext? runContext, IFrameworkHandle frameworkHandle)
+    public bool Deploy(IEnumerable<UnitTestElement> testElements, DeploymentContext deploymentContext, IAdapterMessageLogger messageLogger)
     {
-        DebugEx.Assert(testCases != null, "tests");
+        DebugEx.Assert(testElements != null, "tests");
 
         // Reset runDirectories before doing deployment, so that older values of runDirectories is not picked
         // even if test host is kept alive.
@@ -118,7 +120,7 @@ internal sealed class TestDeployment : ITestDeployment
 
         _adapterSettings = MSTestSettingsProvider.Settings;
         bool canDeploy = CanDeploy();
-        bool hasDeploymentItems = testCases.Any(DeploymentItemUtility.HasDeploymentItems);
+        bool hasDeploymentItems = testElements.Any(DeploymentItemUtility.HasDeploymentItems);
 
         // deployment directories should not be created in this case,simply return
         if (!canDeploy && hasDeploymentItems)
@@ -127,8 +129,8 @@ internal sealed class TestDeployment : ITestDeployment
         }
 
 #if NETFRAMEWORK
-        string? firstTestSource = testCases.FirstOrDefault()?.Source;
-        RunDirectories = _deploymentUtility.CreateDeploymentDirectories(runContext, firstTestSource);
+        string? firstTestSource = testElements.FirstOrDefault()?.TestMethod.AssemblyName;
+        RunDirectories = _deploymentUtility.CreateDeploymentDirectories(deploymentContext, firstTestSource);
 
         // Deployment directories are created but deployment will not happen.
         // This is added just to keep consistency with MSTest v1 behavior.
@@ -143,8 +145,8 @@ internal sealed class TestDeployment : ITestDeployment
             return false;
         }
 
-        string? firstTestSource = testCases.FirstOrDefault()?.Source;
-        RunDirectories = _deploymentUtility.CreateDeploymentDirectories(runContext, firstTestSource);
+        string? firstTestSource = testElements.FirstOrDefault()?.TestMethod.AssemblyName;
+        RunDirectories = _deploymentUtility.CreateDeploymentDirectories(deploymentContext, firstTestSource);
 #endif
 
         // Object model currently does not have support for SuspendCodeCoverage. We can remove this once support is added
@@ -153,15 +155,15 @@ internal sealed class TestDeployment : ITestDeployment
 #endif
         {
             // Group the tests by source
-            var testsBySource = from test in testCases
-                                group test by test.Source into testGroup
+            var testsBySource = from test in testElements
+                                group test by test.TestMethod.AssemblyName into testGroup
                                 select new { Source = testGroup.Key, Tests = testGroup };
 
             TestRunDirectories runDirectories = RunDirectories;
             foreach (var group in testsBySource)
             {
                 // do the deployment
-                _deploymentUtility.Deploy(@group.Tests, @group.Source, runContext, frameworkHandle, RunDirectories);
+                _deploymentUtility.Deploy(@group.Tests, @group.Source, deploymentContext, messageLogger, RunDirectories);
             }
 
             // Update the runDirectories

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentItemUtility.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentItemUtility.cs
@@ -3,9 +3,9 @@
 
 #if !WINDOWS_UWP && !WIN_UI
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
@@ -105,21 +105,17 @@ internal sealed class DeploymentItemUtility
     /// <summary>
     /// Returns whether there are any deployment items defined on the test.
     /// </summary>
-    /// <param name="testCase"> The test Case. </param>
+    /// <param name="testElement"> The test. </param>
     /// <returns> True if has deployment items.</returns>
-    internal static bool HasDeploymentItems(TestCase testCase)
-    {
-        KeyValuePair<string, string>[]? deploymentItems = GetDeploymentItems(testCase);
+    internal static bool HasDeploymentItems(UnitTestElement testElement)
+        => testElement.DeploymentItems is { Length: > 0 };
 
-        return deploymentItems is { Length: > 0 };
-    }
-
-    internal static IList<DeploymentItem> GetDeploymentItems(IEnumerable<TestCase> tests)
+    internal static IList<DeploymentItem> GetDeploymentItems(IEnumerable<UnitTestElement> tests)
     {
         List<DeploymentItem> allDeploymentItems = [];
-        foreach (TestCase test in tests)
+        foreach (UnitTestElement test in tests)
         {
-            KeyValuePair<string, string>[]? items = GetDeploymentItems(test);
+            KeyValuePair<string, string>[]? items = test.DeploymentItems;
             if (items == null || items.Length == 0)
             {
                 continue;
@@ -219,14 +215,6 @@ internal sealed class DeploymentItemUtility
 
         return result;
     }
-
-    /// <summary>
-    /// Returns the deployment items defined on the test.
-    /// </summary>
-    /// <param name="testCase"> The test Case. </param>
-    /// <returns> The <see cref="KeyValuePair{TKey,TValue}"/>. </returns>
-    private static KeyValuePair<string, string>[]? GetDeploymentItems(TestCase testCase) => testCase.GetPropertyValue(EngineConstants.DeploymentItemsProperty) as
-            KeyValuePair<string, string>[];
 
     private static KeyValuePair<string, string>[]? ToKeyValuePairs(IEnumerable<DeploymentItem> deploymentItemList)
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/DeploymentUtilityBase.cs
@@ -4,13 +4,11 @@
 #if !WINDOWS_UWP && !WIN_UI
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
-
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
@@ -43,31 +41,31 @@ internal abstract class DeploymentUtilityBase
 
     protected AssemblyUtility AssemblyUtility { get; set; }
 
-    public bool Deploy(IEnumerable<TestCase> tests, string source, IRunContext? runContext, ITestExecutionRecorder testExecutionRecorder, TestRunDirectories runDirectories)
+    public bool Deploy(IEnumerable<UnitTestElement> tests, string source, DeploymentContext deploymentContext, IAdapterMessageLogger messageLogger, TestRunDirectories runDirectories)
     {
         IList<DeploymentItem> deploymentItems = DeploymentItemUtility.GetDeploymentItems(tests);
 
         // we just deploy source if there are no deployment items for current source but there are deployment items for other sources
-        return Deploy(source, runContext, testExecutionRecorder, deploymentItems, runDirectories);
+        return Deploy(source, deploymentContext, messageLogger, deploymentItems, runDirectories);
     }
 
     /// <summary>
     /// Create deployment directories.
     /// </summary>
-    /// <param name="runContext">The run context.</param>
+    /// <param name="deploymentContext">The host deployment inputs.</param>
     /// <param name="firstTestSource">
     /// The path to the test assembly of the first test case. In most cases, all
     /// test cases belong to the same assembly, but not guaranteed. We are using the path from
     /// the first test case as a "best effort" implementation. DeploymentItem isn't correctly designed and should be deprecated in future.
     /// </param>
     /// <returns>TestRunDirectories instance.</returns>
-    public TestRunDirectories CreateDeploymentDirectories(IRunContext? runContext, string? firstTestSource)
+    public TestRunDirectories CreateDeploymentDirectories(DeploymentContext deploymentContext, string? firstTestSource)
     {
-        string resultsDirectory = GetTestResultsDirectory(runContext);
+        string resultsDirectory = GetTestResultsDirectory(deploymentContext);
         string rootDeploymentDirectory = GetRootDeploymentDirectory(resultsDirectory);
 
 #if NETFRAMEWORK
-        bool isAppDomainCreationDisabled = runContext?.RunSettings != null && MSTestAdapterSettings.IsAppDomainCreationDisabled(runContext.RunSettings.SettingsXml);
+        bool isAppDomainCreationDisabled = deploymentContext.RunSettingsXml is not null && MSTestAdapterSettings.IsAppDomainCreationDisabled(deploymentContext.RunSettingsXml);
 #else
         // AppDomains are only supported in .NET Framework.
         const bool isAppDomainCreationDisabled = true;
@@ -94,10 +92,10 @@ internal abstract class DeploymentUtilityBase
     /// <summary>
     /// Get the parent test results directory where deployment will be done.
     /// </summary>
-    /// <param name="runContext">The run context.</param>
+    /// <param name="deploymentContext">The host deployment inputs.</param>
     /// <returns>The test results directory.</returns>
-    public static string GetTestResultsDirectory(IRunContext? runContext) => !StringEx.IsNullOrEmpty(runContext?.TestRunDirectory)
-            ? runContext.TestRunDirectory
+    public static string GetTestResultsDirectory(DeploymentContext deploymentContext) => !StringEx.IsNullOrEmpty(deploymentContext.TestRunDirectory)
+            ? deploymentContext.TestRunDirectory
             : Path.GetFullPath(Path.Combine(Path.GetTempPath(), TestRunDirectories.DefaultDeploymentRootDirectory));
 
     /// <summary>
@@ -397,20 +395,20 @@ internal abstract class DeploymentUtilityBase
     /// <summary>
     /// Log the parameter warnings on the parameter logger.
     /// </summary>
-    /// <param name="testExecutionRecorder">Execution recorder.</param>
+    /// <param name="messageLogger">Message logger.</param>
     /// <param name="warnings">Warnings.</param>
-    private static void LogWarnings(ITestExecutionRecorder testExecutionRecorder, IEnumerable<string> warnings)
+    private static void LogWarnings(IAdapterMessageLogger messageLogger, IEnumerable<string> warnings)
     {
-        DebugEx.Assert(testExecutionRecorder != null, "Logger should not be null");
+        DebugEx.Assert(messageLogger != null, "Logger should not be null");
 
         // log the warnings
         foreach (string warning in warnings)
         {
-            testExecutionRecorder.SendMessage(TestMessageLevel.Warning, warning);
+            messageLogger.SendMessage(MessageLevel.Warning, warning);
         }
     }
 
-    private bool Deploy(string source, IRunContext? runContext, ITestExecutionRecorder testExecutionRecorder, IList<DeploymentItem> deploymentItems, TestRunDirectories runDirectories)
+    private bool Deploy(string source, DeploymentContext deploymentContext, IAdapterMessageLogger messageLogger, IList<DeploymentItem> deploymentItems, TestRunDirectories runDirectories)
     {
         if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsInfoEnabled)
         {
@@ -427,10 +425,10 @@ internal abstract class DeploymentUtilityBase
             PlatformServiceProvider.Instance.AdapterTraceLogger.Info("MSTestExecutor: Using deployment directory {0} for source {1}.", runDirectories.OutDirectory, source);
         }
 
-        IEnumerable<string> warnings = Deploy([.. deploymentItems], source, runDirectories.OutDirectory, GetTestResultsDirectory(runContext));
+        IEnumerable<string> warnings = Deploy([.. deploymentItems], source, runDirectories.OutDirectory, GetTestResultsDirectory(deploymentContext));
 
         // Log warnings
-        LogWarnings(testExecutionRecorder, warnings);
+        LogWarnings(messageLogger, warnings);
         return deploymentItems is { Count: > 0 };
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Discovery;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.TestableImplementations;
@@ -205,7 +206,7 @@ public class TestExecutionManagerTests : TestContainer
         // Setup mocks.
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
         testablePlatformService.MockTestDeployment.Setup(
-            td => td.Deploy(It.Is<IEnumerable<TestCase>>(t => t.SequenceEqual(tests)), _runContext, _frameworkHandle)).Callback(() => SetCaller("Deploy"));
+            td => td.Deploy(It.IsAny<IEnumerable<UnitTestElement>>(), It.IsAny<DeploymentContext>(), It.IsAny<IAdapterMessageLogger>())).Callback(() => SetCaller("Deploy"));
 
         await _testExecutionManager.RunTestsAsync(
             ToUnitTestElements(tests),
@@ -263,7 +264,7 @@ public class TestExecutionManagerTests : TestContainer
 
         // Setup mocks.
         testablePlatformService.MockTestDeployment.Setup(
-            td => td.Deploy(It.Is<IEnumerable<TestCase>>(t => t.SequenceEqual(tests)), _runContext, _frameworkHandle)).Returns(true);
+            td => td.Deploy(It.IsAny<IEnumerable<UnitTestElement>>(), It.IsAny<DeploymentContext>(), It.IsAny<IAdapterMessageLogger>())).Returns(true);
         testablePlatformService.MockTestDeployment.Setup(td => td.GetDeploymentDirectory())
             .Returns(@"C:\temp");
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDeploymentTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/DesktopTestDeploymentTests.cs
@@ -4,12 +4,11 @@
 #if NETFRAMEWORK
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 
 using Moq;
 
@@ -45,15 +44,12 @@ public class DesktopTestDeploymentTests : TestContainer
 
     public void DeployShouldDeployFilesInASourceAndReturnTrue()
     {
-        TestCase testCase = GetTestCase(Assembly.GetExecutingAssembly().Location);
+        UnitTestElement testCase = GetTestCase(Assembly.GetExecutingAssembly().Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         string? warning;
         string sourceFile = Assembly.GetExecutingAssembly().GetName().Name + ".exe";
@@ -68,17 +64,14 @@ public class DesktopTestDeploymentTests : TestContainer
 
     public void DeployShouldDeployFilesInMultipleSourcesAndReturnTrue()
     {
-        TestCase testCase1 = GetTestCase(Assembly.GetExecutingAssembly().Location);
+        UnitTestElement testCase1 = GetTestCase(Assembly.GetExecutingAssembly().Location);
         string sourceFile2 = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "a.dll");
-        TestCase testCase2 = GetTestCase(sourceFile2);
+        UnitTestElement testCase2 = GetTestCase(sourceFile2);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase1, testCase2 }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase1, testCase2 }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         string? warning;
         string sourceFile1 = Assembly.GetExecutingAssembly().GetName().Name + ".exe";
@@ -100,15 +93,12 @@ public class DesktopTestDeploymentTests : TestContainer
 
     public void DeployShouldCreateDeploymentDirectories()
     {
-        TestCase testCase = GetTestCase(typeof(DesktopTestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(DesktopTestDeploymentTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // matched twice because root deployment and out directory are same in net core
         _mockFileUtility.Verify(fu => fu.CreateDirectoryIfNotExists(testRunDirectories.RootDeploymentDirectory), Times.Once);
@@ -118,16 +108,16 @@ public class DesktopTestDeploymentTests : TestContainer
 
     #region private methods
 
-    private TestCase GetTestCase(string source)
+    private static UnitTestElement GetTestCase(string source)
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), source);
+        var testCase = new UnitTestElement(new TestMethod("M", "C", source, displayName: null));
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                         DefaultDeploymentItemPath,
                         DefaultDeploymentItemOutputDirectory)
         ];
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
 
         return testCase;
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestDeploymentTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestDeploymentTests.cs
@@ -4,12 +4,11 @@
 #if !WINDOWS_UWP && !WIN_UI
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using Moq;
@@ -111,15 +110,12 @@ public class TestDeploymentTests : TestContainer
         MSTestSettingsProvider mstestSettingsProvider = new();
         mstestSettingsProvider.Load(reader);
 
-        TestCase testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         testDeployment.Cleanup();
 
@@ -128,15 +124,12 @@ public class TestDeploymentTests : TestContainer
 
     public void CleanupShouldDeleteRootDeploymentDirectory()
     {
-        TestCase testCase = GetTestCase(typeof(DeploymentUtilityTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(DeploymentUtilityTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // Act.
         testDeployment.Cleanup();
@@ -152,15 +145,12 @@ public class TestDeploymentTests : TestContainer
 
     public void GetDeploymentDirectoryShouldReturnDeploymentOutputDirectory()
     {
-        TestCase testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // Act.
         testDeployment.GetDeploymentDirectory().Should().Be(testRunDirectories.OutDirectory);
@@ -172,14 +162,14 @@ public class TestDeploymentTests : TestContainer
 
     public void DeployShouldReturnFalseWhenDeploymentEnabledSetToFalseButHasDeploymentItems()
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), "path/to/asm.dll");
+        UnitTestElement testCase = CreateTestElement("path/to/asm.dll");
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                 DefaultDeploymentItemPath,
                 DefaultDeploymentItemOutputDirectory)
         ];
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
 
         var testDeployment = new TestDeployment(
             new DeploymentItemUtility(_mockReflectionOperations.Object),
@@ -194,7 +184,7 @@ public class TestDeploymentTests : TestContainer
         mstestSettingsProvider.Load(reader);
 
         // Deployment should not happen
-        testDeployment.Deploy(new List<TestCase> { testCase }, null, null!).Should().BeFalse();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(null, null), new Mock<IAdapterMessageLogger>().Object).Should().BeFalse();
 
         // Deployment directories should not be created
         testDeployment.GetDeploymentDirectory().Should().BeNull();
@@ -202,8 +192,8 @@ public class TestDeploymentTests : TestContainer
 
     public void DeployShouldReturnFalseWhenDeploymentEnabledSetToFalseAndHasNoDeploymentItems()
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), "path/to/asm.dll");
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, null);
+        UnitTestElement testCase = CreateTestElement("path/to/asm.dll");
+        testCase.DeploymentItems = null;
         var testDeployment = new TestDeployment(
             new DeploymentItemUtility(_mockReflectionOperations.Object),
             new DeploymentUtility(),
@@ -217,7 +207,7 @@ public class TestDeploymentTests : TestContainer
         mstestSettingsProvider.Load(reader);
 
         // Deployment should not happen
-        testDeployment.Deploy(new List<TestCase> { testCase }, null, null!).Should().BeFalse();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(null, null), new Mock<IAdapterMessageLogger>().Object).Should().BeFalse();
 
         // Deployment directories should get created on .NET Framework for compat, but not on .NET Core
 #if NETFRAMEWORK
@@ -229,8 +219,8 @@ public class TestDeploymentTests : TestContainer
 
     public void DeployShouldReturnFalseWhenDeploymentEnabledSetToTrueButHasNoDeploymentItems()
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), "path/to/asm.dll");
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, null);
+        UnitTestElement testCase = CreateTestElement("path/to/asm.dll");
+        testCase.DeploymentItems = null;
         var testDeployment = new TestDeployment(
             new DeploymentItemUtility(_mockReflectionOperations.Object),
             new DeploymentUtility(),
@@ -244,7 +234,7 @@ public class TestDeploymentTests : TestContainer
         mstestSettingsProvider.Load(reader);
 
         // Deployment should not happen
-        testDeployment.Deploy(new List<TestCase> { testCase }, null, null!).Should().BeFalse();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(null, null), new Mock<IAdapterMessageLogger>().Object).Should().BeFalse();
 
         // Deployment directories should get created on .NET Framework for compat, but not on .NET Core
 #if NETFRAMEWORK
@@ -257,14 +247,14 @@ public class TestDeploymentTests : TestContainer
     // TODO: This test has to have mocks (tracked by https://github.com/microsoft/testfx/issues/8086). It actually deploys stuff and we cannot assume that all the dependencies get copied over to bin\debug.
     internal void DeployShouldReturnTrueWhenDeploymentEnabledSetToTrueAndHasDeploymentItems()
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), typeof(TestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = CreateTestElement(typeof(TestDeploymentTests).Assembly.Location);
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                         DefaultDeploymentItemPath,
                         DefaultDeploymentItemOutputDirectory)
         ];
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
         var testDeployment = new TestDeployment(
             new DeploymentItemUtility(_mockReflectionOperations.Object),
             new DeploymentUtility(),
@@ -278,7 +268,7 @@ public class TestDeploymentTests : TestContainer
         mstestSettingsProvider.Load(reader);
 
         // Deployment should happen
-        testDeployment.Deploy(new List<TestCase> { testCase }, null, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(null, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // Deployment directories should get created
         testDeployment.GetDeploymentDirectory().Should().NotBeNull();
@@ -309,15 +299,12 @@ public class TestDeploymentTests : TestContainer
     public void GetDeploymentInformationShouldReturnRunDirectoryInformationIfSourceIsNull()
     {
         // Arrange.
-        TestCase testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // Act.
         IDictionary<string, object> properties = TestDeployment.GetDeploymentInformation(null);
@@ -339,15 +326,12 @@ public class TestDeploymentTests : TestContainer
     public void GetDeploymentInformationShouldReturnRunDirectoryInformationIfSourceIsNotNull()
     {
         // Arrange.
-        TestCase testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
+        UnitTestElement testCase = GetTestCase(typeof(TestDeploymentTests).Assembly.Location);
 
         // Setup mocks.
         TestDeployment testDeployment = CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories);
 
-        var mockRunContext = new Mock<IRunContext>();
-        mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(testRunDirectories.RootDeploymentDirectory);
-
-        testDeployment.Deploy(new List<TestCase> { testCase }, mockRunContext.Object, new Mock<IFrameworkHandle>().Object).Should().BeTrue();
+        testDeployment.Deploy(new List<UnitTestElement> { testCase }, new DeploymentContext(testRunDirectories.RootDeploymentDirectory, null), new Mock<IAdapterMessageLogger>().Object).Should().BeTrue();
 
         // Act.
         IDictionary<string, object> properties = TestDeployment.GetDeploymentInformation(typeof(TestDeploymentTests).Assembly.Location);
@@ -383,19 +367,22 @@ public class TestDeploymentTests : TestContainer
             ru => ru.GetAttributes<DeploymentItemAttribute>(attributeProvider)).Returns(deploymentItemAttributes);
     }
 
-    private static TestCase GetTestCase(string source)
+    private static UnitTestElement GetTestCase(string source)
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), source);
+        UnitTestElement testCase = CreateTestElement(source);
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                 DefaultDeploymentItemPath,
                 DefaultDeploymentItemOutputDirectory)
         ];
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
 
         return testCase;
     }
+
+    private static UnitTestElement CreateTestElement(string source)
+        => new(new TestMethod("M", "C", source, displayName: null));
 
     private TestDeployment CreateAndSetupDeploymentRelatedUtilities(out TestRunDirectories testRunDirectories)
     {

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentItemUtilityTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentItemUtilityTests.cs
@@ -4,12 +4,12 @@
 #if !WINDOWS_UWP && !WIN_UI
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 
 using Moq;
 
@@ -19,13 +19,6 @@ namespace MSTestAdapter.PlatformServices.UnitTests.Utilities;
 
 public class DeploymentItemUtilityTests : TestContainer
 {
-    internal static readonly TestProperty DeploymentItemsProperty = TestProperty.Register(
-        "MSTestDiscoverer.DeploymentItems",
-        "DeploymentItems",
-        typeof(KeyValuePair<string, string>[]),
-        TestPropertyAttributes.Hidden,
-        typeof(TestCase));
-
     private readonly Mock<IReflectionOperations> _mockReflectionOperations;
     private readonly DeploymentItemUtility _deploymentItemUtility;
     private readonly ICollection<string> _warnings;
@@ -391,22 +384,24 @@ public class DeploymentItemUtilityTests : TestContainer
 
     public void HasDeployItemsShouldReturnFalseForNoDeploymentItems()
     {
-        TestCase testCase = new("A.C.M", new Uri("executor://testExecutor"), "A");
-        testCase.SetPropertyValue(DeploymentItemsProperty, null);
+        var testCase = new UnitTestElement(new TestMethod("M", "C", "A", displayName: null))
+        {
+            DeploymentItems = null,
+        };
 
         DeploymentItemUtility.HasDeploymentItems(testCase).Should().BeFalse();
     }
 
     public void HasDeployItemsShouldReturnTrueWhenDeploymentItemsArePresent()
     {
-        TestCase testCase = new("A.C.M", new Uri("executor://testExecutor"), "A");
+        var testCase = new UnitTestElement(new TestMethod("M", "C", "A", displayName: null));
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                 _defaultDeploymentItemPath,
                 _defaultDeploymentItemOutputDirectory)
         ];
-        testCase.SetPropertyValue(DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
 
         DeploymentItemUtility.HasDeploymentItems(testCase).Should().BeTrue();
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentUtilityTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Utilities/DeploymentUtilityTests.cs
@@ -4,14 +4,12 @@
 #if !WINDOWS_UWP && !WIN_UI
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using Moq;
 
@@ -29,8 +27,7 @@ public class DeploymentUtilityTests : TestContainer
     private readonly Mock<IReflectionOperations> _mockReflectionOperations;
     private readonly Mock<FileUtility> _mockFileUtility;
     private readonly Mock<AssemblyUtility> _mockAssemblyUtility;
-    private readonly Mock<IRunContext> _mockRunContext;
-    private readonly Mock<ITestExecutionRecorder> _mockTestExecutionRecorder;
+    private readonly Mock<IAdapterMessageLogger> _mockMessageLogger;
 
     private readonly DeploymentUtility _deploymentUtility;
 
@@ -52,16 +49,15 @@ public class DeploymentUtilityTests : TestContainer
             _mockAssemblyUtility.Object,
             _mockFileUtility.Object);
 
-        _mockRunContext = new Mock<IRunContext>();
-        _mockTestExecutionRecorder = new Mock<ITestExecutionRecorder>();
+        _mockMessageLogger = new Mock<IAdapterMessageLogger>();
     }
 
     #region Deploy tests
 
     public void DeployShouldReturnFalseWhenNoDeploymentItemsOnTestCase()
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), Path.Combine(RootDeploymentDirectory, "asm.dll"));
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, null);
+        UnitTestElement testCase = CreateTestElement(Path.Combine(RootDeploymentDirectory, "asm.dll"));
+        testCase.DeploymentItems = null;
         var testRunDirectories = new TestRunDirectories(RootDeploymentDirectory, Path.Combine(RootDeploymentDirectory, "asm.dll"), isAppDomainCreationDisabled: true);
 
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -77,17 +73,17 @@ public class DeploymentUtilityTests : TestContainer
 #endif
 
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeFalse();
     }
 
 #if NETFRAMEWORK
     public void DeployShouldDeploySourceAndItsConfigFile()
     {
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
 
         // Setup mocks.
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -102,10 +98,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -132,7 +128,7 @@ public class DeploymentUtilityTests : TestContainer
     {
         string dependencyFile = "C:\\temp\\dependency.dll";
 
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
 
         // Setup mocks.
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -147,10 +143,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -167,7 +163,7 @@ public class DeploymentUtilityTests : TestContainer
 
     public void DeployShouldDeploySatelliteAssemblies()
     {
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
         string assemblyFullPath = Assembly.GetExecutingAssembly().Location;
         string satelliteFullPath = Path.Combine(Path.GetDirectoryName(assemblyFullPath), "de", "satellite.dll");
 
@@ -184,10 +180,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -208,7 +204,7 @@ public class DeploymentUtilityTests : TestContainer
         string deploymentItemPath = "C:\\temp\\sample.dll";
         string deploymentItemOutputDirectory = "..\\..\\out";
 
-        TestCase testCase = GetTestCaseAndTestRunDirectories(deploymentItemPath, deploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(deploymentItemPath, deploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
 
         // Setup mocks.
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -225,10 +221,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -243,10 +239,10 @@ public class DeploymentUtilityTests : TestContainer
             Times.Never);
 
         // Verify the warning.
-        _mockTestExecutionRecorder.Verify(
+        _mockMessageLogger.Verify(
             ter =>
             ter.SendMessage(
-                TestMessageLevel.Warning,
+                MessageLevel.Warning,
                 string.Format(
                     CultureInfo.InvariantCulture,
                     Resource.DeploymentErrorBadDeploymentItem,
@@ -257,7 +253,7 @@ public class DeploymentUtilityTests : TestContainer
 
     public void DeployShouldDeployContentsOfADirectoryIfSpecified()
     {
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
         string content1 = Path.Combine(DefaultDeploymentItemPath, "directoryContents.dll");
         var directoryContentFiles = new List<string> { content1 };
 
@@ -280,10 +276,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -301,7 +297,7 @@ public class DeploymentUtilityTests : TestContainer
 #if NETFRAMEWORK
     public void DeployShouldDeployPdbWithSourceIfPdbFileIsPresentInSourceDirectory()
     {
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
 
         // Setup mocks.
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -324,10 +320,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -356,7 +352,7 @@ public class DeploymentUtilityTests : TestContainer
         // Path for pdb file of dependent assembly if pdb file is present.
         string pdbFile = Path.ChangeExtension(dependencyFile, "pdb");
 
-        TestCase testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
+        UnitTestElement testCase = GetTestCaseAndTestRunDirectories(DefaultDeploymentItemPath, DefaultDeploymentItemOutputDirectory, out TestRunDirectories testRunDirectories);
 
         // Setup mocks.
         _mockFileUtility.Setup(fu => fu.DoesDirectoryExist(It.Is<string>(s => !s.EndsWith(".dll") && !s.EndsWith(".exe") && !s.EndsWith(".config"))))
@@ -379,10 +375,10 @@ public class DeploymentUtilityTests : TestContainer
 
         // Act.
         _deploymentUtility.Deploy(
-            new List<TestCase> { testCase },
-            testCase.Source,
-            _mockRunContext.Object,
-            _mockTestExecutionRecorder.Object,
+            new List<UnitTestElement> { testCase },
+            testCase.TestMethod.AssemblyName,
+            new DeploymentContext(null, null),
+            _mockMessageLogger.Object,
             testRunDirectories).Should().BeTrue();
 
         // Assert.
@@ -411,12 +407,11 @@ public class DeploymentUtilityTests : TestContainer
     public void CreateDeploymentDirectoriesShouldCreateDeploymentDirectoryFromRunContext()
     {
         // Setup mocks
-        _mockRunContext.Setup(rc => rc.TestRunDirectory).Returns(TestRunDirectory);
         _mockFileUtility.Setup(fu => fu.GetNextIterationDirectoryName(TestRunDirectory, It.IsAny<string>()))
             .Returns(RootDeploymentDirectory);
 
         // Act.
-        _deploymentUtility.CreateDeploymentDirectories(_mockRunContext.Object, null);
+        _deploymentUtility.CreateDeploymentDirectories(new DeploymentContext(TestRunDirectory, null), null);
 
         // Assert.
         _mockFileUtility.Verify(fu => fu.CreateDirectoryIfNotExists(RootDeploymentDirectory), Times.Once);
@@ -428,12 +423,11 @@ public class DeploymentUtilityTests : TestContainer
     public void CreateDeploymentDirectoriesShouldCreateDefaultDeploymentDirectoryIfTestRunDirectoryIsNull()
     {
         // Setup mocks
-        _mockRunContext.Setup(rc => rc.TestRunDirectory).Returns((string)null!);
         _mockFileUtility.Setup(fu => fu.GetNextIterationDirectoryName(It.Is<string>(s => s.Contains(TestRunDirectories.DefaultDeploymentRootDirectory)), It.IsAny<string>()))
             .Returns(RootDeploymentDirectory);
 
         // Act.
-        _deploymentUtility.CreateDeploymentDirectories(_mockRunContext.Object, null);
+        _deploymentUtility.CreateDeploymentDirectories(new DeploymentContext(null, null), null);
 
         // Assert.
         _mockFileUtility.Verify(fu => fu.CreateDirectoryIfNotExists(RootDeploymentDirectory), Times.Once);
@@ -449,7 +443,7 @@ public class DeploymentUtilityTests : TestContainer
             .Returns(RootDeploymentDirectory);
 
         // Act.
-        _deploymentUtility.CreateDeploymentDirectories(null, null);
+        _deploymentUtility.CreateDeploymentDirectories(new DeploymentContext(null, null), null);
 
         // Assert.
         _mockFileUtility.Verify(fu => fu.CreateDirectoryIfNotExists(RootDeploymentDirectory), Times.Once);
@@ -462,16 +456,16 @@ public class DeploymentUtilityTests : TestContainer
 
     #region private methods
 
-    private static TestCase GetTestCaseAndTestRunDirectories(string deploymentItemPath, string defaultDeploymentItemOutputDirectoryOut, out TestRunDirectories testRunDirectories)
+    private static UnitTestElement GetTestCaseAndTestRunDirectories(string deploymentItemPath, string defaultDeploymentItemOutputDirectoryOut, out TestRunDirectories testRunDirectories)
     {
-        var testCase = new TestCase("A.C.M", new Uri("executor://testExecutor"), Assembly.GetExecutingAssembly().Location);
+        UnitTestElement testCase = CreateTestElement(Assembly.GetExecutingAssembly().Location);
         KeyValuePair<string, string>[] kvpArray =
         [
             new KeyValuePair<string, string>(
                 deploymentItemPath,
                 defaultDeploymentItemOutputDirectoryOut)
         ];
-        testCase.SetPropertyValue(DeploymentItemUtilityTests.DeploymentItemsProperty, kvpArray);
+        testCase.DeploymentItems = kvpArray;
         string currentExecutingFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
 
         const bool isAppDomainCreationDisabled =
@@ -485,6 +479,9 @@ public class DeploymentUtilityTests : TestContainer
 
         return testCase;
     }
+
+    private static UnitTestElement CreateTestElement(string source)
+        => new(new TestMethod("M", "C", source, displayName: null));
 
     #endregion
 }


### PR DESCRIPTION
## Why

Part of removing the VSTest object model (`Microsoft.TestPlatform.ObjectModel`) dependency from `src/Adapter/MSTestAdapter.PlatformServices` (the later "Phase 6/7" of the platform-agnostic effort — continues after Phase 4 #9572). This PR neutralizes the **deployment** subsystem's inputs.

## What

`ITestDeployment.Deploy` and the deployment utilities no longer take VSTest types:

- **Before:** `Deploy(IEnumerable<TestCase> testCases, IRunContext? runContext, IFrameworkHandle frameworkHandle)`
- **After:** `Deploy(IEnumerable<UnitTestElement> testElements, DeploymentContext deploymentContext, IAdapterMessageLogger messageLogger)`

- Deployment items already live on `UnitTestElement.DeploymentItems`, so `DeploymentItemUtility.HasDeploymentItems`/`GetDeploymentItems` read them directly (no more `TestCase.GetPropertyValue`).
- The two values actually read off `IRunContext` (`TestRunDirectory`, `RunSettings.SettingsXml`) are carried by a small neutral `DeploymentContext`, built at the single execution call site (`TestExecutionManager.Deploy`).
- Deployment warnings go through the existing neutral `IAdapterMessageLogger` (`MessageLevel.Warning`) instead of `ITestExecutionRecorder.SendMessage`.
- The old `ToHostTestCasesForDeployment` TestCase materialization in the engine is removed — deployment consumes `UnitTestElement` directly.

`TestDeployment.cs`, `DeploymentUtilityBase.cs`, `DeploymentItemUtility.cs`, `ITestDeployment.cs` are now free of `TestCase`/`IRunContext`/`IFrameworkHandle`.

## Residual (deferred)

The netfx-only `SuspendCodeCoverage` (a VSTest `ObjectModel.Utilities` type that pauses dynamic code coverage while deployment copies files) is intentionally kept for now to preserve behavior; neutralizing it is a separate later step. It is the only remaining VSTest reference in `TestDeployment.cs`.

## No behavior change

Deployment executes the same set, to the same directories, with the same warnings; only netfx actually deploys and that path is unchanged (verified by the Desktop deployment tests).

## Verification

- `build.cmd -c Debug` green across all TFMs (net462, net8.0, net9.0, UWP, WinUI).
- `MSTestAdapter.PlatformServices.UnitTests`: 897 (net8.0) / 935 (net462, incl. Desktop deployment tests) green.
- `MSTest.IntegrationTests` green (only the known `[CICondition(Exclude)]` `OutputIsNotMixedWhenTestsRunInParallel` timing flake, unrelated).

## Stacked

Base = `dev/amauryleve/vstest-decoupling-base` (contains Phases 2/3/4). Independent of the other Phase-6 sub-PRs; the `Microsoft.TestPlatform.ObjectModel` PackageReference removal comes last, once all subsystems are neutralized.
