### PR TITLE
Move test-case filter parsing to adapter boundary (Phase 6d-1)

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestMethodFilter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestMethodFilter.cs
@@ -182,3 +182,20 @@ internal sealed class TestMethodFilter
         }
     }
 }
+
+/// <summary>
+/// Adapter-boundary <see cref="ITestElementFilterProvider"/> that closes over the VSTest discovery/run context
+/// and produces the neutral <see cref="ITestElementFilter"/> via <see cref="TestMethodFilter"/>. Created at the
+/// boundary and passed into the platform services engine/discoverer so the filter (and any parse-error report)
+/// is built at the exact point the engine needs it, preserving the original per-source timing.
+/// </summary>
+internal sealed class TestElementFilterProvider : ITestElementFilterProvider
+{
+    private readonly TestMethodFilter _testMethodFilter = new();
+    private readonly IDiscoveryContext? _context;
+
+    public TestElementFilterProvider(IDiscoveryContext? context) => _context = context;
+
+    public ITestElementFilter? GetTestElementFilter(IAdapterMessageLogger logger, out bool filterHasError)
+        => _testMethodFilter.GetTestElementFilter(_context, logger, out filterHasError);
+}

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -87,7 +87,7 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
             IAdapterMessageLogger adapterLogger = logger.ToAdapterMessageLogger();
             if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext, adapterLogger, configuration, _testSourceHandler))
             {
-                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, discoverySink.ToUnitTestElementSink(), discoveryContext, isMTP);
+                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, discoverySink.ToUnitTestElementSink(), discoveryContext, new TestElementFilterProvider(discoveryContext), isMTP);
             }
         }
         finally

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -156,7 +156,7 @@ internal sealed class MSTestExecutor : ITestExecutor
             // execution engine reports results through this neutral recorder and never constructs VSTest results.
             ITestResultRecorder testResultRecorder = frameworkHandle.ToTestResultRecorder(Environment.MachineName, MSTestSettings.CurrentSettings);
 
