### PR TITLE
Transfer ownership in ReflectionMetadataHook.Register instead of cloning

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/CompositeSourceGeneratedReflectionDataProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/CompositeSourceGeneratedReflectionDataProvider.cs
@@ -222,7 +222,7 @@ internal sealed class CompositeSourceGeneratedReflectionDataProvider : SourceGen
             };
         }
 
-        private static void MergeInto<TKey, TValue>(Dictionary<TKey, TValue> target, Dictionary<TKey, TValue> source)
+        private static void MergeInto<TKey, TValue>(Dictionary<TKey, TValue> target, IReadOnlyDictionary<TKey, TValue> source)
             where TKey : notnull
         {
             foreach (KeyValuePair<TKey, TValue> kvp in source)

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
@@ -127,11 +127,12 @@ public static class ReflectionMetadataHook
     /// <para>
     /// <b>Ownership transfer.</b> The adapter takes ownership of every collection passed in
     /// (the <paramref name="types"/> array, the <paramref name="assemblyAttributes"/> array, and
-    /// each dictionary with its value arrays) and stores them without cloning. The generator emits
-    /// fresh, throwaway collections for each call, so the caller MUST NOT mutate any of these
-    /// inputs after the call returns. This trades the previous defensive copies for zero-copy
-    /// startup, relying on the single trusted caller (the generator, versioned in lockstep with
-    /// this adapter) rather than defending a public surface that is documented as not for direct use.
+    /// each dictionary with its value arrays) and stores them without cloning. Callers MUST hand
+    /// over freshly-built collections and MUST NOT mutate them after the call returns; the source
+    /// generator (the only intended caller) already emits fresh, throwaway collections that satisfy
+    /// this. This is a contract about ownership and mutation, not caller identity: it trades the
+    /// previous defensive copies for zero-copy startup on the understanding that the inputs are the
+    /// adapter's to keep.
     /// </para>
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
@@ -127,12 +127,13 @@ public static class ReflectionMetadataHook
     /// <para>
     /// <b>Ownership transfer.</b> The adapter takes ownership of every collection passed in
     /// (the <paramref name="types"/> array, the <paramref name="assemblyAttributes"/> array, and
-    /// each dictionary with its value arrays) and stores them without cloning. Callers MUST hand
-    /// over freshly-built collections and MUST NOT mutate them after the call returns; the source
-    /// generator (the only intended caller) already emits fresh, throwaway collections that satisfy
-    /// this. This is a contract about ownership and mutation, not caller identity: it trades the
-    /// previous defensive copies for zero-copy startup on the understanding that the inputs are the
-    /// adapter's to keep.
+    /// each dictionary with its value arrays) and stores them without cloning; the read-only
+    /// dictionaries are held as-is behind <see cref="IReadOnlyDictionary{TKey, TValue}"/>. Callers
+    /// MUST hand over freshly-built collections and MUST NOT mutate them after the call returns;
+    /// the source generator (the only intended caller) already emits fresh, throwaway collections
+    /// that satisfy this. This is a contract about ownership and mutation, not caller identity: it
+    /// trades the previous defensive copies for zero-copy startup on the understanding that the
+    /// inputs are the adapter's to keep.
     /// </para>
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -188,17 +189,11 @@ public static class ReflectionMetadataHook
 
         // Ownership transfer (see the remarks on this method): the source generator hands over
         // freshly-built, throwaway collections and never mutates them after the call, so we store
-        // them directly instead of cloning. Arrays are kept by reference; dictionaries are reused
-        // as-is when already concrete and only materialized when the caller passed some other
-        // IReadOnlyDictionary implementation.
-        Dictionary<Type, MethodInfo[]> testMethodsMap = AsOwnedDictionary(testMethods);
-        Dictionary<Type, Attribute[]> typeAttributesMap = AsOwnedDictionary(typeAttributes);
-        Dictionary<MethodInfo, Func<object?, object?[]?, object?>> methodInvokersMap = AsOwnedDictionary(methodInvokers);
-        Dictionary<PropertyInfo, Action<object?, object?>> propertySettersMap = AsOwnedDictionary(propertySetters);
-
-        // ConstructorInvokerInfo (public struct) has to be projected onto the adapter's internal
-        // ConstructorInvoker type; this is a representation change, not a defensive copy, and the
-        // parameter-type arrays are taken by reference.
+        // the passed arrays and read-only dictionaries directly instead of copying them.
+        //
+        // ConstructorInvokerInfo (public struct) still has to be projected onto the adapter's
+        // internal ConstructorInvoker type; this is a representation change, not a defensive copy,
+        // and the parameter-type arrays are taken by reference.
         var constructorInvokersMap = new Dictionary<Type, SourceGeneratedReflectionDataProvider.ConstructorInvoker[]>(constructorInvokers.Count);
         foreach (KeyValuePair<Type, ConstructorInvokerInfo[]> kvp in constructorInvokers)
         {
@@ -235,12 +230,12 @@ public static class ReflectionMetadataHook
             AssemblyName = assembly.GetName().Name ?? string.Empty,
             Types = types,
             TypesByName = typesByName,
-            TypeMethods = testMethodsMap,
-            TypeAttributes = typeAttributesMap,
+            TypeMethods = testMethods,
+            TypeAttributes = typeAttributes,
             AssemblyAttributes = assemblyAttributes,
-            TypeMethodInvokers = methodInvokersMap,
+            TypeMethodInvokers = methodInvokers,
             TypeConstructorsInvoker = constructorInvokersMap,
-            TypePropertySetters = propertySettersMap,
+            TypePropertySetters = propertySetters,
         };
 
         lock (Lock)
@@ -255,27 +250,6 @@ public static class ReflectionMetadataHook
                 concreteProvider.SetSourceGeneratedOperations(reflectionOperations, fileOperations);
             }
         }
