### PR TITLE
Fix GlobalTestInitialize/Cleanup implementation gaps (#9662)

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -12,3 +12,9 @@ MSTEST0067 | Performance | Disabled | AvoidThreadSleepAndTaskWaitInTestsAnalyzer
 MSTEST0068 | Usage | Info | CollectionAssertToAssertAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0068)
 MSTEST0070 | Usage | Warning | MemberConditionShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0070)
 MSTEST0071 | Usage | Info | RedundantTestMethodDisplayNameAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0071)
+
+### Changed Rules
+
+Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
+--------|--------------|--------------|--------------|--------------|-------
+MSTEST0050 | Usage | Warning | Usage | Error | GlobalTestFixtureShouldBeValidAnalyzer

--- a/src/Analyzers/MSTest.Analyzers/GlobalTestFixtureShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/GlobalTestFixtureShouldBeValidAnalyzer.cs
@@ -24,7 +24,7 @@ public sealed class GlobalTestFixtureShouldBeValidAnalyzer : DiagnosticAnalyzer
         new LocalizableResourceString(nameof(Resources.GlobalTestFixtureShouldBeValidMessageFormat), Resources.ResourceManager, typeof(Resources)),
         new LocalizableResourceString(nameof(Resources.GlobalTestFixtureShouldBeValidDescription), Resources.ResourceManager, typeof(Resources)),
         Category.Usage,
-        DiagnosticSeverity.Error,
+        DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
 
     /// <inheritdoc />

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -784,7 +784,6 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</value>
     <comment>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</comment>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -561,10 +561,9 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Aby byly metody s označením [GlobalTestInitialize] nebo [GlobalTestCleanup] platné, musí se řídit následujícím rozložením:
