### PR TITLE
Refactor `RetryOrchestrator.cs` into smaller focused files (#9660)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryArgumentsBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryArgumentsBuilder.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Extensions.Policy;
+
+/// <summary>
+/// Pure argument-construction for the retry orchestrator: strips retry/result-dir flags from the original
+/// command line and builds the per-attempt argument list (result directory, pipe name, and the failed-UID
+/// filter, using a response file when the inline command line would exceed OS length limits). No output or
+/// process concerns live here.
+/// </summary>
+internal static class RetryArgumentsBuilder
+{
+    // Estimate command line length to avoid hitting OS limits (~32K on Windows).
+    // Add per-argument overhead to account for PasteArguments quoting on pre-.NET 8
+    // targets where each argument may gain wrapping quotes and a separator space.
+    private const int CommandLineLengthLimit = 30_000;
+    private const int PerArgumentOverhead = 3;
+
+    /// <summary>
+    /// Computes the indices of the original executable arguments that must be dropped when restarting the test
+    /// host, namely the retry-specific options and the result-directory option (which is re-injected per attempt).
+    /// </summary>
+    public static List<int> ComputeIndicesToCleanup(string[] executableArguments)
+    {
+        List<int> indexToCleanup = [];
+
+        int argIndex = RetryOrchestratorHelper.GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsOptionName, executableArguments);
+        if (argIndex < 0)
+        {
+            throw ApplicationStateGuard.Unreachable();
+        }
+
+        indexToCleanup.Add(argIndex);
+        indexToCleanup.Add(argIndex + 1);
+
+        argIndex = RetryOrchestratorHelper.GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, executableArguments);
+        if (argIndex > -1)
+        {
+            indexToCleanup.Add(argIndex);
+            indexToCleanup.Add(argIndex + 1);
+        }
+
+        argIndex = RetryOrchestratorHelper.GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, executableArguments);
+        if (argIndex > -1)
+        {
+            indexToCleanup.Add(argIndex);
+            indexToCleanup.Add(argIndex + 1);
+        }
+
+        argIndex = RetryOrchestratorHelper.GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName, executableArguments);
+        if (argIndex > -1)
+        {
+            indexToCleanup.Add(argIndex);
+            if (argIndex + 1 < executableArguments.Length)
+            {
+                indexToCleanup.Add(argIndex + 1);
+            }
+        }
+
+        argIndex = RetryOrchestratorHelper.GetOptionArgumentIndex(PlatformCommandLineProvider.ResultDirectoryOptionKey, executableArguments);
+        if (argIndex > -1)
+        {
+            indexToCleanup.Add(argIndex);
+            indexToCleanup.Add(argIndex + 1);
+        }
+
+        return indexToCleanup;
+    }
+
+    /// <summary>
+    /// Builds the argument list for a single retry attempt: the cleaned-up original arguments, the per-attempt
+    /// result directory, the retry pipe name, and (on retry attempts) the failed-UID filter.
+    /// </summary>
+    public static async Task<List<string>> BuildAttemptArgumentsAsync(
+        IFileSystem fileSystem,
+        string[] executableArguments,
+        List<int> indexToCleanup,
+        string currentTryResultFolder,
+        string retryRootFolder,
+        string pipeName,
+        string[]? lastListOfFailedId,
+        int attemptCount)
+    {
+        List<string> finalArguments = [];
+
+        // Cleanup the arguments
+        for (int i = 0; i < executableArguments.Length; i++)
+        {
+            if (indexToCleanup.Contains(i))
+            {
+                continue;
+            }
+
+            finalArguments.Add(executableArguments[i]);
+        }
+
+        // Fix result folder
+        finalArguments.Add($"--{PlatformCommandLineProvider.ResultDirectoryOptionKey}");
+        finalArguments.Add(currentTryResultFolder);
+
+        // Point the child process at the retry pipe server.
+        finalArguments.Add($"--{RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName}");
+        finalArguments.Add(pipeName);
+
+        // When retrying, replace any existing test filter with --filter-uid for the failed tests
+        if (lastListOfFailedId is { Length: > 0 })
+        {
+            RetryOrchestratorHelper.RemoveOption(finalArguments, TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter);
+            RetryOrchestratorHelper.RemoveOption(finalArguments, PlatformCommandLineProvider.FilterUidOptionKey);
+
+            // Strip --minimum-expected-tests on retry attempts: a retry only re-runs the previously
+            // failed tests, so propagating the original threshold (computed against the full test
+            // set) would always trip the policy and fail the run. See issue #5639.
+            RetryOrchestratorHelper.RemoveOption(finalArguments, PlatformCommandLineProvider.MinimumExpectedTestsOptionKey);
+
+            // The RSP parser (ResponseFileHelper.SplitCommandLine) strips all '"' characters
+            // from tokens, so UIDs containing literal '"' (e.g. parameterized tests with
+            // string arguments that include double quotes) cannot safely round-trip through
+            // a response file. In that case we must always use inline arguments.
+            bool hasUidsWithQuotes = false;
+            foreach (string uid in lastListOfFailedId)
+            {
+                if (uid.IndexOf('"') >= 0)
+                {
+                    hasUidsWithQuotes = true;
+                    break;
+                }
+            }
+
+            bool useResponseFile = false;
+            if (!hasUidsWithQuotes)
+            {
+                int predictedLength = 0;
+                foreach (string arg in finalArguments)
+                {
+                    predictedLength += arg.Length + PerArgumentOverhead;
+                }
+
+                predictedLength += 2 + PlatformCommandLineProvider.FilterUidOptionKey.Length + 1;
+                foreach (string uid in lastListOfFailedId)
+                {
+                    predictedLength += uid.Length + PerArgumentOverhead;
+                }
+
+                useResponseFile = predictedLength > CommandLineLengthLimit;
+            }
+
+            if (!useResponseFile)
+            {
+                finalArguments.Add($"--{PlatformCommandLineProvider.FilterUidOptionKey}");
+                finalArguments.AddRange(lastListOfFailedId);
+            }
+            else
+            {
+                // Use a response file to avoid exceeding command-line length limits.
+                // Write to retryRootFolder (not the per-attempt folder) so it won't be included
+                // in the final results move.
+                string responseFilePath = Path.Combine(retryRootFolder, $"retry-filter-uids-{attemptCount}.rsp");
+                using (IFileStream stream = fileSystem.NewFileStream(responseFilePath, FileMode.Create, FileAccess.Write))
+                using (var writer = new StreamWriter(stream.Stream))
+                {
+                    // Write all UIDs on a single line, each quoted. The RSP parser splits
+                    // by whitespace and uses '"' for grouping, so quoting handles UIDs
+                    // containing whitespace or starting with '#' (comment marker).
+                    await writer.WriteAsync($"--{PlatformCommandLineProvider.FilterUidOptionKey}").ConfigureAwait(false);
+                    foreach (string uid in lastListOfFailedId)
+                    {
+                        await writer.WriteAsync($" \"{uid}\"").ConfigureAwait(false);
+                    }
+
+                    await writer.WriteLineAsync().ConfigureAwait(false);
+                }
+
+                finalArguments.Add($"@{responseFilePath}");
+            }
+        }
+
+        return finalArguments;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryArgumentsBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryArgumentsBuilder.cs
@@ -121,15 +121,7 @@ internal static class RetryArgumentsBuilder
             // from tokens, so UIDs containing literal '"' (e.g. parameterized tests with
             // string arguments that include double quotes) cannot safely round-trip through
             // a response file. In that case we must always use inline arguments.
-            bool hasUidsWithQuotes = false;
-            foreach (string uid in lastListOfFailedId)
-            {
-                if (uid.IndexOf('"') >= 0)
-                {
-                    hasUidsWithQuotes = true;
-                    break;
-                }
-            }
+            bool hasUidsWithQuotes = lastListOfFailedId.Any(uid => uid.IndexOf('"') >= 0);
 
             bool useResponseFile = false;
             if (!hasUidsWithQuotes)

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -205,7 +205,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 finalFailedTests = failedThisAttempt;
 
                 // Check thresholds only on the first attempt (computed against the full suite).
-                if (attemptCount == 1 && await EvaluateThresholdPolicyAsync(outputDevice, retryFailedTestsPipeServer, cancellationToken).ConfigureAwait(false))
+                if (attemptCount == 1 && await RetryThresholdPolicy.EvaluateAsync(_commandLineOptions, this, outputDevice, retryFailedTestsPipeServer, cancellationToken).ConfigureAwait(false))
                 {
                     thresholdPolicyKickedIn = true;
                     break;
@@ -265,46 +265,6 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         await RetrySummaryReporter.MoveArtifactsAsync(this, outputDevice, fileSystem, logger, currentTryResultFolder, resultDirectory, cancellationToken).ConfigureAwait(false);
 
         return exitCodes[^1];
-    }
-
-    private async Task<bool> EvaluateThresholdPolicyAsync(IOutputDevice outputDevice, RetryFailedTestsPipeServer retryFailedTestsPipeServer, CancellationToken cancellationToken)
-    {
-        double? maxFailedTests = null;
-        double? maxPercentage = null;
-        double? maxCount = null;
-        if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string[]? retryFailedTestsMaxPercentage))
-        {
-            maxPercentage = double.Parse(retryFailedTestsMaxPercentage[0], CultureInfo.InvariantCulture);
-            maxFailedTests = maxPercentage / 100 * retryFailedTestsPipeServer.TotalTestRan;
-        }
-
-        if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string[]? retryFailedTestsMaxCount))
-        {
-            maxCount = double.Parse(retryFailedTestsMaxCount[0], CultureInfo.InvariantCulture);
-            maxFailedTests = maxCount.Value;
-        }
-
-        // If threshold policy is not enabled, or the failed set is within the threshold, keep retrying.
-        if (maxFailedTests is null || (retryFailedTestsPipeServer.FailedUID?.Count ?? 0) <= maxFailedTests)
-        {
-            return false;
-        }
-
-        StringBuilder explanation = new();
-        explanation.AppendLine(ExtensionResources.FailureThresholdPolicy);
-        if (maxPercentage is not null)
-        {
-            double failedPercentage = Math.Round(retryFailedTestsPipeServer.FailedUID!.Count / (double)retryFailedTestsPipeServer.TotalTestRan * 100, 2);
-            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxPercentage, maxPercentage, failedPercentage, retryFailedTestsPipeServer.FailedUID.Count, retryFailedTestsPipeServer.TotalTestRan));
-        }
-
-        if (maxCount is not null)
-        {
-            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxCount, maxCount, retryFailedTestsPipeServer.FailedUID!.Count));
-        }
-
-        await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(explanation.ToString()), cancellationToken).ConfigureAwait(false);
-        return true;
     }
 
     // Copied from HotReloadTestHostTestFrameworkInvoker

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.Policy.Resources;
@@ -98,48 +98,9 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         ApplicationStateGuard.Ensure(cmdRetries is not null);
         int userMaxRetryCount = int.Parse(cmdRetries[0], CultureInfo.InvariantCulture);
 
