### PR TITLE
Extract duplicated `LogUnexpectedException` into shared helper

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -123,7 +123,7 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
         }
     }
 
@@ -150,7 +150,7 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(ConsumeAsync), ex);
+            _logger.LogUnexpectedException(nameof(ConsumeAsync), ex);
         }
 
         return Task.CompletedTask;
@@ -196,7 +196,7 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
         }
     }
 
@@ -241,7 +241,7 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(EmitArtifactUploadCommandsAsync), ex);
+            _logger.LogUnexpectedException(nameof(EmitArtifactUploadCommandsAsync), ex);
         }
     }
 
@@ -273,14 +273,6 @@ internal sealed class AzureDevOpsArtifactUploader : IDataConsumer, ITestSessionL
         }
 
         return matcher;
-    }
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
-        }
     }
 
     private bool ShouldUploadAllFiles()

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsArtifactUploader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.FileSystemGlobbing;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLogGroupReporter.cs
@@ -94,7 +94,7 @@ internal sealed class AzureDevOpsLogGroupReporter : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
         }
     }
 
@@ -118,15 +118,7 @@ internal sealed class AzureDevOpsLogGroupReporter : IDataConsumer, ITestSessionL
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
-        }
-    }
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
+            _logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
         }
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsSummaryReporter.cs
@@ -114,7 +114,7 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
         }
     }
 
@@ -179,7 +179,7 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(ConsumeAsync), ex);
+            _logger.LogUnexpectedException(nameof(ConsumeAsync), ex);
         }
 
         return Task.CompletedTask;
@@ -247,7 +247,7 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
         }
     }
 
@@ -466,14 +466,6 @@ internal sealed class AzureDevOpsSummaryReporter : IDataConsumer, ITestSessionLi
 #pragma warning restore CS0618, MTP0001
             _ => TerminalKind.NotTerminal,
         };
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
-        }
-    }
 
     internal readonly struct TestRecord
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
@@ -15,6 +15,7 @@
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestNodeIdentity.cs" Link="Helpers\TestNodeIdentity.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\SlowTestReporterBase.cs" Link="Helpers\SlowTestReporterBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReporterLoggingExtensions.cs" Link="Helpers\ReporterLoggingExtensions.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\StackTraceSourceLocationResolver.cs" Link="Helpers\StackTraceSourceLocationResolver.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.GitHubActionsReport.Resources;

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsAnnotationReporter.cs
@@ -110,7 +110,7 @@ internal sealed class GitHubActionsAnnotationReporter :
             // Mirror the sibling reporters: a failure while building/emitting an annotation (e.g. a malformed
             // stack-trace path making IFileSystem.ExistFile throw) degrades to "no annotation" instead of
             // propagating into the platform's consumer dispatch.
-            LogUnexpectedException(nameof(ConsumeAsync), ex);
+            _logger.LogUnexpectedException(nameof(ConsumeAsync), ex);
         }
     }
 
@@ -199,12 +199,4 @@ internal sealed class GitHubActionsAnnotationReporter :
 
     private static string GetTestName(TestNode testNode)
         => TestNodeIdentity.GetTestName(testNode);
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
-        }
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsReporter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.GitHubActionsReport.Resources;

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsReporter.cs
@@ -107,7 +107,7 @@ internal sealed class GitHubActionsReporter :
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
         }
     }
 
@@ -132,15 +132,7 @@ internal sealed class GitHubActionsReporter :
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
-        }
-    }
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
+            _logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
         }
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsSummaryReporter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.GitHubActionsReport.Resources;
@@ -135,7 +135,7 @@ internal sealed class GitHubActionsSummaryReporter :
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(ConsumeAsync), ex);
+            _logger.LogUnexpectedException(nameof(ConsumeAsync), ex);
         }
 
         return Task.CompletedTask;
@@ -196,7 +196,7 @@ internal sealed class GitHubActionsSummaryReporter :
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+            _logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
         }
     }
 
