### PR TITLE
perf: skip TCS bridge in ExecuteTestAsync when no ExecutionContext is captured

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.cs
@@ -496,11 +496,27 @@ internal sealed class TestMethodRunner
     {
         try
         {
+            ExecutionContext? capturedContext = testMethodInfo.Parent.ExecutionContext
+                ?? testMethodInfo.Parent.Parent.ExecutionContext;
+
+            // Fast path: when no ExecutionContext was captured (the common case),
+            // ExecutionContextHelpers.RunOnContext would simply call the action inline.
+            // Skip the TaskCompletionSource bridge, async-lambda closure, and Action
+            // delegate allocations entirely.
+            if (capturedContext is null)
+            {
+                using (TestContextImplementation.SetCurrentTestContext(executionContext as TestContext))
+                {
+                    testMethodInfo.TestContext = executionContext;
+                    return await _testMethodInfo.Executor.ExecuteAsync(testMethodInfo).ConfigureAwait(false);
+                }
+            }
+
             var tcs = new TaskCompletionSource<TestResult[]>();
 
 #pragma warning disable VSTHRD101 // Avoid unsupported async delegates
             ExecutionContextHelpers.RunOnContext(
-                testMethodInfo.Parent.ExecutionContext ?? testMethodInfo.Parent.Parent.ExecutionContext,
+                capturedContext,
                 async () =>
                 {
                     try


### PR DESCRIPTION
Fixes #9635

## Summary

`ExecuteTestAsync` in `TestMethodRunner` used a `TaskCompletionSource<TestResult[]>` bridge to hop test execution onto a captured `ExecutionContext` (set by `[ClassInitialize]` or `[AssemblyInitialize]`). However, `ExecutionContextHelpers.RunOnContext` already handles a `null` context by invoking the action inline — so the `TaskCompletionSource`, async-lambda closure, and `Action` delegate were being allocated for **every test**, even in the common case where no `ExecutionContext` was captured.

## Change

Compute the captured context once and short-circuit the bridge when it is `null`:

- **Fast path** (common case, `capturedContext is null`): execute directly, skipping the TCS bridge and its ~3 heap allocations (~114 bytes) per test.
- **Slow path** (a lifecycle method captured a context): unchanged TCS bridge via `ExecutionContext.Run`.

## Verification

- `MSTestAdapter.PlatformServices` builds clean (0 warnings, 0 errors).
- All 23 `TestMethodRunnerTests` pass unchanged.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>