### PR TITLE
ci: Add --ci to Linux official Build step so the logs artifact is produced

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -233,6 +233,7 @@ extends:
             - script: eng/common/build.sh
                 -configuration $(_BuildConfig)
                 -prepareMachine
+                --ci
                 --restore
                 --build
                 --pack


### PR DESCRIPTION
## Problem

The official pipeline's **Linux** job fails at the 1ES **"Verify output meets non-production criteria"** step:

```
##[error]1ES PT Error: Error while checking non-production output criteria:
Cannot find path '/mnt/vss/_work/1/a/artifacts/log' because it does not exist.
```

## Root cause

The `logs: true` artifact publish targets `$(Build.ArtifactStagingDirectory)/artifacts/log` and is marked `isProduction: false`, so 1ES injects a non-production output scan of that path. That staging directory is only created by arcade's `CopyFiles` step (`SourceFolder: 'artifacts/log'`), which in turn requires `artifacts/log/<Config>/Build.binlog` to exist.

In `eng/common/build.sh`, binary logging is only enabled when `--ci` is passed (`ci=true` → `binary_log=true`). The Linux **Build** step invoked `build.sh` **without `--ci`**, so no binlog was written, `artifacts/log` stayed empty, the staging directory was never created, and the scan failed.

The Windows job passes because it builds via `CIBuild.cmd`, which adds `-ci` internally.

## Fix

Add `--ci` to the Linux Build step, matching the Windows job and the Linux Test step (which already uses `--ci`).

A companion PR applies the same one-line fix to `rel/4.3`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>