### PR TITLE
Deduplicate TestResult output capture block

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Cleanup.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Cleanup.cs
@@ -169,25 +169,20 @@ internal sealed partial class TestClassInfo
             var testContextImpl = testContext as TestContextImplementation;
             if (ex is not null)
             {
-                return new TestResult()
+                var failedResult = new TestResult()
                 {
                     Outcome = UnitTestOutcome.Failed,
                     DisplayName = $"[{ClassType.FullName} ClassCleanup]",
                     TestFailureException = ex,
-                    LogOutput = testContextImpl?.GetAndClearOutput(),
-                    LogError = testContextImpl?.GetAndClearError(),
-                    DebugTrace = testContextImpl?.GetAndClearTrace(),
-                    TestContextMessages = testContext.GetAndClearDiagnosticMessages(),
                 };
+                failedResult.SetOutputAndTraces(testContextImpl, testContext);
+                return failedResult;
             }
 
             if (results.Length > 0)
             {
                 TestResult lastResult = results[results.Length - 1];
-                lastResult.LogOutput += testContextImpl?.GetAndClearOutput();
-                lastResult.LogError += testContextImpl?.GetAndClearError();
-                lastResult.DebugTrace += testContextImpl?.GetAndClearTrace();
-                lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
+                lastResult.AppendOutputAndTraces(testContextImpl, testContext);
             }
 
             return null;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Initializer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestClassInfo.Initializer.cs
