### PR TITLE
Neutralize the runsettings-parsing helpers (Phase 6e-4a)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/RunSettingsUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/RunSettingsUtilities.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
@@ -18,6 +17,11 @@ internal static class RunSettingsUtilities
         IgnoreWhitespace = true,
     };
 
+    // The runsettings node names, historically taken from the VSTest object model's Constants type.
+    internal const string RunConfigurationSettingsName = "RunConfiguration";
+
+    internal const string TestRunParametersName = "TestRunParameters";
+
     /// <summary>
     /// Gets the set of user defined test run parameters from settings xml as key value pairs.
     /// </summary>
@@ -25,23 +29,23 @@ internal static class RunSettingsUtilities
     /// <returns>The test run parameters.</returns>
     /// <remarks>If there is no test run parameters section defined in the settingsxml a blank dictionary is returned.</remarks>
     internal static Dictionary<string, object>? GetTestRunParameters(string? settingsXml)
-        => GetNodeValue(settingsXml, Constants.TestRunParametersName, TestRunParameters.FromXml);
+        => GetNodeValue(settingsXml, TestRunParametersName, TestRunParameters.FromXml);
 
     /// <summary>
     /// Throws if the node has an attribute.
     /// </summary>
     /// <param name="reader"> The reader. </param>
-    /// <exception cref="SettingsException"> Thrown if the node has an attribute. </exception>
+    /// <exception cref="InvalidRunSettingsException"> Thrown if the node has an attribute. </exception>
     internal static void ThrowOnHasAttributes(XmlReader reader)
     {
         if (reader.HasAttributes)
         {
             reader.MoveToNextAttribute();
-            throw new SettingsException(
+            throw new InvalidRunSettingsException(
                 string.Format(
                     CultureInfo.CurrentCulture,
                     Resource.InvalidSettingsXmlAttribute,
-                    TestPlatform.ObjectModel.Constants.RunConfigurationSettingsName,
+                    RunConfigurationSettingsName,
                     reader.Name));
         }
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/TestRunParameters.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/TestRunParameters.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 
@@ -47,11 +47,11 @@ internal static class TestRunParameters
 
                     break;
                 default:
-                    throw new SettingsException(
+                    throw new InvalidRunSettingsException(
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Resource.InvalidSettingsXmlElement,
-                            Constants.TestRunParametersName,
+                            RunSettingsUtilities.TestRunParametersName,
                             reader.Name));
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/XmlReaderUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/XmlReaderUtilities.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+
+/// <summary>
+/// Minimal, platform-agnostic <see cref="XmlReader"/> navigation helpers for reading runsettings XML.
+/// These replace the equivalent helpers from the VSTest object model so the platform services layer does not
+/// depend on it; the navigation semantics are unchanged.
+/// </summary>
+internal static class XmlReaderUtilities
+{
+    private const string RunSettingsRootNodeName = "RunSettings";
+
+    /// <summary>
+    /// Advances the reader to the root element and verifies it is the <c>&lt;RunSettings&gt;</c> node.
+    /// </summary>
+    /// <param name="reader">The reader positioned before the root element.</param>
+    /// <exception cref="InvalidRunSettingsException">Thrown when the root element is not <c>&lt;RunSettings&gt;</c>.</exception>
+    internal static void ReadToRootNode(XmlReader reader)
+    {
+        reader.ReadToNextElement();
+
+        // Verify that it is a "RunSettings" node.
+        if (reader.Name != RunSettingsRootNodeName)
+        {
+            throw new InvalidRunSettingsException($"Could not find '{RunSettingsRootNodeName}' node in the runsettings XML. Found '<{reader.Name}>' instead.");
+        }
+    }
+
+    /// <summary>
+    /// Reads until the next element node (or end of document).
+    /// </summary>
+    /// <param name="reader">The reader.</param>
+    internal static void ReadToNextElement(this XmlReader reader)
+    {
+        while (!reader.EOF && reader.Read() && reader.NodeType != XmlNodeType.Element)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Skips the current subtree and positions the reader on the next element node.
+    /// </summary>
+    /// <param name="reader">The reader.</param>
+    internal static void SkipToNextElement(this XmlReader reader)
+    {
+        reader.Skip();
+
+        if (reader.NodeType != XmlNodeType.Element)
+        {
+            reader.ReadToNextElement();
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using DebuggerLaunchMode = Microsoft.VisualStudio.TestTools.UnitTesting.DebuggerLaunchMode;
 using MessageLevel = Microsoft.VisualStudio.TestTools.UnitTesting.MessageLevel;
@@ -45,7 +45,7 @@ internal sealed partial class MSTestSettings
         }
 
         using var stringReader = new StringReader(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
 
         XmlReaderUtilities.ReadToRootNode(reader);
         reader.ReadToNextElement();
@@ -69,7 +69,7 @@ internal sealed partial class MSTestSettings
         }
 
         using var stringReader = new StringReader(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
 
         XmlReaderUtilities.ReadToRootNode(reader);
         reader.ReadToNextElement();

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/InvalidRunSettingsException.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/InvalidRunSettingsException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+/// <summary>
+/// Thrown when the runsettings XML is structurally invalid (for example a bad attribute, an unexpected element,
+/// or a wrong root node). This is the platform-agnostic replacement for the settings exception the platform
+/// services layer historically surfaced from the VSTest object model. It is intentionally distinct from
+/// <see cref="AdapterSettingsException"/>: <see cref="AdapterSettingsException"/> is caught by the discovery
+/// initialization path (reported and treated as "no tests"), whereas a structural runsettings error propagates
+/// to the host, preserving the original behavior.
+/// </summary>
+internal sealed class InvalidRunSettingsException : Exception
+{
+    internal InvalidRunSettingsException(string? message)
+        : base(message)
+    {
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -4,9 +4,9 @@
 #if !WINDOWS_UWP
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
@@ -206,7 +206,7 @@ internal class MSTestAdapterSettings
         if (!StringEx.IsNullOrEmpty(settingsXml))
         {
             StringReader stringReader = new(settingsXml);
-            var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+            var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
             var xmlDoc = new XmlDocument() { XmlResolver = null };
             xmlDoc.Load(reader);
 
@@ -384,7 +384,7 @@ internal class MSTestAdapterSettings
                 else
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.InvalidSettingsXmlElement, reader.Name, "AssemblyResolution");
-                    throw new SettingsException(message);
+                    throw new InvalidRunSettingsException(message);
                 }
 
                 // Move to the next element under tag AssemblyResolution

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
@@ -6,7 +6,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
@@ -18,8 +17,21 @@ internal static class AppDomainUtilities
 {
     private const string ObjectModelVersionBuiltAgainst = "11.0.0.0";
 
+    private const string ObjectModelAssemblyName = "Microsoft.VisualStudio.TestPlatform.ObjectModel";
+
     private static readonly Version DefaultVersion = new();
     private static readonly Version Version45 = new("4.5");
+
+    /// <summary>
+    /// Resolves the loaded VSTest object-model assembly by simple name, so this AppDomain-wiring code does not
+    /// need a compile-time reference to it. By the time these methods run (test source host setup during
+    /// discovery/execution) the adapter has already loaded the object model into the current (parent) domain,
+    /// so its identity — including any binding redirect in effect — matches what a direct type reference resolved to.
+    /// </summary>
+    /// <returns>The object-model assembly.</returns>
+    private static Assembly GetObjectModelAssembly()
+        => AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => string.Equals(a.GetName().Name, ObjectModelAssemblyName, StringComparison.Ordinal))
+            ?? Assembly.Load(ObjectModelAssemblyName);
 
     /// <summary>
     /// Gets or sets the Xml Utilities instance.
@@ -90,7 +102,7 @@ internal static class AppDomainUtilities
 
             var resolutionPaths = new List<string>
                 {
-                    Path.GetDirectoryName(typeof(TestCase).Assembly.Location),
+                    Path.GetDirectoryName(GetObjectModelAssembly().Location),
                     Path.GetDirectoryName(testSourcePath),
                 };
 
@@ -157,10 +169,10 @@ internal static class AppDomainUtilities
         try
         {
             // Add redirection of the built 11.0 Object Model assembly to the current version if that is not 11.0
-            string currentVersionOfObjectModel = typeof(TestCase).Assembly.GetName().Version.ToString();
+            string currentVersionOfObjectModel = GetObjectModelAssembly().GetName().Version.ToString();
             if (!string.Equals(currentVersionOfObjectModel, ObjectModelVersionBuiltAgainst, StringComparison.Ordinal))
             {
-                AssemblyName assemblyName = typeof(TestCase).Assembly.GetName();
+                AssemblyName assemblyName = GetObjectModelAssembly().GetName();
                 byte[] configurationBytes =
                     XmlUtilities.AddAssemblyRedirection(
                         testSourceConfigFile,

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/RunSettingsUtilitiesTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/RunSettingsUtilitiesTests.cs
@@ -4,7 +4,7 @@
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 
 using TestFramework.ForTestingMSTest;
 
@@ -131,7 +131,7 @@ public class RunSettingsUtilitiesTests : TestContainer
             </RunSettings>
             """;
 
-        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<SettingsException>();
+        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<InvalidRunSettingsException>();
     }
 
     public void GetTestRunParametersThrowsWhenTRPNodeHasNonParameterTypeChildNodes()
@@ -152,7 +152,7 @@ public class RunSettingsUtilitiesTests : TestContainer
             </RunSettings>
             """;
 
-        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<SettingsException>();
+        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<InvalidRunSettingsException>();
     }
 
     public void GetTestRunParametersIgnoresMalformedKeyValues()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
@@ -3,10 +3,10 @@
 
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using Moq;
 
@@ -202,7 +202,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             """;
 
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
 
         MSTestAdapterSettings.ToSettings(reader);
@@ -222,12 +222,12 @@ public class MSTestAdapterSettingsTests : TestContainer
             """;
 
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
 
         void ShouldThrowException() => MSTestAdapterSettings.ToSettings(reader);
 
-        new Action(ShouldThrowException).Should().Throw<SettingsException>();
+        new Action(ShouldThrowException).Should().Throw<InvalidRunSettingsException>();
     }
 
     #endregion
@@ -242,7 +242,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeploymentEnabled.Should().BeTrue();
@@ -257,7 +257,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeploymentEnabled.Should().BeFalse();
@@ -275,7 +275,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeTrue();
@@ -290,7 +290,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeFalse();
@@ -305,7 +305,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeTrue();


### PR DESCRIPTION
## Phase 6e-4a — Neutralize the runsettings-parsing helpers

Part of the initiative to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.TestPlatform.ObjectModel`). Strict **byte-for-byte** refactor.

### What this does

Decouples the four runsettings-XML parsing files (`RunSettingsUtilities`, `TestRunParameters`, `MSTestAdapterSettings`, `MSTestSettings.RunSettingsXml`):

1. **`SettingsException` → new neutral `InvalidRunSettingsException`** (derives directly from `Exception`, **not** from `AdapterSettingsException`).
2. Inline the `ObjectModel.Constants` node names (`"RunConfiguration"`, `"TestRunParameters"`).
3. Repoint `XmlRunSettingsUtilities.ReaderSettings` at the neutral `RunSettingsUtilities.ReaderSettings`.
4. New neutral `XmlReaderUtilities` (`ReadToRootNode` + `ReadToNextElement`/`SkipToNextElement`), reusing the exact navigation semantics the adapter already vendored privately in `RunConfigurationSettings`.

Coupling drops **10 → 6 files**.

### Fidelity — exception-handler trace (the proof)

The adapter has a **two-tier** settings-exception topology this change **preserves**. `MSTestDiscovererHelpers.InitializeDiscovery` catches `AdapterSettingsException` (invalid MSTest settings *values* → log + "no tests"); a **structural** runsettings error escapes that handler to the host. Per-site — which handler catches it, before vs after:

| Throw site | Sole reachable path | As VSTest `SettingsException` (today) | As `InvalidRunSettingsException` (after) |
|---|---|---|---|
| `RunSettingsUtilities.ThrowOnHasAttributes` | `TestRunParameters.FromXml` → `GetTestRunParameters` → `TestExecutionManager.CacheSessionParameters` | broad `catch (Exception)` | **same** broad `catch (Exception)` |
| `TestRunParameters.FromXml` | `GetTestRunParameters` → `CacheSessionParameters` | broad `catch (Exception)` | **same** broad `catch (Exception)` |
| `MSTestAdapterSettings.ToSettings` (AssemblyResolution) | `SettingsProvider.Load` (from `PopulateSettings`, wrapped by `InitializeDiscovery`'s `catch (AdapterSettingsException)`) | **escapes** that catch → `DiscoverTests`/`RunTests` (all `try/finally`, no catch) → **host** | **escapes** (distinct type) → **host** |

A distinct type (not `AdapterSettingsException`) is required for site 3: reusing `AdapterSettingsException` would make a malformed `<AssemblyResolution>` newly caught at `InitializeDiscovery` (log + "no tests") instead of escaping — an observable behavior change.

**Cross-process note (site 3 escapes to the host).** Perfect type-and-stack fidelity on this path is *not achievable* while decoupling, because `SettingsException` is itself an object-model type and must leave `PlatformServices` before the package-reference drop. The neutral `InvalidRunSettingsException` **preserves the message, the throw origin/stack, and the escape topology** (still escapes `InitializeDiscovery` and `DiscoverTests`/`RunTests` exactly as before); only the exception *type name* differs, and only on a rare, user-authored malformed-`<AssemblyResolution>` runsettings that no test exercises. The test platform surfaces adapter-thrown exceptions during Discover/RunTests uniformly as `TestMessageLevel.Error` (its runsettings-validation special-casing lives in the host's own session-start parsing, not adapter invocation), so this is behavior-neutral on observable output. Adding a dedicated cross-process TRX/error-parity regression test is tracked by #9587. Unifying the two exceptions onto one model is a separate deliberate behavior change, tracked in #9629.

`MSTestExecutor`/`MSTestDiscoverer` have no typed settings-exception catch, so there is no boundary catch to update. The `…BailOutOnSettingsException` tests (which exercise the `AdapterSettingsException` path) pass unchanged.

### Verification

- Full `build.cmd -c Debug` green all TFMs, IDE0005 clean.
- `MSTestAdapter.PlatformServices.UnitTests`: **897** (net8.0) / **935** (net462), 0 failed.
- `MSTestAdapter.UnitTests`: **21**, 0 failed (incl. BailOut tests).
- `MSTest.IntegrationTests` (cross-proc, net462): **48** total, 0 failed, 1 skipped (pre-existing known-flaky).

### Stacking

`6c2 #9590` → `6d-1 #9591` → `6d-2 #9621` → `6e-1 #9622` → `6e-2 #9623` → `6e-3a #9624` → `6e-3b #9626` → **6e-4a (this)**. Base = 6e-3b branch. **Do not rebase/reset the base.**