+        <target state="needs-review-translation">Aby byly metody s označením [GlobalTestInitialize] nebo [GlobalTestCleanup] platné, musí se řídit následujícím rozložením:
 – Nesmí být deklarované pro obecnou class.
 – Musí být „public“.
 – Musí být „static“.

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -562,10 +562,9 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Methoden, die mit „[GlobalTestInitialize]“ oder „[GlobalTestCleanup]“ gekennzeichnet sind, sollten dem folgenden Layout folgen, um gültig zu sein:
+        <target state="needs-review-translation">Methoden, die mit „[GlobalTestInitialize]“ oder „[GlobalTestCleanup]“ gekennzeichnet sind, sollten dem folgenden Layout folgen, um gültig zu sein:
 – kann nicht für eine generische class deklariert werden
 – muss „public“ sein
 – muss „static“ sein

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -561,10 +561,9 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Los métodos marcados con '[GlobalTestInitialize]' o '[GlobalTestCleanup]' deben seguir el siguiente diseño para ser válidos:
+        <target state="needs-review-translation">Los métodos marcados con '[GlobalTestInitialize]' o '[GlobalTestCleanup]' deben seguir el siguiente diseño para ser válidos:
 -no se puede declarar en una class genérica
 - debería ser 'public' 
 - debería estar 'static'

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -561,10 +561,9 @@ Le type doit être une classe
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
+        <target state="needs-review-translation">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
 - elle ne peut pas être déclarée dans une classe générique
 – elle doit être « public »
 – elle doit être « static »

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -561,10 +561,9 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">I metodi contrassegnati con ‘[GlobalTestInitialize]’ o ‘[GlobalTestCleanup]’ devono seguire il layout seguente per essere validi:
+        <target state="needs-review-translation">I metodi contrassegnati con ‘[GlobalTestInitialize]’ o ‘[GlobalTestCleanup]’ devono seguire il layout seguente per essere validi:
 - Non può essere dichiarato in una classe generica
 - Deve essere 'public'
 - Deve essere 'static'

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -561,10 +561,9 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">'[GlobalTestInitialize]' または '[GlobalTestCleanup]' でマークされたメソッドを有効にするには、次のレイアウトに従う必要があります:
+        <target state="needs-review-translation">'[GlobalTestInitialize]' または '[GlobalTestCleanup]' でマークされたメソッドを有効にするには、次のレイアウトに従う必要があります:
 - ジェネリック class で宣言することはできません
 - 'public' である必要があります
 - 'static' である必要があります

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -561,10 +561,9 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">'[GlobalTestInitialize]' 또는 '[GlobalTestCleanup]'으로 표시된 메서드는 다음 레이아웃을 따라야 유효합니다.
+        <target state="needs-review-translation">'[GlobalTestInitialize]' 또는 '[GlobalTestCleanup]'으로 표시된 메서드는 다음 레이아웃을 따라야 유효합니다.
 - 제네릭 class에서 선언할 수 없습니다.
 - 'public'이어야 합니다. 
 - 'static'이어야 합니다.

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -561,10 +561,9 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Metody oznaczone znakiem „[GlobalTestInitialize]” lub „[GlobalTestCleanup]” powinny być zgodne z następującym układem, aby były prawidłowe:
+        <target state="needs-review-translation">Metody oznaczone znakiem „[GlobalTestInitialize]” lub „[GlobalTestCleanup]” powinny być zgodne z następującym układem, aby były prawidłowe:
 — nie może być zadeklarowana w class ogólnej
 — powinna być typu „public”
 — powinna mieć wartość „static”

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -561,10 +561,9 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Os métodos marcados com "[GlobalTestInitialize]" ou "[GlobalTestCleanup]" devem seguir o seguinte layout para serem válidos:
+        <target state="needs-review-translation">Os métodos marcados com "[GlobalTestInitialize]" ou "[GlobalTestCleanup]" devem seguir o seguinte layout para serem válidos:
 -não podem ser declarados em uma classe genérica
 -devem ser "public"
 -devem ser "static"

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -567,10 +567,9 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Чтобы метод, помеченный "[GlobalTestInitialize]" или "[GlobalTestCleanup]", был допустимым, он должен соответствовать следующей структуре:
+        <target state="needs-review-translation">Чтобы метод, помеченный "[GlobalTestInitialize]" или "[GlobalTestCleanup]", был допустимым, он должен соответствовать следующей структуре:
 – не может быть объявлен для универсального class ("generic")
 – должен быть общедоступным ("public")
 – должен быть статическим ("static")

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -561,10 +561,9 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">‘[GlobalTestInitialize]’ veya ‘[GlobalTestCleanup]’ ile işaretlenmiş yöntemlerin geçerli olabilmesi için şu düzeni izlemesi gerekir:
+        <target state="needs-review-translation">‘[GlobalTestInitialize]’ veya ‘[GlobalTestCleanup]’ ile işaretlenmiş yöntemlerin geçerli olabilmesi için şu düzeni izlemesi gerekir:
 -genel bir class tanımlanamaz
 -'public' olmalıdır
 -'static' olmalıdır

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -561,10 +561,9 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">标记有 "[GlobalTestInitialize]" 或 "[GlobalTestCleanup]" 的方法应遵循以下布局才会有效:
+        <target state="needs-review-translation">标记有 "[GlobalTestInitialize]" 或 "[GlobalTestCleanup]" 的方法应遵循以下布局才会有效:
 - 不能在泛型 class 上声明它
 - 它应为 "public"
 - 它应为 "static"

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -561,10 +561,9 @@ The type declaring these methods should also respect the following rules:
 The type declaring these methods should also respect the following rules:
 -The type should be a class
 -The class should be 'public'
--The class shouldn't be 'static'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">標示為 '[GlobalTestInitialize]' 或 '[GlobalTestCleanup]' 的方法應該遵循下列配置才能有效：
+        <target state="needs-review-translation">標示為 '[GlobalTestInitialize]' 或 '[GlobalTestCleanup]' 的方法應該遵循下列配置才能有效：
 -其不能在泛型 class 上宣告
 -其應為 'public'
 -其應為 'static'

