### PR TITLE
Neutralize test message logging in PlatformServices execution engine (Phase 6c)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ClassCleanupManager.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 
 using AdapterApplicationStateGuard = Microsoft.VisualStudio.TestPlatform.MSTestAdapter.ApplicationStateGuard;
 
@@ -53,7 +53,7 @@ internal sealed class ClassCleanupManager
         }
     }
 
-    internal static void ForceCleanup(TypeCache typeCache, IDictionary<string, object?> sourceLevelParameters, IMessageLogger logger)
+    internal static void ForceCleanup(TypeCache typeCache, IDictionary<string, object?> sourceLevelParameters, IAdapterMessageLogger logger)
     {
         IEnumerable<TestClassInfo> classInfoCache = typeCache.ClassInfoListWithExecutableCleanupMethods;
         foreach (TestClassInfo classInfo in classInfoCache)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -26,7 +26,7 @@ internal partial class TestExecutionManager
     {
         _testResultRecorder = testResultRecorder;
 
-        InitializeRandomTestOrder(frameworkHandle);
+        InitializeRandomTestOrder(frameworkHandle.ToAdapterMessageLogger());
 
         var testsBySource = (from test in tests
                              group test by test.TestMethod.AssemblyName into testGroup
@@ -223,7 +223,7 @@ internal partial class TestExecutionManager
 
                                 if (queue.TryDequeue(out IEnumerable<UnitTestElement>? testSet))
                                 {
-                                    await ExecuteTestsWithTestRunnerAsync(testSet, frameworkHandle, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
+                                    await ExecuteTestsWithTestRunnerAsync(testSet, adapterMessageLogger, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
                                 }
                             }
                         }
@@ -258,17 +258,17 @@ internal partial class TestExecutionManager
             // Queue the non parallel set
             if (nonParallelizableTestSet != null)
             {
-                await ExecuteTestsWithTestRunnerAsync(nonParallelizableTestSet, frameworkHandle, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
+                await ExecuteTestsWithTestRunnerAsync(nonParallelizableTestSet, adapterMessageLogger, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
             }
         }
         else
         {
-            await ExecuteTestsWithTestRunnerAsync(testsToRun, frameworkHandle, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
+            await ExecuteTestsWithTestRunnerAsync(testsToRun, adapterMessageLogger, source, sourceLevelParameters, testRunner, usesAppDomains).ConfigureAwait(false);
         }
 
         if (PlatformServiceProvider.Instance.IsGracefulStopRequested)
         {
-            testRunner.ForceCleanup(sourceLevelParameters!, new RemotingMessageLogger(frameworkHandle));
+            testRunner.ForceCleanup(sourceLevelParameters!, new RemotingMessageLogger(adapterMessageLogger));
         }
 
         if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsInfoEnabled)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 
@@ -52,7 +50,7 @@ internal partial class TestExecutionManager
 
     private async Task ExecuteTestsWithTestRunnerAsync(
         IEnumerable<UnitTestElement> tests,
-        ITestExecutionRecorder testExecutionRecorder,
+        IAdapterMessageLogger adapterMessageLogger,
         string source,
         IDictionary<string, object> sourceLevelParameters,
         UnitTestRunner testRunner,
@@ -65,11 +63,11 @@ internal partial class TestExecutionManager
                 .ThenBy(t => t.TestMethod.HasManagedMethodAndTypeProperties ? t.TestMethod.ManagedMethodName : null)
             : tests;
 
-        // If testRunner is in a different AppDomain, we cannot pass the testExecutionRecorder directly.
+        // If testRunner is in a different AppDomain, we cannot pass the message logger directly.
         // Instead, we pass a proxy (remoting object) that is marshallable by ref.
-        IMessageLogger remotingMessageLogger = usesAppDomains
-            ? new RemotingMessageLogger(testExecutionRecorder)
-            : testExecutionRecorder;
+        IAdapterMessageLogger remotingMessageLogger = usesAppDomains
+            ? new RemotingMessageLogger(adapterMessageLogger)
+            : adapterMessageLogger;
 
         foreach (UnitTestElement currentTest in orderedTests)
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.TestContext.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.TestContext.cs
@@ -3,9 +3,9 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
@@ -99,7 +99,7 @@ internal partial class TestExecutionManager
     }
 
     [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Requirement is to handle errors in user specified run parameters")]
-    private void CacheSessionParameters(IRunContext? runContext, ITestExecutionRecorder testExecutionRecorder)
+    private void CacheSessionParameters(IRunContext? runContext, IAdapterMessageLogger messageLogger)
     {
         if (StringEx.IsNullOrEmpty(runContext?.RunSettings?.SettingsXml))
         {
@@ -122,7 +122,7 @@ internal partial class TestExecutionManager
         }
         catch (Exception ex)
         {
-            testExecutionRecorder.SendMessage(TestMessageLevel.Error, ex.Message);
+            messageLogger.SendMessage(MessageLevel.Error, ex.Message);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Utilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Utilities.cs
@@ -1,28 +1,35 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 
 internal partial class TestExecutionManager
 {
+    /// <summary>
+    /// A message logger that can be marshaled into the isolation (child app-domain) host so log messages
+    /// raised while running a test cross back to the parent-domain <see cref="IAdapterMessageLogger"/>.
+    /// Marshaling is by reference (the wrapped logger stays in the parent domain), so no VSTest object-model
+    /// type is required in the child domain.
+    /// </summary>
     private sealed class RemotingMessageLogger :
 #if NETFRAMEWORK
         MarshalByRefObject,
 #endif
-        IMessageLogger
+        IAdapterMessageLogger
     {
-        private readonly IMessageLogger _realMessageLogger;
+        private readonly IAdapterMessageLogger _realMessageLogger;
 
-        public RemotingMessageLogger(IMessageLogger messageLogger)
+        public RemotingMessageLogger(IAdapterMessageLogger messageLogger)
             => _realMessageLogger = messageLogger;
 
-        public void SendMessage(TestMessageLevel testMessageLevel, string message)
-            => _realMessageLogger.SendMessage(testMessageLevel, message);
+        public void SendMessage(MessageLevel level, string message)
+            => _realMessageLogger.SendMessage(level, message);
     }
 
-    private void InitializeRandomTestOrder(IMessageLogger frameworkHandle)
+    private void InitializeRandomTestOrder(IAdapterMessageLogger messageLogger)
     {
         if (!MSTestSettings.CurrentSettings.RandomizeTestOrder)
         {
@@ -36,8 +43,8 @@ internal partial class TestExecutionManager
         int seed = MSTestSettings.CurrentSettings.RandomTestOrderSeed ?? Guid.NewGuid().GetHashCode();
         _testOrderRandom = new Random(seed);
 
-        frameworkHandle.SendMessage(
-            TestMessageLevel.Informational,
+        messageLogger.SendMessage(
+            MessageLevel.Informational,
             string.Format(CultureInfo.CurrentCulture, Resource.RandomTestOrderBanner, seed));
     }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -110,7 +110,7 @@ internal partial class TestExecutionManager
 #endif
 
         // Placing this after deployment since we need information post deployment that we pass in as properties.
-        CacheSessionParameters(runContext, frameworkHandle);
+        CacheSessionParameters(runContext, frameworkHandle.ToAdapterMessageLogger());
 
         // Execute the tests
         await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone).ConfigureAwait(false);
@@ -154,7 +154,7 @@ internal partial class TestExecutionManager
 #endif
 
         // Placing this after deployment since we need information post deployment that we pass in as properties.
-        CacheSessionParameters(runContext, frameworkHandle);
+        CacheSessionParameters(runContext, frameworkHandle.ToAdapterMessageLogger());
 
         // Run tests.
         await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone).ConfigureAwait(false);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.RunSingleTest.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.RunSingleTest.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
@@ -14,7 +13,7 @@ internal sealed partial class UnitTestRunner
 {
     // Task cannot cross app domains.
     // For now, TestExecutionManager will call this sync method which is hacky.
-    internal TestResult[] RunSingleTest(UnitTestElement unitTestElement, IDictionary<string, object?> testContextProperties, IMessageLogger messageLogger)
+    internal TestResult[] RunSingleTest(UnitTestElement unitTestElement, IDictionary<string, object?> testContextProperties, IAdapterMessageLogger messageLogger)
         => RunSingleTestAsync(unitTestElement, testContextProperties, messageLogger).GetAwaiter().GetResult();
 
     /// <summary>
@@ -24,7 +23,7 @@ internal sealed partial class UnitTestRunner
     /// <param name="testContextProperties"> The test context properties. </param>
     /// <param name="messageLogger"> The message logger. </param>
     /// <returns> The <see cref="TestResult"/>. </returns>
-    internal async Task<TestResult[]> RunSingleTestAsync(UnitTestElement unitTestElement, IDictionary<string, object?> testContextProperties, IMessageLogger messageLogger)
+    internal async Task<TestResult[]> RunSingleTestAsync(UnitTestElement unitTestElement, IDictionary<string, object?> testContextProperties, IAdapterMessageLogger messageLogger)
     {
         if (unitTestElement is null)
         {
@@ -288,5 +287,5 @@ internal sealed partial class UnitTestRunner
         return true;
     }
 
-    internal void ForceCleanup(IDictionary<string, object?> sourceLevelParameters, IMessageLogger logger) => ClassCleanupManager.ForceCleanup(_typeCache, sourceLevelParameters, logger);
+    internal void ForceCleanup(IDictionary<string, object?> sourceLevelParameters, IAdapterMessageLogger logger) => ClassCleanupManager.ForceCleanup(_typeCache, sourceLevelParameters, logger);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.TestFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.TestFilter.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Extensions;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // The programmatic test-filter types (ITestFilter, TestFilterContext, TestFilterResult,
@@ -150,7 +149,7 @@ internal sealed partial class UnitTestRunner
     private async Task<TestResult[]> FinishFilteredOutTestAsync(
         TestMethod testMethod,
         IDictionary<string, object?> testContextProperties,
-        IMessageLogger messageLogger,
+        IAdapterMessageLogger messageLogger,
         TestResult[] filterResult,
         ITestContext testContextForTestExecution)
     {

--- a/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/IPlatformServiceProvider.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using UTF = Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -97,5 +96,5 @@ internal interface IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
+    ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IAdapterMessageLogger messageLogger, UTF.UnitTestOutcome outcome);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/PlatformServiceProvider.cs
@@ -4,7 +4,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using UTF = Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -166,7 +165,7 @@ internal sealed class PlatformServiceProvider : IPlatformServiceProvider
     /// <remarks>
     /// This was required for compatibility reasons since the TestContext object that the V1 adapter had for desktop is not .Net Core compliant.
     /// </remarks>
-    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IAdapterMessageLogger messageLogger, UTF.UnitTestOutcome outcome)
     {
         var testContextImplementation = new TestContextImplementation(testMethod, testClassFullName, properties, messageLogger, TestRunCancellationToken);
         testContextImplementation.SetOutcome(outcome);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -10,7 +10,6 @@ using System.Collections.ObjectModel;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using ITestMethod = Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.ObjectModel.ITestMethod;
@@ -71,7 +70,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
 #else
     private readonly object _propertiesLock = new();
 #endif
-    private readonly IMessageLogger? _messageLogger;
+    private readonly IAdapterMessageLogger? _messageLogger;
     private readonly TestRunCancellationToken? _testRunCancellationToken;
 
     private CancellationTokenRegistration? _cancellationTokenRegistration;
@@ -113,7 +112,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <param name="properties">Properties/configuration passed in.</param>
     /// <param name="messageLogger">The message logger to use.</param>
     /// <param name="testRunCancellationToken">The global test run cancellation token.</param>
-    internal TestContextImplementation(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger? messageLogger, TestRunCancellationToken? testRunCancellationToken)
+    internal TestContextImplementation(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IAdapterMessageLogger? messageLogger, TestRunCancellationToken? testRunCancellationToken)
     {
         // testMethod can be null when running ForceCleanup (done when reaching --maximum-failed-tests.
         DebugEx.Assert(properties != null, "properties is not null");
@@ -428,7 +427,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
 
     /// <inheritdoc/>
     public override void DisplayMessage(MessageLevel messageLevel, string message)
-        => _messageLogger?.SendMessage(messageLevel.ToTestMessageLevel(), message);
+        => _messageLogger?.SendMessage(messageLevel, message);
     #endregion
 
     /// <inheritdoc/>

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -9,8 +9,8 @@ using System.Data.Common;
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using Moq;
 
@@ -28,7 +28,7 @@ public class TestContextImplementationTests : TestContainer
 
     private TestContextImplementation _testContextImplementation = null!;
 
-    private TestContextImplementation CreateTestContextImplementation(IMessageLogger? messageLogger = null)
+    private TestContextImplementation CreateTestContextImplementation(IAdapterMessageLogger? messageLogger = null)
         => new(_testMethod.Object, null, _properties, messageLogger, null);
 
     public void TestContextConstructorShouldInitializeProperties()
@@ -346,19 +346,19 @@ public class TestContextImplementationTests : TestContainer
 
     public void DisplayMessageShouldForwardToIMessageLogger()
     {
-        var messageLoggerMock = new Mock<IMessageLogger>(MockBehavior.Strict);
+        var messageLoggerMock = new Mock<IAdapterMessageLogger>(MockBehavior.Strict);
 
         messageLoggerMock
-            .Setup(l => l.SendMessage(It.IsAny<TestMessageLevel>(), It.IsAny<string>()));
+            .Setup(l => l.SendMessage(It.IsAny<MessageLevel>(), It.IsAny<string>()));
 
         _testContextImplementation = CreateTestContextImplementation(messageLoggerMock.Object);
         _testContextImplementation.DisplayMessage(MessageLevel.Informational, "InfoMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Warning, "WarningMessage");
         _testContextImplementation.DisplayMessage(MessageLevel.Error, "ErrorMessage");
 
-        messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Informational, "InfoMessage"), Times.Once);
-        messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Warning, "WarningMessage"), Times.Once);
-        messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Error, "ErrorMessage"), Times.Once);
+        messageLoggerMock.Verify(x => x.SendMessage(MessageLevel.Informational, "InfoMessage"), Times.Once);
+        messageLoggerMock.Verify(x => x.SendMessage(MessageLevel.Warning, "WarningMessage"), Times.Once);
+        messageLoggerMock.Verify(x => x.SendMessage(MessageLevel.Error, "ErrorMessage"), Times.Once);
     }
 
     public void GetAndClearOutput_ShouldReturnContentThenClearBuffer()
@@ -399,7 +399,7 @@ public class TestContextImplementationTests : TestContainer
 
     public void WritesFromBackgroundThreadShouldNotThrow()
     {
-        TestContextImplementation testContextImplementation = CreateTestContextImplementation(new Mock<IMessageLogger>().Object);
+        TestContextImplementation testContextImplementation = CreateTestContextImplementation(new Mock<IAdapterMessageLogger>().Object);
         var t = new Thread(() =>
         {
             for (int i = 0; i < 100; i++)
@@ -704,12 +704,12 @@ public class TestContextImplementationTests : TestContainer
 
     public void CloneForDataDrivenIterationShouldShareMessageLogger()
     {
-        var messageLoggerMock = new Mock<IMessageLogger>();
+        var messageLoggerMock = new Mock<IAdapterMessageLogger>();
         _testContextImplementation = CreateTestContextImplementation(messageLoggerMock.Object);
 
         TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
         clone.DisplayMessage(MessageLevel.Informational, "from-clone");
 
-        messageLoggerMock.Verify(x => x.SendMessage(TestMessageLevel.Informational, "from-clone"), Times.Once);
+        messageLoggerMock.Verify(x => x.SendMessage(MessageLevel.Informational, "from-clone"), Times.Once);
     }
 }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/TestablePlatformServiceProvider.cs
@@ -4,7 +4,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
 using Moq;
 
@@ -69,7 +68,7 @@ internal class TestablePlatformServiceProvider : IPlatformServiceProvider
 
     public int GetTestContextCallCount { get; private set; }
 
-    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IMessageLogger messageLogger, UnitTestOutcome outcome)
+    public ITestContext GetTestContext(ITestMethod? testMethod, string? testClassFullName, IDictionary<string, object?> properties, IAdapterMessageLogger messageLogger, UnitTestOutcome outcome)
     {
         GetTestContextCallCount++;
         var testContextImpl = new TestContextImplementation(testMethod, testClassFullName, properties, messageLogger, testRunCancellationToken: null);


### PR DESCRIPTION
## Phase 6c of the PlatformServices platform-agnostic initiative

Part of the effort to remove the VSTest object model (`Microsoft.TestPlatform.ObjectModel`) dependency from `MSTestAdapter.PlatformServices`, moving VSTest coupling **up** into `MSTest.TestAdapter`.

This phase neutralizes the **test message logger**: it replaces the VSTest `IMessageLogger` with the platform-agnostic `IAdapterMessageLogger` (introduced in Phase 1) throughout the execution engine, test-context, and class-cleanup paths — **including the logger marshaled into the isolation host (child AppDomain)** for `RunSingleTest`.

### What changed
- **`RemotingMessageLogger`** now implements `IAdapterMessageLogger` instead of VSTest `IMessageLogger` (still `MarshalByRefObject` on netfx). It wraps a parent-domain `IAdapterMessageLogger` and forwards `SendMessage(MessageLevel, string)`. Marshaling stays **by reference** — the wrapped logger never crosses into the child domain, and `MessageLevel` is a serializable enum, so no VSTest type is needed child-side.
- **`IPlatformServiceProvider.GetTestContext`**, **`UnitTestRunner.RunSingleTest(Async)`/`ForceCleanup`**, **`ClassCleanupManager.ForceCleanup`**, **`TestContextImplementation`** (field + ctor), and **`InitializeRandomTestOrder`** now take `IAdapterMessageLogger`.
- **`TestContext.DisplayMessage`** forwards `MessageLevel` directly to the neutral logger (the `MessageLevel`→`TestMessageLevel` conversion now happens once, at the boundary bridge).
- The engine obtains the neutral logger via `frameworkHandle.ToAdapterMessageLogger()` at the same points it already used for discovery.

### No behavior change
The same messages cross the same AppDomain boundary to the same host logger; `MessageLevel` maps 1:1 to `TestMessageLevel` at the bridge. The non-AppDomain path is unchanged. The single remaining VSTest logging reference in PlatformServices is the `AdapterMessageLoggerExtensions` bridge, to be relocated with the other bridges in a later phase.

### Verification
- Full build green across all TFMs (net462, net8.0, net9.0, UWP, WinUI).
- `MSTestAdapter.PlatformServices.UnitTests`: 897 (net8.0) / 935 (net462); `MSTestAdapter.UnitTests`: 21 — all pass.
- `MSTest.IntegrationTests` (net462, exercises **AppDomain-isolated** execution → child-domain logging via the marshaled logger): 47 passed / 1 skipped / 0 failed.
- Expert MSTest/MTP reviewer: no correctness/marshaling/fidelity/public-API findings.

### Base
- **Base = `dev/amauryleve/vstest-decoupling-base`**, which already contains Phase 3 (#9566), Phase 4 (#9572), Phase 6a (#9576), and Phase 6b (#9579). Developed stacked on 6b; 6b has since merged into the base, so the diff here is 6c only (13 files).

### Remaining work (later phases)
- Host run-contexts/settings (`IRunContext`/`IRunSettings`/`IDiscoveryContext`; `CreateTestSourceHost(IRunSettings)`).
- 6d: filter internals (folds in #9568).
- 6e: relocate remaining bridges (recorder/deployment/logger/message-level).
- 7: remove the `Microsoft.TestPlatform.ObjectModel` PackageReference + guard test.