-            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(testElements, runContext, frameworkHandle, testResultRecorder, testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
+            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(testElements, runContext, frameworkHandle, testResultRecorder, new TestElementFilterProvider(runContext), testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
         }
         finally
         {
@@ -214,7 +214,7 @@ internal sealed class MSTestExecutor : ITestExecutor
             // execution engine reports results through this neutral recorder and never constructs VSTest results.
             ITestResultRecorder testResultRecorder = frameworkHandle.ToTestResultRecorder(Environment.MachineName, MSTestSettings.CurrentSettings);
 
-            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(sources, runContext, frameworkHandle, testResultRecorder, testSourceHandler, isMTP, testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
+            await RunTestsFromRightContextAsync(frameworkHandle, async testRunToken => await TestExecutionManager.RunTestsAsync(sources, runContext, frameworkHandle, testResultRecorder, new TestElementFilterProvider(runContext), testSourceHandler, isMTP, testRunToken).ConfigureAwait(false)).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -12,13 +12,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 [SuppressMessage("Performance", "CA1852: Seal internal types", Justification = "Overrides required for testability")]
 internal class UnitTestDiscoverer
 {
-    private readonly TestMethodFilter _testMethodFilter;
-
-    internal UnitTestDiscoverer(ITestSourceHandler testSourceHandler)
-    {
-        _testMethodFilter = new TestMethodFilter();
-        _testSource = testSourceHandler;
-    }
+    internal UnitTestDiscoverer(ITestSourceHandler testSourceHandler) => _testSource = testSourceHandler;
 
     /// <summary>
     /// Discovers the tests available from the provided sources.
@@ -27,17 +21,19 @@ internal class UnitTestDiscoverer
     /// <param name="logger"> The logger. </param>
     /// <param name="discoverySink"> The discovery Sink. </param>
     /// <param name="discoveryContext"> The discovery context. </param>
+    /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
     internal void DiscoverTests(
         IEnumerable<string> sources,
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
         IDiscoveryContext discoveryContext,
+        ITestElementFilterProvider? filterProvider,
         bool isMTP)
     {
         foreach (string source in sources)
         {
-            DiscoverTestsInSource(source, logger, discoverySink, discoveryContext, isMTP);
+            DiscoverTestsInSource(source, logger, discoverySink, discoveryContext, filterProvider, isMTP);
         }
     }
 
@@ -48,12 +44,14 @@ internal class UnitTestDiscoverer
     /// <param name="logger"> The logger. </param>
     /// <param name="discoverySink"> The discovery Sink. </param>
     /// <param name="discoveryContext"> The discovery context. </param>
+    /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
     internal virtual void DiscoverTestsInSource(
         string source,
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
         IDiscoveryContext? discoveryContext,
+        ITestElementFilterProvider? filterProvider,
         bool isMTP)
     {
         ICollection<UnitTestElement>? testElements = AssemblyEnumeratorWrapper.GetTests(source, discoveryContext?.RunSettings?.SettingsXml, _testSource, isMTP, out List<string> warnings);
@@ -103,15 +101,16 @@ internal class UnitTestDiscoverer
                 source);
         }
 
-        SendTestCases(testElements, discoverySink, discoveryContext, logger);
+        SendTestCases(testElements, discoverySink, filterProvider, logger);
     }
 
     private readonly ITestSourceHandler _testSource;
 
-    internal void SendTestCases(IEnumerable<UnitTestElement> testElements, IUnitTestElementSink discoverySink, IDiscoveryContext? discoveryContext, IAdapterMessageLogger logger)
+    internal static void SendTestCases(IEnumerable<UnitTestElement> testElements, IUnitTestElementSink discoverySink, ITestElementFilterProvider? filterProvider, IAdapterMessageLogger logger)
     {
         // Get filter and skip discovery in case filter expression has parsing error.
-        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(discoveryContext, logger, out bool filterHasError);
+        bool filterHasError = false;
+        ITestElementFilter? filter = filterProvider?.GetTestElementFilter(logger, out filterHasError);
         if (filterHasError)
         {
             return;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Parallelization.cs
@@ -21,10 +21,12 @@ internal partial class TestExecutionManager
     /// <param name="runContext">The run context.</param>
     /// <param name="frameworkHandle">Handle to record test start/end/results.</param>
     /// <param name="testResultRecorder">Recorder used to report test results back to the host.</param>
+    /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="isDeploymentDone">Indicates if deployment is done.</param>
-    internal virtual async Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, bool isDeploymentDone)
+    internal virtual async Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, ITestElementFilterProvider? filterProvider, bool isDeploymentDone)
     {
         _testResultRecorder = testResultRecorder;
+        _testElementFilterProvider = filterProvider;
 
         InitializeRandomTestOrder(frameworkHandle.ToAdapterMessageLogger());
 
@@ -74,7 +76,8 @@ internal partial class TestExecutionManager
         }
 
         // Default test set is filtered tests based on user provided filter criteria
-        ITestElementFilter? filter = _testMethodFilter.GetTestElementFilter(runContext, adapterMessageLogger, out bool filterHasError);
+        bool filterHasError = false;
+        ITestElementFilter? filter = _testElementFilterProvider?.GetTestElementFilter(adapterMessageLogger, out filterHasError);
         if (filterHasError)
         {
             // Bail out without processing everything else below.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -53,7 +53,6 @@ internal partial class TestExecutionManager
 
     internal TestExecutionManager(Func<Func<Task>, Task>? taskFactory = null)
     {
-        _testMethodFilter = new TestMethodFilter();
         _sessionParameters = new Dictionary<string, object>();
         _taskFactory = taskFactory ?? DefaultFactoryAsync;
     }
@@ -74,9 +73,11 @@ internal partial class TestExecutionManager
     }
 
     /// <summary>
-    /// Gets or sets method filter for filtering tests.
+    /// Provider for the test filter, supplied at the adapter boundary and set once per run in
+    /// <see cref="ExecuteTestsAsync"/> so the filter is built at the same point (and with the same per-source
+    /// timing) as before.
     /// </summary>
-    private readonly TestMethodFilter _testMethodFilter;
+    private ITestElementFilterProvider? _testElementFilterProvider;
 
 #if !WINDOWS_UWP && !WIN_UI
     /// <summary>
@@ -92,8 +93,9 @@ internal partial class TestExecutionManager
     /// <param name="runContext">Context to use when executing the tests.</param>
     /// <param name="frameworkHandle">Handle to the framework to record results and to do framework operations.</param>
     /// <param name="testResultRecorder">Recorder used to report test results back to the host.</param>
+    /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="runCancellationToken">Test run cancellation token.</param>
-    internal async Task RunTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, TestRunCancellationToken runCancellationToken)
+    internal async Task RunTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, ITestElementFilterProvider? filterProvider, TestRunCancellationToken runCancellationToken)
     {
         DebugEx.Assert(tests != null, "tests");
         DebugEx.Assert(runContext != null, "runContext");
@@ -113,7 +115,7 @@ internal partial class TestExecutionManager
         CacheSessionParameters(runContext?.RunSettings?.SettingsXml, frameworkHandle.ToAdapterMessageLogger());
 
         // Execute the tests
-        await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone).ConfigureAwait(false);
+        await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, filterProvider, isDeploymentDone).ConfigureAwait(false);
 
 #if !WINDOWS_UWP && !WIN_UI
         if (!_hasAnyTestFailed)
