### PR TITLE
perf: skip intermediate Dictionary alloc in CloneForDataDrivenIteration

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -524,16 +524,15 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <returns>A fresh context suitable for one folded data-driven iteration.</returns>
     internal TestContextImplementation CloneForDataDrivenIteration()
     {
-        // Take a shallow snapshot of the current property bag so that the clone starts with
-        // the same properties (including TestNameLabel / FullyQualifiedTestClassNameLabel and
-        // anything merged from AssemblyInitialize / ClassInitialize) but is otherwise isolated.
-        // Per-iteration mutations to the clone's property bag won't leak back to this instance
-        // nor to subsequent iterations.
-        var snapshot = new Dictionary<string, object?>(_properties);
-
-        // Pass testMethod: null and testClassFullName: null because the relevant labels are
-        // already in the snapshot. The constructor will copy the snapshot as-is.
-        var clone = new TestContextImplementation(testMethod: null, testClassFullName: null, snapshot, _messageLogger, _testRunCancellationToken);
+        // Pass _properties directly and testMethod: null / testClassFullName: null because the
+        // relevant labels (including TestNameLabel / FullyQualifiedTestClassNameLabel and anything
+        // merged from AssemblyInitialize / ClassInitialize) are already in the property bag. The
+        // constructor's null/null branch copies the supplied properties into a fresh dictionary
+        // via the [with(properties)] spread, so no intermediate snapshot allocation is needed and
+        // isolation is preserved: per-iteration mutations to the clone's property bag won't leak
+        // back to this instance nor to subsequent iterations, and mutations to this instance after
+        // clone creation won't leak into the clone.
+        var clone = new TestContextImplementation(testMethod: null, testClassFullName: null, _properties, _messageLogger, _testRunCancellationToken);
 
         // Preserve TestRunCount so user code that observes it (e.g. retry-aware tests) sees
         // the same value it would see in the unfolded path. TestRunCount represents the


### PR DESCRIPTION
## Summary

Fixes #9634.

`CloneForDataDrivenIteration` in `TestContextImplementation` created an intermediate `Dictionary<string, object?>` copy before passing it to the constructor:

```csharp
var snapshot = new Dictionary<string, object?>(_properties);
var clone = new TestContextImplementation(testMethod: null, testClassFullName: null, snapshot, ...);
```

The constructor's `testMethod == null && testClassFullName == null` branch immediately copies the supplied properties into another fresh dictionary via the `[with(properties)]` collection-expression spread. So the `snapshot` intermediate was redundant — the constructor copy alone provides isolation.

This PR passes `_properties` directly to the constructor, saving **one heap allocation and one O(n) copy per data-driven test iteration**.

## Correctness

All isolation invariants are preserved because the constructor still copies `_properties` into its own dictionary:
- Clone mutations do not leak back to the original context.
- Original mutations after clone creation do not leak into the clone.

## Verification

- `MSTestAdapter.PlatformServices` builds clean (0 warnings, 0 errors).
- `TestContextImplementationTests` — all 52 tests pass, including the clone isolation / shallow-copy / property-bag independence cases.