-        // Find out the retry args index inside the arguments to after cleanup the command line when we restart
-        List<int> indexToCleanup = [];
+        // Find out the retry args indices so we can clean up the command line when we restart.
         string[] executableArguments = [.. executableInfo.Arguments];
-        int argIndex = GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsOptionName, executableArguments);
-        if (argIndex < 0)
-        {
-            throw ApplicationStateGuard.Unreachable();
-        }
-
-        indexToCleanup.Add(argIndex);
-        indexToCleanup.Add(argIndex + 1);
-
-        argIndex = GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, executableArguments);
-        if (argIndex > -1)
-        {
-            indexToCleanup.Add(argIndex);
-            indexToCleanup.Add(argIndex + 1);
-        }
-
-        argIndex = GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, executableArguments);
-        if (argIndex > -1)
-        {
-            indexToCleanup.Add(argIndex);
-            indexToCleanup.Add(argIndex + 1);
-        }
-
-        argIndex = GetOptionArgumentIndex(RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName, executableArguments);
-        if (argIndex > -1)
-        {
-            indexToCleanup.Add(argIndex);
-            if (argIndex + 1 < executableArguments.Length)
-            {
-                indexToCleanup.Add(argIndex + 1);
-            }
-        }
-
-        argIndex = GetOptionArgumentIndex(PlatformCommandLineProvider.ResultDirectoryOptionKey, executableArguments);
-        if (argIndex > -1)
-        {
-            indexToCleanup.Add(argIndex);
-            indexToCleanup.Add(argIndex + 1);
-        }
+        List<int> indexToCleanup = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
 
         // Override the result directory with the attempt one
         string resultDirectory = configuration.GetTestResultDirectory();
@@ -149,7 +110,6 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         IFileSystem fileSystem = _serviceProvider.GetFileSystem();
 
         int attemptCount = 0;
-        List<string> finalArguments = [];
         string[]? lastListOfFailedId = null;
         string? currentTryResultFolder = null;
         bool thresholdPolicyKickedIn = false;
