### PR TITLE
Deduplicate TestResultCapture base-field population

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -23,32 +23,24 @@ internal static class TestResultCapture
 
         CapturedTestResultCoreData core = coreData.GetValueOrDefault();
         (string status, string? rawStatus) = ClassifyStatus(core.State);
-        (string? ns, string? className, string? methodName) = GetClassAndMethodName(core.Properties.Identifier);
+        (string? ns, string? className, _) = GetClassAndMethodName(core.Properties.Identifier);
 
-        return new CapturedTestResult
+        var result = new CapturedTestResult
         {
-            // Identity fields are test-controlled and can be unbounded (e.g. very long
-            // UIDs/display names from generated data), so we also cap them to keep the
-            // session-wide result list and generated report within a predictable budget.
-            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
-            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             Status = status,
             RawStatus = rawStatus,
-            Duration = core.Duration,
-            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
-            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
             Namespace = TestResultCaptureHelper.Truncate(ns, TestResultCaptureHelper.MaxIdentityFieldLength),
-            ClassName = TestResultCaptureHelper.Truncate(className, TestResultCaptureHelper.MaxIdentityFieldLength),
-            MethodName = TestResultCaptureHelper.Truncate(methodName, TestResultCaptureHelper.MaxIdentityFieldLength),
-            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
-            ExceptionType = core.ExceptionDetails.ExceptionType,
-            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
-            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
-            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
             FilePath = TestResultCaptureHelper.Truncate(core.Properties.Location?.FilePath, TestResultCaptureHelper.MaxIdentityFieldLength),
             Line = core.Properties.Location?.LineSpan.Start.Line,
-            Traits = core.Properties.Traits,
         };
+        result.PopulateBaseFields(node, core);
+
+        // CTRF decomposes the identifier into a separate Namespace plus a type-name-only
+        // ClassName, rather than the namespace-prefixed ClassName the shared base-field
+        // population produces, so override ClassName here (MethodName already matches the
+        // shared value).
+        result.ClassName = TestResultCaptureHelper.Truncate(className, TestResultCaptureHelper.MaxIdentityFieldLength);
+        return result;
     }
 
     // CTRF status enum: passed, failed, skipped, pending, other.

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/TestResultCapture.cs
@@ -19,27 +19,13 @@ internal static class TestResultCapture
         }
 
         CapturedTestResultCoreData core = coreData.GetValueOrDefault();
-        return new CapturedTestResult
+        var result = new CapturedTestResult
         {
-            // Identity fields are test-controlled and can be unbounded (e.g. very long
-            // UIDs/display names from generated data), so we also cap them to keep the
-            // session-wide result list and generated HTML within a predictable budget.
-            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
-            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             // HTML does not special-case cancellation — it falls through to the shared
             // helper which maps it to "failed", unlike JUnit which maps it to "cancelled".
             Outcome = TestResultCaptureHelper.ClassifyOutcome(core.State),
-            Duration = core.Duration,
-            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
-            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
-            ClassName = TestResultCaptureHelper.Truncate(core.ClassName, TestResultCaptureHelper.MaxIdentityFieldLength),
-            MethodName = TestResultCaptureHelper.Truncate(core.MethodName, TestResultCaptureHelper.MaxIdentityFieldLength),
-            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
-            ExceptionType = core.ExceptionDetails.ExceptionType,
-            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
-            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
-            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
-            Traits = core.Properties.Traits,
         };
+        result.PopulateBaseFields(node, core);
+        return result;
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/TestResultCapture.cs
@@ -36,31 +36,17 @@ internal static class TestResultCapture
         }
 
         CapturedTestResultCoreData core = coreData.GetValueOrDefault();
-        return new CapturedTestResult
+        var result = new CapturedTestResult
         {
-            // Identity fields are test-controlled and can be unbounded (e.g. very long
-            // UIDs/display names from generated data), so we also cap them to keep the
-            // session-wide result list and generated XML within a predictable budget.
             // RawUid and ParentRawUid are used as keys/edges in the parent-chain
-            // dictionary, so they must be capped with the same budget on both sides
-            // to keep lookups consistent.
-            Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
+            // dictionary, so they must be capped with the same MaxIdentityFieldLength
+            // budget on both sides to keep lookups consistent.
             RawUid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             ParentRawUid = TestResultCaptureHelper.Truncate(update.ParentTestNodeUid?.Value, TestResultCaptureHelper.MaxIdentityFieldLength),
-            DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!,
             Outcome = ClassifyOutcome(core.State),
-            Duration = core.Duration,
-            StartTime = core.Properties.Timing?.GlobalTiming.StartTime,
-            EndTime = core.Properties.Timing?.GlobalTiming.EndTime,
-            ClassName = TestResultCaptureHelper.Truncate(core.ClassName, TestResultCaptureHelper.MaxIdentityFieldLength),
-            MethodName = TestResultCaptureHelper.Truncate(core.MethodName, TestResultCaptureHelper.MaxIdentityFieldLength),
-            ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength),
-            ExceptionType = core.ExceptionDetails.ExceptionType,
-            StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength),
-            StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength),
-            StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength),
-            Traits = core.Properties.Traits,
         };
+        result.PopulateBaseFields(node, core);
+        return result;
     }
 
     private static string ClassifyOutcome(TestNodeStateProperty state)

