### PR TITLE
Resolve source-host anchor assemblies by name (Phase 6e-4c1)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/RunSettingsUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/RunSettingsUtilities.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
@@ -18,6 +17,11 @@ internal static class RunSettingsUtilities
         IgnoreWhitespace = true,
     };
 
+    // The runsettings node names, historically taken from the VSTest object model's Constants type.
+    internal const string RunConfigurationSettingsName = "RunConfiguration";
+
+    internal const string TestRunParametersName = "TestRunParameters";
+
     /// <summary>
     /// Gets the set of user defined test run parameters from settings xml as key value pairs.
     /// </summary>
@@ -25,23 +29,23 @@ internal static class RunSettingsUtilities
     /// <returns>The test run parameters.</returns>
     /// <remarks>If there is no test run parameters section defined in the settingsxml a blank dictionary is returned.</remarks>
     internal static Dictionary<string, object>? GetTestRunParameters(string? settingsXml)
-        => GetNodeValue(settingsXml, Constants.TestRunParametersName, TestRunParameters.FromXml);
+        => GetNodeValue(settingsXml, TestRunParametersName, TestRunParameters.FromXml);
 
     /// <summary>
     /// Throws if the node has an attribute.
     /// </summary>
     /// <param name="reader"> The reader. </param>
-    /// <exception cref="SettingsException"> Thrown if the node has an attribute. </exception>
+    /// <exception cref="InvalidRunSettingsException"> Thrown if the node has an attribute. </exception>
     internal static void ThrowOnHasAttributes(XmlReader reader)
     {
         if (reader.HasAttributes)
         {
             reader.MoveToNextAttribute();
-            throw new SettingsException(
+            throw new InvalidRunSettingsException(
                 string.Format(
                     CultureInfo.CurrentCulture,
                     Resource.InvalidSettingsXmlAttribute,
-                    TestPlatform.ObjectModel.Constants.RunConfigurationSettingsName,
+                    RunConfigurationSettingsName,
                     reader.Name));
         }
     }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/TestRunParameters.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/TestRunParameters.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 
@@ -47,11 +47,11 @@ internal static class TestRunParameters
 
                     break;
                 default:
-                    throw new SettingsException(
+                    throw new InvalidRunSettingsException(
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Resource.InvalidSettingsXmlElement,
-                            Constants.TestRunParametersName,
+                            RunSettingsUtilities.TestRunParametersName,
                             reader.Name));
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/XmlReaderUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/XmlReaderUtilities.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+
+/// <summary>
+/// Minimal, platform-agnostic <see cref="XmlReader"/> navigation helpers for reading runsettings XML.
+/// These replace the equivalent helpers from the VSTest object model so the platform services layer does not
+/// depend on it; the navigation semantics are unchanged.
+/// </summary>
+internal static class XmlReaderUtilities
+{
+    private const string RunSettingsRootNodeName = "RunSettings";
+
+    /// <summary>
+    /// Advances the reader to the root element and verifies it is the <c>&lt;RunSettings&gt;</c> node.
+    /// </summary>
+    /// <param name="reader">The reader positioned before the root element.</param>
+    /// <exception cref="InvalidRunSettingsException">Thrown when the root element is not <c>&lt;RunSettings&gt;</c>.</exception>
+    internal static void ReadToRootNode(XmlReader reader)
+    {
+        reader.ReadToNextElement();
+
+        // Verify that it is a "RunSettings" node.
+        if (reader.Name != RunSettingsRootNodeName)
+        {
+            throw new InvalidRunSettingsException($"Could not find '{RunSettingsRootNodeName}' node in the runsettings XML. Found '<{reader.Name}>' instead.");
+        }
+    }
+
+    /// <summary>
+    /// Reads until the next element node (or end of document).
+    /// </summary>
+    /// <param name="reader">The reader.</param>
+    internal static void ReadToNextElement(this XmlReader reader)
+    {
+        while (!reader.EOF && reader.Read() && reader.NodeType != XmlNodeType.Element)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Skips the current subtree and positions the reader on the next element node.
+    /// </summary>
+    /// <param name="reader">The reader.</param>
+    internal static void SkipToNextElement(this XmlReader reader)
+    {
+        reader.Skip();
+
+        if (reader.NodeType != XmlNodeType.Element)
+        {
+            reader.ReadToNextElement();
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using DebuggerLaunchMode = Microsoft.VisualStudio.TestTools.UnitTesting.DebuggerLaunchMode;
 using MessageLevel = Microsoft.VisualStudio.TestTools.UnitTesting.MessageLevel;
@@ -45,7 +45,7 @@ internal sealed partial class MSTestSettings
         }
 
         using var stringReader = new StringReader(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
 
         XmlReaderUtilities.ReadToRootNode(reader);
         reader.ReadToNextElement();
@@ -69,7 +69,7 @@ internal sealed partial class MSTestSettings
         }
 
         using var stringReader = new StringReader(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
 
         XmlReaderUtilities.ReadToRootNode(reader);
         reader.ReadToNextElement();

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/InvalidRunSettingsException.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/InvalidRunSettingsException.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+
+/// <summary>
+/// Thrown when the runsettings XML is structurally invalid (for example a bad attribute, an unexpected element,
+/// or a wrong root node). This is the platform-agnostic replacement for the settings exception the platform
+/// services layer historically surfaced from the VSTest object model. It is intentionally distinct from
+/// <see cref="AdapterSettingsException"/>: <see cref="AdapterSettingsException"/> is caught by the discovery
+/// initialization path (reported and treated as "no tests"), whereas a structural runsettings error propagates
+/// to the host, preserving the original behavior.
+/// </summary>
+internal sealed class InvalidRunSettingsException : Exception
+{
+    internal InvalidRunSettingsException(string? message)
+        : base(message)
+    {
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/MSTestAdapterSettings.cs
@@ -4,9 +4,9 @@
 #if !WINDOWS_UWP
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
@@ -206,7 +206,7 @@ internal class MSTestAdapterSettings
         if (!StringEx.IsNullOrEmpty(settingsXml))
         {
             StringReader stringReader = new(settingsXml);
-            var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+            var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
             var xmlDoc = new XmlDocument() { XmlResolver = null };
             xmlDoc.Load(reader);
 
@@ -384,7 +384,7 @@ internal class MSTestAdapterSettings
                 else
                 {
                     string message = string.Format(CultureInfo.CurrentCulture, Resource.InvalidSettingsXmlElement, reader.Name, "AssemblyResolution");
-                    throw new SettingsException(message);
+                    throw new InvalidRunSettingsException(message);
                 }
 
                 // Move to the next element under tag AssemblyResolution

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
@@ -8,12 +8,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-#if NETFRAMEWORK
-// SuspendCodeCoverage (used below to pause dynamic code coverage while deployment copies files) is a VSTest
-// object-model type. Its neutralization is deferred to a later platform-services decoupling step; the rest of
-// the deployment input is already platform-agnostic.
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
-#endif
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
@@ -5,9 +5,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.AppContainer;
 #endif
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-#if NETFRAMEWORK
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
-#endif
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
@@ -79,7 +76,7 @@ internal sealed class TestSourceHandler : ITestSourceHandler
     {
 #if NETFRAMEWORK
         // This loads the dll in a different app domain. We can optimize this to load in the current domain since this code could be run in a new app domain anyway.
-        bool? utfReference = AssemblyHelper.DoesReferencesAssembly(source, assemblyName);
+        bool? utfReference = DoesSourceReferenceAssembly(source, assemblyName);
 
         // If no reference to UTF don't run discovery. Take conservative approach. If not able to find proceed with discovery.
         return !utfReference.HasValue || utfReference.Value;
@@ -93,6 +90,73 @@ internal sealed class TestSourceHandler : ITestSourceHandler
         return true;
 #endif
     }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Checks whether the source assembly directly references the given assembly.
+    /// Only the assembly simple name and public key token are matched; version is ignored.
+    /// Returns <see langword="null"/> if the reference could not be determined.
+    /// </summary>
+    /// <param name="source"> The path to the source assembly to inspect. </param>
+    /// <param name="referenceAssembly"> The assembly to look for in the source's references. </param>
+    /// <returns> <see langword="true"/> if referenced, <see langword="false"/> if not, <see langword="null"/> if undeterminable. </returns>
+    private static bool? DoesSourceReferenceAssembly(string source, AssemblyName referenceAssembly)
+    {
+        if (string.IsNullOrEmpty(source) || referenceAssembly is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            string? referenceAssemblyName = referenceAssembly.Name;
+            byte[] referenceAssemblyPublicKeyToken = referenceAssembly.GetPublicKeyToken();
+
+            // ReflectionOnlyLoadFrom loads from the specified path only (no probing) and does not
+            // execute any code from the loaded assembly.
+            var assembly = Assembly.ReflectionOnlyLoadFrom(source);
+
+            foreach (AssemblyName referencedAssembly in assembly.GetReferencedAssemblies())
+            {
+                // Match without version: only the simple name and public key token.
+                if (!string.Equals(referencedAssembly.Name, referenceAssemblyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (ArePublicKeyTokensEqual(referencedAssembly.GetPublicKeyToken(), referenceAssemblyPublicKeyToken))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            // Return null if we are not able to check.
+            return null;
+        }
+    }
+
+    private static bool ArePublicKeyTokensEqual(byte[] left, byte[] right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Length; ++i)
+        {
+            if (left[i] != right[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+#endif
 
     /// <summary>
     /// Gets the set of sources (dll's/exe's) that contain tests. If a source is a package (appx), return the file (dll/exe) that contains tests from it.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
@@ -7,12 +7,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 #if NETFRAMEWORK
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-#endif
-#if NETFRAMEWORK
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-#endif
-#if NETFRAMEWORK || (NET && !WINDOWS_UWP)
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 #endif
 #if !WINDOWS_UWP
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -29,6 +23,13 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 #pragma warning disable CA1852 // Seal internal types - needs to be non-sealed because it's mocked in tests.
 internal class TestSourceHost : ITestSourceHost
 {
+#if NETFRAMEWORK || (NET && !WINDOWS_UWP)
+    private const string ObjectModelAssemblyName = "Microsoft.VisualStudio.TestPlatform.ObjectModel";
+#endif
+#if NETFRAMEWORK
+    private const string CoreUtilitiesAssemblyName = "Microsoft.TestPlatform.CoreUtilities";
+#endif
+
 #if !WINDOWS_UWP
 #pragma warning disable IDE0052 // Remove unread private members
     private readonly string _sourceFileName;
@@ -178,7 +179,7 @@ internal class TestSourceHost : ITestSourceHost
             // For unknown reasons, with MSTest 3.4+ we start to see infinite cycles of assembly resolution of this dll in the new app
             // domain. In older versions, this was not the case, and the callback was allowing to fully lookup and load the dll before
             // triggering the next resolution.
-            AppDomain.Load(typeof(EqtTrace).Assembly.GetName());
+            AppDomain.Load(GetLoadedAssembly(CoreUtilitiesAssemblyName).GetName());
 
             // Add an assembly resolver in the child app-domain...
             Type assemblyResolverType = typeof(AssemblyResolver);
@@ -352,6 +353,17 @@ internal class TestSourceHost : ITestSourceHost
 
 #if NETFRAMEWORK || (NET && !WINDOWS_UWP)
     /// <summary>
+    /// Resolves a loaded test-platform assembly by simple name, so this file needs no compile-time reference to
+    /// the VSTest object model. These assemblies are loaded by the adapter/host before the source host runs, so
+    /// the resolved identity matches what a direct type reference would have produced.
+    /// </summary>
+    /// <param name="simpleName">The simple assembly name.</param>
+    /// <returns>The loaded assembly.</returns>
+    private static Assembly GetLoadedAssembly(string simpleName)
+        => AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => string.Equals(a.GetName().Name, simpleName, StringComparison.Ordinal))
+            ?? Assembly.Load(simpleName);
+
+    /// <summary>
     /// Gets the probing paths to load the test assembly dependencies.
     /// </summary>
     /// <param name="sourceFileName">
@@ -402,7 +414,7 @@ internal class TestSourceHost : ITestSourceHost
             resolutionPaths.Add(adapterDirectory);
         }
 
-        string? testPlatformDirectory = Path.GetDirectoryName(AssemblyFileLocator.TryGetLocation(typeof(AssemblyHelper).Assembly));
+        string? testPlatformDirectory = Path.GetDirectoryName(AssemblyFileLocator.TryGetLocation(GetLoadedAssembly(ObjectModelAssemblyName)));
         if (!string.IsNullOrEmpty(testPlatformDirectory) && !resolutionPaths.Contains(testPlatformDirectory))
         {
             // Adding TestPlatform folder to resolution paths

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/AppDomainUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK
@@ -6,7 +6,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
@@ -18,8 +17,21 @@ internal static class AppDomainUtilities
 {
     private const string ObjectModelVersionBuiltAgainst = "11.0.0.0";
 
+    private const string ObjectModelAssemblyName = "Microsoft.VisualStudio.TestPlatform.ObjectModel";
+
     private static readonly Version DefaultVersion = new();
     private static readonly Version Version45 = new("4.5");
+
+    /// <summary>
+    /// Resolves the loaded VSTest object-model assembly by simple name, so this AppDomain-wiring code does not
+    /// need a compile-time reference to it. By the time these methods run (test source host setup during
+    /// discovery/execution) the adapter has already loaded the object model into the current (parent) domain,
+    /// so its identity — including any binding redirect in effect — matches what a direct type reference resolved to.
+    /// </summary>
+    /// <returns>The object-model assembly.</returns>
+    private static Assembly GetObjectModelAssembly()
+        => AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => string.Equals(a.GetName().Name, ObjectModelAssemblyName, StringComparison.Ordinal))
+            ?? Assembly.Load(ObjectModelAssemblyName);
 
     /// <summary>
     /// Gets or sets the Xml Utilities instance.
@@ -90,7 +102,7 @@ internal static class AppDomainUtilities
 
             var resolutionPaths = new List<string>
                 {
-                    Path.GetDirectoryName(typeof(TestCase).Assembly.Location),
+                    Path.GetDirectoryName(GetObjectModelAssembly().Location),
                     Path.GetDirectoryName(testSourcePath),
                 };
 
@@ -157,10 +169,10 @@ internal static class AppDomainUtilities
         try
         {
             // Add redirection of the built 11.0 Object Model assembly to the current version if that is not 11.0
-            string currentVersionOfObjectModel = typeof(TestCase).Assembly.GetName().Version.ToString();
+            string currentVersionOfObjectModel = GetObjectModelAssembly().GetName().Version.ToString();
             if (!string.Equals(currentVersionOfObjectModel, ObjectModelVersionBuiltAgainst, StringComparison.Ordinal))
             {
-                AssemblyName assemblyName = typeof(TestCase).Assembly.GetName();
+                AssemblyName assemblyName = GetObjectModelAssembly().GetName();
                 byte[] configurationBytes =
                     XmlUtilities.AddAssemblyRedirection(
                         testSourceConfigFile,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SuspendCodeCoverage.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SuspendCodeCoverage.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
+
+/// <summary>
+/// Suspends dynamic code-coverage instrumentation of the modules that are loaded while this object is alive
+/// (between construction and disposal) by setting the well-known collector environment variable. The previous
+/// value of the environment variable is restored on dispose.
+/// </summary>
+internal sealed class SuspendCodeCoverage : IDisposable
+{
+    private const string SuspendCodeCoverageEnvVarName = "__VANGUARD_SUSPEND_INSTRUMENT__";
+    private const string SuspendCodeCoverageEnvVarTrueValue = "TRUE";
+
+    private readonly string? _previousEnvironmentValue;
+
+    private bool _isDisposed;
+
+    public SuspendCodeCoverage()
+    {
+        _previousEnvironmentValue = Environment.GetEnvironmentVariable(SuspendCodeCoverageEnvVarName, EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable(SuspendCodeCoverageEnvVarName, SuspendCodeCoverageEnvVarTrueValue, EnvironmentVariableTarget.Process);
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(SuspendCodeCoverageEnvVarName, _previousEnvironmentValue, EnvironmentVariableTarget.Process);
+        _isDisposed = true;
+    }
+}
+#endif

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/RunSettingsUtilitiesTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/RunSettingsUtilitiesTests.cs
@@ -4,7 +4,7 @@
 using AwesomeAssertions;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 
 using TestFramework.ForTestingMSTest;
 
@@ -131,7 +131,7 @@ public class RunSettingsUtilitiesTests : TestContainer
             </RunSettings>
             """;
 
-        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<SettingsException>();
+        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<InvalidRunSettingsException>();
     }
 
     public void GetTestRunParametersThrowsWhenTRPNodeHasNonParameterTypeChildNodes()
@@ -152,7 +152,7 @@ public class RunSettingsUtilitiesTests : TestContainer
             </RunSettings>
             """;
 
-        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<SettingsException>();
+        new Action(() => RunSettingsUtilities.GetTestRunParameters(settingsXml)).Should().Throw<InvalidRunSettingsException>();
     }
 
     public void GetTestRunParametersIgnoresMalformedKeyValues()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/MSTestAdapterSettingsTests.cs
@@ -3,10 +3,10 @@
 
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 
 using Moq;
 
@@ -202,7 +202,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             """;
 
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
 
         MSTestAdapterSettings.ToSettings(reader);
@@ -222,12 +222,12 @@ public class MSTestAdapterSettingsTests : TestContainer
             """;
 
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
 
         void ShouldThrowException() => MSTestAdapterSettings.ToSettings(reader);
 
-        new Action(ShouldThrowException).Should().Throw<SettingsException>();
+        new Action(ShouldThrowException).Should().Throw<InvalidRunSettingsException>();
     }
 
     #endregion
@@ -242,7 +242,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeploymentEnabled.Should().BeTrue();
@@ -257,7 +257,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeploymentEnabled.Should().BeFalse();
@@ -275,7 +275,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeTrue();
@@ -290,7 +290,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeFalse();
@@ -305,7 +305,7 @@ public class MSTestAdapterSettingsTests : TestContainer
             </MSTestV2>
             """;
         StringReader stringReader = new(runSettingsXml);
-        var reader = XmlReader.Create(stringReader, XmlRunSettingsUtilities.ReaderSettings);
+        var reader = XmlReader.Create(stringReader, RunSettingsUtilities.ReaderSettings);
         reader.Read();
         var adapterSettings = MSTestAdapterSettings.ToSettings(reader);
         adapterSettings.DeployTestSourceDependencies.Should().BeTrue();


### PR DESCRIPTION
## Phase 6e-4c1 — Resolve the source-host anchor assemblies by name

Part of the initiative to make `MSTestAdapter.PlatformServices` platform-agnostic by removing its dependency on the VSTest object model. Strict **byte-for-byte** refactor.

### What this does

`TestSourceHost` used two `typeof(...).Assembly` anchors into the VSTest object model (both in netfx / net-non-uwp source-host setup):

1. **`typeof(EqtTrace).Assembly`** — force-loads `Microsoft.TestPlatform.CoreUtilities` into the **child app domain** to avoid a recursive assembly-resolution cycle (per the existing comment).
2. **`typeof(AssemblyHelper).Assembly`** — locates the test-platform directory for the resolution paths.

Both reflect **parent-side loaded assemblies** before the child domain resolves anything, so they are now resolved by **simple name** via a small `GetLoadedAssembly(simpleName)` helper (the same pattern proven in 6e-4b), returning the same loaded assembly identity the type references did.

Key detail (empirically verified against the built assemblies): the two anchors target **different** assemblies — `EqtTrace` is type-forwarded from the object model, so its defining assembly is **CoreUtilities** (matching the "Force loading … CoreUtilities" comment); `AssemblyHelper` lives in the **object model**. The helper is guarded to exactly the TFMs where the `typeof`s compiled (`NETFRAMEWORK` for the EqtTrace anchor; `NETFRAMEWORK || (NET && !WINDOWS_UWP)` for the AssemblyHelper anchor / `GetResolutionPaths`).

The only remaining object-model mention in the file is the assembly simple name as a **string literal** (not an assembly reference). This fully decouples `TestSourceHost`.

### Fidelity proof

- **`PlatformServices.Desktop.IntegrationTests`** (net462 child-app-domain force-load + assembly-resolution + deployment paths): **15/15 green** — the exact scenario these anchors protect.
- Timing: both run after the adapter/host loaded CoreUtilities + the object model, so the by-name lookups find them (no null / no fallback probing on the real path).

### Verification

- Full `build.cmd -c Debug` green all TFMs (net462/net8.0/net9.0/UWP/WinUI), IDE0005 clean.
- `PlatformServices.Desktop.IntegrationTests`: **15**, 0 failed.
- `MSTestAdapter.PlatformServices.UnitTests`: **897** (net8.0) / **935** (net462), 0 failed.

### Remaining after this

2 files with real deps: `TestSourceHandler` (`AssemblyHelper.DoesReferencesAssembly`) and `TestDeployment` (`SuspendCodeCoverage`, netfx). Then Phase 7 (drop the PackageReference + guard test).

### Stacking

`… 6e-3b #9626` → `6e-4a #9627` → `6e-4b #9628` → **6e-4c1 (this)**, onto `dev/amauryleve/vstest-decoupling-base`. Base = 6e-4b branch (`dev/amauryleve/vstest-decoupling-appdomain`). **Do not rebase/reset the base.**