@@ -182,7 +142,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             {
                 await outputDevice.DisplayAsync(
                     this,
-                    new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryWaitingBeforeNextAttempt, FormatDelay(delay), attemptCount, userMaxRetryCount + 1))
+                    new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryWaitingBeforeNextAttempt, RetryOrchestratorHelper.FormatDelay(delay), attemptCount, userMaxRetryCount + 1))
                     {
                         ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGray },
                     },
@@ -190,186 +150,39 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
             }
 
-            // Cleanup the arguments
-            for (int i = 0; i < executableArguments.Length; i++)
-            {
-                if (indexToCleanup.Contains(i))
-                {
-                    continue;
-                }
-
-                finalArguments.Add(executableArguments[i]);
-            }
-
-            // Fix result folder
             currentTryResultFolder = Path.Combine(retryRootFolder, attemptCount.ToString(CultureInfo.InvariantCulture));
-            finalArguments.Add($"--{PlatformCommandLineProvider.ResultDirectoryOptionKey}");
-            finalArguments.Add(currentTryResultFolder);
 
-            // Prepare the pipeserver
+            // Prepare the pipe server that collects the child process's failed test UIDs.
             using RetryFailedTestsPipeServer retryFailedTestsPipeServer = new(_serviceProvider, lastListOfFailedId ?? [], logger);
-            finalArguments.Add($"--{RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName}");
-            finalArguments.Add(retryFailedTestsPipeServer.PipeName);
 
-            // When retrying, replace any existing test filter with --filter-uid for the failed tests
-            if (lastListOfFailedId is { Length: > 0 })
+            List<string> finalArguments = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
+                _fileSystem,
+                executableArguments,
+                indexToCleanup,
+                currentTryResultFolder,
+                retryRootFolder,
+                retryFailedTestsPipeServer.PipeName,
+                lastListOfFailedId,
+                attemptCount).ConfigureAwait(false);
+
+            RetryTestHostRunner.AttemptResult attemptResult = await RetryTestHostRunner.RunAttemptAsync(
+                _serviceProvider,
+                this,
+                outputDevice,
+                logger,
+                retryFailedTestsPipeServer,
+                executableInfo,
+                finalArguments,
+                attemptCount,
+                userMaxRetryCount,
+                cancellationToken).ConfigureAwait(false);
+
+            if (attemptResult.ExitedBeforeConnect)
             {
-                RemoveOption(finalArguments, TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter);
-                RemoveOption(finalArguments, PlatformCommandLineProvider.FilterUidOptionKey);
-
-                // Strip --minimum-expected-tests on retry attempts: a retry only re-runs the previously
-                // failed tests, so propagating the original threshold (computed against the full test
-                // set) would always trip the policy and fail the run. See issue #5639.
-                RemoveOption(finalArguments, PlatformCommandLineProvider.MinimumExpectedTestsOptionKey);
-
-                // The RSP parser (ResponseFileHelper.SplitCommandLine) strips all '"' characters
-                // from tokens, so UIDs containing literal '"' (e.g. parameterized tests with
-                // string arguments that include double quotes) cannot safely round-trip through
-                // a response file. In that case we must always use inline arguments.
-                bool hasUidsWithQuotes = false;
-                foreach (string uid in lastListOfFailedId)
-                {
-                    if (uid.IndexOf('"') >= 0)
-                    {
-                        hasUidsWithQuotes = true;
-                        break;
-                    }
-                }
-
-                bool useResponseFile = false;
-                if (!hasUidsWithQuotes)
-                {
-                    // Estimate command line length to avoid hitting OS limits (~32K on Windows).
-                    // Add per-argument overhead to account for PasteArguments quoting on pre-.NET 8
-                    // targets where each argument may gain wrapping quotes and a separator space.
-                    const int CommandLineLengthLimit = 30_000;
-                    const int PerArgumentOverhead = 3;
-                    int predictedLength = 0;
-                    foreach (string arg in finalArguments)
-                    {
-                        predictedLength += arg.Length + PerArgumentOverhead;
-                    }
-
-                    predictedLength += 2 + PlatformCommandLineProvider.FilterUidOptionKey.Length + 1;
-                    foreach (string uid in lastListOfFailedId)
-                    {
-                        predictedLength += uid.Length + PerArgumentOverhead;
-                    }
-
-                    useResponseFile = predictedLength > CommandLineLengthLimit;
-                }
-
-                if (!useResponseFile)
-                {
-                    finalArguments.Add($"--{PlatformCommandLineProvider.FilterUidOptionKey}");
-                    finalArguments.AddRange(lastListOfFailedId);
-                }
-                else
-                {
-                    // Use a response file to avoid exceeding command-line length limits.
-                    // Write to retryRootFolder (not the per-attempt folder) so it won't be included
-                    // in the final results move.
-                    string responseFilePath = Path.Combine(retryRootFolder, $"retry-filter-uids-{attemptCount}.rsp");
-                    using (IFileStream stream = _fileSystem.NewFileStream(responseFilePath, FileMode.Create, FileAccess.Write))
-                    using (var writer = new StreamWriter(stream.Stream))
-                    {
-                        // Write all UIDs on a single line, each quoted. The RSP parser splits
-                        // by whitespace and uses '"' for grouping, so quoting handles UIDs
-                        // containing whitespace or starting with '#' (comment marker).
-                        await writer.WriteAsync($"--{PlatformCommandLineProvider.FilterUidOptionKey}").ConfigureAwait(false);
-                        foreach (string uid in lastListOfFailedId)
-                        {
-                            await writer.WriteAsync($" \"{uid}\"").ConfigureAwait(false);
-                        }
-
-                        await writer.WriteLineAsync().ConfigureAwait(false);
-                    }
-
-                    finalArguments.Add($"@{responseFilePath}");
-                }
+                return (int)ExitCode.GenericFailure;
             }
 
