### PR TITLE
Emit `::warning` annotations for skipped tests in GitHubActionsReport

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Testing.Extensions.GitHubActionsReport;
 /// <summary>
 /// Emits a GitHub Actions <c>::error</c> workflow command for each failing test so the failure surfaces
 /// both in the workflow run's Annotations tab and, when the source location can be resolved, on the
-/// pull request's "Files changed" diff gutter.
+/// pull request's "Files changed" diff gutter. Skipped tests are surfaced as title-only <c>::warning</c>
+/// workflow commands so they are visible in the Annotations tab too.
 /// </summary>
 internal sealed class GitHubActionsAnnotationReporter :
     IDataConsumer,
@@ -87,6 +88,14 @@ internal sealed class GitHubActionsAnnotationReporter :
 
             if (failure is null)
             {
+                // Skipped tests carry no exception (and therefore no source location); surface them as a
+                // title-only '::warning' so intentionally or unexpectedly skipped tests are visible in the
+                // workflow Annotations tab alongside failures, rather than being silently absent.
+                if (nodeState is SkippedTestNodeStateProperty skipped)
+                {
+                    await WriteSkippedAnnotationAsync(GetTestName(nodeUpdateMessage.TestNode), skipped.Explanation, cancellationToken).ConfigureAwait(false);
+                }
+
                 return;
             }
 
@@ -151,6 +160,39 @@ internal sealed class GitHubActionsAnnotationReporter :
         return string.Format(
             CultureInfo.InvariantCulture,
             "::error title={0}::{1}",
+            GitHubActionsEscaper.EscapeProperty(title),
+            GitHubActionsEscaper.EscapeData(message));
+    }
+
+    private async Task WriteSkippedAnnotationAsync(string testName, string? explanation, CancellationToken cancellationToken)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace("Skip received.");
+        }
+
+        string line = GetSkippedAnnotation(testName, explanation);
+
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            _logger.LogTrace($"Showing skip annotation '{line}'.");
+        }
+
+        // Prepend a newline for the same reason as the failure annotation: it guarantees the '::warning'
+        // workflow command starts at column 0 on its own line so GitHub recognizes it.
+        await _outputDisplay.DisplayAsync(this, new FormattedTextOutputDeviceData($"\n{line}"), cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static /* for testing */ string GetSkippedAnnotation(string testName, string? explanation)
+    {
+        string message = explanation ?? GitHubActionsResources.NoSkipReasonFallback;
+        string title = string.Format(CultureInfo.InvariantCulture, GitHubActionsResources.SkippedAnnotationTitle, testName);
+
+        // Skipped nodes never carry a stack trace, so there is no file/line to pin the annotation to; a
+        // title-only '::warning' still surfaces in the workflow Annotations tab.
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "::warning title={0}::{1}",
             GitHubActionsEscaper.EscapeProperty(title),
             GitHubActionsEscaper.EscapeData(message));
     }

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/PACKAGE.md
@@ -15,7 +15,7 @@ dotnet add package Microsoft.Testing.Extensions.GitHubActionsReport
 This package extends Microsoft.Testing.Platform with:
 
 - **Per-assembly log groups**: emits `::group::` / `::endgroup::` workflow commands so each test assembly's output is collapsed by default in the runner UI
-- **Failure annotations**: emits an `::error` workflow command for each failing test so failures appear in the workflow Annotations tab and, when the source location can be resolved, on the pull request's "Files changed" diff gutter
+- **Failure annotations**: emits an `::error` workflow command for each failing test so failures appear in the workflow Annotations tab and, when the source location can be resolved, on the pull request's "Files changed" diff gutter. Skipped tests are surfaced as title-only `::warning` annotations so they are visible in the Annotations tab too
 - **Job summary**: appends a markdown roll-up (totals, failures, slowest tests) to the file pointed to by `GITHUB_STEP_SUMMARY`, which GitHub renders on the workflow run summary page
 - **Slow-test notices**: emits a `::notice` workflow command for any test still running past a threshold (default 60 seconds)
 