-    }
-
-    // Reuses the caller-provided dictionary when it is already a concrete Dictionary<,> (the shape
-    // the source generator always emits), honoring the ownership-transfer contract with zero
-    // copying. Any other IReadOnlyDictionary implementation is materialized once so the provider
-    // still owns a concrete instance. Values are always taken by reference.
-    private static Dictionary<TKey, TValue> AsOwnedDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> source)
-        where TKey : notnull
-    {
-        if (source is Dictionary<TKey, TValue> concrete)
-        {
-            return concrete;
-        }
-
-        var copy = new Dictionary<TKey, TValue>(source.Count);
-        foreach (KeyValuePair<TKey, TValue> kvp in source)
-        {
-            copy[kvp.Key] = kvp.Value;
-        }
-
-        return copy;
     }
 
     private static readonly Dictionary<Type, Attribute[]> EmptyTypeAttributes = [];

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/ReflectionMetadataHook.cs
@@ -52,8 +52,8 @@ public static class ReflectionMetadataHook
     /// <param name="types">All types directly annotated with <c>[TestClass]</c> in the assembly.</param>
     /// <param name="testMethods">
     /// A map from each test class to its <c>[TestMethod]</c>-annotated <see cref="MethodInfo"/>
-    /// set. The dictionary and arrays are copied defensively; the caller may mutate the inputs
-    /// after the call.
+    /// set. Ownership transfers to the adapter: the source generator hands over freshly-built
+    /// collections and must not mutate them after the call (see the remarks on the full overload).
     /// </param>
     /// <remarks>
     /// Do not call this method from hand-written code; it is meant to be invoked exclusively from
@@ -120,8 +120,19 @@ public static class ReflectionMetadataHook
     /// assigns it directly.
     /// </param>
     /// <remarks>
+    /// <para>
     /// Do not call this method from hand-written code; it is meant to be invoked exclusively from
     /// the <c>[ModuleInitializer]</c> emitted by the MSTest source generator.
+    /// </para>
+    /// <para>
+    /// <b>Ownership transfer.</b> The adapter takes ownership of every collection passed in
+    /// (the <paramref name="types"/> array, the <paramref name="assemblyAttributes"/> array, and
+    /// each dictionary with its value arrays) and stores them without cloning. The generator emits
+    /// fresh, throwaway collections for each call, so the caller MUST NOT mutate any of these
+    /// inputs after the call returns. This trades the previous defensive copies for zero-copy
+    /// startup, relying on the single trusted caller (the generator, versioned in lockstep with
+    /// this adapter) rather than defending a public surface that is documented as not for direct use.
+    /// </para>
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void Register(
@@ -174,29 +185,20 @@ public static class ReflectionMetadataHook
             throw new ArgumentNullException(nameof(propertySetters));
         }
 