-#if NET8_0_OR_GREATER
-            // On net8.0+, we can pass the arguments as a collection directly to ProcessStartInfo.
-            // When passing the collection, it's expected to be unescaped, so we pass what we have directly.
-            List<string> arguments = finalArguments;
-#else
-            // Current target framework (.NET Framework and .NET Standard 2.0) only supports arguments as a single string.
-            // In this case, escaping is essential. For example, one of the arguments could already contain spaces.
-            // PasteArguments is borrowed from dotnet/runtime.
-            var builder = new StringBuilder();
-            foreach (string arg in finalArguments)
-            {
-                PasteArguments.AppendArgument(builder, arg);
-            }
-
-            string arguments = builder.ToString();
-#endif
-
-            // Prepare the process start
-            ProcessStartInfo processStartInfo = new(executableInfo.FilePath, arguments)
-            {
-                UseShellExecute = false,
-            };
-
-            await logger.LogDebugAsync($"Starting test host process, attempt {attemptCount}/{userMaxRetryCount}").ConfigureAwait(false);
-            using IProcess testHostProcess = _serviceProvider.GetProcessHandler().Start(processStartInfo)
-                ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryFailedTestsCannotStartProcessErrorMessage, processStartInfo.FileName));
-
-            using var processExitedCancellationToken = new CancellationTokenSource();
-            EventHandler exitedHandler = (sender, e) =>
-            {
-                try
-                {
-                    processExitedCancellationToken.Cancel();
-                }
-                catch (ObjectDisposedException ex)
-                {
-                    // The handler can race with the end-of-iteration cleanup: if the OS process
-                    // exit signal is queued to the thread pool before we detach the handler but
-                    // executes after the CTS has been disposed, Cancel() throws. Log at debug
-                    // level so an unexpected pattern stays observable without becoming a fatal
-                    // failure in the retry loop.
-                    logger.LogDebug($"CancellationTokenSource already disposed when process exited: {ex.Message}");
-                }
-
-                logger.LogDebug($"Test host process exited, PID: '{(sender as Process)?.Id}'");
-            };
-
-            testHostProcess.Exited += exitedHandler;
-            try
-            {
-                using var timeout = new CancellationTokenSource(TimeoutHelper.DefaultHangTimeSpanTimeout);
-                using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
-                using var linkedToken2 = CancellationTokenSource.CreateLinkedTokenSource(linkedToken.Token, processExitedCancellationToken.Token);
-
-                await logger.LogDebugAsync("Wait connection from the test host process").ConfigureAwait(false);
-                try
-                {
-#if NETCOREAPP
-                    await retryFailedTestsPipeServer.WaitForConnectionAsync(linkedToken2.Token).ConfigureAwait(false);
-#else
-                    // We don't know why but if the cancellation is called quickly in `testHostProcess.Exited`: `processExitedCancellationToken.Cancel();` for netfx we stuck sometime here, like if
-                    // the token we pass to the named pipe is not "correctly" verified inside the pipe implementation self.
-                    // We fallback with our custom agnostic cancellation mechanism in that case.
-                    // We see it happen only in .NET FX and not in .NET Core so for now we don't do it for core.
-                    await retryFailedTestsPipeServer.WaitForConnectionAsync(linkedToken2.Token).WithCancellationAsync(linkedToken2.Token).ConfigureAwait(false);
-#endif
-                }
-                catch (OperationCanceledException) when (processExitedCancellationToken.IsCancellationRequested)
-                {
-                    await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                    return (int)ExitCode.GenericFailure;
-                }
-            }
-            finally
-            {
-                testHostProcess.Exited -= exitedHandler;
-            }
-
-            await testHostProcess.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-
-            exitCodes.Add(testHostProcess.ExitCode);
+            exitCodes.Add(attemptResult.ExitCode);
 
             int failedThisAttempt = retryFailedTestsPipeServer.FailedUID?.Count ?? 0;
             if (attemptCount == 1)
@@ -380,58 +193,22 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 firstAttemptFailedTests = failedThisAttempt;
             }
 
-            if (testHostProcess.ExitCode != (int)ExitCode.Success)
+            if (attemptResult.ExitCode != (int)ExitCode.Success)
             {
-                if (testHostProcess.ExitCode != (int)ExitCode.AtLeastOneTestFailed)
+                if (attemptResult.ExitCode != (int)ExitCode.AtLeastOneTestFailed)
                 {
-                    await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedWithWrongExitCode, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
+                    await outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestSuiteFailedWithWrongExitCode, attemptResult.ExitCode)), cancellationToken).ConfigureAwait(false);
                     retryInterrupted = true;
                     break;
                 }
 
                 finalFailedTests = failedThisAttempt;
 
-                // Check thresholds
-                if (attemptCount == 1)
+                // Check thresholds only on the first attempt (computed against the full suite).
+                if (attemptCount == 1 && await EvaluateThresholdPolicyAsync(outputDevice, retryFailedTestsPipeServer, cancellationToken).ConfigureAwait(false))
                 {
-                    double? maxFailedTests = null;
-                    double? maxPercentage = null;
-                    double? maxCount = null;
-                    if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string[]? retryFailedTestsMaxPercentage))
-                    {
-                        maxPercentage = double.Parse(retryFailedTestsMaxPercentage[0], CultureInfo.InvariantCulture);
-                        maxFailedTests = maxPercentage / 100 * retryFailedTestsPipeServer.TotalTestRan;
-                    }
-
-                    if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string[]? retryFailedTestsMaxCount))
-                    {
-                        maxCount = double.Parse(retryFailedTestsMaxCount[0], CultureInfo.InvariantCulture);
-                        maxFailedTests = maxCount.Value;
-                    }
-
-                    // If threshold policy enable
-                    if (maxFailedTests is not null)
-                    {
-                        if ((retryFailedTestsPipeServer.FailedUID?.Count ?? 0) > maxFailedTests)
-                        {
-                            thresholdPolicyKickedIn = true;
-                            StringBuilder explanation = new();
-                            explanation.AppendLine(ExtensionResources.FailureThresholdPolicy);
-                            if (maxPercentage is not null)
-                            {
-                                double failedPercentage = Math.Round(retryFailedTestsPipeServer.FailedUID!.Count / (double)retryFailedTestsPipeServer.TotalTestRan * 100, 2);
-                                explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxPercentage, maxPercentage, failedPercentage, retryFailedTestsPipeServer.FailedUID.Count, retryFailedTestsPipeServer.TotalTestRan));
-                            }
-
-                            if (maxCount is not null)
-                            {
-                                explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxCount, maxCount, retryFailedTestsPipeServer.FailedUID!.Count));
-                            }
-
-                            await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(explanation.ToString()), cancellationToken).ConfigureAwait(false);
-                            break;
-                        }
-                    }
+                    thresholdPolicyKickedIn = true;
+                    break;
                 }
 
                 // Only announce an attempt as "retrying" when another attempt will actually follow; the final
@@ -453,7 +230,6 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                     retriedExecutions += failedThisAttempt;
                 }
 
-                finalArguments.Clear();
                 lastListOfFailedId = retryFailedTestsPipeServer.FailedUID?.ToArray();
             }
             else
