### PR TITLE
Extract shared fixture method invocation helper (#9685)

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestAssemblyInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestAssemblyInfo.cs
@@ -189,39 +189,27 @@ internal sealed class TestAssemblyInfo
                     try
                     {
                         AssemblyInitializationException = await FixtureMethodRunner.RunWithTimeoutAndCancellationAsync(
-                            async () =>
-                            {
-                                // NOTE: It's unclear what the effect is if we reset the current test context before vs after the capture.
-                                // It's safer to reset it before the capture.
-                                using (TestContextImplementation.SetCurrentTestContext(testContext))
+                            () => AssemblyInitializeMethod.InvokeAsFixtureMethodAsync(
+                                testContext,
+                                ec => ExecutionContext = ec,
+                                () =>
                                 {
-                                    Task? task = AssemblyInitializeMethod.GetInvokeResultAsync(null, testContext);
-                                    if (task is not null)
+                                    // The `is` check is defensive: this method is part of an internal
+                                    // but mockable surface, so unit tests can legitimately pass a
+                                    // mocked TestContext. Production callers always pass a
+                                    // TestContextImplementation.
+                                    if (testContext is TestContextImplementation testContextImpl)
                                     {
-                                        await task.ConfigureAwait(false);
+                                        // Capture a snapshot of TestContext.Properties so that values
+                                        // set during AssemblyInitialize flow to subsequent contexts
+                                        // (class init, test execution, class cleanup, assembly cleanup).
+                                        // PostAssemblyInitProperties uses Volatile.Read/Write so that
+                                        // callers on the IsAssemblyInitializeExecuted fast path
+                                        // (which bypasses _assemblyInfoExecuteSyncSemaphore) safely
+                                        // observe the published snapshot.
+                                        PostAssemblyInitProperties = testContextImpl.CaptureLifecycleProperties();
                                     }
-                                }
-
-                                // **After** we have executed the assembly initialize, we save the current context.
-                                // This context will contain async locals set by the assembly initialize method.
-                                ExecutionContext = ExecutionContext.Capture();
-
-                                // The `is` check is defensive: this method is part of an internal
-                                // but mockable surface, so unit tests can legitimately pass a
-                                // mocked TestContext. Production callers always pass a
-                                // TestContextImplementation.
-                                if (testContext is TestContextImplementation testContextImpl)
-                                {
-                                    // Capture a snapshot of TestContext.Properties so that values
-                                    // set during AssemblyInitialize flow to subsequent contexts
-                                    // (class init, test execution, class cleanup, assembly cleanup).
-                                    // PostAssemblyInitProperties uses Volatile.Read/Write so that
-                                    // callers on the IsAssemblyInitializeExecuted fast path
-                                    // (which bypasses _assemblyInfoExecuteSyncSemaphore) safely
-                                    // observe the published snapshot.
-                                    PostAssemblyInitProperties = testContextImpl.CaptureLifecycleProperties();
-                                }
-                            },
+                                }),
                             testContext.CancellationTokenSource,
                             AssemblyInitializeMethodTimeoutMilliseconds,
                             AssemblyInitializeMethod,
@@ -286,23 +274,9 @@ internal sealed class TestAssemblyInfo
         {
             await _assemblyInfoExecuteSyncSemaphore.WaitAsync().ConfigureAwait(false);
             AssemblyCleanupException = await FixtureMethodRunner.RunWithTimeoutAndCancellationAsync(
-                 async () =>
-                 {
-                     // NOTE: It's unclear what the effect is if we reset the current test context before vs after the capture.
-                     // It's safer to reset it before the capture.
-                     using (TestContextImplementation.SetCurrentTestContext(testContext))
-                     {
-                         Task? task = AssemblyCleanupMethod.GetParameters().Length == 0
-                             ? AssemblyCleanupMethod.GetInvokeResultAsync(null)
-                             : AssemblyCleanupMethod.GetInvokeResultAsync(null, testContext);
-                         if (task is not null)
-                         {
-                             await task.ConfigureAwait(false);
-                         }
-                     }
-
-                     ExecutionContext = ExecutionContext.Capture();
-                 },
+                 () => AssemblyCleanupMethod.InvokeAsFixtureMethodAsync(
+                     testContext,
+                     ec => ExecutionContext = ec),
                  testContext.CancellationTokenSource,
                  AssemblyCleanupMethodTimeoutMilliseconds,
                  AssemblyCleanupMethod,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Cleanup.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Cleanup.cs
@@ -203,27 +203,9 @@ internal sealed partial class TestClassInfo
         }
 
         TestFailedException? result = await FixtureMethodRunner.RunWithTimeoutAndCancellationAsync(
-            async () =>
-            {
-                // NOTE: It's unclear what the effect is if we reset the current test context before vs after the capture.
-                // It's safer to reset it before the capture.
-                using (TestContextImplementation.SetCurrentTestContext(testContext))
-                {
-                    Task? task = methodInfo.GetParameters().Length == 0
-                        ? methodInfo.GetInvokeResultAsync(null)
-                        : methodInfo.GetInvokeResultAsync(null, testContext);
-
-                    if (task is not null)
-                    {
-                        await task.ConfigureAwait(false);
-                    }
-                }
-
-                // **After** we have executed the class cleanup, we save the current context.
-                // This context will contain async locals set by the current class cleanup method.
-                // This is essential to propagate async locals between multiple class cleanup methods.
-                ExecutionContext = ExecutionContext.Capture();
-            },
+            () => methodInfo.InvokeAsFixtureMethodAsync(
+                testContext,
+                ec => ExecutionContext = ec),
             testContext.CancellationTokenSource,
             timeout,
             methodInfo,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Initializer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Initializer.cs
@@ -283,23 +283,9 @@ internal sealed partial class TestClassInfo
         }
 
         TestFailedException? result = await FixtureMethodRunner.RunWithTimeoutAndCancellationAsync(
-            async () =>
-            {
-                // NOTE: It's unclear what the effect is if we reset the current test context before vs after the capture.
-                // It's safer to reset it before the capture.
-                using (TestContextImplementation.SetCurrentTestContext(testContext))
-                {
-                    Task? task = methodInfo.GetInvokeResultAsync(null, testContext);
-                    if (task is not null)
-                    {
-                        await task.ConfigureAwait(false);
-                    }
-                }
-
-                // **After** we have executed the class initialize, we save the current context.
-                // This context will contain async locals set by the class initialize method.
-                ExecutionContext = ExecutionContext.Capture();
-            },
+            () => methodInfo.InvokeAsFixtureMethodAsync(
+                testContext,
+                ec => ExecutionContext = ec),
             testContext.CancellationTokenSource,
             timeout,
             methodInfo,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/MethodInfoExtensions.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Execution;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -114,6 +116,43 @@ internal static class MethodInfoExtensions
     {
         AsyncStateMachineAttribute? asyncStateMachineAttribute = (reflectHelper ?? ReflectHelper.Instance).GetFirstAttributeOrDefault<AsyncStateMachineAttribute>(method);
         return asyncStateMachineAttribute?.StateMachineType?.FullName;
+    }
+
+    /// <summary>
+    /// Invokes a static lifecycle fixture method (assembly/class initialize or cleanup) and captures the
+    /// <see cref="ExecutionContext"/> that results from its execution.
+    /// </summary>
+    /// <param name="methodInfo">The fixture method to invoke.</param>
+    /// <param name="testContext">The test context to set as current and (when the method is parameterized) pass to the method.</param>
+    /// <param name="setExecutionContext">
+    /// Receives the <see cref="ExecutionContext"/> captured after the fixture method executed. This context
+    /// contains async locals set by the fixture method and is used to flow state to subsequent lifecycle methods.
+    /// </param>
+    /// <param name="afterExecutionContextCaptured">Optional callback invoked after the execution context has been captured (e.g. to snapshot test context properties).</param>
+    internal static async SynchronizationContextPreservingTask InvokeAsFixtureMethodAsync(
+        this MethodInfo methodInfo,
+        TestContext testContext,
+        Action<ExecutionContext?> setExecutionContext,
+        Action? afterExecutionContextCaptured = null)
+    {
+        // NOTE: It's unclear what the effect is if we reset the current test context before vs after the capture.
+        // It's safer to reset it before the capture.
+        using (TestContextImplementation.SetCurrentTestContext(testContext))
+        {
+            Task? task = methodInfo.GetParameters().Length == 0
+                ? methodInfo.GetInvokeResultAsync(null)
+                : methodInfo.GetInvokeResultAsync(null, testContext);
+            if (task is not null)
+            {
+                await task.ConfigureAwait(false);
+            }
+        }
+
+        // **After** we have executed the fixture method, we save the current context.
+        // This context will contain async locals set by the fixture method.
+        setExecutionContext(ExecutionContext.Capture());
+
+        afterExecutionContextCaptured?.Invoke();
     }
 
     internal static Task? GetInvokeResultAsync(this MethodInfo methodInfo, object? classInstance, params object?[]? arguments)


### PR DESCRIPTION
Fixes #9685.

## Summary

The inner lambda passed to `FixtureMethodRunner.RunWithTimeoutAndCancellationAsync` followed an identical three-step structure — (1) set the current test context via `TestContextImplementation.SetCurrentTestContext`, (2) invoke the method with `GetInvokeResultAsync`, (3) capture `ExecutionContext` — in four separate lifecycle sites across two files. The `// NOTE: It's unclear...` comment was even duplicated verbatim in three of them.

This extracts that logic into a single `InvokeAsFixtureMethodAsync` extension method on `MethodInfoExtensions` and replaces all four call sites.

## Changes

- **`MethodInfoExtensions.cs`**: New `InvokeAsFixtureMethodAsync` extension. It sets the current test context, invokes the method (passing `testContext` only when the method is parameterized), captures the resulting `ExecutionContext` via a `setExecutionContext` callback, and runs an optional `afterExecutionContextCaptured` callback for post-capture side effects. It returns `SynchronizationContextPreservingTask` so semantics are identical to the original inline async lambdas.
- **`TestAssemblyInfo.cs`**: Assembly initialize and assembly cleanup now call the helper. The `PostAssemblyInitProperties` snapshot is passed through the `afterExecutionContextCaptured` callback.
- **`TestClassInfo.Initializer.cs`** / **`TestClassInfo.Cleanup.cs`**: Class initialize and class cleanup now call the helper.

The unified parameter check (`GetParameters().Length == 0`) is behavior-preserving: initialize methods always have exactly one `TestContext` parameter, so they still receive `testContext`; cleanup methods keep their parameterless/parameterized handling.

Net change: 66 insertions, 85 deletions (~56 duplicated lines removed).

## Validation

- `MSTestAdapter.PlatformServices` builds cleanly across all TFMs (net462, net8.0, net9.0, uap, windows) with 0 warnings.
- `MSTestAdapter.UnitTests` pass across net462, net48, net8.0, net9.0, and net8.0-windows.