@@ -123,7 +125,7 @@ internal partial class TestExecutionManager
 #endif
     }
 
-    internal async Task RunTestsAsync(IEnumerable<string> sources, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, ITestSourceHandler testSourceHandler, bool isMTP, TestRunCancellationToken cancellationToken)
+    internal async Task RunTestsAsync(IEnumerable<string> sources, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, ITestElementFilterProvider? filterProvider, ITestSourceHandler testSourceHandler, bool isMTP, TestRunCancellationToken cancellationToken)
     {
         _testRunCancellationToken = cancellationToken;
         PlatformServiceProvider.Instance.TestRunCancellationToken = _testRunCancellationToken;
@@ -140,7 +142,7 @@ internal partial class TestExecutionManager
             _testRunCancellationToken?.ThrowIfCancellationRequested();
 
             // discover the tests
-            GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSource(source, logger, discoverySink, runContext, isMTP);
+            GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSource(source, logger, discoverySink, runContext, filterProvider, isMTP);
             tests.AddRange(discoverySink.TestElements);
 
             // Clear discoverSinksTests so that it just stores test for one source at one point of time
@@ -157,7 +159,7 @@ internal partial class TestExecutionManager
         CacheSessionParameters(runContext?.RunSettings?.SettingsXml, frameworkHandle.ToAdapterMessageLogger());
 
         // Run tests.
-        await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone).ConfigureAwait(false);
+        await ExecuteTestsAsync(tests, runContext, frameworkHandle, testResultRecorder, filterProvider, isDeploymentDone).ConfigureAwait(false);
 
 #if !WINDOWS_UWP && !WIN_UI
         if (!_hasAnyTestFailed)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilterProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestElementFilterProvider.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+/// <summary>
+/// Platform-agnostic factory that produces the <see cref="ITestElementFilter"/> in effect for the current
+/// run or discovery.
+/// </summary>
+/// <remarks>
+/// This abstraction lets the platform services discovery and execution pipelines obtain the active filter
+/// without taking a dependency on a specific test platform's filter object model (for example the VSTest
+/// <c>ITestCaseFilterExpression</c> parsed from an <c>IRunContext</c> / <c>IDiscoveryContext</c>). The concrete
+/// provider is created at the adapter boundary, closing over the host filter context; the engine invokes it at
+/// the exact point it needs the filter so parse-error reporting keeps the same timing and per-source semantics.
+/// </remarks>
+internal interface ITestElementFilterProvider
+{
+    /// <summary>
+    /// Builds the <see cref="ITestElementFilter"/> for the current run/discovery.
+    /// </summary>
+    /// <param name="logger">Logger used to report a filter parsing error.</param>
+    /// <param name="filterHasError">
+    /// Set to <see langword="true"/> when the filter is unsupported or failed to parse; in that case the caller
+    /// should report no tests for the affected source.
+    /// </param>
+    /// <returns>
+    /// The filter to apply, or <see langword="null"/> when no filter applies (every element is included).
+    /// </returns>
+    ITestElementFilter? GetTestElementFilter(IAdapterMessageLogger logger, out bool filterHasError);
+}

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -30,7 +30,7 @@ public abstract partial class CLITestBase
         string runSettingsXml = GetRunSettingsXml(string.Empty);
         var context = new InternalDiscoveryContext(runSettingsXml, testCaseFilter);
 
