### PR TITLE
Fix #9595: TestContext API surface consistency gaps

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/TestContextPropertyUsageAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestContextPropertyUsageAnalyzer.cs
@@ -42,14 +42,12 @@ public sealed class TestContextPropertyUsageAnalyzer : DiagnosticAnalyzer
         "TestDisplayName",
         "DataRow",
         "DataConnection",
-        "TestName",
-        "ManagedMethod");
+        "TestName");
 
     // Properties that cannot be accessed in assembly initialize or assembly cleanup
     private static readonly ImmutableHashSet<string> RestrictedInAssemblyMethods = ImmutableHashSet.Create(
         StringComparer.Ordinal,
-        "FullyQualifiedTestClassName",
-        "ManagedType");
+        "FullyQualifiedTestClassName");
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -68,13 +66,16 @@ public sealed class TestContextPropertyUsageAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            context.RegisterOperationAction(context => AnalyzePropertyReference(context, testContextSymbol, assemblyInitializeAttributeSymbol, assemblyCleanupAttributeSymbol, classInitializeAttributeSymbol, classCleanupAttributeSymbol), OperationKind.PropertyReference);
+            IPropertySymbol? propertiesSymbol = testContextSymbol.GetMembers("Properties").OfType<IPropertySymbol>().FirstOrDefault();
+
+            context.RegisterOperationAction(context => AnalyzePropertyReference(context, testContextSymbol, propertiesSymbol, assemblyInitializeAttributeSymbol, assemblyCleanupAttributeSymbol, classInitializeAttributeSymbol, classCleanupAttributeSymbol), OperationKind.PropertyReference);
         });
     }
 
     private static void AnalyzePropertyReference(
         OperationAnalysisContext context,
         INamedTypeSymbol testContextSymbol,
+        IPropertySymbol? propertiesSymbol,
         INamedTypeSymbol assemblyInitializeAttributeSymbol,
         INamedTypeSymbol assemblyCleanupAttributeSymbol,
         INamedTypeSymbol classInitializeAttributeSymbol,
@@ -82,13 +83,21 @@ public sealed class TestContextPropertyUsageAnalyzer : DiagnosticAnalyzer
     {
         var propertyReference = (IPropertyReferenceOperation)context.Operation;
 
-        // Check if the property is a TestContext property
-        if (!SymbolEqualityComparer.Default.Equals(propertyReference.Property.ContainingType, testContextSymbol))
+        string? propertyName;
+        if (SymbolEqualityComparer.Default.Equals(propertyReference.Property.ContainingType, testContextSymbol))
+        {
+            // Direct typed property access, e.g. testContext.TestName.
+            propertyName = propertyReference.Property.Name;
+        }
+        else if (TryGetRestrictedPropertiesIndexerKey(propertyReference, propertiesSymbol) is { } key)
+        {
+            // Indirect access through the string-keyed bag, e.g. testContext.Properties["TestName"].
+            propertyName = key;
+        }
+        else
         {
             return;
         }
-
-        string propertyName = propertyReference.Property.Name;
 
         // Check if we're in a forbidden context
         if (context.ContainingSymbol is not IMethodSymbol containingMethod)
@@ -114,6 +123,38 @@ public sealed class TestContextPropertyUsageAnalyzer : DiagnosticAnalyzer
         {
             context.ReportDiagnostic(propertyReference.CreateDiagnostic(Rule, propertyName, GetMethodType(isAssemblyInitialize, isAssemblyCleanup, isClassInitialize, isClassCleanup)));
         }
+    }
+
+    private static string? TryGetRestrictedPropertiesIndexerKey(IPropertyReferenceOperation propertyReference, IPropertySymbol? propertiesSymbol)
+    {
+        // We only care about indexer access such as testContext.Properties["TestName"].
+        if (propertiesSymbol is null
+            || !propertyReference.Property.IsIndexer
+            || propertyReference.Arguments.Length != 1
+            || propertyReference.Instance is not IPropertyReferenceOperation instanceReference
+            || !IsTestContextPropertiesReference(instanceReference.Property, propertiesSymbol))
+        {
+            return null;
+        }
+
+        // The key must be a compile-time constant string.
+        return propertyReference.Arguments[0].Value.ConstantValue is { HasValue: true, Value: string key }
+            ? key
+            : null;
+    }
+
+    private static bool IsTestContextPropertiesReference(IPropertySymbol property, IPropertySymbol propertiesSymbol)
+    {
+        // Match TestContext.Properties as well as overrides of it in derived contexts.
+        for (IPropertySymbol? current = property; current is not null; current = current.OverriddenProperty)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, propertiesSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string GetMethodType(bool isAssemblyInitialize, bool isAssemblyCleanup, bool isClassInitialize, bool isClassCleanup)

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -223,15 +223,13 @@ public abstract class TestContext
         where T : class
     {
         DebugEx.Assert(Properties is not null, "Properties is null");
-#if WINDOWS_UWP || WIN_UI
+
+        // Use TryGetValue rather than the indexer so a missing key returns null instead of throwing,
+        // regardless of the IDictionary implementation a custom subclass provides.
         if (!Properties.TryGetValue(name, out object? propertyValue))
         {
             return null;
         }
-#else
-        // This old API doesn't throw when key is not found, but returns null.
-        object? propertyValue = Properties[name];
-#endif
 
         // If propertyValue has a value, but it's not the right type
         if (propertyValue is not null and not T)

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextPropertyUsageAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestContextPropertyUsageAnalyzerTests.cs
@@ -315,4 +315,105 @@ public sealed class TestContextPropertyUsageAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenRestrictedPropertyAccessedThroughPropertiesBagInFixtureMethods_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext testContext)
+                {
+                    _ = [|testContext.Properties["TestData"]|];
+                    _ = [|testContext.Properties["TestDisplayName"]|];
+                    _ = [|testContext.Properties["TestName"]|];
+                    _ = [|testContext.Properties["FullyQualifiedTestClassName"]|];
+                }
+
+                [ClassInitialize]
+                public static void ClassInit(TestContext testContext)
+                {
+                    _ = [|testContext.Properties["TestName"]|];
+                    // FullyQualifiedTestClassName is allowed in class initialize.
+                    _ = testContext.Properties["FullyQualifiedTestClassName"];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenRestrictedPropertyAccessedThroughPropertiesBagInTestMethod_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public void TestMethod()
+                {
+                    _ = TestContext.Properties["TestName"];
+                    _ = TestContext.Properties["TestData"];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenNonConstantOrUnrelatedKeyAccessedThroughPropertiesBagInFixtureMethods_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext testContext)
+                {
+                    // Non-restricted key.
+                    _ = testContext.Properties["MyCustomKey"];
+                    // Non-constant key cannot be resolved.
+                    string key = "TestName";
+                    _ = testContext.Properties[key];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenManagedMethodOrManagedTypeAccessedThroughPropertiesBagInFixtureMethods_NoDiagnostic()
+    {
+        // "ManagedMethod" and "ManagedType" are VSTest TestCase-level keys in the string-keyed
+        // Properties bag; they are not restricted TestContext properties, so no diagnostic is reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext testContext)
+                {
+                    _ = testContext.Properties["ManagedMethod"];
+                    _ = testContext.Properties["ManagedType"];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
Fixes #9595 (Tasks 1, 4, and 5). Task 2 is intentionally not included, and Task 3 is deliberately skipped — see notes below.

## Task 1 — Remove dead MSTEST0048 entries
Removed `"ManagedMethod"` and `"ManagedType"` from the restriction sets in `TestContextPropertyUsageAnalyzer`. Neither is a typed C# property on `TestContext` (they only exist as string keys in the `TestContext.Properties` bag), so the analyzer's `OperationKind.PropertyReference` path could never match them — they were permanently dead code.

## Task 5 — Extend MSTEST0048 to cover `Properties["restricted-key"]`
The analyzer now also flags restricted access through the string-keyed bag (e.g. `testContext.Properties["TestName"]`) when the key is a compile-time constant. This prevents users from silencing MSTEST0048 by switching to the string-key path only to hit a `KeyNotFoundException` at runtime instead of the intended `InvalidOperationException`.

## Task 4 — Fix the misleading `GetProperty<T>` comment / switch to `TryGetValue`
In `TestContext.GetProperty<T>` the non-UWP branch used `Properties[name]` with a comment claiming it "doesn't throw when key is not found, but returns null" — but `IDictionary`'s indexer **does** throw `KeyNotFoundException`. Replaced it with `TryGetValue` so a missing key returns `null` as documented, regardless of the `IDictionary` implementation a custom subclass provides. The UWP/non-UWP branches are now identical and collapsed.

## Tests
Added analyzer coverage for the new behavior:
- Diagnostic on `Properties["restricted-key"]` in fixture methods (respecting the assembly-vs-all-fixture distinction).
- No diagnostic on the same access in a test method.
- No diagnostic for non-constant keys or unrelated keys.
- No diagnostic for `ManagedMethod`/`ManagedType` bag keys.

All 14 `TestContextPropertyUsageAnalyzerTests` pass; full repo build is green.

## On Task 2 and Task 3 (not implemented)
- **Task 2** (parameterless `WriteLine()`): excluded at the requester's direction.
- **Task 3** (ISH overloads on `Write`/`WriteLine`): deliberately skipped. The Assert ISH pattern is valuable only because it *short-circuits* — it never builds the message when the assertion passes. But `Write`/`WriteLine` **always** emit output, and the issue's suggested `Write(message.ToString())` impl would build a `StringBuilder`, materialize a string, then write it — strictly more allocation than today's single-string path — while also changing overload resolution for every existing `context.Write($"...")` call and adding permanent public API. This is the same flaw class as the excluded Task 2, so it was left out.