### PR TITLE
perf: avoid GetParameters() allocation in test-invocation hot path

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Execution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Execution.cs
@@ -144,7 +144,7 @@ internal partial class TestMethodInfo
                     {
                         if (_executionContext is null)
                         {
-                            Task? invokeResult = MethodInfo.GetInvokeResultAsync(_classInstance, arguments);
+                            Task? invokeResult = MethodInfo.GetInvokeResultWithParametersAsync(_classInstance, ParameterTypes, arguments);
                             if (invokeResult is not null)
                             {
                                 await invokeResult.ConfigureAwait(true);
@@ -161,7 +161,7 @@ internal partial class TestMethodInfo
 #if NETFRAMEWORK
                                     CallContext.HostContext = _hostContext;
 #endif
-                                    Task? invokeResult = MethodInfo.GetInvokeResultAsync(_classInstance, arguments);
+                                    Task? invokeResult = MethodInfo.GetInvokeResultWithParametersAsync(_classInstance, ParameterTypes, arguments);
                                     if (invokeResult is not null)
                                     {
                                         await invokeResult.ConfigureAwait(false);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
@@ -117,12 +117,17 @@ internal static class MethodInfoExtensions
     }
 
     internal static Task? GetInvokeResultAsync(this MethodInfo methodInfo, object? classInstance, params object?[]? arguments)
-    {
-        ParameterInfo[]? methodParameters = methodInfo.GetParameters();
+        // MethodInfo.GetParameters() allocates a fresh ParameterInfo[] on every call (CLR safety
+        // guarantee). Non-hot-path callers go through this thin wrapper; the hot path (data-driven
+        // test invocation) calls GetInvokeResultWithParametersAsync directly with an already-cached
+        // array to avoid the per-invocation allocation.
+        => methodInfo.GetInvokeResultWithParametersAsync(classInstance, methodInfo.GetParameters(), arguments);
 
+    internal static Task? GetInvokeResultWithParametersAsync(this MethodInfo methodInfo, object? classInstance, ParameterInfo[] methodParameters, params object?[]? arguments)
+    {
         // check if test method expected parameter values but no test data was provided,
         // throw error with appropriate message.
-        if (methodParameters is { Length: > 0 } && arguments == null)
+        if (methodParameters is { Length: > 0 } && arguments is null)
         {
             throw new TestFailedException(
                 UnitTestOutcome.Error,
@@ -150,7 +155,7 @@ internal static class MethodInfoExtensions
             // IndexOutOfRangeException. Mirror the reflection path's friendly diagnostic instead. We
             // only validate the count here — a type mismatch surfaces as the test's own exception and
             // must not be reinterpreted as an arguments error.
-            int expectedParameterCount = methodParameters?.Length ?? 0;
+            int expectedParameterCount = methodParameters.Length;
             int providedArgumentCount = sourceGeneratedArguments?.Length ?? 0;
             if (expectedParameterCount != providedArgumentCount)
             {
@@ -162,7 +167,7 @@ internal static class MethodInfoExtensions
                         methodInfo.DeclaringType!.FullName,
                         methodInfo.Name,
                         expectedParameterCount,
-                        string.Join(", ", methodParameters?.Select(p => p.ParameterType.Name) ?? []),
+                        string.Join(", ", methodParameters.Select(p => p.ParameterType.Name)),
                         providedArgumentCount,
                         string.Join(", ", sourceGeneratedArguments?.Select(a => a?.GetType().Name ?? "null") ?? [])));
             }
@@ -184,7 +189,7 @@ internal static class MethodInfoExtensions
         }
         else
         {
-            int methodParametersLengthOrZero = methodParameters?.Length ?? 0;
+            int methodParametersLengthOrZero = methodParameters.Length;
             int argumentsLengthOrZero = arguments?.Length ?? 0;
 
 #if WINDOWS_UWP
@@ -203,7 +208,7 @@ internal static class MethodInfoExtensions
             {
                 if (methodInfo.IsGenericMethod)
                 {
-                    methodInfo = ConstructGenericMethod(methodInfo, arguments);
+                    methodInfo = ConstructGenericMethod(methodInfo, methodParameters, arguments);
                 }
 
                 invokeResult = methodInfo.Invoke(classInstance, arguments);
@@ -218,7 +223,7 @@ internal static class MethodInfoExtensions
                         methodInfo.DeclaringType!.FullName,
                         methodInfo.Name,
                         methodParametersLengthOrZero,
-                        string.Join(", ", methodParameters?.Select(p => p.ParameterType.Name) ?? []),
+                        string.Join(", ", methodParameters.Select(p => p.ParameterType.Name)),
                         argumentsLengthOrZero,
                         string.Join(", ", arguments?.Select(a => a?.GetType().Name ?? "null") ?? [])), ex);
             }
@@ -285,7 +290,7 @@ internal static class MethodInfoExtensions
     // public void TestMethod<T1, T2>(T2 p0, T1, p1) { }
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2060:Call to 'System.Reflection.MethodInfo.MakeGenericMethod' can not be statically analyzed.", Justification = "Generic test methods with substituted type arguments are part of MSTest's reflection-mode adapter. Native AOT support relies on MSTest source-generated metadata, not on this code path.")]
     [UnconditionalSuppressMessage("Aot", "IL3050:Avoid calling members annotated with 'RequiresDynamicCodeAttribute' when publishing as Native AOT", Justification = "Generic test methods with substituted type arguments are part of MSTest's reflection-mode adapter. Native AOT support relies on MSTest source-generated metadata, not on this code path.")]
-    private static MethodInfo ConstructGenericMethod(MethodInfo methodInfo, object?[]? arguments)
+    private static MethodInfo ConstructGenericMethod(MethodInfo methodInfo, ParameterInfo[] parameters, object?[]? arguments)
     {
         DebugEx.Assert(methodInfo.IsGenericMethod, "ConstructGenericMethod should only be called for a generic method.");
 
@@ -304,7 +309,6 @@ internal static class MethodInfoExtensions
             map[i] = (genericDefinitions[i], null);
         }
 
-        ParameterInfo[] parameters = methodInfo.GetParameters();
         for (int i = 0; i < parameters.Length; i++)
         {
             Type parameterType = parameters[i].ParameterType;


### PR DESCRIPTION
## Summary

`MethodInfo.GetParameters()` returns a freshly allocated `ParameterInfo[]` on every call (CLR safety guarantee). `MethodInfoExtensions.GetInvokeResultAsync` re-called it on **every** test invocation, allocating one array per data-driven test row — and **two** for generic test methods, because `ConstructGenericMethod` called `GetParameters()` again internally.

`TestMethodInfo.ParameterTypes` already caches this array (`field ??= MethodInfo.GetParameters()`, added in #9514/#9614), but the invocation call site never received it.

## Changes

- Added `GetInvokeResultWithParametersAsync`, which accepts a pre-cached `ParameterInfo[]`, holding the previous implementation.
- Kept `GetInvokeResultAsync` as a thin wrapper that calls `GetParameters()` once and delegates — all non-hot-path callers (assembly/class init & cleanup, test init/cleanup) are unchanged.
- Threaded the cached array into `ConstructGenericMethod` instead of it calling `GetParameters()` itself, removing the second allocation for generic methods.
- Updated the two hot-path call sites in `TestMethodInfo.Execution.cs` to pass the already-cached `ParameterTypes`.
- Dropped the now-redundant `?.`/`?? []` on the non-nullable `ParameterInfo[]`.

A distinct method name (rather than an overload) is used deliberately: an overload with a `ParameterInfo[]` parameter would win overload resolution over the `params object?[]?` wrapper for callers passing a literal `null` (array covariance makes `null → ParameterInfo[]` the "better" conversion), breaking the `GetInvokeResultAsync(instance, null)` call sites.

## Impact

| Scenario | Before | After |
|---|---|---|
| Data-driven test, N rows (non-generic) | N `ParameterInfo[]` allocs | 0 (served from cache) |
| Data-driven test, N rows (generic) | 2N `ParameterInfo[]` allocs | 0 |

## Validation

- `MSTestAdapter.PlatformServices.csproj` builds clean (0 warnings, 0 errors) across all TFMs.
- `MSTestAdapter.PlatformServices.UnitTests` (incl. the `GetInvokeResultAsync` region) pass on net462/net48/net8.0/net9.0/net8.0-windows.

Fixes #9661
Fixes #9647
Fixes #9659

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>