-        var typesCopy = (Type[])types.Clone();
+        // Ownership transfer (see the remarks on this method): the source generator hands over
+        // freshly-built, throwaway collections and never mutates them after the call, so we store
+        // them directly instead of cloning. Arrays are kept by reference; dictionaries are reused
+        // as-is when already concrete and only materialized when the caller passed some other
+        // IReadOnlyDictionary implementation.
+        Dictionary<Type, MethodInfo[]> testMethodsMap = AsOwnedDictionary(testMethods);
+        Dictionary<Type, Attribute[]> typeAttributesMap = AsOwnedDictionary(typeAttributes);
+        Dictionary<MethodInfo, Func<object?, object?[]?, object?>> methodInvokersMap = AsOwnedDictionary(methodInvokers);
+        Dictionary<PropertyInfo, Action<object?, object?>> propertySettersMap = AsOwnedDictionary(propertySetters);
 
-        var testMethodsCopy = new Dictionary<Type, MethodInfo[]>(testMethods.Count);
-        foreach (KeyValuePair<Type, MethodInfo[]> kvp in testMethods)
-        {
-            testMethodsCopy[kvp.Key] = (MethodInfo[])kvp.Value.Clone();
-        }
-
-        var typeAttributesCopy = new Dictionary<Type, Attribute[]>(typeAttributes.Count);
-        foreach (KeyValuePair<Type, Attribute[]> kvp in typeAttributes)
-        {
-            typeAttributesCopy[kvp.Key] = (Attribute[])kvp.Value.Clone();
-        }
-
-        object[] assemblyAttributesCopy = (object[])assemblyAttributes.Clone();
-
-        var methodInvokersCopy = new Dictionary<MethodInfo, Func<object?, object?[]?, object?>>(methodInvokers.Count);
-        foreach (KeyValuePair<MethodInfo, Func<object?, object?[]?, object?>> kvp in methodInvokers)
-        {
-            methodInvokersCopy[kvp.Key] = kvp.Value;
-        }
-
-        var constructorInvokersCopy = new Dictionary<Type, SourceGeneratedReflectionDataProvider.ConstructorInvoker[]>(constructorInvokers.Count);
+        // ConstructorInvokerInfo (public struct) has to be projected onto the adapter's internal
+        // ConstructorInvoker type; this is a representation change, not a defensive copy, and the
+        // parameter-type arrays are taken by reference.
+        var constructorInvokersMap = new Dictionary<Type, SourceGeneratedReflectionDataProvider.ConstructorInvoker[]>(constructorInvokers.Count);
         foreach (KeyValuePair<Type, ConstructorInvokerInfo[]> kvp in constructorInvokers)
         {
             var invokers = new SourceGeneratedReflectionDataProvider.ConstructorInvoker[kvp.Value.Length];
@@ -205,26 +207,20 @@ public static class ReflectionMetadataHook
                 ConstructorInvokerInfo info = kvp.Value[i];
                 invokers[i] = new SourceGeneratedReflectionDataProvider.ConstructorInvoker
                 {
-                    Parameters = (Type[])info.ParameterTypes.Clone(),
+                    Parameters = info.ParameterTypes,
                     Invoker = info.Invoker,
                 };
             }
 
-            constructorInvokersCopy[kvp.Key] = invokers;
-        }
-
-        var propertySettersCopy = new Dictionary<PropertyInfo, Action<object?, object?>>(propertySetters.Count);
-        foreach (KeyValuePair<PropertyInfo, Action<object?, object?>> kvp in propertySetters)
-        {
-            propertySettersCopy[kvp.Key] = kvp.Value;
+            constructorInvokersMap[kvp.Key] = invokers;
         }
 
         // TypesByName must always match Type.FullName at runtime (see comment in the source
         // generator emitter): compute it on the runtime side from typeof(T).FullName so the
         // generator emits less code and the same FullName conventions are honored for nested
         // and generic types.
