### PR TITLE
Fix CloneWithUpdatedSource mutating `this` instead of the clone (rel/4.3)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -138,8 +138,8 @@ internal sealed class TestMethod : ITestMethod
     internal TestMethod CloneWithUpdatedSource(string source)
     {
         var clone = (TestMethod)MemberwiseClone();
-        AssemblyName = source;
-        MethodInfo = null;
+        clone.AssemblyName = source;
+        clone.MethodInfo = null;
         return clone;
     }
 }


### PR DESCRIPTION
Fixes #9573

Backport to `rel/4.3` of the `CloneWithUpdatedSource` fix.

`TestMethod.CloneWithUpdatedSource(string source)` (and by extension `UnitTestElement.CloneWithUpdatedSource`) assigned the new source and cleared `MethodInfo` on **`this`** rather than on the returned **clone**. As a result, the ""updated-source"" clone kept the *old* source/`MethodInfo`, while the shared original element was mutated as a side effect.

## Change

```csharp
var clone = (TestMethod)MemberwiseClone();
clone.AssemblyName = source;   // was: AssemblyName = source;
clone.MethodInfo = null;       // was: MethodInfo = null;
return clone;
```