### PR TITLE
test: add edge case tests for MSTEST0045/0050/0060 analyzers

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DuplicateTestMethodAttributeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DuplicateTestMethodAttributeAnalyzerTests.cs
@@ -378,4 +378,79 @@ public sealed class DuplicateTestMethodAttributeAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasDuplicateAttributesOutsideTestClass_Diagnostic()
+    {
+        // The analyzer fires on duplicate TestMethod-like attributes regardless of whether
+        // the containing class is marked [TestClass].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class NonTestClass
+            {
+                [TestMethod]
+                [DataTestMethod]
+                public void [|TestMethod1|]()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenDerivedAttributeIsFirstAndTestMethodIsSecond_CodeFix_KeepsDerivedAttribute()
+    {
+        // The fixer uses a "first-wins" strategy: iterates attribute lists in order and
+        // keeps the first TestMethod-derived attribute it encounters. When a derived
+        // attribute appears before [TestMethod], the derived one is retained.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Runtime.CompilerServices;
+
+            public class MyTestMethod : TestMethodAttribute
+            {
+                public MyTestMethod([CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+                    : base(callerFilePath, callerLineNumber)
+                {
+                }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                [TestMethod]
+                public void [|TestMethod1|]()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Runtime.CompilerServices;
+
+            public class MyTestMethod : TestMethodAttribute
+            {
+                public MyTestMethod([CallerFilePath] string callerFilePath = "", [CallerLineNumber] int callerLineNumber = -1)
+                    : base(callerFilePath, callerLineNumber)
+                {
+                }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/GlobalTestFixtureShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/GlobalTestFixtureShouldBeValidAnalyzerTests.cs
@@ -298,4 +298,49 @@ public sealed class GlobalTestFixtureShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenGlobalTestInitializeInGenericClass_Diagnostic()
+    {
+        // Generic containing type is rejected by `allowGenericType: false` in the analyzer.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass<T>
+            {
+                [GlobalTestInitialize]
+                public static void [|GlobalTestInitialize|](TestContext testContext)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenGlobalTestCleanupWithDerivedTestClassAttribute_NoDiagnostic()
+    {
+        // A class marked with a TestClassAttribute-derived attribute satisfies the TestClass check
+        // because the guard uses `Inherits(testClassAttributeSymbol)`.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestClassAttribute : TestClassAttribute
+            {
+            }
+
+            [MyTestClass]
+            public class MyTestClass
+            {
+                [GlobalTestCleanup]
+                public static void GlobalTestCleanup(TestContext testContext)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseCooperativeCancellationForTimeoutAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseCooperativeCancellationForTimeoutAnalyzerTests.cs
@@ -476,4 +476,106 @@ public sealed class UseCooperativeCancellationForTimeoutAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTimeoutAttributeOnAsyncTestMethod_Diagnostic()
+    {
+        string code = """
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [[|Timeout(5000)|]]
+                public async Task MyAsyncTestMethod()
+                {
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Timeout(5000, CooperativeCancellation = true)]
+                public async Task MyAsyncTestMethod()
+                {
+                    await Task.Yield();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTimeoutAttributeOnMethodInNonTestClass_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class RegularClass
+            {
+                [[|Timeout(3000)|]]
+                public void SomeMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class RegularClass
+            {
+                [Timeout(3000, CooperativeCancellation = true)]
+                public void SomeMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTimeoutAttributeWithNamedArgument_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [[|Timeout(timeout: 5000)|]]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [Timeout(timeout: 5000, CooperativeCancellation = true)]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
Fixes #9606 and #9596.

Applies the edge-case analyzer tests that the Test Improver workflow staged on branches (it could not open PRs directly). Purely additive test code — no production changes.

## #9606 — `UseCooperativeCancellationForTimeoutAnalyzer` (MSTEST0045), +3 tests
- `WhenTimeoutAttributeOnAsyncTestMethod_Diagnostic` — `[Timeout]` on an `async Task` method fires and the fixer adds `CooperativeCancellation = true`.
- `WhenTimeoutAttributeOnMethodInNonTestClass_Diagnostic` — analyzer fires on a method in a plain class (not scoped to `[TestClass]`).
- `WhenTimeoutAttributeWithNamedArgument_Diagnostic` — `[Timeout(timeout: 5000)]` named-argument syntax is fixed correctly.

## #9596 — MSTEST0050 & MSTEST0060, +4 tests
`GlobalTestFixtureShouldBeValidAnalyzer` (MSTEST0050):
- `WhenGlobalTestInitializeInGenericClass_Diagnostic` — generic containing type rejected via `allowGenericType: false`.
- `WhenGlobalTestCleanupWithDerivedTestClassAttribute_NoDiagnostic` — derived `TestClassAttribute` satisfies the `Inherits` guard.

`DuplicateTestMethodAttributeAnalyzer` (MSTEST0060):
- `WhenTestMethodHasDuplicateAttributesOutsideTestClass_Diagnostic` — analyzer has no `[TestClass]` guard.
- `WhenDerivedAttributeIsFirstAndTestMethodIsSecond_CodeFix_KeepsDerivedAttribute` — fixer first-wins strategy.

## Verification
Debug build clean (0 warnings, 0 errors). All three affected analyzer test classes pass: **49/49**.