### PR TITLE
Document GH_AW_GITHUB_TOKEN removal and enterprise 8-day PAT policy

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,14 +43,22 @@ Agentic workflows authenticate through repository secrets:
 | Secret / permission | Used for | Notes |
 | --- | --- | --- |
 | `COPILOT_GITHUB_TOKEN` | GitHub Copilot CLI (model inference) | Fine-grained PAT. **Preferably replaced** by the `copilot-requests: write` permission — see below. |
-| `GH_AW_GITHUB_TOKEN` | GitHub MCP reads / safe-output writes that need more than the default `GITHUB_TOKEN` | Fine-grained PAT and the token that used to be forced by lockdown mode. **Preferably replaced** by a GitHub App — see below. |
+| `GH_AW_GITHUB_TOKEN` | GitHub MCP reads / safe-output writes that need more than the default `GITHUB_TOKEN` | Fine-grained PAT and the token that used to be forced by lockdown mode. **Preferably replaced** by a GitHub App — see below. **Currently unset**: the compiler's token chain (`GH_AW_GITHUB_MCP_SERVER_TOKEN \|\| GH_AW_GITHUB_TOKEN \|\| GITHUB_TOKEN`) falls back to the per-run `GITHUB_TOKEN` when this secret is absent, so leave it unset unless a workflow needs elevated access. |
 
 > [!IMPORTANT]
