### PR TITLE
perf: reduce allocations in data-driven test execution hot path

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
@@ -10,6 +10,9 @@ internal partial class TestMethodInfo
 
     internal object?[] ResolveArguments(object?[] arguments)
     {
+        // Use the cached ParameterTypes property rather than calling MethodInfo.GetParameters()
+        // (which allocates a fresh ParameterInfo[] on every call). ResolveArguments only reads the
+        // array, so sharing the cached instance is safe.
         ParameterInfo[] parametersInfo = ParameterTypes;
         int requiredParameterCount = 0;
         bool hasParamsValue = false;

--- a/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
+++ b/src/TestFramework/TestFramework/Internal/ReflectionTestMethodInfo.cs
@@ -42,6 +42,22 @@ internal sealed class ReflectionTestMethodInfo : MethodInfo
 
     public override MethodImplAttributes GetMethodImplementationFlags() => _methodInfo.GetMethodImplementationFlags();
 
+    /// <summary>
+    /// Returns the parameters of the wrapped method, caching the array across calls.
+    /// </summary>
+    /// <returns>The cached <see cref="ParameterInfo"/> array of the wrapped method.</returns>
+    /// <remarks>
+    /// <c>MethodInfo.GetParameters()</c> allocates a fresh <see cref="ParameterInfo"/> array on
+    /// every call (a CLR safety guarantee). The wrapped <see cref="MethodInfo"/> is immutable, so the
+    /// array is cached and shared across callers of this wrapper (e.g. display-name computation for every
+    /// data-driven row) to avoid that per-call allocation.
+    /// <para>
+    /// Because the same instance is handed out to every caller, the returned array MUST be treated as
+    /// read-only. Mutating it (including callers such as user-provided
+    /// <c>ITestDataSource.GetDisplayName</c> implementations) would corrupt the cache for all subsequent
+    /// callers.
+    /// </para>
+    /// </remarks>
     public override ParameterInfo[] GetParameters() => _parameters ??= _methodInfo.GetParameters();
 
     public override object? Invoke(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? parameters, CultureInfo? culture) => _methodInfo.Invoke(obj, invokeAttr, binder, parameters, culture);


### PR DESCRIPTION
Fixes #9602, #9603, #9605, #9593.

These four issues are all allocation micro-optimizations in the same MSTest adapter test-execution hot path, so they are grouped into a single PR. Notably #9605 and #9593 were near-duplicates (both cache `GetParameters()` / `ReflectionTestMethodInfo` across data rows); this PR unifies them.

## Changes

- **`CloneForDataDrivenIteration` (#9602)** — Pass `_properties` directly to the `TestContextImplementation` constructor instead of building an intermediate `snapshot` Dictionary. The `testMethod: null, testClassFullName: null` ctor branch already takes a shallow copy, so the clone's property bag stays fully isolated while one `Dictionary` + O(n) copy per data-driven iteration is eliminated.

- **`ExecuteTestAsync` (#9603)** — Add a fast path for the common case where neither `[AssemblyInitialize]` nor `[ClassInitialize]` captured an `ExecutionContext`. In that case `RunOnContext(null, …)` just invokes the action directly, so the `TaskCompletionSource<TestResult[]>` + async-lambda closure + `Action` delegate are pure overhead. The fast path awaits the executor directly; the captured-context slow path is unchanged and still bridges through the TCS to restore the captured context. Observable behavior (success and exception paths) is identical.

- **`ReflectionTestMethodInfo.GetParameters()` (#9605, #9593)** — Cache the `ParameterInfo[]`. `MethodInfo.GetParameters()` allocates a fresh array on every call (CLR safety guarantee) and the wrapped `MethodInfo` is immutable, so the array can be shared. `MakeGenericMethod` creates a new wrapper with a fresh (null) cache, so genericization is unaffected.

- **`TestMethodInfo.ResolveArguments()` (#9605)** — Use the already-cached `ParameterTypes` property instead of calling `MethodInfo.GetParameters()` directly (which bypassed the cache added in #9514). `ResolveArguments` only reads the array, so sharing is safe.

- **`TestMethodRunner` (#9605, #9593)** — Reuse a single lazily-created `ReflectionTestMethodInfo` wrapper across all data rows instead of allocating one per row. Both the wrapped `MethodInfo` and `DisplayName` are immutable for the runner's lifetime.

## Impact

For a data-driven test with N rows, the redundant per-row allocations (intermediate snapshot Dictionary, TCS bridge trio, and `ReflectionTestMethodInfo` + `ParameterInfo[]`) collapse from O(N) to O(1), reducing GC pressure with no behavioral change.

## Validation

- `.\build.cmd -c Release` — Build succeeded, 0 warnings, 0 errors.
- `MSTestAdapter.PlatformServices.UnitTests` — 893 passed.
- `MSTestAdapter.UnitTests` — 21 passed.
- `TestFramework.UnitTests` — 1354 passed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>