@@ -467,151 +243,72 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
 
         if (!thresholdPolicyKickedIn && !retryInterrupted)
         {
-            bool runSucceeded = exitCodes[^1] == (int)ExitCode.Success;
-            int flakyTests = Math.Max(0, firstAttemptFailedTests - finalFailedTests);
-            int totalAttempts = userMaxRetryCount + 1;
-
-            // Headline verdict, colored by the FINAL outcome so a run rescued by retry reads as green.
-            if (runSucceeded)
-            {
-                string header = attemptCount == 1
-                    ? ExtensionResources.RetrySummaryPassedNoRetry
-                    : string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryPassed, attemptCount, totalAttempts);
-                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(header) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGreen } }, cancellationToken).ConfigureAwait(false);
-            }
-            else
-            {
-                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailed, attemptCount, totalAttempts)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
-            }
-
-            if (!runSucceeded && finalFailedTests > 0)
-            {
-                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailedLine, finalFailedTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
-            }
-
-            // "flaky" = failed at least once but eventually passed — the headline value of the retry feature.
-            if (flakyTests > 0)
-            {
-                await outputDevice.DisplayAsync(this, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFlakyLine, flakyTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkYellow } }, cancellationToken).ConfigureAwait(false);
-            }
-
-            string totalLine = string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryTotalLine, suiteTotalTests);
-            if (retriedExecutions > 0)
-            {
-                totalLine += string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryRetriedSuffix, retriedExecutions);
-            }
-
-            await outputDevice.DisplayAsync(this, new TextOutputDeviceData(totalLine), cancellationToken).ConfigureAwait(false);
-            await outputDevice.DisplayAsync(this, new TextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryDurationLine, FormatDuration(orchestrationStopwatch.Elapsed))), cancellationToken).ConfigureAwait(false);
-        }
-
-        ApplicationStateGuard.Ensure(currentTryResultFolder is not null);
-
-        string[] filesToMove = _fileSystem.GetFiles(currentTryResultFolder, "*.*", SearchOption.AllDirectories);
-        if (filesToMove.Length > 0)
-        {
-            // Move last attempt assets. The per-file detail is demoted to a debug log; the user-facing output is a
-            // single collapsed line so a large artifact set no longer spams the console.
-            foreach (string file in filesToMove)
-            {
-                string finalFileLocation = file.Replace(currentTryResultFolder, resultDirectory);
-
-                // Create the directory if missing
-                fileSystem.CreateDirectory(Path.GetDirectoryName(finalFileLocation)!);
-
-                logger.LogDebug($"Moving file '{file}' to '{finalFileLocation}'");
-#if NETCOREAPP
-                fileSystem.MoveFile(file, finalFileLocation, overwrite: true);
-#else
-                fileSystem.CopyFile(file, finalFileLocation, overwrite: true);
-                fileSystem.DeleteFile(file);
-#endif
-            }
-
-            await outputDevice.DisplayAsync(
+            await RetrySummaryReporter.ReportSummaryAsync(
                 this,
-                new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryArtifactsMoved, filesToMove.Length, resultDirectory))
+                outputDevice,
+                new RetryRunSummary
                 {
-                    ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGray },
+                    ExitCodes = exitCodes,
+                    AttemptCount = attemptCount,
+                    UserMaxRetryCount = userMaxRetryCount,
+                    SuiteTotalTests = suiteTotalTests,
+                    FirstAttemptFailedTests = firstAttemptFailedTests,
+                    FinalFailedTests = finalFailedTests,
+                    RetriedExecutions = retriedExecutions,
+                    Elapsed = orchestrationStopwatch.Elapsed,
                 },
                 cancellationToken).ConfigureAwait(false);
         }
 
+        ApplicationStateGuard.Ensure(currentTryResultFolder is not null);
+
+        await RetrySummaryReporter.MoveArtifactsAsync(this, outputDevice, fileSystem, logger, currentTryResultFolder, resultDirectory, cancellationToken).ConfigureAwait(false);
+
         return exitCodes[^1];
+    }
+
+    private async Task<bool> EvaluateThresholdPolicyAsync(IOutputDevice outputDevice, RetryFailedTestsPipeServer retryFailedTestsPipeServer, CancellationToken cancellationToken)
+    {
+        double? maxFailedTests = null;
+        double? maxPercentage = null;
+        double? maxCount = null;
+        if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string[]? retryFailedTestsMaxPercentage))
+        {
+            maxPercentage = double.Parse(retryFailedTestsMaxPercentage[0], CultureInfo.InvariantCulture);
+            maxFailedTests = maxPercentage / 100 * retryFailedTestsPipeServer.TotalTestRan;
+        }
+
+        if (_commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string[]? retryFailedTestsMaxCount))
+        {
+            maxCount = double.Parse(retryFailedTestsMaxCount[0], CultureInfo.InvariantCulture);
+            maxFailedTests = maxCount.Value;
+        }
+
+        // If threshold policy is not enabled, or the failed set is within the threshold, keep retrying.
+        if (maxFailedTests is null || (retryFailedTestsPipeServer.FailedUID?.Count ?? 0) <= maxFailedTests)
+        {
+            return false;
+        }
+
+        StringBuilder explanation = new();
+        explanation.AppendLine(ExtensionResources.FailureThresholdPolicy);
+        if (maxPercentage is not null)
+        {
+            double failedPercentage = Math.Round(retryFailedTestsPipeServer.FailedUID!.Count / (double)retryFailedTestsPipeServer.TotalTestRan * 100, 2);
+            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxPercentage, maxPercentage, failedPercentage, retryFailedTestsPipeServer.FailedUID.Count, retryFailedTestsPipeServer.TotalTestRan));
+        }
+
+        if (maxCount is not null)
+        {
+            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxCount, maxCount, retryFailedTestsPipeServer.FailedUID!.Count));
+        }
+
+        await outputDevice.DisplayAsync(this, new ErrorMessageOutputDeviceData(explanation.ToString()), cancellationToken).ConfigureAwait(false);
+        return true;
     }
 
     // Copied from HotReloadTestHostTestFrameworkInvoker
     private static bool IsHotReloadEnabled(IEnvironment environment)
         => environment.GetEnvironmentVariable(EnvironmentVariableConstants.DOTNET_WATCH) == "1"
         || environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_HOTRELOAD_ENABLED) == "1";