--- a/src/TestFramework/TestFramework/Attributes/Lifecycle/Initialization/GlobalTestInitializeAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/Lifecycle/Initialization/GlobalTestInitializeAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// The method to which this attribute is applied must be public, static, non-generic, has a single parameter of type TestContext, and either returns void or a Task.
 /// </summary>
 /// <remarks>
-/// Multiple methods with this attribute in the assembly is allowed, but there is no guarantee of the order in which they will be executed. In addition, TimeoutAttribute isn't supported on methods with this attribute.
+/// Multiple methods with this attribute in the assembly is allowed, but there is no guarantee of the order in which they will be executed.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class GlobalTestInitializeAttribute : Attribute;


### PR DESCRIPTION
Fixes the concrete correctness gaps identified in #9662.

## Changes

**1. Incorrect `[Timeout]` documentation (HIGH)**
Removed the false remark *"In addition, TimeoutAttribute isn't supported on methods with this attribute"* from `GlobalTestInitializeAttribute`. `[Timeout]` **is** supported and takes precedence over the RunSettings global timeout — the runtime reads it via `TryGetTimeoutInfo`, and the acceptance test `GlobalTestInitialize_WhenTimeoutExpires_GlobalTestInitializeIsCanceled_AttributeTakesPrecedence` verifies this end-to-end.

**2. MSTEST0050 severity mismatch (HIGH)**
Lowered `GlobalTestFixtureShouldBeValidAnalyzer` from `Error` to `Warning` to match the six peer fixture rules MSTEST0008–0013 (all `Warning`). An invalid `[GlobalTestInitialize]`/`[GlobalTestCleanup]` signature no longer hard-breaks the build while the equivalent `ClassInitialize` mistake only warns. Recorded as a **Changed Rule** in `AnalyzerReleases.Unshipped.md` (the rule shipped in 3.10.0, so release-tracking requires the entry).

**3. Incorrect static-class restriction in MSTEST0050 description (MEDIUM)**
Removed the `-The class shouldn't be 'static'` bullet from the description in `Resources.resx`. The analyzer's own `WhenGlobalTestInitializeInStaticClass_NoDiagnostic` test confirms a `[TestClass] public static class` is valid. Regenerated all `.xlf` files via `UpdateXlf`.

## Verification
- Analyzers + TestFramework build clean (0 warnings / 0 errors).
- Full analyzer unit suite: **1347 passed, 0 failed**.

## Deferred (Tasks 3 & 5 from #9662)

Two of the report's suggestions were intentionally **not** implemented here because they introduce new public/config surface and behavioral changes that are design decisions for maintainers, per the repo's public-API and breaking-change guidelines:

- **Task 3 — Dedicated timeout config for global fixtures.** Global fixtures currently reuse `FixtureKind.TestInitialize`/`TestCleanup`, so `<TestInitializeTimeout>`/`<TestCleanupTimeout>` (and `timeout:testInitialize` in `testconfig.json`) silently also control the global fixtures — there's no way to time out global fixtures independently. Fixing this means adding `GlobalTestInitialize`/`GlobalTestCleanup` to `FixtureKind`, new `GlobalTestInitializeTimeout`/`GlobalTestCleanupTimeout` settings parsed from both RunSettings XML and `testconfig.json`, a `TimeoutInfo.FromFixtureSettings` switch update with backward-compat fallback to the existing keys, wiring in `TypeCache.AssemblyInfo.cs`, plus new acceptance tests. This is a new configuration feature with backward-compat semantics that warrants explicit design sign-off.

- **Task 5 — Split MSTEST0050 into separate Initialize/Cleanup rules.** Every peer fixture pair has two rule IDs (MSTEST0008/0009, 0010/0011, 0012/0013), whereas MSTEST0050 collapses both global fixtures into one rule and one generic message. Splitting it would allow distinct messages and independent configuration, but introduces a **new diagnostic ID**, which affects users' existing suppressions/`.editorconfig` entries and is effectively a public contract change — again better decided by maintainers.

I'm happy to implement either (or both) in a follow-up if the team wants to pursue them.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>