### PR TITLE
Resolve the object-model assembly by name in AppDomain wiring (Phase 6e-4b)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
@@ -6,7 +6,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
@@ -18,8 +17,21 @@ internal static class AppDomainUtilities
 {
     private const string ObjectModelVersionBuiltAgainst = "11.0.0.0";
 
+    private const string ObjectModelAssemblyName = "Microsoft.VisualStudio.TestPlatform.ObjectModel";
+
     private static readonly Version DefaultVersion = new();
     private static readonly Version Version45 = new("4.5");
+
+    /// <summary>
+    /// Resolves the loaded VSTest object-model assembly by simple name, so this AppDomain-wiring code does not
+    /// need a compile-time reference to it. By the time these methods run (test source host setup during
+    /// discovery/execution) the adapter has already loaded the object model into the current (parent) domain,
+    /// so its identity — including any binding redirect in effect — matches what a direct type reference resolved to.
+    /// </summary>
+    /// <returns>The object-model assembly.</returns>
+    private static Assembly GetObjectModelAssembly()
+        => AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => string.Equals(a.GetName().Name, ObjectModelAssemblyName, StringComparison.Ordinal))
+            ?? Assembly.Load(ObjectModelAssemblyName);
 
     /// <summary>
     /// Gets or sets the Xml Utilities instance.
@@ -90,7 +102,7 @@ internal static class AppDomainUtilities
 
             var resolutionPaths = new List<string>
                 {
-                    Path.GetDirectoryName(typeof(TestCase).Assembly.Location),
+                    Path.GetDirectoryName(GetObjectModelAssembly().Location),
                     Path.GetDirectoryName(testSourcePath),
                 };
 
@@ -157,10 +169,10 @@ internal static class AppDomainUtilities
         try
         {
             // Add redirection of the built 11.0 Object Model assembly to the current version if that is not 11.0
-            string currentVersionOfObjectModel = typeof(TestCase).Assembly.GetName().Version.ToString();
+            string currentVersionOfObjectModel = GetObjectModelAssembly().GetName().Version.ToString();
             if (!string.Equals(currentVersionOfObjectModel, ObjectModelVersionBuiltAgainst, StringComparison.Ordinal))
             {
-                AssemblyName assemblyName = typeof(TestCase).Assembly.GetName();
+                AssemblyName assemblyName = GetObjectModelAssembly().GetName();
                 byte[] configurationBytes =
                     XmlUtilities.AddAssemblyRedirection(
                         testSourceConfigFile,


### PR DESCRIPTION
## Phase 6e-4b — Resolve the object-model assembly by name in the netfx AppDomain wiring

Part of the initiative to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model (`Microsoft.TestPlatform.ObjectModel`). Strict **byte-for-byte** refactor.

### What this does

`AppDomainUtilities` (netfx) used `typeof(TestCase).Assembly` to:
1. Add the object-model assembly's directory to the **child app-domain's resolution paths**, and
2. Anchor the **11.0 → current binding redirect** applied to the child domain's config.

Both run **parent-side** during test-source-host setup (`GetTargetFrameworkVersionString` / `SetConfigurationFile`), **after** the adapter has already loaded the object model into the current domain. So the assembly is now resolved by **simple name** from the current domain:

```csharp
AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name == "Microsoft.VisualStudio.TestPlatform.ObjectModel")
    ?? Assembly.Load("Microsoft.VisualStudio.TestPlatform.ObjectModel");
```

This returns the **same (post-redirect) assembly identity** the type reference did, without a compile-time reference — so the resolution path and the generated binding redirect are unchanged. The only remaining mention of the object model in this file is its **simple name as a string literal** (not an assembly reference — does not block dropping the package).

This removes the real code dependency from `AppDomainUtilities`. (`XmlUtilities.AddAssemblyRedirection` here is the adapter's **own** neutral type, not VSTest's.)

### Fidelity proof

Per the review guardrail for this — the last real netfx-isolation risk in the initiative — the swap is proven on the exact scenario the type reference protects:

- **`PlatformServices.Desktop.IntegrationTests`** (net462 AppDomain assembly-resolution-from-runsettings + deployment app-domain paths): **15/15 green**.
- Timing: both call sites run parent-side after the adapter loaded the object model, so there is no child-domain "looked up before loaded → null" hole.

### Verification

- Full `build.cmd -c Debug` green across all TFMs (net462/net8.0/net9.0/UWP/WinUI), IDE0005 clean.
- `PlatformServices.Desktop.IntegrationTests`: **15**, 0 failed.
- `MSTestAdapter.PlatformServices.UnitTests`: **897** (net8.0) / **935** (net462), 0 failed.
- `MSTestAdapter.UnitTests`: **21**, 0 failed.

### Remaining after this

3 files with real deps: `TestDeployment` (`SuspendCodeCoverage`, netfx), `TestSourceHost`/`TestSourceHandler` (`AssemblyHelper` + `EqtTrace`) — 6e-4c. Then Phase 7 drops the `PackageReference` + adds the zero-ObjectModel-reference guard test (the `AssemblyResolver` + this file's string literals don't block it).

### Stacking

`… #9624` → `6e-3b #9626` → `6e-4a #9627` → **6e-4b (this)**, onto `dev/amauryleve/vstest-decoupling-base`. Base = 6e-4a branch (`dev/amauryleve/vstest-decoupling-settings-utils`). **Do not rebase/reset the base.**
