### PR TITLE
Deduplicate low-level file-write in report engines

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileWriter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileWriter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
-using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
@@ -17,7 +16,7 @@ internal sealed partial class CtrfReportEngine
         if (fileNameExplicitlyProvided)
         {
             bool willOverwrite = _fileSystem.ExistFile(finalPath);
-            await WriteAsync(finalPath, FileMode.Create, bytes).ConfigureAwait(false);
+            await WriteBytesAsync(finalPath, FileMode.Create, bytes).ConfigureAwait(false);
             return (
                 finalPath,
                 willOverwrite
@@ -38,7 +37,7 @@ internal sealed partial class CtrfReportEngine
 
             try
             {
-                await WriteAsync(candidate, FileMode.CreateNew, bytes).ConfigureAwait(false);
+                await WriteBytesAsync(candidate, FileMode.CreateNew, bytes).ConfigureAwait(false);
                 return (candidate, null);
             }
             catch (IOException) when (_fileSystem.ExistFile(candidate))
@@ -75,17 +74,5 @@ internal sealed partial class CtrfReportEngine
 
         baseName = Path.GetFileNameWithoutExtension(fileName);
         extension = Path.GetExtension(fileName);
-    }
-
-    private async Task WriteAsync(string path, FileMode mode, byte[] bytes)
-    {
-        // Note that we need to dispose the IFileStream, not the inner stream.
-        // IFileStream implementations will be responsible to dispose their inner stream.
-        using IFileStream stream = _fileSystem.NewFileStream(path, mode);
-#if NETCOREAPP
-        await stream.Stream.WriteAsync(bytes.AsMemory(), _cancellationToken).ConfigureAwait(false);
-#else
-        await stream.Stream.WriteAsync(bytes, 0, bytes.Length, _cancellationToken).ConfigureAwait(false);
-#endif
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -73,24 +73,12 @@ internal sealed class HtmlReportEngine : ReportEngineBase
         // provided or generated from the default <asm>_<tfm>_<arch>.html shape. Emit a warning
         // when overwriting so users have a single, predictable rule to reason about.
         bool willOverwrite = _fileSystem.ExistFile(finalPath);
-        await WriteFileAsync(finalPath, bytes).ConfigureAwait(false);
+        await WriteBytesAsync(finalPath, FileMode.Create, bytes).ConfigureAwait(false);
         return (
             finalPath,
             willOverwrite
                 ? string.Format(CultureInfo.InvariantCulture, ExtensionResources.HtmlReportFileExistsAndWillBeOverwritten, finalPath)
                 : null);
-    }
-
-    private async Task WriteFileAsync(string path, byte[] bytes)
-    {
-        // Note that we need to dispose the IFileStream, not the inner stream.
-        // IFileStream implementations will be responsible to dispose their inner stream.
-        using IFileStream stream = _fileSystem.NewFileStream(path, FileMode.Create);
-#if NETCOREAPP
-        await stream.Stream.WriteAsync(bytes.AsMemory(), _cancellationToken).ConfigureAwait(false);
-#else
-        await stream.Stream.WriteAsync(bytes, 0, bytes.Length, _cancellationToken).ConfigureAwait(false);
-#endif
     }
 
     private static string LoadTemplate()

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -112,4 +112,16 @@ internal abstract class ReportEngineBase
 
         return (finalPath, wasExplicit);
     }
+
+    protected async Task WriteBytesAsync(string path, FileMode mode, byte[] bytes)
+    {
+        // Note that we need to dispose the IFileStream, not the inner stream.
+        // IFileStream implementations will be responsible to dispose their inner stream.
+        using IFileStream stream = _fileSystem.NewFileStream(path, mode);
+#if NETCOREAPP
+        await stream.Stream.WriteAsync(bytes.AsMemory(), _cancellationToken).ConfigureAwait(false);
+#else
+        await stream.Stream.WriteAsync(bytes, 0, bytes.Length, _cancellationToken).ConfigureAwait(false);
+#endif
+    }
 }


### PR DESCRIPTION
Fixes #9610.

## Summary

`HtmlReportEngine` and `CtrfReportEngine` each had a private async method performing the identical low-level `IFileStream` byte-write, with the same `#if NETCOREAPP` branch structure and the same dispose comment — differing only in whether `FileMode` was hardcoded (`Create`) or passed as a parameter.

## Changes

Implemented approach 1 from the issue:

- Added `protected async Task WriteBytesAsync(string path, FileMode mode, byte[] bytes)` to `ReportEngineBase`, using the base class's existing `_fileSystem` and `_cancellationToken`. The single `#if NETCOREAPP` branch now lives here.
- `HtmlReportEngine`: removed `WriteFileAsync`; now delegates to `WriteBytesAsync(finalPath, FileMode.Create, bytes)`.
- `CtrfReportEngine.FileWriter.cs`: removed its `WriteAsync` primitive; both the overwrite and retry paths now delegate to `WriteBytesAsync(...)`. Dropped the now-unused `Microsoft.Testing.Platform.Helpers` using directive.

## Verification

Both `Microsoft.Testing.Extensions.HtmlReport` and `Microsoft.Testing.Extensions.CtrfReport` build with 0 warnings / 0 errors across net8.0, net9.0, and netstandard2.0.