-        unitTestDiscoverer.DiscoverTestsInSource(assemblyPath, logger.ToAdapterMessageLogger(), sink.ToUnitTestElementSink(), context, false);
+        unitTestDiscoverer.DiscoverTestsInSource(assemblyPath, logger.ToAdapterMessageLogger(), sink.ToUnitTestElementSink(), context, new TestElementFilterProvider(context), false);
 
         return sink.DiscoveredTests;
     }
@@ -41,7 +41,7 @@ public abstract partial class CLITestBase
         var frameworkHandle = new InternalFrameworkHandle();
 
         ITestResultRecorder testResultRecorder = frameworkHandle.ToTestResultRecorder(Environment.MachineName, MSTestSettings.CurrentSettings);
-        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), null, frameworkHandle, testResultRecorder, false);
+        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), null, frameworkHandle, testResultRecorder, filterProvider: null, false);
         return frameworkHandle.GetFlattenedTestResults();
     }
 
@@ -54,7 +54,7 @@ public abstract partial class CLITestBase
         var runContext = new InternalRunContext(runSettingsXml, testCaseFilter);
 
         ITestResultRecorder testResultRecorder = frameworkHandle.ToTestResultRecorder(Environment.MachineName, MSTestSettings.CurrentSettings);
-        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), runContext, frameworkHandle, testResultRecorder, false);
+        await testExecutionManager.ExecuteTestsAsync(ToUnitTestElements(testCases), runContext, frameworkHandle, testResultRecorder, new TestElementFilterProvider(runContext), false);
         return frameworkHandle.GetFlattenedTestResults();
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -80,7 +80,7 @@ public class UnitTestDiscovererTests : TestContainer
                 .Returns(false);
         }
 
-        Action act = () => _unitTestDiscoverer.DiscoverTests(sources, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, false);
+        Action act = () => _unitTestDiscoverer.DiscoverTests(sources, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
         act.Should().Throw<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, sources[0]));
     }
@@ -93,7 +93,7 @@ public class UnitTestDiscovererTests : TestContainer
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.DoesFileExist(Source))
             .Returns(false);
 
-        Action act = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, false);
+        Action act = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
         act.Should().Throw<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, Source));
     }
@@ -125,7 +125,7 @@ public class UnitTestDiscovererTests : TestContainer
         MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, false);
+        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.AtLeastOnce);
@@ -160,7 +160,7 @@ public class UnitTestDiscovererTests : TestContainer
         MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        Action action = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, false);
+        Action action = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Assert
         action.Should().Throw<MSTestException>()
@@ -199,7 +199,7 @@ public class UnitTestDiscovererTests : TestContainer
 
         // Act & Assert
         // Should not throw an exception
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, false);
+        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Verify warning message was sent to logger (not error)
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.AtLeastOnce);
@@ -209,7 +209,7 @@ public class UnitTestDiscovererTests : TestContainer
     public void SendTestCasesShouldNotSendAnyTestCasesIfThereAreNoTestElements()
     {
         // There is a null check for testElements in the code flow before this function call. So not adding a unit test for that.
-        _unitTestDiscoverer.SendTestCases(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.Never);
@@ -221,7 +221,7 @@ public class UnitTestDiscovererTests : TestContainer
         var test2 = new UnitTestElement(CreateTestMethod("M2", "C", "A", displayName: null));
         var testElements = new List<UnitTestElement> { test1, test2 };
 
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -240,7 +240,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -259,7 +259,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -278,7 +278,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -297,7 +297,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        _unitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), discoveryContext, _mockMessageLogger.Object.ToAdapterMessageLogger());
+        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Never);
@@ -328,6 +328,7 @@ internal class TestableUnitTestDiscoverer(ITestSourceHandler? testSourceHandler 
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
         IDiscoveryContext? discoveryContext,
+        ITestElementFilterProvider? filterProvider,
         bool isMTP)
     {
         var testElement1 = new UnitTestElement(new TestMethod("A", "C", source, displayName: null));

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -100,7 +100,7 @@ public class TestExecutionManagerTests : TestContainer
         // Causing the FilterExpressionError
         _runContext = new TestableRunContextTestExecutionTests(() => throw new TestPlatformFormatException());
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _cancellationToken);
 
         // No Results
         _frameworkHandle.TestCaseStartList.Count.Should().Be(0);
