### PR TITLE
Reimplement source assembly-reference check without ObjectModel (Phase 6e-4c2)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
@@ -5,9 +5,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.AppContainer;
 #endif
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-#if NETFRAMEWORK
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
-#endif
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
@@ -79,7 +76,7 @@ internal sealed class TestSourceHandler : ITestSourceHandler
     {
 #if NETFRAMEWORK
         // This loads the dll in a different app domain. We can optimize this to load in the current domain since this code could be run in a new app domain anyway.
-        bool? utfReference = AssemblyHelper.DoesReferencesAssembly(source, assemblyName);
+        bool? utfReference = DoesSourceReferenceAssembly(source, assemblyName);
 
         // If no reference to UTF don't run discovery. Take conservative approach. If not able to find proceed with discovery.
         return !utfReference.HasValue || utfReference.Value;
@@ -93,6 +90,73 @@ internal sealed class TestSourceHandler : ITestSourceHandler
         return true;
 #endif
     }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Checks whether the source assembly directly references the given assembly.
+    /// Only the assembly simple name and public key token are matched; version is ignored.
+    /// Returns <see langword="null"/> if the reference could not be determined.
+    /// </summary>
+    /// <param name="source"> The path to the source assembly to inspect. </param>
+    /// <param name="referenceAssembly"> The assembly to look for in the source's references. </param>
+    /// <returns> <see langword="true"/> if referenced, <see langword="false"/> if not, <see langword="null"/> if undeterminable. </returns>
+    private static bool? DoesSourceReferenceAssembly(string source, AssemblyName referenceAssembly)
+    {
+        if (string.IsNullOrEmpty(source) || referenceAssembly is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            string? referenceAssemblyName = referenceAssembly.Name;
+            byte[] referenceAssemblyPublicKeyToken = referenceAssembly.GetPublicKeyToken();
+
+            // ReflectionOnlyLoadFrom loads from the specified path only (no probing) and does not
+            // execute any code from the loaded assembly.
+            var assembly = Assembly.ReflectionOnlyLoadFrom(source);
+
+            foreach (AssemblyName referencedAssembly in assembly.GetReferencedAssemblies())
+            {
+                // Match without version: only the simple name and public key token.
+                if (!string.Equals(referencedAssembly.Name, referenceAssemblyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (ArePublicKeyTokensEqual(referencedAssembly.GetPublicKeyToken(), referenceAssemblyPublicKeyToken))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            // Return null if we are not able to check.
+            return null;
+        }
+    }
+
+    private static bool ArePublicKeyTokensEqual(byte[] left, byte[] right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Length; ++i)
+        {
+            if (left[i] != right[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+#endif
 
     /// <summary>
     /// Gets the set of sources (dll's/exe's) that contain tests. If a source is a package (appx), return the file (dll/exe) that contains tests from it.


### PR DESCRIPTION
## Phase 6e-4c2 — reimplement the source assembly-reference check without ObjectModel

Part of the initiative to make **`Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices`** platform-agnostic by removing its dependency on `Microsoft.TestPlatform.ObjectModel`. VSTest coupling moves up into `MSTest.TestAdapter`; the platform-services engine becomes neutral. Strict **byte-for-byte, no behavior change**.

### What this changes

`TestSourceHandler.IsAssemblyReferenced` (netfx-only) decided whether a source assembly references the test framework — used to skip discovery on sources that don't reference MSTest — by calling `AssemblyHelper.DoesReferencesAssembly` from `Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities`.

This replaces that call with a local neutral `DoesSourceReferenceAssembly` helper that reproduces the **exact observable behavior** of the VSTest implementation:

- `Assembly.ReflectionOnlyLoadFrom(source)` → `GetReferencedAssemblies()`.
- Match a referenced assembly by **simple name** (`OrdinalIgnoreCase`) **plus public-key-token bytes**; version is ignored — identical to `AssemblyLoadWorker.CheckAssemblyReference`.
- Name match + public-key-token length/byte mismatch keeps scanning further references (mirrors the original `continue`), rather than short-circuiting.
- Null/empty source or null reference assembly → `null` (undeterminable).
- Any exception → `null`, so discovery proceeds conservatively.

The `IsAssemblyReferenced` decision line (`return !utfReference.HasValue || utfReference.Value;` — null-or-true ⇒ proceed, false ⇒ skip) is **unchanged**.

### Fidelity note (dead child-AppDomain)

VSTest's `DoesReferencesAssembly` created a child `AppDomain` and an `AssemblyLoadWorker` instance, but then called the **static** `AssemblyLoadWorker.CheckAssemblyReference(...)` — the worker instance is assigned and **never used**, and the `ReflectionOnlyLoadFrom` actually runs in the **current** domain. The child domain is therefore dead code for the result, so omitting it is behavior-preserving for every input where `AppDomain.CreateDomain` would have succeeded (the only theoretical divergence — a machine where domain creation throws but reflection-only load succeeds — is unreachable in practice, and the conservative null-return there would only *proceed* with discovery either way).

Removes the last real ObjectModel dependency from `TestSourceHandler` (it now carries only string-literal well-known-assembly names, which don't reference the package).

### Verification

- All real TFMs build **0-warning** (UWP builds via full msbuild in CI, unaffected — change is `#if NETFRAMEWORK`-guarded).
- `MSTestAdapter.PlatformServices.UnitTests`: **935/935** (net462), **897/897** (net8.0).
- `DesktopTestSourceTests` — the direct `IsAssemblyReferenced` net — **7/7**, covering: assembly referenced (true), not referenced (false), null name (true), null source (true).
- `PlatformServices.Desktop.IntegrationTests`: **15/15** (net462).
- Expert-reviewer pass.

### Stacking

Stacks on **#9630** (Phase 6e-4c1); base branch `dev/amauryleve/vstest-decoupling-sourcehost`. Review/merge after the earlier PRs in the chain reach the base. Do **not** squash-rebase the base.
