### PR TITLE
Extract shared extension build loop into ExtensionBuilderHelper

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExtensionBuilderHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExtensionBuilderHelper.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Resources;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.Helpers;
+
+/// <summary>
+/// Shared helpers implementing the common "instantiate → validate unique → check enabled →
+/// initialize → register" loop used to build platform extensions across the various
+/// <c>*Manager</c> classes.
+/// </summary>
+internal static class ExtensionBuilderHelper
+{
+    /// <summary>
+    /// Builds and registers extensions produced by simple factories into <paramref name="result"/>.
+    /// For each factory the extension is instantiated, validated for uniqueness, and — when enabled —
+    /// initialized and added to the result (optionally registered in the service provider).
+    /// </summary>
+    /// <typeparam name="T">The extension type produced by the factories.</typeparam>
+    public static async Task BuildAndRegisterExtensionsAsync<T>(
+        IEnumerable<Func<IServiceProvider, T>> factories,
+        ServiceProvider serviceProvider,
+        List<T> result,
+        bool registerInServiceProvider = false)
+        where T : class, IExtension
+    {
+        foreach (Func<IServiceProvider, T> factory in factories)
+        {
+            T service = factory(serviceProvider);
+
+            // Check if we have already extensions of the same type with same id registered
+            result.ValidateUniqueExtension(service);
+
+            // We initialize only if enabled
+            if (await service.IsEnabledAsync().ConfigureAwait(false))
+            {
+                await service.TryInitializeAsync().ConfigureAwait(false);
+
+                // Register the extension for usage
+                result.Add(service);
+
+                if (registerInServiceProvider)
+                {
+                    serviceProvider.TryAddService(service);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds and registers extensions produced by simple factories into <paramref name="result"/>,
+    /// preserving the registration order captured in <paramref name="factoryOrdering"/>.
+    /// </summary>
+    /// <typeparam name="T">The extension type produced by the factories.</typeparam>
+    public static async Task BuildAndRegisterExtensionsAsync<T>(
+        IEnumerable<Func<IServiceProvider, T>> factories,
+        ServiceProvider serviceProvider,
+        List<(IExtension Extension, int RegistrationOrder)> result,
+        List<object> factoryOrdering,
+        bool registerInServiceProvider = false)
+        where T : class, IExtension
+    {
+        foreach (Func<IServiceProvider, T> factory in factories)
+        {
+            T service = factory(serviceProvider);
+
+            // Check if we have already extensions of the same type with same id registered
+            result.ValidateUniqueExtension(service, static x => x.Extension);
+
+            // We initialize only if enabled
+            if (await service.IsEnabledAsync().ConfigureAwait(false))
+            {
+                await service.TryInitializeAsync().ConfigureAwait(false);
+
+                // Register the extension for usage
+                result.Add((service, factoryOrdering.IndexOf(factory)));
+
+                if (registerInServiceProvider)
+                {
+                    serviceProvider.TryAddService(service);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds and registers extensions produced by composite factories, cloning each factory to get a
+    /// fresh instance the first time it is seen and reusing the shared singleton afterwards. The built
+    /// extension must implement <typeparamref name="T"/>, otherwise an <see cref="InvalidOperationException"/>
+    /// is thrown.
+    /// </summary>
+    /// <typeparam name="T">The extension interface the built extension is expected to implement.</typeparam>
+    public static async Task BuildAndRegisterCompositeExtensionsAsync<T>(
+        IEnumerable<ICompositeExtensionFactory> compositeFactories,
+        ServiceProvider serviceProvider,
+        List<(IExtension Extension, int RegistrationOrder)> result,
+        List<ICompositeExtensionFactory> alreadyBuiltServices,
+        List<object> factoryOrdering)
+        where T : IExtension
+    {
+        foreach (ICompositeExtensionFactory compositeServiceFactory in compositeFactories)
+        {
+            ICompositeExtensionFactory? compositeFactoryInstance;
+
+            // We check if the same service is already built in some other build phase
+            if ((compositeFactoryInstance = alreadyBuiltServices.SingleOrDefault(x => x.GetType() == compositeServiceFactory.GetType())) is null)
+            {
+                // We clone the instance because we want to have fresh instance per build phase
+                compositeFactoryInstance = (ICompositeExtensionFactory)compositeServiceFactory.Clone();
+
+                // Create the new fresh instance
+                var instance = (IExtension)compositeFactoryInstance.GetInstance(serviceProvider);
+
+                // Check if we have already extensions of the same type with same id registered
+                result.ValidateUniqueExtension(instance, static x => x.Extension);
+
+                // We initialize only if enabled
+                if (await instance.IsEnabledAsync().ConfigureAwait(false))
+                {
+                    await instance.TryInitializeAsync().ConfigureAwait(false);
+                }
+
+                // Add to the list of shared singletons
+                alreadyBuiltServices.Add(compositeFactoryInstance);
+            }
+
+            // Get the singleton
+            var extension = (IExtension)compositeFactoryInstance.GetInstance();
+
+            // We register the extension only if enabled
+            if (await extension.IsEnabledAsync().ConfigureAwait(false))
+            {
+                if (extension is T typedExtension)
+                {
+                    // Register the extension for usage
+                    result.Add((typedExtension, factoryOrdering.IndexOf(compositeServiceFactory)));
+                    continue;
+                }
+
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(T)));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds and registers extensions produced by composite factories, reusing the singleton in place
+    /// (without cloning) and tracking already-built factories in <paramref name="alreadyBuiltServices"/>.
+    /// The built extension must implement <typeparamref name="T"/>, otherwise an
+    /// <see cref="InvalidOperationException"/> is thrown. Enabled extensions are also registered in the
+    /// service provider.
+    /// </summary>
+    /// <typeparam name="T">The extension interface the built extension is expected to implement.</typeparam>
+    public static async Task BuildAndRegisterCompositeExtensionsInPlaceAsync<T>(
+        IEnumerable<ICompositeExtensionFactory> compositeFactories,
+        ServiceProvider serviceProvider,
+        List<(IExtension Extension, int RegistrationOrder)> result,
+        List<ICompositeExtensionFactory> alreadyBuiltServices,
+        List<object> factoryOrdering)
+        where T : IExtension
+    {
+        foreach (ICompositeExtensionFactory compositeServiceFactory in compositeFactories)
+        {
+            // Get the singleton
+            var extension = (IExtension)compositeServiceFactory.GetInstance(serviceProvider);
+            bool isEnabledAsync = await extension.IsEnabledAsync().ConfigureAwait(false);
+
+            // Check if we have already built the singleton for this composite factory
+            if (!alreadyBuiltServices.Contains(compositeServiceFactory))
+            {
+                // Check if we have already extensions of the same type with same id registered
+                result.ValidateUniqueExtension(extension, static x => x.Extension);
+
+                // We initialize only if enabled
+                if (isEnabledAsync)
+                {
+                    await extension.TryInitializeAsync().ConfigureAwait(false);
+                }
+
+                // Add to the list of shared singletons
+                alreadyBuiltServices.Add(compositeServiceFactory);
+            }
+
+            // We register the extension only if enabled
+            if (isEnabledAsync)
+            {
+                if (extension is T typedExtension)
+                {
+                    // Register the extension for usage
+                    result.Add((typedExtension, factoryOrdering.IndexOf(compositeServiceFactory)));
+                    serviceProvider.TryAddService(typedExtension);
+                }
+                else
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(T)));
+                }
+            }
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
@@ -94,22 +94,7 @@ internal sealed class TestHostManager : ITestHostManager
     internal async Task<ITestHostApplicationLifetime[]> BuildTestApplicationLifecycleCallbackAsync(ServiceProvider serviceProvider)
     {
         List<ITestHostApplicationLifetime> testApplicationLifecycleCallbacks = [];
-        foreach (Func<IServiceProvider, ITestHostApplicationLifetime> testApplicationLifecycleCallbacksFactory in _testApplicationLifecycleCallbacksFactories)
-        {
-            ITestHostApplicationLifetime service = testApplicationLifecycleCallbacksFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            testApplicationLifecycleCallbacks.ValidateUniqueExtension(service);
-
-            // We initialize only if enabled
-            if (await service.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await service.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                testApplicationLifecycleCallbacks.Add(service);
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_testApplicationLifecycleCallbacksFactories, serviceProvider, testApplicationLifecycleCallbacks).ConfigureAwait(false);
 
         return [.. testApplicationLifecycleCallbacks];
     }
@@ -135,65 +120,8 @@ internal sealed class TestHostManager : ITestHostManager
     internal async Task<(IExtension Consumer, int RegistrationOrder)[]> BuildDataConsumersAsync(ServiceProvider serviceProvider, List<ICompositeExtensionFactory> alreadyBuiltServices)
     {
         List<(IExtension Consumer, int RegistrationOrder)> dataConsumers = [];
-        foreach (Func<IServiceProvider, IDataConsumer> dataConsumerFactory in _dataConsumerFactories)
-        {
-            IDataConsumer service = dataConsumerFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            dataConsumers.ValidateUniqueExtension(service, x => x.Consumer);
-
-            // We initialize only if enabled
-            if (await service.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await service.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                dataConsumers.Add((service, _factoryOrdering.IndexOf(dataConsumerFactory)));
-            }
-        }
-
-        foreach (ICompositeExtensionFactory compositeServiceFactory in _dataConsumersCompositeServiceFactories)
-        {
-            ICompositeExtensionFactory? compositeFactoryInstance;
-
-            // We check if the same service is already built in some other build phase
-            if ((compositeFactoryInstance = alreadyBuiltServices.SingleOrDefault(x => x.GetType() == compositeServiceFactory.GetType())) is null)
-            {
-                // We clone the instance because we want to have fresh instance per BuildTestApplicationLifecycleCallbackAsync call
-                compositeFactoryInstance = (ICompositeExtensionFactory)compositeServiceFactory.Clone();
-
-                // Create the new fresh instance
-                var instance = (IExtension)compositeFactoryInstance.GetInstance(serviceProvider);
-
-                // Check if we have already extensions of the same type with same id registered
-                dataConsumers.ValidateUniqueExtension(instance, x => x.Consumer);
-
-                // We initialize only if enabled
-                if (await instance.IsEnabledAsync().ConfigureAwait(false))
-                {
-                    await instance.TryInitializeAsync().ConfigureAwait(false);
-                }
-
-                // Add to the list of shared singletons
-                alreadyBuiltServices.Add(compositeFactoryInstance);
-            }
-
-            // Get the singleton
-            var extension = (IExtension)compositeFactoryInstance.GetInstance();
-
-            // We register the extension only if enabled
-            if (await extension.IsEnabledAsync().ConfigureAwait(false))
-            {
-                if (extension is IDataConsumer consumer)
-                {
-                    // Register the extension for usage
-                    dataConsumers.Add((consumer, _factoryOrdering.IndexOf(compositeServiceFactory)));
-                    continue;
-                }
-
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(IDataConsumer)));
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_dataConsumerFactories, serviceProvider, dataConsumers, _factoryOrdering).ConfigureAwait(false);
+        await ExtensionBuilderHelper.BuildAndRegisterCompositeExtensionsAsync<IDataConsumer>(_dataConsumersCompositeServiceFactories, serviceProvider, dataConsumers, alreadyBuiltServices, _factoryOrdering).ConfigureAwait(false);
 
         return [.. dataConsumers];
     }
@@ -230,66 +158,8 @@ internal sealed class TestHostManager : ITestHostManager
     internal async Task<(IExtension TestSessionLifetimeHandler, int RegistrationOrder)[]> BuildTestSessionLifetimeHandleAsync(ServiceProvider serviceProvider, List<ICompositeExtensionFactory> alreadyBuiltServices)
     {
         List<(IExtension TestSessionLifetimeHandler, int RegistrationOrder)> testSessionLifetimeHandlers = [];
-        foreach (Func<IServiceProvider, ITestSessionLifetimeHandler> testSessionLifetimeHandlerFactory in _testSessionLifetimeHandlerFactories)
-        {
-            ITestSessionLifetimeHandler service = testSessionLifetimeHandlerFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            testSessionLifetimeHandlers.ValidateUniqueExtension(service, x => x.TestSessionLifetimeHandler);
-
-            // We initialize only if enabled
-            if (await service.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await service.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                testSessionLifetimeHandlers.Add((service, _factoryOrdering.IndexOf(testSessionLifetimeHandlerFactory)));
-            }
-        }
-
-        foreach (ICompositeExtensionFactory compositeServiceFactory in _testSessionLifetimeHandlerCompositeFactories)
-        {
-            ICompositeExtensionFactory? compositeFactoryInstance;
-
-            // We check if the same service is already built in some other build phase
-            if ((compositeFactoryInstance = alreadyBuiltServices.SingleOrDefault(x => x.GetType() == compositeServiceFactory.GetType())) is null)
-            {
-                // We clone the instance because we want to have fresh instance per BuildTestApplicationLifecycleCallbackAsync call
-                compositeFactoryInstance = (ICompositeExtensionFactory)compositeServiceFactory.Clone();
-
-                // Create the new fresh instance
-                var instance = (IExtension)compositeFactoryInstance.GetInstance(serviceProvider);
-
-                // Check if we have already extensions of the same type with same id registered
-                testSessionLifetimeHandlers.ValidateUniqueExtension(instance, x => x.TestSessionLifetimeHandler);
-
-                // We initialize only if enabled
-                if (await instance.IsEnabledAsync().ConfigureAwait(false))
-                {
-                    await instance.TryInitializeAsync().ConfigureAwait(false);
-                }
-
-                // Add to the list of shared singletons
-                alreadyBuiltServices.Add(compositeFactoryInstance);
-            }
-
-            // Get the singleton
-            var extension = (IExtension)compositeFactoryInstance.GetInstance();
-
-            // We register the extension only if enabled
-            if (await extension.IsEnabledAsync().ConfigureAwait(false))
-            {
-                if (extension is ITestSessionLifetimeHandler testSessionLifetimeHandler)
-                {
-                    // Register the extension for usage
-                    testSessionLifetimeHandlers.Add((testSessionLifetimeHandler, _factoryOrdering.IndexOf(compositeServiceFactory)));
-                }
-                else
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(ITestSessionLifetimeHandler)));
-                }
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_testSessionLifetimeHandlerFactories, serviceProvider, testSessionLifetimeHandlers, _factoryOrdering).ConfigureAwait(false);
+        await ExtensionBuilderHelper.BuildAndRegisterCompositeExtensionsAsync<ITestSessionLifetimeHandler>(_testSessionLifetimeHandlerCompositeFactories, serviceProvider, testSessionLifetimeHandlers, alreadyBuiltServices, _factoryOrdering).ConfigureAwait(false);
 
         return [.. testSessionLifetimeHandlers];
     }

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -154,163 +154,16 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
 
     internal async Task<TestHostControllerConfiguration> BuildAsync(ServiceProvider serviceProvider)
     {
-        List<(ITestHostEnvironmentVariableProvider TestHostEnvironmentVariableProvider, int RegistrationOrder)> environmentVariableProviders = [];
-        foreach (Func<IServiceProvider, ITestHostEnvironmentVariableProvider> environmentVariableProviderFactory in _environmentVariableProviderFactories)
-        {
-            ITestHostEnvironmentVariableProvider envVarProvider = environmentVariableProviderFactory(serviceProvider);
+        List<(IExtension Extension, int RegistrationOrder)> environmentVariableProviders = [];
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_environmentVariableProviderFactories, serviceProvider, environmentVariableProviders, _factoryOrdering, registerInServiceProvider: true).ConfigureAwait(false);
+        await ExtensionBuilderHelper.BuildAndRegisterCompositeExtensionsInPlaceAsync<ITestHostEnvironmentVariableProvider>(_environmentVariableProviderCompositeFactories, serviceProvider, environmentVariableProviders, _alreadyBuiltServices, _factoryOrdering).ConfigureAwait(false);
 
-            // Check if we have already extensions of the same type with same id registered
-            environmentVariableProviders.ValidateUniqueExtension(envVarProvider, x => x.TestHostEnvironmentVariableProvider);
+        List<(IExtension Extension, int RegistrationOrder)> lifetimeHandlers = [];
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_lifetimeHandlerFactories, serviceProvider, lifetimeHandlers, _factoryOrdering, registerInServiceProvider: true).ConfigureAwait(false);
+        await ExtensionBuilderHelper.BuildAndRegisterCompositeExtensionsInPlaceAsync<ITestHostProcessLifetimeHandler>(_lifetimeHandlerCompositeFactories, serviceProvider, lifetimeHandlers, _alreadyBuiltServices, _factoryOrdering).ConfigureAwait(false);
 
-            // We initialize only if enabled
-            if (await envVarProvider.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await envVarProvider.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                environmentVariableProviders.Add((envVarProvider, _factoryOrdering.IndexOf(environmentVariableProviderFactory)));
-                serviceProvider.TryAddService(envVarProvider);
-            }
-        }
-
-        foreach (ICompositeExtensionFactory compositeServiceFactory in _environmentVariableProviderCompositeFactories)
-        {
-            // Get the singleton
-            var extension = (IExtension)compositeServiceFactory.GetInstance(serviceProvider);
-            bool isEnabledAsync = await extension.IsEnabledAsync().ConfigureAwait(false);
-
-            // Check if we have already built the singleton for this composite factory
-            if (!_alreadyBuiltServices.Contains(compositeServiceFactory))
-            {
-                // Check if we have already extensions of the same type with same id registered
-                environmentVariableProviders.ValidateUniqueExtension(extension, x => x.TestHostEnvironmentVariableProvider);
-
-                // We initialize only if enabled
-                if (isEnabledAsync)
-                {
-                    await extension.TryInitializeAsync().ConfigureAwait(false);
-                }
-
-                // Add to the list of shared singletons
-                _alreadyBuiltServices.Add(compositeServiceFactory);
-            }
-
-            // We register the extension only if enabled
-            if (isEnabledAsync)
-            {
-                if (extension is ITestHostEnvironmentVariableProvider testHostEnvironmentVariableProvider)
-                {
-                    // Register the extension for usage
-                    environmentVariableProviders.Add((testHostEnvironmentVariableProvider, _factoryOrdering.IndexOf(compositeServiceFactory)));
-                    serviceProvider.TryAddService(testHostEnvironmentVariableProvider);
-                }
-                else
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(ITestHostEnvironmentVariableProvider)));
-                }
-            }
-        }
-
-        List<(ITestHostProcessLifetimeHandler TestHostProcessLifetimeHandler, int RegistrationOrder)> lifetimeHandlers = [];
-        foreach (Func<IServiceProvider, ITestHostProcessLifetimeHandler> lifetimeHandlerFactory in _lifetimeHandlerFactories)
-        {
-            ITestHostProcessLifetimeHandler lifetimeHandler = lifetimeHandlerFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            lifetimeHandlers.ValidateUniqueExtension(lifetimeHandler, x => x.TestHostProcessLifetimeHandler);
-
-            // We initialize only if enabled
-            if (await lifetimeHandler.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await lifetimeHandler.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                lifetimeHandlers.Add((lifetimeHandler, _factoryOrdering.IndexOf(lifetimeHandlerFactory)));
-                serviceProvider.TryAddService(lifetimeHandler);
-            }
-        }
-
-        foreach (ICompositeExtensionFactory compositeServiceFactory in _lifetimeHandlerCompositeFactories)
-        {
-            // Get the singleton
-            var extension = (IExtension)compositeServiceFactory.GetInstance(serviceProvider);
-            bool isEnabledAsync = await extension.IsEnabledAsync().ConfigureAwait(false);
-
-            // Check if we have already built the singleton for this composite factory
-            if (!_alreadyBuiltServices.Contains(compositeServiceFactory))
-            {
-                lifetimeHandlers.ValidateUniqueExtension(extension, x => x.TestHostProcessLifetimeHandler);
-
-                // We initialize only if enabled
-                if (isEnabledAsync)
-                {
-                    await extension.TryInitializeAsync().ConfigureAwait(false);
-                }
-
-                // Add to the list of shared singletons
-                _alreadyBuiltServices.Add(compositeServiceFactory);
-            }
-
-            // We register the extension only if enabled
-            if (isEnabledAsync)
-            {
-                if (extension is ITestHostProcessLifetimeHandler testHostProcessLifetimeHandler)
-                {
-                    // Register the extension for usage
-                    lifetimeHandlers.Add((testHostProcessLifetimeHandler, _factoryOrdering.IndexOf(compositeServiceFactory)));
-                    serviceProvider.TryAddService(testHostProcessLifetimeHandler);
-                }
-                else
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(ITestHostProcessLifetimeHandler)));
-                }
-            }
-        }
-
-        List<(IDataConsumer Consumer, int RegistrationOrder)> dataConsumers = [];
-
-        foreach (ICompositeExtensionFactory compositeServiceFactory in _dataConsumersCompositeServiceFactories)
-        {
-            ICompositeExtensionFactory? compositeFactoryInstance;
-
-            // We check if the same service is already built in some other build phase
-            if ((compositeFactoryInstance = _alreadyBuiltServices.SingleOrDefault(x => x.GetType() == compositeServiceFactory.GetType())) is null)
-            {
-                // We clone the instance because we want to have fresh instance per BuildTestApplicationLifecycleCallbackAsync call
-                compositeFactoryInstance = (ICompositeExtensionFactory)compositeServiceFactory.Clone();
-
-                // Create the new fresh instance
-                var instance = (IExtension)compositeFactoryInstance.GetInstance(serviceProvider);
-
-                // Check if we have already extensions of the same type with same id registered
-                dataConsumers.ValidateUniqueExtension(instance, x => x.Consumer);
-
-                // We initialize only if enabled
-                if (await instance.IsEnabledAsync().ConfigureAwait(false))
-                {
-                    await instance.TryInitializeAsync().ConfigureAwait(false);
-                }
-
-                // Add to the list of shared singletons
-                _alreadyBuiltServices.Add(compositeFactoryInstance);
-            }
-
-            // Get the singleton
-            var extension = (IExtension)compositeFactoryInstance.GetInstance();
-
-            // We register the extension only if enabled
-            if (await extension.IsEnabledAsync().ConfigureAwait(false))
-            {
-                if (extension is IDataConsumer consumer)
-                {
-                    // Register the extension for usage
-                    dataConsumers.Add((consumer, _factoryOrdering.IndexOf(compositeServiceFactory)));
-                    continue;
-                }
-
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.ExtensionDoesNotImplementGivenInterfaceErrorMessage, extension.GetType(), typeof(IDataConsumer)));
-            }
-        }
+        List<(IExtension Extension, int RegistrationOrder)> dataConsumers = [];
+        await ExtensionBuilderHelper.BuildAndRegisterCompositeExtensionsAsync<IDataConsumer>(_dataConsumersCompositeServiceFactories, serviceProvider, dataConsumers, _alreadyBuiltServices, _factoryOrdering).ConfigureAwait(false);
 
         bool requireProcessRestart = environmentVariableProviders.Count > 0 || lifetimeHandlers.Count > 0 || dataConsumers.Count > 0;
 