-        var typesByName = new Dictionary<string, Type>(typesCopy.Length, StringComparer.Ordinal);
-        foreach (Type type in typesCopy)
+        var typesByName = new Dictionary<string, Type>(types.Length, StringComparer.Ordinal);
+        foreach (Type type in types)
         {
             if (type.FullName is { } fullName)
             {
@@ -236,14 +232,14 @@ public static class ReflectionMetadataHook
         {
             Assembly = assembly,
             AssemblyName = assembly.GetName().Name ?? string.Empty,
-            Types = typesCopy,
+            Types = types,
             TypesByName = typesByName,
-            TypeMethods = testMethodsCopy,
-            TypeAttributes = typeAttributesCopy,
-            AssemblyAttributes = assemblyAttributesCopy,
-            TypeMethodInvokers = methodInvokersCopy,
-            TypeConstructorsInvoker = constructorInvokersCopy,
-            TypePropertySetters = propertySettersCopy,
+            TypeMethods = testMethodsMap,
+            TypeAttributes = typeAttributesMap,
+            AssemblyAttributes = assemblyAttributes,
+            TypeMethodInvokers = methodInvokersMap,
+            TypeConstructorsInvoker = constructorInvokersMap,
+            TypePropertySetters = propertySettersMap,
         };
 
         lock (Lock)
@@ -258,6 +254,27 @@ public static class ReflectionMetadataHook
                 concreteProvider.SetSourceGeneratedOperations(reflectionOperations, fileOperations);
             }
         }
+    }
+
+    // Reuses the caller-provided dictionary when it is already a concrete Dictionary<,> (the shape
+    // the source generator always emits), honoring the ownership-transfer contract with zero
+    // copying. Any other IReadOnlyDictionary implementation is materialized once so the provider
+    // still owns a concrete instance. Values are always taken by reference.
+    private static Dictionary<TKey, TValue> AsOwnedDictionary<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> source)
+        where TKey : notnull
+    {
+        if (source is Dictionary<TKey, TValue> concrete)
+        {
+            return concrete;
+        }
+
+        var copy = new Dictionary<TKey, TValue>(source.Count);
+        foreach (KeyValuePair<TKey, TValue> kvp in source)
+        {
+            copy[kvp.Key] = kvp.Value;
+        }
+
+        return copy;
     }
 
     private static readonly Dictionary<Type, Attribute[]> EmptyTypeAttributes = [];

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
@@ -33,13 +33,13 @@ internal class SourceGeneratedReflectionDataProvider
     /// <summary>
     /// Gets a lookup of types by full name.
     /// </summary>
-    public Dictionary<string, Type> TypesByName { get; init; } = [];
+    public IReadOnlyDictionary<string, Type> TypesByName { get; init; } = new Dictionary<string, Type>();
 
     /// <summary>
     /// Gets attributes declared on each type. The array contains attribute instances
     /// already inflated by the source generator so no reflection call is required to read them.
     /// </summary>
-    public Dictionary<Type, Attribute[]> TypeAttributes { get; init; } = [];
+    public IReadOnlyDictionary<Type, Attribute[]> TypeAttributes { get; init; } = new Dictionary<Type, Attribute[]>();
 
     /// <summary>
     /// Gets attribute instances declared at the assembly level.
@@ -50,7 +50,7 @@ internal class SourceGeneratedReflectionDataProvider
     /// Gets the properties declared on each type that MSTest may inspect (for example
     /// <c>TestContext</c> properties or properties referenced by <c>DynamicData</c>).
     /// </summary>
-    public Dictionary<Type, PropertyInfo[]> TypeProperties { get; init; } = [];
+    public IReadOnlyDictionary<Type, PropertyInfo[]> TypeProperties { get; init; } = new Dictionary<Type, PropertyInfo[]>();
 
     /// <summary>
     /// Gets the methods declared on each type that the source generator was able to surface
