### PR TITLE
Bump bundled Playwright for .NET to 1.61.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
          PackageVersion declared near the bottom of this file (the one Dependabot updates). The
          _ValidateBundledSdkFeatureVersions target (in Directory.Build.targets) fails the build if
          the two drift apart. -->
-    <MicrosoftPlaywrightVersion>1.60.0</MicrosoftPlaywrightVersion>
+    <MicrosoftPlaywrightVersion>1.61.0</MicrosoftPlaywrightVersion>
     <MicrosoftTestingExtensionsFakesVersion>18.1.1</MicrosoftTestingExtensionsFakesVersion>
     <!-- Microsoft.Testing.Internal.Framework is an internal-only NuGet (consumed by tests that
          opt into UseInternalTestFramework via TestFramework.ForTestingMSTest); there is no public
@@ -174,6 +174,6 @@
     -->
   <ItemGroup Label="Declared by MSTest.Sdk but not used directly">
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
-    <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.61.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Manually updates the bundled Playwright for .NET version in the MSTest SDK from 1.60.0 to 1.61.0, since Dependabot has not picked up the 1.61 release.

Both the `MicrosoftPlaywrightVersion` property and the `Microsoft.Playwright.MSTest.v4` `PackageVersion` anchor are bumped together so the `_ValidateBundledSdkFeatureVersions` sync check stays green.

This targets `rel/4.3` only; `main` is intentionally left unchanged so we can keep investigating why Dependabot isn't detecting the new Playwright version there.

Fixes #9362