### PR TITLE
Re-enable LocalizationTests and LocalizationFailingTests

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationFailingTests.cs
@@ -5,9 +5,6 @@ using System.Text;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
-// Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
-// which makes these tests fail on every loc check-in. Re-enable once proper translations flow. See https://github.com/microsoft/testfx/issues/9295.
-[Ignore("Disabled until OneLocBuild ships proper TerminalResources translations. See https://github.com/microsoft/testfx/issues/9295.")]
 [TestClass]
 public sealed class LocalizationFailingTests : AcceptanceTestBase<LocalizationFailingTests.TestAssetFixture>
 {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/LocalizationTests.cs
@@ -5,9 +5,6 @@ using System.Text;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
-// Temporarily disabled: OneLocBuild keeps reverting the TerminalResources.*.xlf targets to English,
-// which makes these tests fail on every loc check-in. Re-enable once proper translations flow. See https://github.com/microsoft/testfx/issues/9295.
-[Ignore("Disabled until OneLocBuild ships proper TerminalResources translations. See https://github.com/microsoft/testfx/issues/9295.")]
 [TestClass]
 public class LocalizationTests : AcceptanceTestBase<LocalizationTests.TestAssetFixture>
 {


### PR DESCRIPTION
Fixes #9295.

The `TerminalResources.*.xlf` translations for French and Spanish have now flowed for every string asserted by `LocalizationTests` and `LocalizationFailingTests`, so the temporary `[Ignore]` attributes (and their explanatory comments) added in #9295 are removed.

## Notes
- The only string still marked `state="new"` in the `fr`/`es` xlf files is `ErroredAssembliesHeader` ("Errored assemblies:"), which none of these tests assert on, so it does not block re-enabling. It may still be worth tracking separately for the downstream loc pipeline (icxLocBug).

## Validation
- `.\build.cmd -pack`
- `dotnet test` on `Microsoft.Testing.Platform.Acceptance.IntegrationTests` filtered to `~Localization`: **12/12 passed**.