-
-    private static int GetOptionArgumentIndex(string optionName, string[] executableArgs)
-    {
-        int index = Array.IndexOf(executableArgs, "-" + optionName);
-        if (index >= 0)
-        {
-            return index;
-        }
-
-        index = Array.IndexOf(executableArgs, "--" + optionName);
-        return index >= 0 ? index : -1;
-    }
-
-    private static void RemoveOption(List<string> arguments, string optionName)
-    {
-        string longForm = $"--{optionName}";
-        string shortForm = $"-{optionName}";
-
-        // Remove all occurrences since options like --filter-uid can appear multiple times.
-        // Also handle --option=value and --option:value forms produced by the command-line parser.
-        while (true)
-        {
-            int idx = -1;
-            for (int i = 0; i < arguments.Count; i++)
-            {
-                string arg = arguments[i];
-                if (arg == longForm || arg == shortForm
-                    || arg.StartsWith(longForm + "=", StringComparison.Ordinal) || arg.StartsWith(longForm + ":", StringComparison.Ordinal)
-                    || arg.StartsWith(shortForm + "=", StringComparison.Ordinal) || arg.StartsWith(shortForm + ":", StringComparison.Ordinal))
-                {
-                    idx = i;
-                    break;
-                }
-            }
-
-            if (idx < 0)
-            {
-                break;
-            }
-
-            arguments.RemoveAt(idx);
-
-            // Always remove subsequent non-option arguments (the option's values),
-            // even when the first value was provided inline with = or :, because
-            // multi-arity options (e.g. --filter-uid=1 2) can have trailing values.
-            while (idx < arguments.Count && (arguments[idx].Length == 0 || arguments[idx][0] != '-'))
-            {
-                arguments.RemoveAt(idx);
-            }
-        }
-    }
-
-    // Renders a retry delay the same way the --retry-failed-tests-delay option accepts it (e.g. '500ms', '1s',
-    // '1500ms') so the displayed wait is consistent with how the user configured it. The output is always a single
-    // value + unit that TimeSpanParser round-trips, and uses InvariantCulture so it never varies by locale.
-    private static string FormatDelay(TimeSpan delay)
-        => delay.TotalMilliseconds < 1000
-            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)delay.TotalMilliseconds)
-            : delay.Milliseconds == 0
-                ? string.Format(CultureInfo.InvariantCulture, "{0}s", (long)delay.TotalSeconds)
-                : string.Format(CultureInfo.InvariantCulture, "{0}ms", (long)delay.TotalMilliseconds);
-
-    // Compact, human-friendly duration for the retry summary, mirroring the platform terminal style
-    // (e.g. '240ms', '1s 240ms', '2m 03s'). InvariantCulture keeps the numeric separators stable across locales.
-    private static string FormatDuration(TimeSpan duration)
-        => duration.TotalSeconds < 1
-            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds)
-            : duration.TotalMinutes < 1
-                ? string.Format(CultureInfo.InvariantCulture, "{0}s {1:000}ms", duration.Seconds, duration.Milliseconds)
-                : string.Format(CultureInfo.InvariantCulture, "{0}m {1:00}s", (int)duration.TotalMinutes, duration.Seconds);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestratorHelper.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestratorHelper.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.Policy;
+
+/// <summary>
+/// Stateless string/list utilities used by the retry orchestrator and its collaborators.
+/// </summary>
+internal static class RetryOrchestratorHelper
+{
+    public static int GetOptionArgumentIndex(string optionName, string[] executableArgs)
+    {
+        int index = Array.IndexOf(executableArgs, "-" + optionName);
+        if (index >= 0)
+        {
+            return index;
+        }
+
+        index = Array.IndexOf(executableArgs, "--" + optionName);
+        return index >= 0 ? index : -1;
+    }
+
+    public static void RemoveOption(List<string> arguments, string optionName)
+    {
+        string longForm = $"--{optionName}";
+        string shortForm = $"-{optionName}";
+
+        // Remove all occurrences since options like --filter-uid can appear multiple times.
+        // Also handle --option=value and --option:value forms produced by the command-line parser.
+        while (true)
+        {
+            int idx = -1;
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                string arg = arguments[i];
+                if (arg == longForm || arg == shortForm
+                    || arg.StartsWith(longForm + "=", StringComparison.Ordinal) || arg.StartsWith(longForm + ":", StringComparison.Ordinal)
+                    || arg.StartsWith(shortForm + "=", StringComparison.Ordinal) || arg.StartsWith(shortForm + ":", StringComparison.Ordinal))
+                {
+                    idx = i;
+                    break;
+                }
+            }
+
+            if (idx < 0)
+            {
+                break;
+            }
+
+            arguments.RemoveAt(idx);
+
+            // Always remove subsequent non-option arguments (the option's values),
+            // even when the first value was provided inline with = or :, because
+            // multi-arity options (e.g. --filter-uid=1 2) can have trailing values.
+            while (idx < arguments.Count && (arguments[idx].Length == 0 || arguments[idx][0] != '-'))
+            {
+                arguments.RemoveAt(idx);
+            }
+        }
+    }
+
+    // Renders a retry delay the same way the --retry-failed-tests-delay option accepts it (e.g. '500ms', '1s',
+    // '1500ms') so the displayed wait is consistent with how the user configured it. The output is always a single
+    // value + unit that TimeSpanParser round-trips, and uses InvariantCulture so it never varies by locale.
+    public static string FormatDelay(TimeSpan delay)
+        => delay.TotalMilliseconds < 1000
+            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)delay.TotalMilliseconds)
+            : delay.Milliseconds == 0
+                ? string.Format(CultureInfo.InvariantCulture, "{0}s", (long)delay.TotalSeconds)
+                : string.Format(CultureInfo.InvariantCulture, "{0}ms", (long)delay.TotalMilliseconds);
+
+    // Compact, human-friendly duration for the retry summary, mirroring the platform terminal style
+    // (e.g. '240ms', '1s 240ms', '2m 03s'). InvariantCulture keeps the numeric separators stable across locales.
+    public static string FormatDuration(TimeSpan duration)
+        => duration.TotalSeconds < 1
+            ? string.Format(CultureInfo.InvariantCulture, "{0}ms", (int)duration.TotalMilliseconds)
+            : duration.TotalMinutes < 1
+                ? string.Format(CultureInfo.InvariantCulture, "{0}s {1:000}ms", duration.Seconds, duration.Milliseconds)
+                : string.Format(CultureInfo.InvariantCulture, "{0}m {1:00}s", (int)duration.TotalMinutes, duration.Seconds);
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetrySummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetrySummaryReporter.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.Policy.Resources;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+
+namespace Microsoft.Testing.Extensions.Policy;
+
+/// <summary>
+/// Accounting reconciled across retry attempts and used to render the single headline retry summary.
+/// </summary>
+internal readonly struct RetryRunSummary
+{
+    public required List<int> ExitCodes { get; init; }
+
+    public required int AttemptCount { get; init; }
+
+    public required int UserMaxRetryCount { get; init; }
+
+    public required int SuiteTotalTests { get; init; }
+
+    public required int FirstAttemptFailedTests { get; init; }
+
+    public required int FinalFailedTests { get; init; }
+
+    public required int RetriedExecutions { get; init; }
+
+    public required TimeSpan Elapsed { get; init; }
+}
+
+/// <summary>
+/// Renders the retry summary output and moves the last attempt's artifacts to the final result directory.
+/// </summary>
+internal static class RetrySummaryReporter
+{
+    public static async Task ReportSummaryAsync(
+        IOutputDeviceDataProducer producer,
+        IOutputDevice outputDevice,
+        RetryRunSummary summary,
+        CancellationToken cancellationToken)
+    {
+        bool runSucceeded = summary.ExitCodes[^1] == (int)ExitCode.Success;
+        int flakyTests = Math.Max(0, summary.FirstAttemptFailedTests - summary.FinalFailedTests);
+        int totalAttempts = summary.UserMaxRetryCount + 1;
+
+        // Headline verdict, colored by the FINAL outcome so a run rescued by retry reads as green.
+        if (runSucceeded)
+        {
+            string header = summary.AttemptCount == 1
+                ? ExtensionResources.RetrySummaryPassedNoRetry
+                : string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryPassed, summary.AttemptCount, totalAttempts);
+            await outputDevice.DisplayAsync(producer, new FormattedTextOutputDeviceData(header) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGreen } }, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await outputDevice.DisplayAsync(producer, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailed, summary.AttemptCount, totalAttempts)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!runSucceeded && summary.FinalFailedTests > 0)
+        {
+            await outputDevice.DisplayAsync(producer, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFailedLine, summary.FinalFailedTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkRed } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        // "flaky" = failed at least once but eventually passed — the headline value of the retry feature.
+        if (flakyTests > 0)
+        {
+            await outputDevice.DisplayAsync(producer, new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryFlakyLine, flakyTests)) { ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkYellow } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        string totalLine = string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryTotalLine, summary.SuiteTotalTests);
+        if (summary.RetriedExecutions > 0)
+        {
+            totalLine += string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryRetriedSuffix, summary.RetriedExecutions);
+        }
+
+        await outputDevice.DisplayAsync(producer, new TextOutputDeviceData(totalLine), cancellationToken).ConfigureAwait(false);
+        await outputDevice.DisplayAsync(producer, new TextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetrySummaryDurationLine, RetryOrchestratorHelper.FormatDuration(summary.Elapsed))), cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task MoveArtifactsAsync(
+        IOutputDeviceDataProducer producer,
+        IOutputDevice outputDevice,
+        IFileSystem fileSystem,
+        ILogger logger,
+        string currentTryResultFolder,
+        string resultDirectory,
+        CancellationToken cancellationToken)
+    {
+        string[] filesToMove = fileSystem.GetFiles(currentTryResultFolder, "*.*", SearchOption.AllDirectories);
+        if (filesToMove.Length == 0)
+        {
+            return;
+        }
+
+        // Move last attempt assets. The per-file detail is demoted to a debug log; the user-facing output is a
+        // single collapsed line so a large artifact set no longer spams the console.
+        foreach (string file in filesToMove)
+        {
+            string finalFileLocation = file.Replace(currentTryResultFolder, resultDirectory);
+
+            // Create the directory if missing
+            fileSystem.CreateDirectory(Path.GetDirectoryName(finalFileLocation)!);
+
+            logger.LogDebug($"Moving file '{file}' to '{finalFileLocation}'");
+#if NETCOREAPP
+            fileSystem.MoveFile(file, finalFileLocation, overwrite: true);
+#else
+            fileSystem.CopyFile(file, finalFileLocation, overwrite: true);
+            fileSystem.DeleteFile(file);
+#endif
+        }
+
+        await outputDevice.DisplayAsync(
+            producer,
+            new FormattedTextOutputDeviceData(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryArtifactsMoved, filesToMove.Length, resultDirectory))
+            {
+                ForegroundColor = new SystemConsoleColor { ConsoleColor = ConsoleColor.DarkGray },
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.Policy.Resources;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions.Policy;
+
+/// <summary>
+/// Owns a single retry attempt's child-process lifecycle: builds the process command line, starts the test host,
+/// waits for the retry pipe connection (with hang timeout), and returns the attempt's exit code.
+/// </summary>
+[UnsupportedOSPlatform("browser")]
+internal static class RetryTestHostRunner
+{
+    /// <summary>
+    /// Result of running one attempt. When <see cref="ExitedBeforeConnect"/> is <see langword="true"/>, the child
+    /// process died before it could connect to the retry pipe, and the orchestrator should stop with a generic failure.
+    /// </summary>
+    public readonly struct AttemptResult
+    {
+        public required int ExitCode { get; init; }
+
+        public required bool ExitedBeforeConnect { get; init; }
+    }
+
+    public static async Task<AttemptResult> RunAttemptAsync(
+        IServiceProvider serviceProvider,
+        IOutputDeviceDataProducer producer,
+        IOutputDevice outputDevice,
+        ILogger logger,
+        RetryFailedTestsPipeServer retryFailedTestsPipeServer,
+        ExecutableInfo executableInfo,
+        List<string> finalArguments,
+        int attemptCount,
+        int userMaxRetryCount,
+        CancellationToken cancellationToken)
+    {
+#if NET8_0_OR_GREATER
+        // On net8.0+, we can pass the arguments as a collection directly to ProcessStartInfo.
+        // When passing the collection, it's expected to be unescaped, so we pass what we have directly.
+        List<string> arguments = finalArguments;
+#else
+        // Current target framework (.NET Framework and .NET Standard 2.0) only supports arguments as a single string.
+        // In this case, escaping is essential. For example, one of the arguments could already contain spaces.
+        // PasteArguments is borrowed from dotnet/runtime.
+        var builder = new StringBuilder();
+        foreach (string arg in finalArguments)
+        {
+            PasteArguments.AppendArgument(builder, arg);
+        }
+
+        string arguments = builder.ToString();
+#endif
+
+        // Prepare the process start
+        ProcessStartInfo processStartInfo = new(executableInfo.FilePath, arguments)
+        {
+            UseShellExecute = false,
+        };
+
+        await logger.LogDebugAsync($"Starting test host process, attempt {attemptCount}/{userMaxRetryCount}").ConfigureAwait(false);
+        using IProcess testHostProcess = serviceProvider.GetProcessHandler().Start(processStartInfo)
+            ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryFailedTestsCannotStartProcessErrorMessage, processStartInfo.FileName));
+
+        using var processExitedCancellationToken = new CancellationTokenSource();
+        EventHandler exitedHandler = (sender, e) =>
+        {
+            try
+            {
+                processExitedCancellationToken.Cancel();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // The handler can race with the end-of-iteration cleanup: if the OS process
+                // exit signal is queued to the thread pool before we detach the handler but
+                // executes after the CTS has been disposed, Cancel() throws. Log at debug
+                // level so an unexpected pattern stays observable without becoming a fatal
+                // failure in the retry loop.
+                logger.LogDebug($"CancellationTokenSource already disposed when process exited: {ex.Message}");
+            }
+
+            logger.LogDebug($"Test host process exited, PID: '{(sender as Process)?.Id}'");
+        };
+
+        testHostProcess.Exited += exitedHandler;
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeoutHelper.DefaultHangTimeSpanTimeout);
+            using var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
+            using var linkedToken2 = CancellationTokenSource.CreateLinkedTokenSource(linkedToken.Token, processExitedCancellationToken.Token);
+
+            await logger.LogDebugAsync("Wait connection from the test host process").ConfigureAwait(false);
+            try
+            {
+#if NETCOREAPP
+                await retryFailedTestsPipeServer.WaitForConnectionAsync(linkedToken2.Token).ConfigureAwait(false);
+#else
+                // We don't know why but if the cancellation is called quickly in `testHostProcess.Exited`: `processExitedCancellationToken.Cancel();` for netfx we stuck sometime here, like if
+                // the token we pass to the named pipe is not "correctly" verified inside the pipe implementation self.
+                // We fallback with our custom agnostic cancellation mechanism in that case.
+                // We see it happen only in .NET FX and not in .NET Core so for now we don't do it for core.
+                await retryFailedTestsPipeServer.WaitForConnectionAsync(linkedToken2.Token).WithCancellationAsync(linkedToken2.Token).ConfigureAwait(false);
+#endif
+            }
+            catch (OperationCanceledException) when (processExitedCancellationToken.IsCancellationRequested)
+            {
+                await outputDevice.DisplayAsync(producer, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
+                return new AttemptResult { ExitCode = testHostProcess.ExitCode, ExitedBeforeConnect = true };
+            }
+        }
+        finally
+        {
+            testHostProcess.Exited -= exitedHandler;
+        }
+
+        await testHostProcess.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+
+        return new AttemptResult { ExitCode = testHostProcess.ExitCode, ExitedBeforeConnect = false };
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryThresholdPolicy.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryThresholdPolicy.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.Policy.Resources;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.OutputDevice;
+
+namespace Microsoft.Testing.Extensions.Policy;
+
+/// <summary>
+/// Evaluates the failure-threshold policy (--retry-failed-tests-max-percentage / --retry-failed-tests-max-tests)
+/// against the first attempt's result and reports an explanation when the policy disables retrying.
+/// </summary>
+[UnsupportedOSPlatform("browser")]
+internal static class RetryThresholdPolicy
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when the number of failed tests exceeds the configured threshold, meaning
+    /// the retry mechanism should be disabled. When the policy trips, an explanatory error is written to the
+    /// output device.
+    /// </summary>
+    public static async Task<bool> EvaluateAsync(
+        ICommandLineOptions commandLineOptions,
+        IOutputDeviceDataProducer producer,
+        IOutputDevice outputDevice,
+        RetryFailedTestsPipeServer retryFailedTestsPipeServer,
+        CancellationToken cancellationToken)
+    {
+        double? maxFailedTests = null;
+        double? maxPercentage = null;
+        double? maxCount = null;
+        if (commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, out string[]? retryFailedTestsMaxPercentage))
+        {
+            maxPercentage = double.Parse(retryFailedTestsMaxPercentage[0], CultureInfo.InvariantCulture);
+            maxFailedTests = maxPercentage / 100 * retryFailedTestsPipeServer.TotalTestRan;
+        }
+
+        if (commandLineOptions.TryGetOptionArgumentList(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, out string[]? retryFailedTestsMaxCount))
+        {
+            maxCount = double.Parse(retryFailedTestsMaxCount[0], CultureInfo.InvariantCulture);
+            maxFailedTests = maxCount.Value;
+        }
+
+        // If threshold policy is not enabled, or the failed set is within the threshold, keep retrying.
+        if (maxFailedTests is null || (retryFailedTestsPipeServer.FailedUID?.Count ?? 0) <= maxFailedTests)
+        {
+            return false;
+        }
+
+        StringBuilder explanation = new();
+        explanation.AppendLine(ExtensionResources.FailureThresholdPolicy);
+        if (maxPercentage is not null)
+        {
+            double failedPercentage = Math.Round(retryFailedTestsPipeServer.FailedUID!.Count / (double)retryFailedTestsPipeServer.TotalTestRan * 100, 2);
+            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxPercentage, maxPercentage, failedPercentage, retryFailedTestsPipeServer.FailedUID.Count, retryFailedTestsPipeServer.TotalTestRan));
+        }
+
+        if (maxCount is not null)
+        {
+            explanation.AppendLine(string.Format(CultureInfo.InvariantCulture, ExtensionResources.FailureThresholdPolicyMaxCount, maxCount, retryFailedTestsPipeServer.FailedUID!.Count));
+        }
+
+        await outputDevice.DisplayAsync(producer, new ErrorMessageOutputDeviceData(explanation.ToString()), cancellationToken).ConfigureAwait(false);
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #9660.