@@ -25,7 +25,7 @@ The extension activates when the test run is on GitHub Actions (`GITHUB_ACTIONS=
 |---|---|---|
 | `--report-gh` | Master switch that turns the extension on (required, in addition to running on GitHub Actions) | off |
 | `--report-gh-groups on\|off` | Per-assembly log groups | on |
-| `--report-gh-annotations on\|off` | Failure annotations | on |
+| `--report-gh-annotations on\|off` | Failure and skip annotations | on |
 | `--report-gh-step-summary on\|off` | Markdown job summary | on |
 | `--report-gh-slow-test-notices on\|off` | Slow-test notices | on |
 | `--report-gh-slow-test-threshold <duration>` | Time before a slow-test notice is emitted; accepts a bare number of seconds or a unit suffix such as `90s`, `2m`, `1.5h` | 60s |

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/GitHubActionsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/GitHubActionsResources.resx
@@ -62,15 +62,22 @@
     <value>GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</value>
   </data>
   <data name="AnnotationsOptionDescription" xml:space="preserve">
-    <value>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</value>
+    <value>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</value>
     <comment>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</comment>
   </data>
   <data name="AnnotationTitle" xml:space="preserve">
     <value>Test failed: {0}</value>
     <comment>{0} is the fully qualified test name.</comment>
   </data>
+  <data name="SkippedAnnotationTitle" xml:space="preserve">
+    <value>Test skipped: {0}</value>
+    <comment>{0} is the fully qualified test name.</comment>
+  </data>
   <data name="NoFailureMessageFallback" xml:space="preserve">
     <value>The test failed without providing a failure message.</value>
+  </data>
+  <data name="NoSkipReasonFallback" xml:space="preserve">
+    <value>The test was skipped without providing a reason.</value>
   </data>
   <data name="StepSummaryOptionDescription" xml:space="preserve">
     <value>Enable or disable writing a markdown job summary to the GITHUB_STEP_SUMMARY file. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.cs.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.de.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.es.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.fr.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.it.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ja.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ko.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pl.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.tr.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="AnnotationsOptionDescription">
-        <source>Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
-        <target state="new">Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
+        <source>Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</source>
+        <target state="new">Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.</target>
         <note>{Locked="on"}{Locked="off"}{Locked="true"}{Locked="enable"}{Locked="1"}{Locked="false"}{Locked="disable"}{Locked="0"}</note>
       </trans-unit>
       <trans-unit id="Description">
@@ -47,10 +47,20 @@
         <target state="new">The test failed without providing a failure message.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoSkipReasonFallback">
+        <source>The test was skipped without providing a reason.</source>
+        <target state="new">The test was skipped without providing a reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescription">
         <source>Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</source>
         <target state="new">Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SkippedAnnotationTitle">
+        <source>Test skipped: {0}</source>
+        <target state="new">Test skipped: {0}</target>
+        <note>{0} is the fully qualified test name.</note>
       </trans-unit>
       <trans-unit id="SlowTestNoticeTitle">
         <source>Slow test: {0}</source>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -184,7 +184,7 @@ Extension options:
     --report-gh
         Enable GitHub Actions report generator to emit workflow commands so test runs produce a first-class experience on GitHub Actions.
     --report-gh-annotations
-        Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.
+        Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.
     --report-gh-groups
         Enable or disable per-assembly log groups. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.
     --report-gh-slow-test-notices
@@ -558,7 +558,7 @@ Registered command line providers:
       --report-gh-annotations
         Arity: 1
         Hidden: False
-        Description: Enable or disable GitHub Actions failure annotations. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.
+        Description: Enable or disable GitHub Actions annotations for failed and skipped tests. Valid values are 'on' (also accepts 'true', 'enable', '1') or 'off' (also accepts 'false', 'disable', '0'). Defaults to 'on' when running on GitHub Actions.
       --report-gh-groups
         Arity: 1
         Hidden: False

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/GitHubActionsAnnotationReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/GitHubActionsAnnotationReporterTests.cs
@@ -87,6 +87,22 @@ public sealed class GitHubActionsAnnotationReporterTests
         Assert.IsTrue(text.StartsWith("::error title=Test failed%3A MyNamespace.MyTest::", StringComparison.Ordinal), text);
     }
 
+    [TestMethod]
+    public void GetSkippedAnnotation_EmitsTitleOnlyWarningWithReasonAndEscaping()
+    {
+        string text = GitHubActionsAnnotationReporter.GetSkippedAnnotation("MyNamespace.MyTest", "not today\nmaybe\rlater");
+
+        Assert.AreEqual("::warning title=Test skipped%3A MyNamespace.MyTest::not today%0Amaybe%0Dlater", text);
+    }
+
+    [TestMethod]
+    public void GetSkippedAnnotation_FallsBackToDefaultReason_WhenNoExplanation()
+    {
+        string text = GitHubActionsAnnotationReporter.GetSkippedAnnotation("MyNamespace.MyTest", explanation: null);
+
+        Assert.AreEqual("::warning title=Test skipped%3A MyNamespace.MyTest::The test was skipped without providing a reason.", text);
+    }
+
     // Throws (and catches) an exception, reporting the exact line of the throw statement so tests can assert the
     // resolved line without hard-coding a physical number that shifts whenever code above changes.
     private static Exception CaptureException(string message, out int throwLine)


### PR DESCRIPTION
## What

Adds skipped-test annotations to `Microsoft.Testing.Extensions.GitHubActionsReport`. Previously, only failing tests produced `::error` annotations; skipped tests were silently absent from the GitHub Actions **Annotations** tab. This change surfaces each skipped test as a title-only `::warning` workflow command so intentionally/unexpectedly skipped tests are visible alongside failures.

## Why

While assessing RFC #9003 against the shipped extension, this was the one clearly-scoped **Tier 1** (no-auth, workflow-command) gap. The RFC explicitly lists "`::warning` … for skipped" in Tier 1. Tiers 2/3 (Check Runs and sticky PR comments via the GitHub API + `GITHUB_TOKEN`) remain a separate follow-up.

## How

- `GitHubActionsAnnotationReporter` now handles `SkippedTestNodeStateProperty` and emits a title-only `::warning` (skipped nodes carry no exception/stack trace, so there is no `file:line` to pin to). Added a testable `GetSkippedAnnotation` helper mirroring `GetErrorAnnotation`.
- Folded into the existing `--report-gh-annotations` knob (no new CLI option); broadened its description to "failed and skipped tests".
- New resources `SkippedAnnotationTitle` / `NoSkipReasonFallback`; regenerated all 14 `.xlf` files via `UpdateXlf`.
- Updated `HelpInfoAllExtensionsTests` (`--help` + `--info`) and `PACKAGE.md` to match.
- Added unit tests for the reason and fallback paths.

## Behavioral notes

`::warning` is purely informational in GitHub Actions — it does **not** affect step/job pass-fail (that's driven solely by the process exit code, which this reporter never touches). The reporter's `ConsumeAsync` is wrapped in try/catch that degrades to "no annotation" on any exception. The feature stays behind the `--report-gh` master switch (off by default) and the on-by-default `--report-gh-annotations` knob.

## Verification

- Extension + `Microsoft.Testing.Extensions.UnitTests` build clean (0 warnings/errors).
- Full extensions unit-test suite passes on net9.0 (failed: 0), including the 2 new tests.

🤖 Assisted by GitHub Copilot CLI.