@@ -62,36 +62,36 @@ internal class SourceGeneratedReflectionDataProvider
     /// source for <c>BindingFlags.DeclaredOnly</c>-style enumerations; the reflection-backed
     /// fallback is responsible for completeness.
     /// </remarks>
-    public Dictionary<Type, MethodInfo[]> TypeMethods { get; init; } = [];
+    public IReadOnlyDictionary<Type, MethodInfo[]> TypeMethods { get; init; } = new Dictionary<Type, MethodInfo[]>();
 
     /// <summary>
     /// Gets source-location data for each type's methods so navigation in the IDE works
     /// without a PDB round-trip.
     /// </summary>
-    public Dictionary<string, TypeLocation> TypeMethodLocations { get; init; } = [];
+    public IReadOnlyDictionary<string, TypeLocation> TypeMethodLocations { get; init; } = new Dictionary<string, TypeLocation>();
 
     /// <summary>
     /// Gets attributes declared on each method, keyed by the <see cref="MethodInfo"/> instance
     /// that the source-generator resolved at startup. Keying by <see cref="MethodInfo"/>
     /// (rather than method name) preserves the ability to distinguish overloaded methods.
     /// </summary>
-    public Dictionary<MethodInfo, Attribute[]> TypeMethodAttributes { get; init; } = [];
+    public IReadOnlyDictionary<MethodInfo, Attribute[]> TypeMethodAttributes { get; init; } = new Dictionary<MethodInfo, Attribute[]>();
 
     /// <summary>
     /// Gets constructors declared on each type. These are returned by
     /// <c>GetDeclaredConstructors</c>.
     /// </summary>
-    public Dictionary<Type, ConstructorInfo[]> TypeConstructors { get; init; } = [];
+    public IReadOnlyDictionary<Type, ConstructorInfo[]> TypeConstructors { get; init; } = new Dictionary<Type, ConstructorInfo[]>();
 
     /// <summary>
     /// Gets a lookup of properties on a type by property name.
     /// </summary>
-    public Dictionary<Type, Dictionary<string, PropertyInfo>> TypePropertiesByName { get; init; } = [];
+    public IReadOnlyDictionary<Type, Dictionary<string, PropertyInfo>> TypePropertiesByName { get; init; } = new Dictionary<Type, Dictionary<string, PropertyInfo>>();
 
     /// <summary>
     /// Gets the constructor invokers that allow instantiating types without reflection.
     /// </summary>
-    public Dictionary<Type, ConstructorInvoker[]> TypeConstructorsInvoker { get; init; } = [];
+    public IReadOnlyDictionary<Type, ConstructorInvoker[]> TypeConstructorsInvoker { get; init; } = new Dictionary<Type, ConstructorInvoker[]>();
 
     /// <summary>
     /// Gets the delegate-based invokers for test methods and fixtures, keyed by the
@@ -102,14 +102,14 @@ internal class SourceGeneratedReflectionDataProvider
     /// a <see cref="System.Threading.Tasks.ValueTask"/> is converted with <c>AsTask()</c>, and any
     /// return value is discarded — so callers can simply await the result.
     /// </summary>
-    public Dictionary<MethodInfo, Func<object?, object?[]?, object?>> TypeMethodInvokers { get; init; } = [];
+    public IReadOnlyDictionary<MethodInfo, Func<object?, object?[]?, object?>> TypeMethodInvokers { get; init; } = new Dictionary<MethodInfo, Func<object?, object?[]?, object?>>();
 
     /// <summary>
     /// Gets the delegate-based property setters, keyed by the <see cref="PropertyInfo"/> the
     /// adapter holds (today: the <c>TestContext</c> property). Each delegate assigns the value
     /// directly instead of calling <see cref="PropertyInfo.SetValue(object, object)"/>.
     /// </summary>
-    public Dictionary<PropertyInfo, Action<object?, object?>> TypePropertySetters { get; init; } = [];
+    public IReadOnlyDictionary<PropertyInfo, Action<object?, object?>> TypePropertySetters { get; init; } = new Dictionary<PropertyInfo, Action<object?, object?>>();
 
     /// <summary>
     /// Returns the snapshot of merged metadata that callers should read. Single-assembly

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
@@ -34,7 +34,7 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
 
         var provider = new SourceGeneratedReflectionDataProvider
         {
-            TypeMethodInvokers = { [add] = invoker },
+            TypeMethodInvokers = new Dictionary<MethodInfo, Func<object?, object?[]?, object?>> { [add] = invoker },
         };
         var operations = new SourceGeneratedReflectionOperations(provider);
 
