### PR TITLE
docs: add missing changelog entries for #9542, #9545, #9549, #9581

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -44,6 +44,9 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Forward Azure DevOps logging commands over the dotnet test pipe for multi-assembly test runs by @Evangelink in [#9463](https://github.com/microsoft/testfx/pull/9463)
 * Add `PropertyBag.FirstOrDefault<TProperty>()` for efficient single-property lookup without per-call array allocation by @Evangelink in [#9488](https://github.com/microsoft/testfx/pull/9488)
 * Add experimental `Microsoft.Testing.Extensions.GitHubActionsReport` extension emitting GitHub Actions workflow commands (per-assembly log groups, failure annotations, job summary, slow-test notices) by @azat-msft in [#9541](https://github.com/microsoft/testfx/pull/9541)
+* Add `--report-azdo-groups <on|off>` and `--report-azdo-annotations <on|off>` toggles to Azure DevOps report extension by @Evangelink in [#9542](https://github.com/microsoft/testfx/pull/9542)
+* Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
+* Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
 
 ### Fixed
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -53,6 +53,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Remove redundant `actual type:` line from Assert.Throws\* failure message by @Evangelink in [#9195](https://github.com/microsoft/testfx/pull/9195)
 * Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages by @Evangelink in [#9212](https://github.com/microsoft/testfx/pull/9212)
 * Fix `[ClassCleanup]` resource leak when `ITestFilter` drops the last test of an initialized class by @Evangelink in [#9503](https://github.com/microsoft/testfx/pull/9503)
+* Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
 
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 


### PR DESCRIPTION
Adds missing changelog entries for user-visible changes merged since the last update. Fixes #9600.

**`docs/Changelog-Platform.md` (2.3.0 UNRELEASED — Added)**
- `#9542` — Add `--report-azdo-groups <on|off>` and `--report-azdo-annotations <on|off>` toggles to Azure DevOps report extension
- `#9545` — Re-print errored assemblies in dotnet test end-of-run recap
- `#9549` — Add server-initiated session cancellation to the dotnet test IPC protocol

**`docs/Changelog.md` (4.3.0 UNRELEASED — Fixed)**
- `#9581` — Fix `CloneWithUpdatedSource` mutating `this` instead of the clone