@@ -116,7 +116,7 @@ public class TestExecutionManagerTests : TestContainer
 
         _runContext = new TestableRunContextTestExecutionTests(() => new TestableTestCaseFilterExpression(p => p.DisplayName == "PassingTest"));
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _cancellationToken);
 
         // FailingTest should be skipped because it does not match the filter criteria.
         List<string> expectedTestCaseStartList = ["PassingTest"];
@@ -144,7 +144,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "IgnoredTest");
         TestCase[] tests = [testCase];
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _cancellationToken);
 
         _frameworkHandle.TestCaseStartList[0].Should().Be("IgnoredTest");
         _frameworkHandle.TestCaseEndList[0].Should().Be("IgnoredTest:Skipped");
@@ -157,7 +157,7 @@ public class TestExecutionManagerTests : TestContainer
 
         TestCase[] tests = [testCase];
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         List<string> expectedTestCaseStartList = ["PassingTest"];
         List<string> expectedTestCaseEndList = ["PassingTest:Passed"];
@@ -174,7 +174,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase failingTestCase = GetTestCase(typeof(DummyTestClass), "FailingTest");
         TestCase[] tests = [testCase, failingTestCase];
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _cancellationToken);
 
         List<string> expectedTestCaseStartList = ["PassingTest", "FailingTest"];
         List<string> expectedTestCaseEndList = ["PassingTest:Passed", "FailingTest:Failed"];
@@ -194,7 +194,7 @@ public class TestExecutionManagerTests : TestContainer
 
         // Cancel the test run
         _cancellationToken.Cancel();
-        Func<Task> func = () => _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, _cancellationToken);
+        Func<Task> func = () => _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _cancellationToken);
         await func.Should().ThrowAsync<OperationCanceledException>();
 
         // No Results
@@ -218,7 +218,7 @@ public class TestExecutionManagerTests : TestContainer
             ToUnitTestElements(tests),
             _runContext,
             _frameworkHandle,
-            TestResultRecorder, new TestRunCancellationToken());
+            TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         _callers[0].Should().Be("Deploy", "Deploy should be called before execution.");
         _callers[1].Should().Be("LoadAssembly", "Deploy should be called before execution.");
@@ -238,7 +238,7 @@ public class TestExecutionManagerTests : TestContainer
             td => td.Cleanup()).Callback(() => SetCaller("Cleanup"));
 #endif
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         _callers[0].Should().Be("LoadAssembly", "Cleanup should be called after execution.");
 
@@ -255,7 +255,7 @@ public class TestExecutionManagerTests : TestContainer
         TestCase[] tests = [testCase, failingTestCase];
 
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         testablePlatformService.MockTestDeployment.Verify(td => td.Cleanup(), Times.Never);
     }
@@ -274,7 +274,7 @@ public class TestExecutionManagerTests : TestContainer
         testablePlatformService.MockTestDeployment.Setup(td => td.GetDeploymentDirectory())
             .Returns(@"C:\temp");
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         testablePlatformService.MockFileOperations.Verify(
             fo => fo.LoadAssembly(It.Is<string>(s => s.StartsWith("C:\\temp"))),
@@ -300,7 +300,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         DummyTestClass.TestContextProperties!.Contains(
             new KeyValuePair<string, object>("webAppUrl", "http://localhost")).Should().BeTrue();
@@ -322,7 +322,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         VerifyTcmProperties(DummyTestClass.TestContextProperties, testCase);
     }
@@ -335,7 +335,7 @@ public class TestExecutionManagerTests : TestContainer
         // Setup mocks.
         TestablePlatformServiceProvider testablePlatformService = SetupTestablePlatformService();
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         testablePlatformService.MockSettingsProvider.Verify(sp => sp.GetProperties(It.IsAny<string>()), Times.Once);
     }
@@ -359,7 +359,7 @@ public class TestExecutionManagerTests : TestContainer
             """);
 
         // Trigger First Run
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         // Update runsettings to have different values for similar keys
         _runContext.MockRunSettings.Setup(rs => rs.SettingsXml).Returns(
@@ -376,7 +376,7 @@ public class TestExecutionManagerTests : TestContainer
             """);
 
         // Trigger another Run
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         "http://updatedLocalHost".Equals(DummyTestClass.TestContextProperties!["webAppUrl"]).Should().BeTrue();
     }