-> **Fine-grained PATs expire and, under the `microsoft` org policy, may live at most ~1 week.**
-> A PAT-based setup therefore breaks on a short cycle: when the token lapses, every workflow
-> that depends on it fails at once and files a burst of `[aw] … failed` issues. Prefer the
-> two PAT-free options below — together they let this repo run agentic workflows with **no
-> long-lived PAT at all**.
+> **Fine-grained PATs expire, and the `Microsoft Open Source` enterprise now hard-rejects any
+> fine-grained PAT whose lifetime exceeds 8 days** (the API returns `403` with a message pointing
+> at the token's settings page). A PAT-based setup therefore breaks on a short cycle: when the
+> token lapses — or simply outlives the 8-day window — every workflow that depends on it fails at
+> once (e.g. the `Checkout PR branch` step 403s on the collaborator-permission and PR lookups) and
+> files a burst of `[aw] … failed` issues. Prefer the two PAT-free options below — together they
+> let this repo run agentic workflows with **no long-lived PAT at all**.
+>
+> **Fast unblock:** delete the `GH_AW_GITHUB_TOKEN` secret (`gh secret delete GH_AW_GITHUB_TOKEN
+> --repo microsoft/testfx`). Because no source workflow forces a custom PAT anymore (`lockdown` was
+> removed repo-wide and all declare `min-integrity: none`), every workflow then degrades gracefully
+> to the built-in `GITHUB_TOKEN`. The only case that still needs elevated auth is a write-back on a
+> **fork** PR (where `GITHUB_TOKEN` is read-only) — use the GitHub App below for those.
 
 ### Preferred: eliminate the expiring PATs
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,7 +43,7 @@ Agentic workflows authenticate through repository secrets:
 | Secret / permission | Used for | Notes |
 | --- | --- | --- |
 | `COPILOT_GITHUB_TOKEN` | GitHub Copilot CLI (model inference) | Fine-grained PAT. **Preferably replaced** by the `copilot-requests: write` permission — see below. |
-| `GH_AW_GITHUB_TOKEN` | GitHub MCP reads / safe-output writes that need more than the default `GITHUB_TOKEN` | Fine-grained PAT and the token that used to be forced by lockdown mode. **Preferably replaced** by a GitHub App — see below. **Currently unset**: the compiler's token chain (`GH_AW_GITHUB_MCP_SERVER_TOKEN \|\| GH_AW_GITHUB_TOKEN \|\| GITHUB_TOKEN`) falls back to the per-run `GITHUB_TOKEN` when this secret is absent, so leave it unset unless a workflow needs elevated access. |
+| `GH_AW_GITHUB_TOKEN` | GitHub MCP reads / safe-output writes that need more than the default `GITHUB_TOKEN` | Fine-grained PAT and the token that used to be forced by lockdown mode. **Preferably replaced** by a GitHub App — see below. **Currently unset**: the compiler's token chain (`GH_AW_GITHUB_MCP_SERVER_TOKEN` \|\| `GH_AW_GITHUB_TOKEN` \|\| `GITHUB_TOKEN`) falls back to the per-run `GITHUB_TOKEN` when this secret is absent, so leave it unset unless a workflow needs elevated access. |
 
 > [!IMPORTANT]
 > **Fine-grained PATs expire, and the `Microsoft Open Source` enterprise now hard-rejects any
@@ -54,8 +54,8 @@ Agentic workflows authenticate through repository secrets:
 > files a burst of `[aw] … failed` issues. Prefer the two PAT-free options below — together they
 > let this repo run agentic workflows with **no long-lived PAT at all**.
 >
-> **Fast unblock:** delete the `GH_AW_GITHUB_TOKEN` secret (`gh secret delete GH_AW_GITHUB_TOKEN
-> --repo microsoft/testfx`). Because no source workflow forces a custom PAT anymore (`lockdown` was
+> **Fast unblock:** delete the `GH_AW_GITHUB_TOKEN` secret (run `gh secret delete GH_AW_GITHUB_TOKEN --repo microsoft/testfx`).
+> Because no source workflow forces a custom PAT anymore (`lockdown` was
 > removed repo-wide and all declare `min-integrity: none`), every workflow then degrades gracefully
 > to the built-in `GITHUB_TOKEN`. The only case that still needs elevated auth is a write-back on a
 > **fork** PR (where `GITHUB_TOKEN` is read-only) — use the GitHub App below for those.


### PR DESCRIPTION
## Why

The `Grade Tests on PR` agentic workflow (and every other gh-aw workflow here) was failing at the **Checkout PR branch** step, e.g. run [28666711551](https://github.com/microsoft/testfx/actions/runs/28666711551) on #9583:

```
GET /repos/microsoft/testfx/collaborators/Evangelink/permission - 403
GET /repos/microsoft/testfx/pulls/9583 - 403
The 'Microsoft Open Source' enterprise forbids access via a fine-grained
personal access token if the token's lifetime is greater than 8 days.
```

The enterprise now **hard-rejects fine-grained PATs whose lifetime exceeds 8 days**. The failing step resolves its token as `GH_AW_GITHUB_MCP_SERVER_TOKEN || GH_AW_GITHUB_TOKEN || GITHUB_TOKEN`, so the over-lifetime `GH_AW_GITHUB_TOKEN` PAT it picked up got 403'd.

## Fix

The actual remediation is an **ops action, not a code change**: delete the `GH_AW_GITHUB_TOKEN` secret so the compiler's token chain falls back to the built-in per-run `GITHUB_TOKEN`. This is safe repo-wide because:

- No source `.md` workflow uses `lockdown: true` (removed repo-wide) or references the PAT secrets by hand.
- All declare `min-integrity: none`, so nothing *forces* a custom PAT — they only *prefer* it when present.
- All 30 compiled workflows share the identical fallback chain, so a single secret deletion fixes them all at once.

The only residual gap is write-backs on **fork** PRs (where `GITHUB_TOKEN` is read-only) — those should move to the org-owned GitHub App already documented in this README.

## Change

Docs-only: updates `.github/workflows/README.md` to
- reflect the concrete enterprise **≤8-day** enforcement (previously worded as "~1 week" org policy),
- note that `GH_AW_GITHUB_TOKEN` should be left **unset** so workflows degrade to `GITHUB_TOKEN`,
- record the fast-unblock command and the fork-PR caveat.

No workflow behavior changes; `.lock.yml` files are untouched (no recompile needed).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>