--- a/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
+++ b/src/Platform/SharedExtensionHelpers/CapturedTestResultBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.Extensions.Messages;
+
 namespace Microsoft.Testing.Extensions;
 
 // Minimal projection of a terminal test result, shared by the HtmlReport, JUnitReport and
@@ -12,29 +14,55 @@ namespace Microsoft.Testing.Extensions;
 // fields that follow their own truncation rules, so do not assume every field is capped.
 internal abstract class CapturedTestResultBase
 {
-    public required string Uid { get; init; }
+    public string Uid { get; set; } = string.Empty;
 
-    public required string DisplayName { get; init; }
+    public string DisplayName { get; set; } = string.Empty;
 
-    public required TimeSpan Duration { get; init; }
+    public TimeSpan Duration { get; set; }
 
-    public DateTimeOffset? StartTime { get; init; }
+    public DateTimeOffset? StartTime { get; set; }
 
-    public DateTimeOffset? EndTime { get; init; }
+    public DateTimeOffset? EndTime { get; set; }
 
-    public string? ClassName { get; init; }
+    public string? ClassName { get; set; }
 
-    public string? MethodName { get; init; }
+    public string? MethodName { get; set; }
 
-    public string? ErrorMessage { get; init; }
+    public string? ErrorMessage { get; set; }
 
-    public string? ExceptionType { get; init; }
+    public string? ExceptionType { get; set; }
 
-    public string? StackTrace { get; init; }
+    public string? StackTrace { get; set; }
 
-    public string? StandardOutput { get; init; }
+    public string? StandardOutput { get; set; }
 
-    public string? StandardError { get; init; }
+    public string? StandardError { get; set; }
 
-    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; init; }
+    public IReadOnlyList<KeyValuePair<string, string>>? Traits { get; set; }
+
+    // Populates the fields declared on this base type from the captured core data. This is
+    // the single truncation-and-assignment path shared by every report format so that a
+    // change to a truncation-length constant (or a newly added base field) is applied
+    // consistently across HtmlReport, JUnitReport and CtrfReport. Format-specific fields
+    // (e.g. Outcome/Status) and any per-format overrides of a base field are set by the
+    // caller after this method returns.
+    internal void PopulateBaseFields(TestNode node, in CapturedTestResultCoreData core)
+    {
+        // Identity fields are test-controlled and can be unbounded (e.g. very long
+        // UIDs/display names from generated data), so we cap them to keep the
+        // session-wide result list and generated report within a predictable budget.
+        Uid = TestResultCaptureHelper.Truncate(node.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!;
+        DisplayName = TestResultCaptureHelper.Truncate(node.DisplayName, TestResultCaptureHelper.MaxIdentityFieldLength)!;
+        Duration = core.Duration;
+        StartTime = core.Properties.Timing?.GlobalTiming.StartTime;
+        EndTime = core.Properties.Timing?.GlobalTiming.EndTime;
+        ClassName = TestResultCaptureHelper.Truncate(core.ClassName, TestResultCaptureHelper.MaxIdentityFieldLength);
+        MethodName = TestResultCaptureHelper.Truncate(core.MethodName, TestResultCaptureHelper.MaxIdentityFieldLength);
+        ErrorMessage = TestResultCaptureHelper.Truncate(core.ExceptionDetails.ErrorMessage, TestResultCaptureHelper.MaxMessageLength);
+        ExceptionType = core.ExceptionDetails.ExceptionType;
+        StackTrace = TestResultCaptureHelper.Truncate(core.ExceptionDetails.StackTrace, TestResultCaptureHelper.MaxStackTraceLength);
+        StandardOutput = TestResultCaptureHelper.Truncate(core.Properties.StandardOutput?.StandardOutput, TestResultCaptureHelper.MaxStandardStreamLength);
+        StandardError = TestResultCaptureHelper.Truncate(core.Properties.StandardError?.StandardError, TestResultCaptureHelper.MaxStandardStreamLength);
+        Traits = core.Properties.Traits;
+    }
 }


### PR DESCRIPTION
Fixes #9611.

## Summary

`HtmlReport`, `JUnitReport`, and `CtrfReport` each had a `TryCapture` method whose object-initializer body copy-pasted the same ~13 lines that populate the fields declared on `CapturedTestResultBase` (identical `TestResultCaptureHelper.Truncate(...)` calls and length constants). This PR removes that duplication.

## Changes

- **`CapturedTestResultBase.cs`**: The 13 shared fields are changed from `required init` to mutable `set`, and a new `internal void PopulateBaseFields(TestNode node, in CapturedTestResultCoreData core)` method becomes the single truncation-and-assignment path for all base fields. Adding a new base field or changing a truncation-length constant now only touches this one method.
- **`HtmlReport` / `JUnitReport` / `CtrfReport` `TestResultCapture.cs`**: Each `TryCapture` now sets only its format-specific fields (`Outcome`, `Status`, `RawUid`/`ParentRawUid`, `Namespace`, `FilePath`, `Line`, …) in the initializer, then calls `PopulateBaseFields`. CTRF overrides `ClassName` afterward because it intentionally uses a type-name-only value plus a separate `Namespace` (the pre-existing drift called out in the issue).

Net result: the duplicated ~26 lines are removed while report output remains identical.

## Verification

- Built the extensions + `Microsoft.Testing.Extensions.UnitTests` project: **0 warnings, 0 errors**.
- Ran the full `Microsoft.Testing.Extensions.UnitTests` suite: **606 passed, 0 failed** (4 unrelated Windows crash-dump skips).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>