@@ -67,7 +67,7 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
         ];
         var provider = new SourceGeneratedReflectionDataProvider
         {
-            TypeConstructorsInvoker = { [typeof(Sample)] = invokers },
+            TypeConstructorsInvoker = new Dictionary<Type, SourceGeneratedReflectionDataProvider.ConstructorInvoker[]> { [typeof(Sample)] = invokers },
         };
         var operations = new SourceGeneratedReflectionOperations(provider);
 
@@ -99,7 +99,7 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
         ];
         var provider = new SourceGeneratedReflectionDataProvider
         {
-            TypeConstructorsInvoker = { [typeof(Sample)] = invokers },
+            TypeConstructorsInvoker = new Dictionary<Type, SourceGeneratedReflectionDataProvider.ConstructorInvoker[]> { [typeof(Sample)] = invokers },
         };
         var operations = new SourceGeneratedReflectionOperations(provider);
 
@@ -119,7 +119,7 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
 
         var provider = new SourceGeneratedReflectionDataProvider
         {
-            TypePropertySetters = { [property] = setter },
+            TypePropertySetters = new Dictionary<PropertyInfo, Action<object?, object?>> { [property] = setter },
         };
         var operations = new SourceGeneratedReflectionOperations(provider);
 


### PR DESCRIPTION
## What

The source-generated `ReflectionMetadataHook.Register` defensively cloned every array and dictionary it received (`types.Clone()`, per-value `MethodInfo[]`/`Attribute[]` clones, `assemblyAttributes.Clone()`, per-constructor `ParameterTypes.Clone()`, plus shallow dictionary re-materialization). This PR replaces that with an **ownership-transfer** contract, eliminating the cloning at startup.

## Why

`Register` is `public` only because the MSTest source generator emits a `[ModuleInitializer]` that calls it across the assembly boundary — it is documented as **not for hand-written use**. Both generators (the shipping `ReflectionMetadataEmitter` and the AOT `RuntimeRegistrationEmitter`) build **fresh, throwaway collections** for each call and never touch them again. So the defensive copies were guarding against a caller mutation that the only sanctioned caller cannot perform.

True caller-identity authentication isn't possible (generated code lives in the untrusted test assembly, so any token/sentinel is forgeable). But we don't need identity trust — we need mutation safety, which we get structurally by taking ownership of the fresh collections the generator hands over.

## How

- Store the passed `Type[]` / `object[]` arrays **by reference** (no clone).
- Reuse the caller's dictionary as-is when it's already a concrete `Dictionary<,>` (the shape both generators always emit) via a new `AsOwnedDictionary` helper; only exotic `IReadOnlyDictionary` implementations get a one-time shallow copy.
- The `ConstructorInvokerInfo` → internal `ConstructorInvoker` projection remains (a representation change, not a defensive copy) but no longer clones parameter arrays.
- Flips the XML-doc contract: the old "caller may mutate after the call" promise is replaced with an explicit ownership-transfer contract in the remarks.

Multi-TFM safe: uses only `is`-pattern, capacity ctors, and `foreach`, so it compiles on the full matrix down to net462 / netstandard2.0 / uap10.0.16299 (avoids newer BCL APIs like `new Dictionary(IEnumerable<KVP>)`).

## Verification

- **Build**: all TFMs (net462, net8.0, net9.0, net8.0-windows, net9.0-windows, uap10.0.16299) — 0 warnings, 0 errors.
- **Unit tests**: `MSTestAdapter.PlatformServices.UnitTests` — 893/893 pass.
- **Acceptance (runtime `Register` path, after `-pack`)**: `SourceGenerationNonAotTests` (2/2, 3-arg overload); `InconclusiveTests` (24/24) across **Reflection, SourceGeneration, and AotSourceGeneration** modes — the last exercises the modified 8-arg overload end-to-end.