### PR TITLE
Vendor a neutral SuspendCodeCoverage in PlatformServices (Phase 6e-4c3)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestDeployment.cs
@@ -8,12 +8,6 @@ using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Deployment;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
-#if NETFRAMEWORK
-// SuspendCodeCoverage (used below to pause dynamic code coverage while deployment copies files) is a VSTest
-// object-model type. Its neutralization is deferred to a later platform-services decoupling step; the rest of
-// the deployment input is already platform-agnostic.
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
-#endif
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestSourceHandler.cs
@@ -5,9 +5,6 @@
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.AppContainer;
 #endif
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-#if NETFRAMEWORK
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
-#endif
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
@@ -79,7 +76,7 @@ internal sealed class TestSourceHandler : ITestSourceHandler
     {
 #if NETFRAMEWORK
         // This loads the dll in a different app domain. We can optimize this to load in the current domain since this code could be run in a new app domain anyway.
-        bool? utfReference = AssemblyHelper.DoesReferencesAssembly(source, assemblyName);
+        bool? utfReference = DoesSourceReferenceAssembly(source, assemblyName);
 
         // If no reference to UTF don't run discovery. Take conservative approach. If not able to find proceed with discovery.
         return !utfReference.HasValue || utfReference.Value;
@@ -93,6 +90,73 @@ internal sealed class TestSourceHandler : ITestSourceHandler
         return true;
 #endif
     }
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Checks whether the source assembly directly references the given assembly.
+    /// Only the assembly simple name and public key token are matched; version is ignored.
+    /// Returns <see langword="null"/> if the reference could not be determined.
+    /// </summary>
+    /// <param name="source"> The path to the source assembly to inspect. </param>
+    /// <param name="referenceAssembly"> The assembly to look for in the source's references. </param>
+    /// <returns> <see langword="true"/> if referenced, <see langword="false"/> if not, <see langword="null"/> if undeterminable. </returns>
+    private static bool? DoesSourceReferenceAssembly(string source, AssemblyName referenceAssembly)
+    {
+        if (string.IsNullOrEmpty(source) || referenceAssembly is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            string? referenceAssemblyName = referenceAssembly.Name;
+            byte[] referenceAssemblyPublicKeyToken = referenceAssembly.GetPublicKeyToken();
+
+            // ReflectionOnlyLoadFrom loads from the specified path only (no probing) and does not
+            // execute any code from the loaded assembly.
+            var assembly = Assembly.ReflectionOnlyLoadFrom(source);
+
+            foreach (AssemblyName referencedAssembly in assembly.GetReferencedAssemblies())
+            {
+                // Match without version: only the simple name and public key token.
+                if (!string.Equals(referencedAssembly.Name, referenceAssemblyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (ArePublicKeyTokensEqual(referencedAssembly.GetPublicKeyToken(), referenceAssemblyPublicKeyToken))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            // Return null if we are not able to check.
+            return null;
+        }
+    }
+
+    private static bool ArePublicKeyTokensEqual(byte[] left, byte[] right)
+    {
+        if (left.Length != right.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < left.Length; ++i)
+        {
+            if (left[i] != right[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+#endif
 
     /// <summary>
     /// Gets the set of sources (dll's/exe's) that contain tests. If a source is a package (appx), return the file (dll/exe) that contains tests from it.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SuspendCodeCoverage.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Utilities/SuspendCodeCoverage.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Utilities;
+
+/// <summary>
+/// Suspends dynamic code-coverage instrumentation of the modules that are loaded while this object is alive
+/// (between construction and disposal) by setting the well-known collector environment variable. The previous
+/// value of the environment variable is restored on dispose.
+/// </summary>
+internal sealed class SuspendCodeCoverage : IDisposable
+{
+    private const string SuspendCodeCoverageEnvVarName = "__VANGUARD_SUSPEND_INSTRUMENT__";
+    private const string SuspendCodeCoverageEnvVarTrueValue = "TRUE";
+
+    private readonly string? _previousEnvironmentValue;
+
+    private bool _isDisposed;
+
+    public SuspendCodeCoverage()
+    {
+        _previousEnvironmentValue = Environment.GetEnvironmentVariable(SuspendCodeCoverageEnvVarName, EnvironmentVariableTarget.Process);
+        Environment.SetEnvironmentVariable(SuspendCodeCoverageEnvVarName, SuspendCodeCoverageEnvVarTrueValue, EnvironmentVariableTarget.Process);
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        Environment.SetEnvironmentVariable(SuspendCodeCoverageEnvVarName, _previousEnvironmentValue, EnvironmentVariableTarget.Process);
+        _isDisposed = true;
+    }
+}
+#endif


### PR DESCRIPTION
## Phase 6e-4c3 — vendor a neutral `SuspendCodeCoverage`

Part of the initiative to make **`Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices`** platform-agnostic by removing its dependency on `Microsoft.TestPlatform.ObjectModel`. Strict **byte-for-byte, no behavior change**.

### What this changes

`TestDeployment` (netfx) wraps the deployment file-copy in `using (new SuspendCodeCoverage())` to pause dynamic code-coverage instrumentation of modules loaded while files are copied. That type came from `Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities`.

This vendors an internal neutral copy at **`Utilities/SuspendCodeCoverage.cs`** (namespace `...PlatformServices.Utilities`), reproducing the VSTest behavior exactly:

- **On construction:** capture the current value of the process environment variable `__VANGUARD_SUSPEND_INSTRUMENT__`, then set it to `TRUE`.
- **On dispose:** restore the captured previous value (idempotent).

The environment-variable **name and value are the collector IPC contract** the dynamic code-coverage (Vanguard) engine reads, so they are preserved byte-identical. The wrapper is `internal sealed` with a straightforward idempotent `Dispose` — the original's `Dispose(bool)` / `GC.SuppressFinalize` plumbing has no finalizer to suppress and is behavior-equivalent to the direct restore.

`TestDeployment` now resolves `SuspendCodeCoverage` through its already-present `using ...PlatformServices.Utilities;`; the VSTest `ObjectModel.Utilities` using (and its deferral comment) is removed.

### Fidelity proof and test-net limitation

The mechanism is a process **environment variable** (`__VANGUARD_SUSPEND_INSTRUMENT__`), **not** a named event / mutex / `EventWaitHandle`. There is no signal/listener model — the dynamic code-coverage (Vanguard) collector *reads* this variable from the process environment when deciding whether to instrument a module being loaded. The fidelity of the vendored copy therefore rests entirely on **replicating that wire contract byte-identically** against the OSS source (`vstest` v18.4.0 `SuspendCodeCoverage.cs`).

**Source-diff (fidelity proof of record) — OSS original vs vendored copy:**

| Contract element | OSS (`Microsoft.TestPlatform.ObjectModel`) | Vendored copy |
|---|---|---|
| env var name | `"__VANGUARD_SUSPEND_INSTRUMENT__"` | `"__VANGUARD_SUSPEND_INSTRUMENT__"` |
| set value | `"TRUE"` | `"TRUE"` |
| target (all 3 accesses) | `EnvironmentVariableTarget.Process` | `EnvironmentVariableTarget.Process` |
| ctor | `GetEnvironmentVariable(name, Process)` → capture; `SetEnvironmentVariable(name, "TRUE", Process)` | identical |
| dispose | `SetEnvironmentVariable(name, prev, Process)`, guarded by `_isDisposed` | identical |

The only intentional difference is the collapse of the OSS `Dispose()` / `protected virtual Dispose(bool)` / `GC.SuppressFinalize` into a single idempotent `Dispose()` — behavior-equivalent because the OSS type declares **no finalizer** (so `GC.SuppressFinalize` is a no-op and `disposing` is always `true` on the public path). The name/value/target/sequence — the entire wire contract the collector keys off — are verbatim.

Note on the test net: `PlatformServices.Desktop.IntegrationTests` runs with **no coverage collector attached**, so its green result proves the vendored code does not crash / the deploy path still works — it does **not** exercise a real collector reading the variable. That is acceptable here precisely because there is no signaling to get wrong: correctness is fully determined by the (source-identical) variable name/value/target above. There is no clean seam to assert the variable mid-deploy without contorting the copy loop, so no brittle probe was added.

### Result: PlatformServices is ObjectModel-type-free

After this change, **PlatformServices has zero `using`/type references to the `Microsoft.TestPlatform.ObjectModel` package** — only string-literal assembly *names* (used for by-name runtime assembly lookup in the AppDomain/source-host wiring) remain. This clears the way to drop the package reference in the capstone (Phase 7).

### Verification

- Builds **0-warning** (net462 and all real TFMs; netfx-guarded change).
- `MSTestAdapter.PlatformServices.UnitTests`: **935/935** (net462), **897/897** (net8.0).
- `PlatformServices.Desktop.IntegrationTests`: **15/15** (net462) — exercises the deployment path that runs inside the `SuspendCodeCoverage` scope.
- Expert-reviewer pass.

### Stacking

Stacks on **#9631** (Phase 6e-4c2); base branch `dev/amauryleve/vstest-decoupling-sourcehandler`. Review/merge after the earlier PRs in the chain reach the base. Do **not** squash-rebase the base.