@@ -253,10 +253,7 @@ internal sealed partial class TestClassInfo
             {
                 // Assembly initialize and class initialize logs are pre-pended to the first result.
                 var testContextImpl = testContext as TestContextImplementation;
-                result.LogOutput = initializationLogs + testContextImpl?.GetAndClearOutput();
-                result.LogError = initializationErrorLogs + testContextImpl?.GetAndClearError();
-                result.DebugTrace = initializationTrace + testContextImpl?.GetAndClearTrace();
-                result.TestContextMessages = initializationTestContextMessages + testContext.GetAndClearDiagnosticMessages();
+                result.SetOutputAndTraces(testContextImpl, testContext, initializationLogs, initializationErrorLogs, initializationTrace, initializationTestContextMessages);
             }
 
             // Publish with Volatile.Write so callers on the cached-result fast path of

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -151,10 +151,7 @@ internal partial class TestMethodInfo : ITestMethod
             if (result != null)
             {
                 var testContextImpl = TestContext as TestContextImplementation;
-                result.LogOutput = testContextImpl?.GetAndClearOutput();
-                result.LogError = testContextImpl?.GetAndClearError();
-                result.DebugTrace = testContextImpl?.GetAndClearTrace();
-                result.TestContextMessages = TestContext?.GetAndClearDiagnosticMessages();
+                result.SetOutputAndTraces(testContextImpl, TestContext);
                 result.ResultFiles = TestContext?.GetResultFiles();
                 result.Duration = watch.Elapsed;
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.AssemblyLifecycle.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.AssemblyLifecycle.cs
@@ -29,10 +29,7 @@ internal sealed partial class UnitTestRunner
         {
             result ??= new TestResult { Outcome = UnitTestOutcome.Error };
             var testContextImpl = testContext.Context as TestContextImplementation;
-            result.LogOutput = testContextImpl?.GetAndClearOutput();
-            result.LogError = testContextImpl?.GetAndClearError();
-            result.DebugTrace = testContextImpl?.GetAndClearTrace();
-            result.TestContextMessages = testContext.GetAndClearDiagnosticMessages();
+            result.SetOutputAndTraces(testContextImpl, testContext);
         }
 
         return result;
@@ -54,24 +51,19 @@ internal sealed partial class UnitTestRunner
 
             if (ex is not null)
             {
-                return new TestResult()
+                var failedResult = new TestResult()
                 {
                     Outcome = UnitTestOutcome.Failed,
                     TestFailureException = ex,
-                    LogOutput = testContextImpl?.GetAndClearOutput(),
-                    LogError = testContextImpl?.GetAndClearError(),
-                    DebugTrace = testContextImpl?.GetAndClearTrace(),
-                    TestContextMessages = testContext.GetAndClearDiagnosticMessages(),
                 };
+                failedResult.SetOutputAndTraces(testContextImpl, testContext);
+                return failedResult;
             }
 
             if (results.Length > 0)
             {
                 TestResult lastResult = results[results.Length - 1];
-                lastResult.LogOutput += testContextImpl?.GetAndClearOutput();
-                lastResult.LogError += testContextImpl?.GetAndClearError();
-                lastResult.DebugTrace += testContextImpl?.GetAndClearTrace();
-                lastResult.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
+                lastResult.AppendOutputAndTraces(testContextImpl, testContext);
             }
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestResultExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestResultExtensions.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+
+internal static class TestResultExtensions
+{
+    /// <summary>
+    /// Captures the output, error, trace and diagnostic messages from the test context and
+    /// assigns them to the corresponding <see cref="TestResult"/> properties.
+    /// </summary>
+    /// <param name="result">The test result to populate.</param>
+    /// <param name="testContextImpl">The test context implementation to read (and clear) output, error and trace from. May be <see langword="null"/>.</param>
+    /// <param name="testContext">The test context to read (and clear) diagnostic messages from.</param>
+    public static void SetOutputAndTraces(this TestResult result, TestContextImplementation? testContextImpl, ITestContext testContext)
+    {
+        result.LogOutput = testContextImpl?.GetAndClearOutput();
+        result.LogError = testContextImpl?.GetAndClearError();
+        result.DebugTrace = testContextImpl?.GetAndClearTrace();
+        result.TestContextMessages = testContext.GetAndClearDiagnosticMessages();
+    }
+
+    /// <summary>
+    /// Captures the output, error, trace and diagnostic messages from the test context and
+    /// assigns them to the corresponding <see cref="TestResult"/> properties, pre-pending the
+    /// provided prefixes (typically assembly/class initialize logs).
+    /// </summary>
+    /// <param name="result">The test result to populate.</param>
+    /// <param name="testContextImpl">The test context implementation to read (and clear) output, error and trace from. May be <see langword="null"/>.</param>
+    /// <param name="testContext">The test context to read (and clear) diagnostic messages from.</param>
+    /// <param name="outputPrefix">The value pre-pended to the captured output.</param>
+    /// <param name="errorPrefix">The value pre-pended to the captured error.</param>
+    /// <param name="tracePrefix">The value pre-pended to the captured trace.</param>
+    /// <param name="messagesPrefix">The value pre-pended to the captured diagnostic messages.</param>
+    public static void SetOutputAndTraces(this TestResult result, TestContextImplementation? testContextImpl, ITestContext testContext, string? outputPrefix, string? errorPrefix, string? tracePrefix, string? messagesPrefix)
+    {
+        result.LogOutput = outputPrefix + testContextImpl?.GetAndClearOutput();
+        result.LogError = errorPrefix + testContextImpl?.GetAndClearError();
+        result.DebugTrace = tracePrefix + testContextImpl?.GetAndClearTrace();
+        result.TestContextMessages = messagesPrefix + testContext.GetAndClearDiagnosticMessages();
+    }
+
+    /// <summary>
+    /// Captures the output, error, trace and diagnostic messages from the test context and
+    /// appends them to the corresponding <see cref="TestResult"/> properties.
+    /// </summary>
+    /// <param name="result">The test result to append to.</param>
+    /// <param name="testContextImpl">The test context implementation to read (and clear) output, error and trace from. May be <see langword="null"/>.</param>
+    /// <param name="testContext">The test context to read (and clear) diagnostic messages from.</param>
+    public static void AppendOutputAndTraces(this TestResult result, TestContextImplementation? testContextImpl, ITestContext testContext)
+    {
+        result.LogOutput += testContextImpl?.GetAndClearOutput();
+        result.LogError += testContextImpl?.GetAndClearError();
+        result.DebugTrace += testContextImpl?.GetAndClearTrace();
+        result.TestContextMessages += testContext.GetAndClearDiagnosticMessages();
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestResultOutputExtensions.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Extensions/TestResultOutputExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
 
-internal static class TestResultExtensions
+internal static class TestResultOutputExtensions
 {
     /// <summary>
     /// Captures the output, error, trace and diagnostic messages from the test context and
@@ -26,16 +26,16 @@ internal static class TestResultExtensions
 
     /// <summary>
     /// Captures the output, error, trace and diagnostic messages from the test context and
-    /// assigns them to the corresponding <see cref="TestResult"/> properties, pre-pending the
+    /// assigns them to the corresponding <see cref="TestResult"/> properties, prepending the
     /// provided prefixes (typically assembly/class initialize logs).
     /// </summary>
     /// <param name="result">The test result to populate.</param>
     /// <param name="testContextImpl">The test context implementation to read (and clear) output, error and trace from. May be <see langword="null"/>.</param>
     /// <param name="testContext">The test context to read (and clear) diagnostic messages from.</param>
-    /// <param name="outputPrefix">The value pre-pended to the captured output.</param>
-    /// <param name="errorPrefix">The value pre-pended to the captured error.</param>
-    /// <param name="tracePrefix">The value pre-pended to the captured trace.</param>
-    /// <param name="messagesPrefix">The value pre-pended to the captured diagnostic messages.</param>
+    /// <param name="outputPrefix">The value prepended to the captured output.</param>
+    /// <param name="errorPrefix">The value prepended to the captured error.</param>
+    /// <param name="tracePrefix">The value prepended to the captured trace.</param>
+    /// <param name="messagesPrefix">The value prepended to the captured diagnostic messages.</param>
     public static void SetOutputAndTraces(this TestResult result, TestContextImplementation? testContextImpl, ITestContext testContext, string? outputPrefix, string? errorPrefix, string? tracePrefix, string? messagesPrefix)
     {
         result.LogOutput = outputPrefix + testContextImpl?.GetAndClearOutput();


### PR DESCRIPTION
Fixes #9684.

## Summary

The 4-line block that captures `LogOutput`, `LogError`, `DebugTrace`, and `TestContextMessages` from a test context into a `TestResult` was copy-pasted 7 times across 4 files. This PR centralizes it into a new `TestResultExtensions` class with three behavior-preserving helpers:

- `SetOutputAndTraces(impl, ctx)` — assignment variant
- `SetOutputAndTraces(impl, ctx, outputPrefix, errorPrefix, tracePrefix, messagesPrefix)` — prefix-concatenation variant (class/assembly init logs)
- `AppendOutputAndTraces(impl, ctx)` — the `+=` variant

All 7 call sites now delegate to these helpers. The two object-initializer sites were converted to construct-then-populate so they can reuse the helper.

## Call sites updated

- `Execution/TestMethodInfo.cs`
- `Execution/UnitTestRunner.AssemblyLifecycle.cs` (3 sites)
- `Execution/TestClassInfo.Cleanup.cs` (2 sites)
- `Execution/TestClassInfo.Initializer.cs`

## Verification

- `MSTestAdapter.PlatformServices` builds clean (0 warnings / 0 errors) across all TFMs.
- `MSTestAdapter.PlatformServices.UnitTests` pass on net462, net48, net8.0, net9.0, and net8.0-windows.

Net: 28 duplicated lines collapsed into a single reusable location, so adding a future output stream requires editing one place.