Splits the 617-line `RetryOrchestrator.cs` into cohesive, focused files so the retry logic is easier to navigate, test, and evolve.

## Files

| File | Lines | Responsibility |
|------|-------|----------------|
| `RetryOrchestrator.cs` *(slimmed)* | 274 | Retry loop + coordination |
| `RetryArgumentsBuilder.cs` | 176 | Cleanup-index computation + per-attempt argument construction (incl. response-file fallback for long command lines) |
| `RetryTestHostRunner.cs` | 125 | Child-process lifecycle (build command line, start, wait-for-connection with hang timeout, exit) |
| `RetrySummaryReporter.cs` | 124 | Retry summary output + last-attempt artifact move |
| `RetryOrchestratorHelper.cs` | 80 | Stateless option/format utilities (`GetOptionArgumentIndex`, `RemoveOption`, `FormatDelay`, `FormatDuration`) |
| `RetryThresholdPolicy.cs` | 66 | Failure-threshold policy evaluation (`--retry-failed-tests-max-percentage` / `--retry-failed-tests-max-tests`) |

## Acceptance criteria

- [x] `RetryOrchestrator.cs` is under 300 lines (274)
- [x] Each new file is under 300 lines
- [x] No breaking changes to the `ITestHostExecutionOrchestrator` contract
- [x] No new public API surface added — all extracted types remain `internal`
- [x] All tests pass after refactoring

## Verification

- Full `build.cmd` and `build.cmd -pack`: **0 warnings, 0 errors**
- All **32** retry acceptance tests (`RetryFailedTestsTests`, `RetryWithMaxFailedTestsTests`) pass — behavior unchanged.

The change is mechanical: existing code was moved verbatim into the new helper classes, with the only structural changes being the threshold-policy block turned into `RetryThresholdPolicy.EvaluateAsync` and the UID quote check simplified to a LINQ `Any`.