@@ -316,14 +316,6 @@ internal sealed class GitHubActionsSummaryReporter :
 #pragma warning restore CS0618, MTP0001
             _ => TerminalKind.NotTerminal,
         };
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (_logger.IsEnabled(LogLevel.Warning))
-        {
-            _logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
-        }
-    }
 
     internal readonly struct TestRecord
     {

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsSummaryReporter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsSummaryReporter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.GitHubActionsReport.Resources;

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Microsoft.Testing.Extensions.GitHubActionsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Microsoft.Testing.Extensions.GitHubActionsReport.csproj
@@ -17,6 +17,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TargetFrameworkMonikerHelper.cs" Link="Helpers\TargetFrameworkMonikerHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\SlowTestReporterBase.cs" Link="Helpers\SlowTestReporterBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReporterLoggingExtensions.cs" Link="Helpers\ReporterLoggingExtensions.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestNodeIdentity.cs" Link="Helpers\TestNodeIdentity.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\StackTraceSourceLocationResolver.cs" Link="Helpers\StackTraceSourceLocationResolver.cs" />
     <Compile Include="$(RepoRoot)\test\Utilities\Microsoft.Testing.TestInfrastructure\RootFinder.cs" Link="RootFinder.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReporterLoggingExtensions.cs
+++ b/src/Platform/SharedExtensionHelpers/ReporterLoggingExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Logging;

--- a/src/Platform/SharedExtensionHelpers/ReporterLoggingExtensions.cs
+++ b/src/Platform/SharedExtensionHelpers/ReporterLoggingExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Logging;
+
+namespace Microsoft.Testing.Extensions;
+
+/// <summary>
+/// Shared logging helpers for the pipeline reporter extensions (Azure DevOps and GitHub Actions).
+/// </summary>
+internal static class ReporterLoggingExtensions
+{
+    /// <summary>
+    /// Logs an otherwise-swallowed exception from a reporter lifecycle callback as a warning, so a failure in a
+    /// reporter degrades gracefully instead of propagating into the platform's dispatch.
+    /// </summary>
+    /// <param name="logger">The logger to write the warning to.</param>
+    /// <param name="callbackName">The name of the callback where the exception was caught.</param>
+    /// <param name="ex">The unexpected exception.</param>
+    public static void LogUnexpectedException(this ILogger logger, string callbackName, Exception ex)
+    {
+        if (logger.IsEnabled(LogLevel.Warning))
+        {
+            logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
+        }
+    }
+}

--- a/src/Platform/SharedExtensionHelpers/SlowTestReporterBase.cs
+++ b/src/Platform/SharedExtensionHelpers/SlowTestReporterBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions;

--- a/src/Platform/SharedExtensionHelpers/SlowTestReporterBase.cs
+++ b/src/Platform/SharedExtensionHelpers/SlowTestReporterBase.cs
@@ -93,7 +93,7 @@ internal abstract class SlowTestReporterBase : IDataConsumer, ITestSessionLifeti
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
+            Logger.LogUnexpectedException(nameof(OnTestSessionStartingAsync), ex);
         }
 
         return Task.CompletedTask;
@@ -134,7 +134,7 @@ internal abstract class SlowTestReporterBase : IDataConsumer, ITestSessionLifeti
         }
         catch (Exception ex)
         {
-            LogUnexpectedException(nameof(ConsumeAsync), ex);
+            Logger.LogUnexpectedException(nameof(ConsumeAsync), ex);
         }
 
         return Task.CompletedTask;
@@ -165,7 +165,7 @@ internal abstract class SlowTestReporterBase : IDataConsumer, ITestSessionLifeti
             }
             catch (Exception ex)
             {
-                LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
+                Logger.LogUnexpectedException(nameof(OnTestSessionFinishingAsync), ex);
             }
         }
 
@@ -247,16 +247,8 @@ internal abstract class SlowTestReporterBase : IDataConsumer, ITestSessionLifeti
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                LogUnexpectedException(nameof(ScanOnceAsync), ex);
+                Logger.LogUnexpectedException(nameof(ScanOnceAsync), ex);
             }
-        }
-    }
-
-    private void LogUnexpectedException(string callbackName, Exception ex)
-    {
-        if (Logger.IsEnabled(LogLevel.Warning))
-        {
-            Logger.LogWarning($"Unexpected exception in {callbackName}: {ex}");
         }
     }
 


### PR DESCRIPTION
Fixes #9650.

## Summary

The 5-line `LogUnexpectedException` helper method was copy-pasted verbatim across 7 reporter classes in two extension packages plus `SharedExtensionHelpers/SlowTestReporterBase`. This PR removes all 7 private copies and replaces them with a single `ILogger` extension method.

## Changes

- Added `src/Platform/SharedExtensionHelpers/ReporterLoggingExtensions.cs` — a static `LogUnexpectedException(this ILogger, string, Exception)` extension in the `Microsoft.Testing.Extensions` namespace (in scope for all `Microsoft.Testing.Extensions.*` sub-namespaces via enclosing-namespace resolution, so no `using` churn).
- Removed the 7 private `LogUnexpectedException` copies and rewired all call sites to `_logger.LogUnexpectedException(...)` / `Logger.LogUnexpectedException(...)`:
  - `AzureDevOpsSummaryReporter`, `AzureDevOpsArtifactUploader`, `AzureDevOpsLogGroupReporter`
  - `GitHubActionsSummaryReporter`, `GitHubActionsAnnotationReporter`, `GitHubActionsReporter`
  - `SlowTestReporterBase`
- Registered the new shared file as a linked `Compile` item in both `Microsoft.Testing.Extensions.AzureDevOpsReport` and `Microsoft.Testing.Extensions.GitHubActionsReport` csprojs (mirroring how `SlowTestReporterBase.cs` is already shared).

I kept the try-catch guard blocks in place (the issue listed extracting them as optional): the callbacks have different bodies/return shapes, so an `ExecuteGuardedAsync` wrapper would obscure more than it saves. The method-level duplication — the concrete win — is eliminated.

## Validation

Both extension projects build cleanly (0 warnings, 0 errors) across `netstandard2.0`, `net8.0`, and `net9.0`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>