### PR TITLE
Remove duplicated convenience constructors from report engines

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
@@ -1,12 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Services;
-
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
 internal sealed partial class CtrfReportEngine : ReportEngineBase
@@ -17,31 +11,6 @@ internal sealed partial class CtrfReportEngine : ReportEngineBase
 
     public CtrfReportEngine(ReportEngineContext context)
         : base(context)
-    {
-    }
-
-    public CtrfReportEngine(
-        IFileSystem fileSystem,
-        ITestApplicationModuleInfo testApplicationModuleInfo,
-        IEnvironment environment,
-        ICommandLineOptions commandLineOptions,
-        IConfiguration configuration,
-        IClock clock,
-        ITestFramework testFramework,
-        DateTimeOffset testStartTime,
-        int exitCode,
-        CancellationToken cancellationToken)
-        : this(new(
-            fileSystem,
-            testApplicationModuleInfo,
-            environment,
-            commandLineOptions,
-            configuration,
-            clock,
-            testFramework,
-            testStartTime,
-            exitCode,
-            cancellationToken))
     {
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
@@ -18,31 +14,6 @@ internal sealed class HtmlReportEngine : ReportEngineBase
 
     public HtmlReportEngine(ReportEngineContext context)
         : base(context)
-    {
-    }
-
-    public HtmlReportEngine(
-        IFileSystem fileSystem,
-        ITestApplicationModuleInfo testApplicationModuleInfo,
-        IEnvironment environment,
-        ICommandLineOptions commandLineOptions,
-        IConfiguration configuration,
-        IClock clock,
-        ITestFramework testFramework,
-        DateTimeOffset testStartTime,
-        int exitCode,
-        CancellationToken cancellationToken)
-        : this(new(
-            fileSystem,
-            testApplicationModuleInfo,
-            environment,
-            commandLineOptions,
-            configuration,
-            clock,
-            testFramework,
-            testStartTime,
-            exitCode,
-            cancellationToken))
     {
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
-using Microsoft.Testing.Platform.CommandLine;
-using Microsoft.Testing.Platform.Configurations;
-using Microsoft.Testing.Platform.Extensions.TestFramework;
-using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
@@ -19,31 +14,6 @@ internal sealed class JUnitReportEngine : ReportEngineBase
 
     public JUnitReportEngine(ReportEngineContext context)
         : base(context)
-    {
-    }
-
-    public JUnitReportEngine(
-        IFileSystem fileSystem,
-        ITestApplicationModuleInfo testApplicationModuleInfo,
-        IEnvironment environment,
-        ICommandLineOptions commandLineOptions,
-        IConfiguration configuration,
-        IClock clock,
-        ITestFramework testFramework,
-        DateTimeOffset testStartTime,
-        int exitCode,
-        CancellationToken cancellationToken)
-        : this(new(
-            fileSystem,
-            testApplicationModuleInfo,
-            environment,
-            commandLineOptions,
-            configuration,
-            clock,
-            testFramework,
-            testStartTime,
-            exitCode,
-            cancellationToken))
     {
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -409,7 +409,7 @@ public class CtrfReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero));
 
-        var engine = new CtrfReportEngine(
+        var engine = new CtrfReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -419,7 +419,7 @@ public class CtrfReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         (string finalPath, _) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
 
@@ -510,7 +510,7 @@ public class CtrfReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var engine = new CtrfReportEngine(
+        var engine = new CtrfReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -520,7 +520,7 @@ public class CtrfReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         (string finalPath, _) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
 
@@ -551,7 +551,7 @@ public class CtrfReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var engine = new CtrfReportEngine(
+        var engine = new CtrfReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -561,7 +561,7 @@ public class CtrfReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         await Assert.ThrowsExactlyAsync<IOException>(() => engine.GenerateReportAsync([Captured("a", "A", "passed")]));
         Assert.AreEqual(1, callCount);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -364,7 +364,7 @@ public class HtmlReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 2, 3, 4, 5, 6, TimeSpan.Zero));
 
-        var engine = new HtmlReportEngine(
+        var engine = new HtmlReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -374,7 +374,7 @@ public class HtmlReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         (string finalPath, _) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
 
@@ -525,7 +525,7 @@ public class HtmlReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var engine = new HtmlReportEngine(
+        var engine = new HtmlReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -535,7 +535,7 @@ public class HtmlReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         (string finalPath, string? warning) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
 
@@ -570,7 +570,7 @@ public class HtmlReportEngineTests
         _ = _testFrameworkMock.SetupGet(_ => _.DisplayName).Returns("F");
         _ = _clockMock.SetupGet(_ => _.UtcNow).Returns(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
 
-        var engine = new HtmlReportEngine(
+        var engine = new HtmlReportEngine(new(
             _fileSystem.Object,
             _testApplicationModuleInfoMock.Object,
             _environmentMock.Object,
@@ -580,7 +580,7 @@ public class HtmlReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None);
+            CancellationToken.None));
 
         await Assert.ThrowsExactlyAsync<IOException>(() => engine.GenerateReportAsync([Captured("a", "A", "passed")]));
         Assert.AreEqual(1, callCount);


### PR DESCRIPTION
## Summary

Fixes #9608.

All three report engine classes (`CtrfReportEngine`, `HtmlReportEngine`, `JUnitReportEngine`) contained an identical 22-line "expanded constructor" that existed solely to unpack 10 individual service parameters into a `ReportEngineContext` and delegate to the primary constructor — ~66 lines of near-identical code duplicated verbatim.

Production code already constructs these engines via the `ReportEngineContext` constructor; the expanded constructors were used only by unit tests.

## Changes

- Removed the duplicated expanded constructor from `CtrfReportEngine`, `HtmlReportEngine`, and `JUnitReportEngine` (Option 2 from the issue).
- Updated the 6 unit-test call sites in `CtrfReportEngineTests` and `HtmlReportEngineTests` to construct via a target-typed `new(...)` `ReportEngineContext`, matching the pattern already used elsewhere in those files.
- Cleaned up `using` directives that became unnecessary once the constructors were removed.

Net result: ~90 lines removed, and adding a new field to `ReportEngineContext` now requires updating a single file instead of three.

## Verification

- All three engine projects build clean across `net8.0`/`net9.0`/`netstandard2.0` (0 warnings, 0 errors).
- `Microsoft.Testing.Extensions.UnitTests` (net9.0): 0 failed, 4 skipped (platform-specific crashdump tests), rest passed.

No public API impact — these were `internal` constructors.