### PR TITLE
test: add edge case tests for MSTEST0020/0021 analyzers

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferConstructorOverTestInitializeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferConstructorOverTestInitializeAnalyzerTests.cs
@@ -405,6 +405,84 @@ public sealed class PreferConstructorOverTestInitializeAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestInitializeMethodInNonTestClass_Diagnostic()
+    {
+        // The analyzer fires regardless of whether the containing class has [TestClass],
+        // and the fixer replaces the method with a constructor carrying its body.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                [TestInitialize]
+                public void [|MyInit|]()
+                {
+                    int x = 1;
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                public MyClass()
+                {
+                    int x = 1;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassHasOnlyParameterizedCtorAndTestInitialize_CodeFix_MergesIntoParameterizedCtor()
+    {
+        // The fixer merges the TestInitialize body into the first non-static constructor found,
+        // even when that constructor has parameters and there is no default constructor.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int _x;
+                private int _y;
+
+                public MyTestClass(int y)
+                {
+                    _y = y;
+                }
+
+                [TestInitialize]
+                public void [|MyTestInit|]()
+                {
+                    _x = 1;
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private int _x;
+                private int _y;
+
+                public MyTestClass(int y)
+                {
+                    _y = y;
+                    _x = 1;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenTestClassHasTestInitializeWithMultiLineBody_PreservesIndentation()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferDisposeOverTestCleanupAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferDisposeOverTestCleanupAnalyzerTests.cs
@@ -382,6 +382,39 @@ public partial class MyTestClass : IDisposable
 #endif
 
     [TestMethod]
+    public async Task WhenTestCleanupMethodInNonTestClass_Diagnostic()
+    {
+        // The analyzer fires regardless of whether the containing class has [TestClass],
+        // and the fixer adds IDisposable to the base list and replaces the method with Dispose().
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                [TestCleanup]
+                public void [|MyCleanup|]()
+                {
+                    int x = 1;
+                }
+            }
+            """;
+        string fixedCode = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass : IDisposable
+            {
+                public void Dispose()
+                {
+                    int x = 1;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenTestClassHasTestCleanupWithMultiLineBody_PreservesIndentation()
     {
         string code = """


### PR DESCRIPTION
## What

Adds 3 edge-case tests documenting existing behavior of the "prefer OOP pattern" analyzers and their code fixers. No production code changes — purely additive tests.

### `PreferConstructorOverTestInitializeAnalyzerTests` (MSTEST0020) — +2 tests

| Test | Covers |
|------|--------|
| `WhenTestInitializeMethodInNonTestClass_Diagnostic` | Analyzer fires on `[TestInitialize]` even when the containing class lacks `[TestClass]`; fixer replaces the method with a constructor carrying its body |
| `WhenTestClassHasOnlyParameterizedCtorAndTestInitialize_CodeFix_MergesIntoParameterizedCtor` | Fixer merges the `[TestInitialize]` body into the first non-static constructor even when it is parameterized (no default constructor exists) |

### `PreferDisposeOverTestCleanupAnalyzerTests` (MSTEST0021) — +1 test

| Test | Covers |
|------|--------|
| `WhenTestCleanupMethodInNonTestClass_Diagnostic` | Analyzer fires on `[TestCleanup]` even when the containing class lacks `[TestClass]`; fixer adds `IDisposable` to the base list and creates a `Dispose()` method |

## Why

Both `PreferConstructorOverTestInitializeAnalyzer` and `PreferDisposeOverTestCleanupAnalyzer` fire whenever `[TestInitialize]`/`[TestCleanup]` is present on a qualifying method, regardless of whether the containing class has `[TestClass]`, and the MSTEST0020 fixer merges into the first non-static constructor even if parameterized. These behaviors were previously undocumented in tests.

## Test status

Debug build clean (0 warnings, 0 errors). `MSTest.Analyzers.UnitTests` passes on both `net472` and `net8.0`.

This consolidates the near-duplicate test-improver contributions from #9663 and #9648 into a single coherent set, addressing the review item tracked in #9597.

Fixes #9597
Fixes #9663
Fixes #9648

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>