@@ -323,9 +176,9 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
         }
 
         return new TestHostControllerConfiguration(
-            [.. environmentVariableProviders.OrderBy(x => x.RegistrationOrder).Select(x => x.TestHostEnvironmentVariableProvider)],
-            [.. lifetimeHandlers.OrderBy(x => x.RegistrationOrder).Select(x => x.TestHostProcessLifetimeHandler)],
-            [.. dataConsumers.OrderBy(x => x.RegistrationOrder).Select(x => x.Consumer)],
+            [.. environmentVariableProviders.OrderBy(x => x.RegistrationOrder).Select(x => (ITestHostEnvironmentVariableProvider)x.Extension)],
+            [.. lifetimeHandlers.OrderBy(x => x.RegistrationOrder).Select(x => (ITestHostProcessLifetimeHandler)x.Extension)],
+            [.. dataConsumers.OrderBy(x => x.RegistrationOrder).Select(x => (IDataConsumer)x.Extension)],
             testHostLauncher,
             requireProcessRestart);
     }
@@ -333,22 +186,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     private async Task<ITestHostLauncher?> BuildTestHostLauncherAsync(ServiceProvider serviceProvider)
     {
         List<ITestHostLauncher> launchers = [];
-
-        foreach (Func<IServiceProvider, ITestHostLauncher> testHostLauncherFactory in _testHostLauncherFactories)
-        {
-            ITestHostLauncher launcher = testHostLauncherFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            launchers.ValidateUniqueExtension(launcher);
-
-            // We initialize only if enabled
-            if (await launcher.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await launcher.TryInitializeAsync().ConfigureAwait(false);
-                launchers.Add(launcher);
-                serviceProvider.TryAddService(launcher);
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_testHostLauncherFactories, serviceProvider, launchers, registerInServiceProvider: true).ConfigureAwait(false);
 
         foreach (ICompositeExtensionFactory compositeServiceFactory in _testHostLauncherCompositeFactories)
         {

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/TestHostOrchestratorManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/TestHostOrchestratorManager.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestHostOrchestrator;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Services;
@@ -38,22 +37,7 @@ internal class TestHostOrchestratorManager : ITestHostOrchestratorManager, Exten
         }
 
         List<ITestHostExecutionOrchestrator> orchestrators = [];
-        foreach (Func<IServiceProvider, ITestHostExecutionOrchestrator> factory in _factories)
-        {
-            ITestHostExecutionOrchestrator orchestrator = factory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            orchestrators.ValidateUniqueExtension(orchestrator);
-
-            // We initialize only if enabled
-            if (await orchestrator.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await orchestrator.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                orchestrators.Add(orchestrator);
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_factories, serviceProvider, orchestrators).ConfigureAwait(false);
 
         return new TestHostOrchestratorConfiguration([.. orchestrators]);
     }
@@ -67,22 +51,7 @@ internal class TestHostOrchestratorManager : ITestHostOrchestratorManager, Exten
     internal async Task<ITestHostOrchestratorApplicationLifetime[]> BuildTestHostOrchestratorApplicationLifetimesAsync(ServiceProvider serviceProvider)
     {
         List<ITestHostOrchestratorApplicationLifetime> lifetimes = [];
-        foreach (Func<IServiceProvider, ITestHostOrchestratorApplicationLifetime> testHostOrchestratorApplicationLifetimeFactory in _testHostOrchestratorApplicationLifetimeFactories)
-        {
-            ITestHostOrchestratorApplicationLifetime service = testHostOrchestratorApplicationLifetimeFactory(serviceProvider);
-
-            // Check if we have already extensions of the same type with same id registered
-            lifetimes.ValidateUniqueExtension(service);
-
-            // We initialize only if enabled
-            if (await service.IsEnabledAsync().ConfigureAwait(false))
-            {
-                await service.TryInitializeAsync().ConfigureAwait(false);
-
-                // Register the extension for usage
-                lifetimes.Add(service);
-            }
-        }
+        await ExtensionBuilderHelper.BuildAndRegisterExtensionsAsync(_testHostOrchestratorApplicationLifetimeFactories, serviceProvider, lifetimes).ConfigureAwait(false);
 
         return [.. lifetimes];
     }


### PR DESCRIPTION
## Summary

Fixes #9652.

Seven `*Manager` classes each independently re-implemented the same "instantiate → validate unique → check enabled → initialize → register" loop for building platform extensions. This PR extracts that logic into a new `Helpers/ExtensionBuilderHelper.cs` and delegates from the managers, removing ~325 lines of duplicated loop bodies.

## Helpers

- `BuildAndRegisterExtensionsAsync<T>(factories, sp, List<T> result, register)` — simple `List<T>` loop.
- `BuildAndRegisterExtensionsAsync<T>(factories, sp, List<(IExtension, int)> result, factoryOrdering, register)` — ordered simple loop (preserves registration order).
- `BuildAndRegisterCompositeExtensionsAsync<T>(...)` — clone-or-reuse-singleton composite variant.
- `BuildAndRegisterCompositeExtensionsInPlaceAsync<T>(...)` — reuse-in-place composite variant (env-var / lifetime providers).

## Call sites refactored

- `TestHostManager`: `BuildTestApplicationLifecycleCallbackAsync`, `BuildDataConsumersAsync`, `BuildTestSessionLifetimeHandleAsync` (simple + composite paths).
- `TestHostControllersManager`: env-var, lifetime, dataConsumers, and launcher build loops (simple + composite paths).
- `TestHostOrchestratorManager`: `BuildAsync`, `BuildTestHostOrchestratorApplicationLifetimesAsync`.

The `CommandLine`, `Configuration`, `Tools`, and `Logging` managers were intentionally **not** folded in: their loops genuinely differ (no uniqueness validation, cache-wrapping, `BuildAsync`/`LoadAsync`, or a different factory signature), so unifying them would change behavior. The single non-ordered composite launcher loop is also left inline as it has a unique result shape.

## Behavior

No functional changes: registration order, service-provider registration, enabled/initialize semantics, and the "does not implement interface" error paths are all preserved. In `TestHostControllersManager`, the local result lists were widened to `List<(IExtension, int)>` with concrete casts at the final projection — same objects, only the static tuple element type changed.

## Validation

- `Microsoft.Testing.Platform` builds clean across `net8.0`, `net9.0`, `netstandard2.0` (0 warnings/errors, IDE0005/StyleCop enforced).
- `Microsoft.Testing.Platform.UnitTests` pass on `net8.0`, `net9.0`, `net462`.