### PR TITLE
perf: cache GetParameters() and ReflectionTestMethodInfo across data rows

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
@@ -10,7 +10,7 @@ internal partial class TestMethodInfo
 
     internal object?[] ResolveArguments(object?[] arguments)
     {
-        ParameterInfo[] parametersInfo = MethodInfo.GetParameters();
+        ParameterInfo[] parametersInfo = ParameterTypes;
         int requiredParameterCount = 0;
         bool hasParamsValue = false;
         object? paramsValues = null;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -36,6 +36,14 @@ internal sealed class TestMethodRunner
     private readonly TestMethodInfo _testMethodInfo;
 
     /// <summary>
+    /// Cached <see cref="ReflectionTestMethodInfo"/> wrapper reused across all data rows of a
+    /// data-driven test. Both <see cref="TestMethodInfo.MethodInfo"/> and <see cref="TestMethod.DisplayName"/>
+    /// are immutable for the lifetime of this <see cref="TestMethodRunner"/>, so the wrapper can be
+    /// safely shared instead of allocating a new one per row.
+    /// </summary>
+    private ReflectionTestMethodInfo? _cachedReflectionMethodInfo;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TestMethodRunner"/> class.
     /// </summary>
     /// <param name="testMethodInfo">
@@ -423,7 +431,7 @@ internal sealed class TestMethodRunner
         // and both GetDisplayName and ComputeDefaultDisplayName need to be consulted.
         if (displayNameFromTestDataRow is null && testDataSource is not null)
         {
-            var reflectionMethodInfo = new ReflectionTestMethodInfo(_testMethodInfo.MethodInfo, _test.DisplayName);
+            ReflectionTestMethodInfo reflectionMethodInfo = _cachedReflectionMethodInfo ??= new ReflectionTestMethodInfo(_testMethodInfo.MethodInfo, _test.DisplayName);
             displayName = testDataSource.GetDisplayName(reflectionMethodInfo, data)
                 ?? TestDataSourceUtilities.ComputeDefaultDisplayName(reflectionMethodInfo, data)
                 ?? displayName;

--- a/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
+++ b/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
 internal sealed class ReflectionTestMethodInfo : MethodInfo
 {
     private readonly MethodInfo _methodInfo;
+    private ParameterInfo[]? _parameters;
 
     public ReflectionTestMethodInfo(MethodInfo methodInfo, string? displayName)
     {
@@ -41,7 +42,7 @@ internal sealed class ReflectionTestMethodInfo : MethodInfo
 
     public override MethodImplAttributes GetMethodImplementationFlags() => _methodInfo.GetMethodImplementationFlags();
 
-    public override ParameterInfo[] GetParameters() => _methodInfo.GetParameters();
+    public override ParameterInfo[] GetParameters() => _parameters ??= _methodInfo.GetParameters();
 
     public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture) => _methodInfo.Invoke(obj, invokeAttr, binder, parameters, culture);
 


### PR DESCRIPTION
## Summary

Eliminates redundant `ParameterInfo[]` and `ReflectionTestMethodInfo` allocations in the data-driven test hot path. Continues the allocation-caching work started in #9514.

## Changes

1. **`ReflectionTestMethodInfo.GetParameters()`** — caches the `ParameterInfo[]` (`_parameters ??= _methodInfo.GetParameters()`). `MethodInfo.GetParameters()` always returns a freshly allocated array (CLR safety guarantee), so caching on the immutable wrapper is safe.
2. **`TestMethodInfo.ResolveArguments()`** — switched from raw `MethodInfo.GetParameters()` to the cached `ParameterTypes` property (added in #9514), fixing a cache bypass.
3. **`TestMethodRunner`** — added a `_cachedReflectionMethodInfo` field so the wrapper is created once per `TestMethodRunner` and reused across all data rows, instead of allocating one per row. Both `_testMethodInfo.MethodInfo` and `_test.DisplayName` are immutable for the runner's lifetime.

## Impact

For an N-row data-driven test (e.g. `[DynamicData]`), this reduces ~3×N short-lived heap allocations down to 3 — roughly a 99% reduction for large row counts — cutting GC pressure with no behavioral change.

## Verification

- `.\build.cmd -c Debug` — Build succeeded, 0 warnings, 0 errors
- `MSTestAdapter.UnitTests` (net8.0) — all tests pass

Fixes #9605
Fixes #9593