@@ -390,7 +390,7 @@ public class TestExecutionManagerTests : TestContainer
     {
         var sources = new List<string> { Assembly.GetExecutingAssembly().Location };
 
-        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, _mockTestSourceHandler.Object, false, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _mockTestSourceHandler.Object, false, _cancellationToken);
 
         _frameworkHandle.TestCaseStartList.Contains("PassingTest").Should().BeTrue();
         _frameworkHandle.TestCaseEndList.Contains("PassingTest:Passed").Should().BeTrue();
@@ -412,7 +412,7 @@ public class TestExecutionManagerTests : TestContainer
             </RunSettings>
             """);
 
-        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, _mockTestSourceHandler.Object, false, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _mockTestSourceHandler.Object, false, _cancellationToken);
 
         DummyTestClass.TestContextProperties!.Contains(
             new KeyValuePair<string, object>("webAppUrl", "http://localhost")).Should().BeTrue();
@@ -423,7 +423,7 @@ public class TestExecutionManagerTests : TestContainer
     {
         var sources = new List<string> { Assembly.GetExecutingAssembly().Location };
 
-        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, _mockTestSourceHandler.Object, false, _cancellationToken);
+        await _testExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _mockTestSourceHandler.Object, false, _cancellationToken);
 
         DummyTestClass.TestContextProperties.Should().NotBeNull();
     }
@@ -437,7 +437,7 @@ public class TestExecutionManagerTests : TestContainer
             ExecuteTestsWrapper = (tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone) => testsCount += tests.Count(),
         };
 
-        await testableTestExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, _mockTestSourceHandler.Object, false, _cancellationToken);
+        await testableTestExecutionManager.RunTestsAsync(sources, _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), _mockTestSourceHandler.Object, false, _cancellationToken);
         testsCount.Should().Be(4);
     }
 
@@ -470,7 +470,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
             DummyTestClassForParallelize2.ThreadIds.Count.Should().Be(1);
@@ -507,7 +507,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
 
@@ -544,7 +544,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
             DummyTestClassForParallelize2.ThreadIds.Count.Should().Be(1);
@@ -607,7 +607,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
         }
@@ -666,7 +666,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             DummyTestClassForParallelize.ThreadIds.Count.Should().Be(1);
         }
@@ -705,7 +705,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
             DummyTestClassWithDoNotParallelizeMethods.ParallelizableTestsThreadIds.Count.Should().BeOneOf(1, 2);
@@ -771,7 +771,7 @@ public class TestExecutionManagerTests : TestContainer
             testablePlatformService.MockReflectionOperations.Setup(fo => fo.GetRuntimeMethods(It.IsAny<Type>()))
                 .Returns((Type t) => originalReflectionOperation.GetRuntimeMethods(t));
 
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             _enqueuedParallelTestsCount.Should().Be(2);
 
@@ -811,7 +811,7 @@ public class TestExecutionManagerTests : TestContainer
         try
         {
             MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
-            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+            await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
             DummyTestClassWithDoNotParallelizeMethods.ThreadApartmentStates.Count.Should().Be(1);
             DummyTestClassWithDoNotParallelizeMethods.ThreadApartmentStates.ToArray()[0].Should().Be(Thread.CurrentThread.GetApartmentState());
@@ -854,11 +854,11 @@ public class TestExecutionManagerTests : TestContainer
 
         var firstHandle = new TestableFrameworkHandle();
         var firstManager = new TestExecutionManager(task => task());
-        await firstManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, firstHandle, firstHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings), new TestRunCancellationToken());
+        await firstManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, firstHandle, firstHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings), new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         var secondHandle = new TestableFrameworkHandle();
         var secondManager = new TestExecutionManager(task => task());
-        await secondManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, secondHandle, secondHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings), new TestRunCancellationToken());
+        await secondManager.RunTestsAsync(ToUnitTestElements(BuildTests()), _runContext, secondHandle, secondHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings), new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         // Same seed must produce the same order across separate runs.
         firstHandle.TestCaseStartList.Should().Equal(secondHandle.TestCaseStartList);
@@ -895,7 +895,7 @@ public class TestExecutionManagerTests : TestContainer
 
         MSTestSettings.PopulateSettings(_runContext, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
-        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestRunCancellationToken());
+        await _testExecutionManager.RunTestsAsync(ToUnitTestElements(tests), _runContext, _frameworkHandle, TestResultRecorder, new TestElementFilterProvider(_runContext), new TestRunCancellationToken());
 
         _frameworkHandle.TestCaseStartList.Should().Equal("TestA", "TestB", "TestC");
     }
@@ -1273,7 +1273,7 @@ internal class TestableTestExecutionManager : TestExecutionManager
 {
     internal Action<IEnumerable<UnitTestElement>, IRunContext?, IFrameworkHandle, ITestResultRecorder, bool> ExecuteTestsWrapper { get; set; } = null!;
 
-    internal override Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, bool isDeploymentDone)
+    internal override Task ExecuteTestsAsync(IEnumerable<UnitTestElement> tests, IRunContext? runContext, IFrameworkHandle frameworkHandle, ITestResultRecorder testResultRecorder, ITestElementFilterProvider? filterProvider, bool isDeploymentDone)
     {
         ExecuteTestsWrapper?.Invoke(tests, runContext, frameworkHandle, testResultRecorder, isDeploymentDone);
         return Task.CompletedTask;


### PR DESCRIPTION
## Phase 6d-1 of the PlatformServices platform-agnostic initiative

Part of removing the VSTest object model (`Microsoft.TestPlatform.ObjectModel`) dependency from `MSTestAdapter.PlatformServices`.

This phase moves the **test-case filter parsing** to the adapter boundary. `TestMethodFilter` (which parses the VSTest `ITestCaseFilterExpression` from `IRunContext`/`IDiscoveryContext.GetTestCaseFilter`) moves out of PlatformServices into `MSTest.TestAdapter`, and the engine/discoverer receive an injected neutral `ITestElementFilter` via a new `ITestElementFilterProvider` abstraction.

### What changed
- **New `ITestElementFilterProvider`** (`PlatformServices.Interface`): `ITestElementFilter? GetTestElementFilter(IAdapterMessageLogger, out bool filterHasError)`.
- **Moved `TestMethodFilter`** (+ nested `TestElementFilter`) → `MSTest.TestAdapter` (class body byte-identical); added a boundary `TestElementFilterProvider` that closes over the VSTest context.
- The boundary (`MSTestExecutor`, `MSTestDiscoverer` — which the MTP `MSTestBridgedTestFramework` also routes through) builds `new TestElementFilterProvider(context)` and injects it into `TestExecutionManager.RunTestsAsync`/`ExecuteTestsAsync` and `UnitTestDiscoverer.DiscoverTests`.
- The engine/discoverer invoke the provider at the **exact same call sites** they previously built the filter (per source), so parse-error reporting keeps the same timing and per-source count.

### No behavior change
`TestElementFilter.Matches` still does `element.ToTestCase()` (byte-for-byte; the #9568 no-round-trip optimization is deferred as its own follow-up). This removes `ITestCaseFilterExpression` / `GetTestCaseFilter` / `MatchTestCase` / the VSTest filter `TestProperty` set from PlatformServices code. `IRunContext`/`IDiscoveryContext` remain only for deployment + settings extraction (removed in 6d-2).

### Verification
- Full build green across all TFMs (net462, net8.0, net9.0, UWP, WinUI).
- `MSTestAdapter.PlatformServices.UnitTests`: 897 (net8.0) / 935 (net462); `MSTestAdapter.UnitTests`: 21; `MSTest.IntegrationTests`: 47 pass / 1 skip — **including `TestCaseFilteringTests`, the out-of-proc filter regression net.**
- Expert MSTest/MTP reviewer: no material findings; definitive byte-for-byte verdict on the per-source parse-error timing/count and the null-provider equivalence.

### Base / stacking
- **Stacked on Phase 6c2 (#9590).** Base = `dev/amauryleve/vstest-decoupling-settings`; review/merge after #9590. When 6c2 merges into `vstest-decoupling-base`, this PR is rebased onto the updated base (diff is 6d-1 only, 10 files).

### Remaining work
- **6d-2**: remove `IRunContext`/`IDiscoveryContext` from PlatformServices entirely (deploy-context + settings extraction to the boundary).
- **#9568**: filter no-round-trip optimization (only if provably byte-for-byte).
- **6e**: relocate remaining bridges + the deep `UnitTestElement`↔`TestCase` conversion + `EngineConstants`.
- **7**: remove the `Microsoft.TestPlatform.ObjectModel` PackageReference + guard test.