### PR TITLE
Native MTP integration for MSTest — RFC 018 + Phases 1–5 (opt-in native path)

### DIFF
--- a/docs/RFCs/018-Native-MTP-Integration-For-MSTest.md
+++ b/docs/RFCs/018-Native-MTP-Integration-For-MSTest.md
@@ -81,7 +81,7 @@ MTP ITestFramework request (Discover/Run)  ──►  Microsoft.Testing.Extensio
                         TestNodeUpdateMessage  ──►  MTP IMessageBus
 ```
 
-The neutral seams already exist in `src\Adapter\MSTestAdapter.PlatformServices\Interfaces`:
+The neutral seams already exist in `src/Adapter/MSTestAdapter.PlatformServices/Interfaces`:
 
 | Neutral seam | Role | VSTest impl today |
 | --- | --- | --- |

--- a/docs/RFCs/018-Native-MTP-Integration-For-MSTest.md
+++ b/docs/RFCs/018-Native-MTP-Integration-For-MSTest.md
@@ -1,0 +1,219 @@
+# RFC 018 - Native Microsoft.Testing.Platform integration for MSTest (retire the VSTest bridge)
+
+- [ ] Approved in principle
+- [x] Under discussion
+- [ ] Implementation
+- [ ] Shipped
+
+## Summary
+
+When MSTest runs on Microsoft.Testing.Platform (MTP) today, it does **not** talk to MTP
+directly. It goes through `Microsoft.Testing.Extensions.VSTestBridge`, which re-materializes the
+VSTest object model (`TestCase`, `TestResult`, `IFrameworkHandle`, `IRunContext`,
+`IDiscoveryContext`, `ITestCaseDiscoverySink`, `IMessageLogger`, `IRunSettings`) so the existing
+VSTest-shaped adapter can be reused, and then converts the VSTest results back into MTP
+`TestNode`/`TestNodeUpdateMessage` objects on the way out.
+
+This RFC proposes to remove that indirection for MSTest and plug MSTest into MTP **natively** as
+a first-class `ITestFramework`, producing `TestNode`s directly from MSTest's own neutral
+execution model. The VSTest adapter (`MSTest.TestAdapter`'s `ITestDiscoverer`/`ITestExecutor`)
+stays for the VSTest host; the bridge is retired only from the MTP code path for MSTest.
+
+This is a **staged** effort. Each phase is independently shippable, keeps the bridge as the
+default until the native path reaches parity, and can be validated by the existing acceptance
+suite before the next phase begins.
+
+## Motivation
+
+The bridge was the right call to get MSTest onto MTP quickly with maximum reuse. It now costs us:
+
+1. **A double conversion on every discovery and every result.** MSTest produces a neutral
+   `UnitTestElement` / framework `TestResult`, the adapter boundary converts it to a VSTest
+   `TestCase` / `TestResult`, and `ObjectModelConverters.ToTestNode` immediately converts that
+   back into an MTP `TestNode`. The VSTest object model is a pure intermediary that carries no
+   information MSTest does not already have.
+
+2. **Information loss.** Because the intermediary is VSTest's `TestCase`, data that MSTest knows
+   but VSTest's model cannot carry is dropped. The clearest example is in
+   `MSTestBridgedTestFramework.GetMethodIdentifierPropertyFromManagedTypeAndManagedMethod`, where
+   `TestMethodIdentifierProperty` is built with `assemblyFullName: string.Empty` and
+   `returnTypeFullName: string.Empty` and an inline comment:
+   *"In the context of the VSTestBridge where we only have access to VSTest object model, we
+   cannot determine ReturnTypeFullName ... the eventual goal should be to stop using the
+   VSTestBridge altogether."*
+
+3. **A large surface of adapter shims** whose only purpose is to fake VSTest contracts on top of
+   MTP: `RunContextAdapter`, `DiscoveryContextAdapter`, `FrameworkHandlerAdapter`,
+   `MessageLoggerAdapter`, `TestCaseDiscoverySinkAdapter`, `RunSettingsAdapter`,
+   `RunSettingsPatcher`, `ContextAdapterBase`, plus the `VSTestDiscover/RunTestExecutionRequest`
+   factories. Every MTP concept (filtering, configuration, output, messages) is round-tripped
+   through an XML/`IRunSettings`/`ITestCaseFilterExpression` representation and back.
+
+4. **Coupling to the VSTest package closure** (`Microsoft.TestPlatform.ObjectModel`) on a code
+   path where MTP already provides everything needed.
+
+Crucially, the investigation behind this RFC found that the VSTest object model is **not** threaded
+through MSTest execution. It exists only at the very edges and is wrapped immediately into neutral
+abstractions that the engine already uses. That makes a native integration a boundary-replacement,
+not an engine rewrite.
+
+## Current architecture (MTP path)
+
+```text
+MTP ITestFramework request (Discover/Run)  ──►  Microsoft.Testing.Extensions.VSTestBridge
+                                                     │  builds VSTest request + context/handle/sink
+                                                     ▼
+   VSTestDiscover/RunTestExecutionRequest  ──►  MSTestBridgedTestFramework
+                                                     │  isMTP: true
+                                                     ▼
+                        MSTestDiscoverer / MSTestExecutor   (VSTest ITestDiscoverer/ITestExecutor)
+                                                     │  wrap VSTest types into NEUTRAL seams:
+                                                     │    frameworkHandle.ToTestResultRecorder()
+                                                     │    discoverySink.ToUnitTestElementSink()
+                                                     │    logger.ToAdapterMessageLogger()
+                                                     │    new TestElementFilterProvider(runContext)
+                                                     ▼
+                        TestExecutionManager / UnitTestDiscoverer   (engine — NEUTRAL)
+                                                     │  operates on UnitTestElement + framework TestResult
+                                                     ▼
+   (results) framework TestResult ──► VSTest TestResult ──► ObjectModelConverters.ToTestNode
+                                                     ▼
+                        TestNodeUpdateMessage  ──►  MTP IMessageBus
+```
+
+The neutral seams already exist in `src\Adapter\MSTestAdapter.PlatformServices\Interfaces`:
+
+| Neutral seam | Role | VSTest impl today |
+| --- | --- | --- |
+| `IUnitTestElementSink` | receives discovered `UnitTestElement`s | `UnitTestElementSinkExtensions.HostDiscoverySink` |
+| `ITestResultRecorder` | receives start/end/`FrameworkTestResult` | `TestResultRecorderExtensions.HostTestResultRecorder` |
+| `IAdapterMessageLogger` | diagnostic/info/warn/error text | `AdapterMessageLoggerExtensions` |
+| `ITestElementFilterProvider` | supplies the test filter | `TestElementFilterProvider` (wraps `IRunContext`/`IDiscoveryContext`) |
+| `DeploymentContext` | test-run directory + runsettings XML | built inline in `MSTestExecutor` |
+
+The docs on `ITestResultRecorder` already state the design intent: *"The concrete recorder ... is
+provided at the adapter boundary."* Native MTP integration = a second concrete implementation of
+these seams that emits MTP objects.
+
+## Target architecture (MTP path)
+
+```text
+MTP ITestFramework request (Discover/Run)  ──►  MSTestTestFramework : ITestFramework, IDataProducer
+                                                     │  reads MTP IServiceProvider directly:
+                                                     │    IMessageBus, ITestExecutionFilter,
+                                                     │    IConfiguration, IOutputDevice, ILoggerFactory,
+                                                     │    ICommandLineOptions, ITrxReportCapability
+                                                     ▼
+                        MSTest engine (unchanged) driven through NEUTRAL seams:
+                          - MtpUnitTestElementSink  : IUnitTestElementSink   -> TestNodeUpdateMessage
+                          - MtpTestResultRecorder   : ITestResultRecorder    -> TestNodeUpdateMessage
+                          - MtpAdapterMessageLogger : IAdapterMessageLogger  -> IOutputDevice / ILogger
+                          - MtpTestElementFilter    : ITestElementFilterProvider (from ITestExecutionFilter)
+                          - DeploymentContext        from IConfiguration (results dir + runsettings)
+                                                     ▼
+                        TestNodeUpdateMessage  ──►  MTP IMessageBus     (no VSTest object model)
+```
+
+`ObjectModelConverters.ToTestNode`'s property mapping (outcome, timing, standard out/err, TRX
+categories/messages/exception, attachments, file location, traits/metadata) is preserved, but
+sourced from `UnitTestElement` + `FrameworkTestResult` instead of VSTest `TestCase`/`TestResult`.
+
+## Design principles
+
+1. **Engine is untouched.** `TestExecutionManager`, `UnitTestRunner`, `TestMethodRunner`,
+   `UnitTestDiscoverer`, `AssemblyEnumeratorWrapper` keep operating on `UnitTestElement` and the
+   framework `TestResult`. This RFC only replaces the *host boundary*.
+2. **Additive and reversible per phase.** The native path is introduced behind the existing
+   `isMTP` seam / a feature switch and does not remove the bridge until it reaches full parity.
+   The VSTest adapter path (real VSTest host) is unaffected throughout.
+3. **No behavior change for users.** `TestNode` shape, UIDs, TRX output, filtering semantics,
+   runsettings handling, `--filter`/`--treenode-filter`, exit codes, and terminal output must be
+   byte-for-byte equivalent, verified by the acceptance suite.
+4. **Reuse, don't fork.** The `TestResult -> TestNode` property mapping currently in
+   `ObjectModelConverters` is moved (not duplicated) into a neutral converter that takes MSTest
+   models, so there is a single source of truth.
+5. **Close the fidelity gaps the bridge forced.** Populate `TestMethodIdentifierProperty`
+   `AssemblyFullName` and `ReturnTypeFullName`, which the VSTest intermediary cannot carry.
+
+## Phasing
+
+| Phase | Deliverable | Removes |
+| --- | --- | --- |
+| 1 | Neutral `TestNode` production: `MtpUnitTestElementSink` + `MtpTestResultRecorder` implementing `IUnitTestElementSink`/`ITestResultRecorder` and emitting `TestNodeUpdateMessage`. Shared converter that maps `UnitTestElement`/`FrameworkTestResult` -> `TestNode` (moved out of `ObjectModelConverters`). Covered by unit tests. | Result/discovery round-trip through VSTest `TestResult`/`TestCase` |
+| 2 | `MSTestTestFramework : ITestFramework, IDataProducer` that handles MTP `DiscoverTestExecutionRequest`/`RunTestExecutionRequest` directly and drives the engine through the Phase 1 seams. Registered behind a switch; bridge remains the default. | `VSTestDiscover/RunTestExecutionRequest` factories, `MSTestBridgedTestFramework` on the MTP path |
+| 3 | Native filtering: build `ITestElementFilterProvider` from MTP `ITestExecutionFilter` (`TestNodeUid`, tree-node, `--filter`) without the VSTest `ITestCaseFilterExpression` round-trip in `ContextAdapterBase`. | `RunContextAdapter`/`DiscoveryContextAdapter` filter path |
+| 4 | Native configuration: `DeploymentContext`, results directory, `--testRunParameters`, runsettings env-var provider, and unsupported-entry warnings sourced from MTP `IConfiguration`/command-line providers. | `RunSettingsAdapter`, `RunSettingsPatcher`, `RunSettingsConfigurationProvider`, `RunSettingsEnvironmentVariableProvider` (bridge copies) |
+| 5 | Capability rewiring: TRX (`ITrxReportCapability`), graceful stop, banner, telemetry wired directly to the native framework; enrich `TestMethodIdentifierProperty` (`AssemblyFullName`, `ReturnTypeFullName`). | Bridge base classes `VSTestBridgedTestFrameworkBase`, `SynchronizedSingleSessionVSTestBridgedTestFramework` (MSTest usage) |
+| 6 | Flip the default to native, delete the MSTest→bridge glue, drop the `Microsoft.Testing.Extensions.VSTestBridge` `PackageReference`/`ProjectReference` from MSTest. | The bridge dependency for MSTest |
+
+`Microsoft.Testing.Extensions.VSTestBridge` itself is **not** deleted by this RFC — NUnit, Expecto,
+and third-party VSTest adapters still consume it. Only MSTest stops depending on it.
+
+## Capability & feature parity checklist
+
+Everything the bridge provides on the MSTest path must have a native owner before Phase 6:
+
+| Feature | Bridge component today | Native owner |
+| --- | --- | --- |
+| Discovery → `TestNode` | `TestCaseDiscoverySinkAdapter` + `ObjectModelConverters` | `MtpUnitTestElementSink` (Phase 1) |
+| Results → `TestNode` | `FrameworkHandlerAdapter` + `ObjectModelConverters` | `MtpTestResultRecorder` (Phase 1) |
+| Outcome/timing/std out+err/attachments | `ObjectModelConverters.ToTestNode` | shared neutral converter (Phase 1) |
+| TRX properties (category/message/exception/type name) | `ObjectModelConverters` + `IInternalVSTestBridgeTrxReportCapability` | shared converter + `MSTestCapabilities` (Phase 1/5) |
+| `--filter` / tree-node / uid filter | `TestCaseFilterCommandLineOptionsProvider`, `ContextAdapterBase` | native filter mapping (Phase 3) |
+| `--runsettings` / `.runsettings` | `RunSettingsCommandLineOptionsProvider`, `RunSettingsAdapter`, `RunSettingsPatcher` | native config (Phase 4) |
+| `--testRunParameters` | `TestRunParametersCommandLineOptionsProvider` | native config (Phase 4) |
+| Results directory | `RunSettingsConfigurationProvider` | native config (Phase 4) |
+| Runsettings env vars | `RunSettingsEnvironmentVariableProvider` | native provider (Phase 4) |
+| Graceful stop | `MSTestGracefulStopTestExecutionCapability` (already MTP-native) | keep as-is |
+| Banner | `MSTestBannerCapability` (already MTP-native) | keep as-is |
+| Telemetry | `MSTestBridgedTestFramework.CreateTelemetrySender` (already MTP-native) | keep as-is |
+| Single-session guard | `SynchronizedSingleSessionVSTestBridgedTestFramework` | small native equivalent (Phase 5) |
+| `TestMethodIdentifierProperty` | `MSTestBridgedTestFramework.AddAdditionalProperties` (lossy) | native, full-fidelity (Phase 5) |
+
+## Testing strategy
+
+- **Golden-output parity.** The `HelpInfoTests`, TRX, terminal-reporter, filtering, runsettings,
+  and discovery acceptance tests under
+  `test/IntegrationTests/MSTest.Acceptance.IntegrationTests` and
+  `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests` are the parity
+  oracle. Each phase must keep them green (after `.\build.cmd -pack`).
+- **Dual-run during transition.** While both paths exist, run the MSTest acceptance suite against
+  the bridge and against the native path (feature switch) to catch divergence early.
+- **Unit tests** for the new neutral converter and the `IUnitTestElementSink`/`ITestResultRecorder`
+  MTP implementations in `MSTestAdapter.PlatformServices.UnitTests` / `MSTestAdapter.UnitTests`.
+- **Public API.** No new *public* MSTest/MTP API is expected; the native framework and seams are
+  `internal`. Any unavoidable public addition goes through `PublicAPI.Unshipped.txt`.
+
+## Risks
+
+1. **Silent output divergence** (e.g. TRX `FullyQualifiedTypeName`, UID stability, std out/err
+   joining). Mitigated by golden-output acceptance parity and moving—not rewriting—the mapping.
+2. **Filter-semantics drift** between VSTest filter expressions and native MTP filters. Phase 3 is
+   isolated and gated behind parity tests specifically for `--filter`/tree-node behavior.
+3. **Runsettings edge cases** (data collectors, loggers, deprecated `RunConfiguration` entries the
+   bridge warns about). Phase 4 must reproduce the same warnings and same ignored-entry behavior.
+4. **In-flight refactor overlap.** There is already active work removing the VSTest object model
+   from platform services (referenced in `UnitTestElementSinkExtensions`/`ITestResultRecorder`
+   remarks). This RFC must be sequenced with that work to avoid conflicting boundaries; Phase 1
+   deliberately builds on those neutral seams rather than around them.
+5. **UWP/WinUI targets.** The MTP path is `#if !WINDOWS_UWP`; the native framework must preserve
+   the same conditional compilation and not regress those TFMs.
+
+## What is intentionally not done
+
+- **Not deleting `Microsoft.Testing.Extensions.VSTestBridge`.** Other adapters depend on it.
+- **Not touching the VSTest host path.** `MSTestDiscoverer`/`MSTestExecutor` continue to implement
+  VSTest's `ITestDiscoverer`/`ITestExecutor` for `vstest.console`.
+- **Not changing the MSTest execution engine.** `UnitTestElement`/`FrameworkTestResult` remain the
+  internal currency.
+- **No user-facing behavior change.** This is an internal integration change; parity is the bar.
+
+## Open questions
+
+1. Rollout switch: env var, `runsettings`/`testconfig` entry, or a hard cutover once parity CI is
+   green? Proposal: internal feature switch during Phases 2–5, hard default flip in Phase 6.
+2. Should the shared `UnitTestElement`/`FrameworkTestResult` → `TestNode` converter live in
+   `MSTest.TestAdapter` (MTP-facing folder) or in `MSTestAdapter.PlatformServices`? Proposal: the
+   MTP-facing adapter folder, next to the other MTP-native capability code.
+3. Coordination point with the ongoing "remove VSTest object model from platform services" work —
+   who owns the neutral-seam contract to avoid churn.

--- a/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
@@ -142,6 +142,21 @@ internal static class UnitTestElementExtensions
         return testCase;
     }
 
+    /// <summary>
+    /// Computes the stable test identifier for a <see cref="UnitTestElement"/> without materializing a VSTest
+    /// <see cref="TestCase"/>. This is the same identifier surfaced as <see cref="TestCase.Id"/> by
+    /// <see cref="ToTestCase"/>, exposed neutrally so the native Microsoft.Testing.Platform integration can build
+    /// a <c>TestNode</c> UID without depending on the VSTest object model.
+    /// </summary>
+    /// <param name="element">The test element to identify.</param>
+    /// <returns>The stable, versioned test identifier.</returns>
+    internal static Guid GetTestId(this UnitTestElement element)
+    {
+        TestMethod testMethod = element.TestMethod;
+        string testFullName = $"{testMethod.FullClassName}.{testMethod.Name}";
+        return GenerateSerializedDataStrategyTestId(element, testFullName);
+    }
+
     private static Guid GenerateSerializedDataStrategyTestId(UnitTestElement element, string testFullName)
     {
         TestMethod testMethod = element.TestMethod;

--- a/src/Adapter/MSTest.TestAdapter/Services/TestResultRecorderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Services/TestResultRecorderExtensions.cs
@@ -48,13 +48,19 @@ internal static class TestResultRecorderExtensions
             _settings = settings;
         }
 
-        public void RecordStart(UnitTestElement testElement)
-            => _testExecutionRecorder.RecordStart(testElement.GetOrCreateHostTestCase());
+        public Task RecordStartAsync(UnitTestElement testElement)
+        {
+            _testExecutionRecorder.RecordStart(testElement.GetOrCreateHostTestCase());
+            return Task.CompletedTask;
+        }
 
-        public void RecordEmptyResult(UnitTestElement testElement)
-            => _testExecutionRecorder.RecordEnd(testElement.GetOrCreateHostTestCase(), TestOutcome.None);
+        public Task RecordEmptyResultAsync(UnitTestElement testElement)
+        {
+            _testExecutionRecorder.RecordEnd(testElement.GetOrCreateHostTestCase(), TestOutcome.None);
+            return Task.CompletedTask;
+        }
 
-        public bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+        public Task<bool> RecordResultAsync(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
         {
             TestCase testCase = testElement.GetOrCreateHostTestCase();
             var testResult = unitTestResult.ToTestResult(testCase, startTime, endTime, _computerName, _settings);
@@ -83,7 +89,7 @@ internal static class TestResultRecorderExtensions
             // A failure is reported only once RecordResult has completed (a swallowed TestCanceledException
             // still counts as completed). This mirrors the original inline flow where the failure was
             // observed as part of reporting the result.
-            return isFailed;
+            return Task.FromResult(isFailed);
         }
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/Services/UnitTestElementSinkExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Services/UnitTestElementSinkExtensions.cs
@@ -37,7 +37,10 @@ internal static class UnitTestElementSinkExtensions
         public HostDiscoverySink(ITestCaseDiscoverySink discoverySink)
             => _discoverySink = discoverySink;
 
-        public void SendTestElement(UnitTestElement testElement)
-            => _discoverySink.SendTestCase(testElement.GetOrCreateHostTestCase());
+        public Task SendTestElementAsync(UnitTestElement testElement)
+        {
+            _discoverySink.SendTestCase(testElement.GetOrCreateHostTestCase());
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
@@ -22,6 +22,12 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [StackTraceHidden]
 internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTestBridgedTestFramework
 {
+    // Opt-in switch for the experimental native Microsoft.Testing.Platform integration: when enabled, MSTest
+    // publishes test nodes directly from its neutral execution model instead of routing discovery and results
+    // through the VSTest bridge object model. Off by default, so the shipping behavior is unchanged.
+    private static readonly bool UseNativeMtpProduction =
+        Environment.GetEnvironmentVariable("MSTEST_EXPERIMENTAL_NATIVE_MTP") is "1" or "true" or "True";
+
     private readonly BridgedConfiguration? _configuration;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -44,7 +50,16 @@ internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTe
             Debugger.Launch();
         }
 
-        return new MSTestDiscoverer(new TestSourceHandler(), CreateTelemetrySender()).DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, request.DiscoverySink, _configuration, isMTP: true);
+        var discoverer = new MSTestDiscoverer(new TestSourceHandler(), CreateTelemetrySender());
+        if (UseNativeMtpProduction && SessionUid is { } sessionUid)
+        {
+            // Publish discovered test nodes directly from the neutral model; the VSTest discovery sink in the
+            // request is bypassed (no VSTest TestCase materialization / ObjectModelConverters round-trip).
+            var elementSink = new MtpUnitTestElementSink(messageBus, this, sessionUid, IsTrxEnabled);
+            return discoverer.DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, elementSink, _configuration, isMTP: true);
+        }
+
+        return discoverer.DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, request.DiscoverySink, _configuration, isMTP: true);
     }
 
     /// <inheritdoc />
@@ -58,6 +73,20 @@ internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTe
         }
 
         MSTestExecutor testExecutor = new(cancellationToken, CreateTelemetrySender());
+        if (UseNativeMtpProduction && SessionUid is { } sessionUid)
+        {
+            // Report results directly as native test nodes; the framework handle is still used for message logging
+            // and apartment-state handling, but its VSTest RecordResult / ObjectModelConverters path is bypassed.
+            await testExecutor.RunTestsAsync(
+                request.AssemblyPaths,
+                request.RunContext,
+                request.FrameworkHandle,
+                settings => new MtpTestResultRecorder(messageBus, this, sessionUid, IsTrxEnabled, settings),
+                _configuration,
+                isMTP: true).ConfigureAwait(false);
+            return;
+        }
+
         await testExecutor.RunTestsAsync(request.AssemblyPaths, request.RunContext, request.FrameworkHandle, _configuration, isMTP: true).ConfigureAwait(false);
     }
 

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Builds Microsoft.Testing.Platform <see cref="TestNode"/>s directly from MSTest's neutral execution model
+/// (<see cref="UnitTestElement"/> and the framework <see cref="FrameworkTestResult"/>), without going through the
+/// VSTest object model (<c>TestCase</c>/<c>TestResult</c>) or the VSTest bridge.
+/// </summary>
+/// <remarks>
+/// This mirrors, field-for-field, the mapping that the bridge performs today in
+/// <c>ObjectModelConverters.ToTestNode</c> (combined with <c>UnitTestElementExtensions.ToTestCase</c>,
+/// <c>TestResultExtensions.ToTestResult</c> and <c>MSTestBridgedTestFramework.AddAdditionalProperties</c>), so
+/// switching MSTest to a native Microsoft.Testing.Platform integration produces identical <see cref="TestNode"/>s.
+/// MSTest does not use the <c>vstestProvider</c> named-feature capability, so the VSTest provider properties the
+/// bridge conditionally emits are intentionally not reproduced here.
+/// </remarks>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal static class MSTestTestNodeConverter
+{
+    /// <summary>
+    /// Builds a discovered-state <see cref="TestNode"/> for a discovered test.
+    /// </summary>
+    public static TestNode ToDiscoveredTestNode(UnitTestElement element, bool isTrxEnabled)
+    {
+        TestNode testNode = CreateBaseTestNode(element, isTrxEnabled, displayNameOverride: null);
+        testNode.Properties.Add(DiscoveredTestNodeStateProperty.CachedInstance);
+        return testNode;
+    }
+
+    /// <summary>
+    /// Builds an in-progress-state <see cref="TestNode"/> reported when a test starts executing.
+    /// </summary>
+    public static TestNode ToInProgressTestNode(UnitTestElement element, bool isTrxEnabled)
+    {
+        TestNode testNode = CreateBaseTestNode(element, isTrxEnabled, displayNameOverride: null);
+        testNode.Properties.Add(InProgressTestNodeStateProperty.CachedInstance);
+        return testNode;
+    }
+
+    /// <summary>
+    /// Builds a completed <see cref="TestNode"/> carrying the outcome, timing, output and (optionally) TRX
+    /// properties for a single executed test result.
+    /// </summary>
+    public static TestNode ToResultTestNode(UnitTestElement element, FrameworkTestResult result, DateTimeOffset startTime, DateTimeOffset endTime, bool isTrxEnabled, MSTestSettings settings)
+    {
+        TestNode testNode = CreateBaseTestNode(element, isTrxEnabled, result.DisplayName);
+
+        // Mirror TestResultExtensions.ToTestResult: the reported error message prefers the exception message and
+        // falls back to the ignore reason; the stack trace comes straight from the framework result.
+        string? errorMessage = result.ExceptionMessage ?? result.IgnoreReason;
+        string? errorStackTrace = result.ExceptionStackTrace;
+        var outcome = UnitTestOutcomeHelper.ToTestOutcome(result.Outcome, settings);
+
+        AddOutcome(testNode, outcome, errorMessage, errorStackTrace);
+
+        if (isTrxEnabled)
+        {
+            AddTrxResultProperties(testNode, element, errorMessage, errorStackTrace);
+        }
+
+        AddMessagesAndOutput(testNode, result, isTrxEnabled);
+
+        testNode.Properties.Add(new TimingProperty(new(startTime, endTime, result.Duration), []));
+
+        AddAttachments(testNode, result);
+
+        return testNode;
+    }
+
+    private static TestNode CreateBaseTestNode(UnitTestElement element, bool isTrxEnabled, string? displayNameOverride)
+    {
+        TestMethod testMethod = element.TestMethod;
+        string testFullName = $"{testMethod.FullClassName}.{testMethod.Name}";
+
+        TestNode testNode = new()
+        {
+            Uid = new TestNodeUid(element.GetTestId().ToString()),
+            DisplayName = displayNameOverride ?? testMethod.DisplayName ?? testFullName,
+        };
+
+        AddCategoriesAndTraits(testNode, element, isTrxEnabled);
+
+        if (element.DeclaringFilePath is not null)
+        {
+            var position = new LinePosition(element.DeclaringLineNumber ?? -1, -1);
+            testNode.Properties.Add(new TestFileLocationProperty(element.DeclaringFilePath, new(position, position)));
+        }
+
+        AddTestMethodIdentifier(testNode, testMethod);
+
+        return testNode;
+    }
+
+    private static void AddCategoriesAndTraits(TestNode testNode, UnitTestElement element, bool isTrxEnabled)
+    {
+        if (element.TestCategory is { Length: > 0 } categories)
+        {
+            if (isTrxEnabled)
+            {
+                testNode.Properties.Add(new TrxCategoriesProperty(categories));
+            }
+
+            foreach (string category in categories)
+            {
+                testNode.Properties.Add(new TestMetadataProperty(category, string.Empty));
+            }
+        }
+
+        if (element.Traits is { Length: > 0 } traits)
+        {
+            foreach (TestTrait trait in traits)
+            {
+                testNode.Properties.Add(new TestMetadataProperty(trait.Name, trait.Value));
+            }
+        }
+    }
+
+    private static void AddTestMethodIdentifier(TestNode testNode, TestMethod testMethod)
+    {
+        // NOTE: ManagedMethodName, in case of MSTest, carries the parameter types, so we prefer it to display the
+        // parameter types in Test Explorer. This mirrors MSTestBridgedTestFramework.AddAdditionalProperties.
+        if (!testMethod.HasManagedMethodAndTypeProperties)
+        {
+            return;
+        }
+
+        string? managedType = testMethod.ManagedTypeName;
+        string? managedMethod = testMethod.ManagedMethodName;
+        if (StringEx.IsNullOrEmpty(managedType) || StringEx.IsNullOrEmpty(managedMethod))
+        {
+            return;
+        }
+
+        ManagedNameParser.ParseManagedMethodName(managedMethod, out string methodName, out int arity, out string[]? parameterTypes);
+        parameterTypes ??= [];
+
+        int lastIndexOfDot = managedType.LastIndexOf('.');
+        string @namespace = lastIndexOfDot == -1 ? string.Empty : managedType.Substring(0, lastIndexOfDot);
+        string typeName = lastIndexOfDot == -1 ? managedType : managedType.Substring(lastIndexOfDot + 1);
+
+        // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to match
+        // the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
+        testNode.Properties.Add(new TestMethodIdentifierProperty(assemblyFullName: string.Empty, @namespace, typeName, methodName, arity, parameterTypes, returnTypeFullName: string.Empty));
+    }
+
+    private static void AddOutcome(TestNode testNode, TestOutcome outcome, string? errorMessage, string? errorStackTrace)
+    {
+        switch (outcome)
+        {
+            case TestOutcome.Passed:
+                testNode.Properties.Add(PassedTestNodeStateProperty.CachedInstance);
+                break;
+
+            case TestOutcome.NotFound:
+                testNode.Properties.Add(new ErrorTestNodeStateProperty(new MSTestTestNodeException(errorMessage ?? "Not found", errorStackTrace)));
+                break;
+
+            case TestOutcome.Failed:
+                testNode.Properties.Add(new FailedTestNodeStateProperty(new MSTestTestNodeException(errorMessage, errorStackTrace)));
+                break;
+
+            case TestOutcome.None:
+            case TestOutcome.Skipped:
+                testNode.Properties.Add(errorMessage is null
+                    ? SkippedTestNodeStateProperty.CachedInstance
+                    : new SkippedTestNodeStateProperty(errorMessage));
+                break;
+
+            default:
+                throw new NotSupportedException($"Unsupported test outcome value '{outcome}'");
+        }
+    }
+
+    private static void AddTrxResultProperties(TestNode testNode, UnitTestElement element, string? errorMessage, string? errorStackTrace)
+    {
+        if (!StringEx.IsNullOrEmpty(errorMessage) || !StringEx.IsNullOrEmpty(errorStackTrace))
+        {
+            testNode.Properties.Add(new TrxExceptionProperty(errorMessage, errorStackTrace));
+        }
+
+        TestMethod testMethod = element.TestMethod;
+        string testFullName = $"{testMethod.FullClassName}.{testMethod.Name}";
+        testNode.Properties.Add(new TrxTestDefinitionName(testMethod.DisplayName ?? testFullName));
+
+        TestMethodIdentifierProperty? testMethodIdentifierProperty = testNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        if (testMethodIdentifierProperty is not null)
+        {
+            testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(
+                StringEx.IsNullOrEmpty(testMethodIdentifierProperty.Namespace)
+                    ? testMethodIdentifierProperty.TypeName
+                    : $"{testMethodIdentifierProperty.Namespace}.{testMethodIdentifierProperty.TypeName}"));
+        }
+        else if (TryParseFullyQualifiedType(testFullName, out string? fullyQualifiedType))
+        {
+            testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(fullyQualifiedType));
+        }
+        else
+        {
+            throw new InvalidOperationException("Unable to parse fully qualified type name from test: " + testFullName);
+        }
+    }
+
+    private static void AddMessagesAndOutput(TestNode testNode, FrameworkTestResult result, bool isTrxEnabled)
+    {
+        // Reproduce, in order, the standard-out / standard-error messages that TestResultExtensions.ToTestResult
+        // pushes onto the VSTest result and that ObjectModelConverters.ToTestNode then re-groups: LogOutput and
+        // (banner-prefixed) DebugTrace / TestContextMessages are standard-out; LogError is standard-error.
+        List<string>? standardOutputMessages = null;
+        List<string>? standardErrorMessages = null;
+        List<TrxMessage>? trxMessages = isTrxEnabled ? [] : null;
+
+        if (!StringEx.IsNullOrEmpty(result.LogOutput))
+        {
+            (standardOutputMessages ??= []).Add(result.LogOutput!);
+            trxMessages?.Add(new StandardOutputTrxMessage(result.LogOutput));
+        }
+
+        if (!StringEx.IsNullOrEmpty(result.LogError))
+        {
+            (standardErrorMessages ??= []).Add(result.LogError!);
+            trxMessages?.Add(new StandardErrorTrxMessage(result.LogError));
+        }
+
+        if (!StringEx.IsNullOrEmpty(result.DebugTrace))
+        {
+            string debugTraceMessagesInStdOut =
+                $"""
+
+
+                {Resource.DebugTraceBanner}
+                {result.DebugTrace}
+                """;
+            (standardOutputMessages ??= []).Add(debugTraceMessagesInStdOut);
+            trxMessages?.Add(new StandardOutputTrxMessage(debugTraceMessagesInStdOut));
+        }
+
+        if (!StringEx.IsNullOrEmpty(result.TestContextMessages))
+        {
+            string testContextMessagesInStdOut =
+                $"""
+
+
+                {Resource.TestContextMessageBanner}
+                {result.TestContextMessages}
+                """;
+            (standardOutputMessages ??= []).Add(testContextMessagesInStdOut);
+            trxMessages?.Add(new StandardOutputTrxMessage(testContextMessagesInStdOut));
+        }
+
+        if (isTrxEnabled)
+        {
+            testNode.Properties.Add(new TrxMessagesProperty(trxMessages is { Count: > 0 } ? [.. trxMessages] : []));
+        }
+
+        if (standardErrorMessages is { Count: > 0 })
+        {
+            testNode.Properties.Add(new StandardErrorProperty(string.Join(Environment.NewLine, standardErrorMessages)));
+        }
+
+        if (standardOutputMessages is { Count: > 0 })
+        {
+            testNode.Properties.Add(new StandardOutputProperty(string.Join(Environment.NewLine, standardOutputMessages)));
+        }
+    }
+
+    private static void AddAttachments(TestNode testNode, FrameworkTestResult result)
+    {
+        if (result.ResultFiles is not { Count: > 0 })
+        {
+            return;
+        }
+
+        foreach (string resultFile in result.ResultFiles)
+        {
+            string pathToResultFile = PlatformServiceProvider.Instance.FileOperations.GetFullFilePath(resultFile);
+            testNode.Properties.Add(new FileArtifactProperty(new FileInfo(pathToResultFile), Resource.AttachmentSetDisplayName, resultFile));
+        }
+    }
+
+    private static bool TryParseFullyQualifiedType(string fullyQualifiedName, [NotNullWhen(true)] out string? fullyQualifiedType)
+    {
+        fullyQualifiedType = null;
+
+        int openBracketIndex = fullyQualifiedName.IndexOf('(');
+        int lastDotIndexBeforeOpenBracket = openBracketIndex <= 0
+            ? fullyQualifiedName.LastIndexOf('.')
+            : fullyQualifiedName.LastIndexOf('.', openBracketIndex - 1);
+        if (lastDotIndexBeforeOpenBracket <= 0)
+        {
+            return false;
+        }
+
+        fullyQualifiedType = fullyQualifiedName.Substring(0, lastDotIndexBeforeOpenBracket);
+        return true;
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeException.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeException.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeException.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// A lightweight exception used to carry a test's failure message and stack trace into a
+/// Microsoft.Testing.Platform failed/error test node state, without depending on the VSTest object model.
+/// It mirrors the shape of the VSTest bridge's exception: the provided stack trace string is returned verbatim
+/// from <see cref="StackTrace"/> instead of being captured from the current call site.
+/// </summary>
+[StackTraceHidden]
+internal sealed class MSTestTestNodeException : Exception
+{
+    public MSTestTestNodeException(string? message, string? stackTrace)
+        : base(message)
+        => StackTrace = stackTrace;
+
+    public override string? StackTrace { get; }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestResultRecorder.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestResultRecorder.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+
+using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// A Microsoft.Testing.Platform-native <see cref="ITestResultRecorder"/> that reports test lifecycle and results
+/// directly as <see cref="TestNodeUpdateMessage"/>s on the platform message bus, without materializing a VSTest
+/// <c>TestResult</c> or going through the VSTest bridge.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MtpTestResultRecorder : ITestResultRecorder
+{
+    private readonly IMessageBus _messageBus;
+    private readonly IDataProducer _dataProducer;
+    private readonly SessionUid _sessionUid;
+    private readonly bool _isTrxEnabled;
+    private readonly MSTestSettings _settings;
+
+    public MtpTestResultRecorder(IMessageBus messageBus, IDataProducer dataProducer, SessionUid sessionUid, bool isTrxEnabled, MSTestSettings settings)
+    {
+        _messageBus = messageBus;
+        _dataProducer = dataProducer;
+        _sessionUid = sessionUid;
+        _isTrxEnabled = isTrxEnabled;
+        _settings = settings;
+    }
+
+    public void RecordStart(UnitTestElement testElement)
+    {
+        TestNode testNode = MSTestTestNodeConverter.ToInProgressTestNode(testElement, _isTrxEnabled);
+        Publish(testNode);
+    }
+
+    // Mirrors the VSTest recorder: an empty result maps to RecordEnd(TestOutcome.None), which does not publish any
+    // test node update to Microsoft.Testing.Platform. So there is nothing to report here.
+    public void RecordEmptyResult(UnitTestElement testElement)
+    {
+    }
+
+    public bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+    {
+        var outcome = UnitTestOutcomeHelper.ToTestOutcome(unitTestResult.Outcome, _settings);
+        bool isFailed = outcome == TestOutcome.Failed;
+
+        // Mirror TestResultRecorderExtensions: a NotFound result is not reported while hot reload is enabled.
+        if (outcome != TestOutcome.NotFound || !RuntimeContext.IsHotReloadEnabled)
+        {
+            TestNode testNode = MSTestTestNodeConverter.ToResultTestNode(testElement, unitTestResult, startTime, endTime, _isTrxEnabled, _settings);
+            Publish(testNode);
+        }
+
+        return isFailed;
+    }
+
+    private void Publish(TestNode testNode)
+        => _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode)).GetAwaiter().GetResult();
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestResultRecorder.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestResultRecorder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
@@ -38,19 +38,18 @@ internal sealed class MtpTestResultRecorder : ITestResultRecorder
         _settings = settings;
     }
 
-    public void RecordStart(UnitTestElement testElement)
+    public Task RecordStartAsync(UnitTestElement testElement)
     {
         TestNode testNode = MSTestTestNodeConverter.ToInProgressTestNode(testElement, _isTrxEnabled);
-        Publish(testNode);
+        return PublishAsync(testNode);
     }
 
     // Mirrors the VSTest recorder: an empty result maps to RecordEnd(TestOutcome.None), which does not publish any
     // test node update to Microsoft.Testing.Platform. So there is nothing to report here.
-    public void RecordEmptyResult(UnitTestElement testElement)
-    {
-    }
+    public Task RecordEmptyResultAsync(UnitTestElement testElement)
+        => Task.CompletedTask;
 
-    public bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
+    public async Task<bool> RecordResultAsync(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime)
     {
         var outcome = UnitTestOutcomeHelper.ToTestOutcome(unitTestResult.Outcome, _settings);
         bool isFailed = outcome == TestOutcome.Failed;
@@ -59,13 +58,13 @@ internal sealed class MtpTestResultRecorder : ITestResultRecorder
         if (outcome != TestOutcome.NotFound || !RuntimeContext.IsHotReloadEnabled)
         {
             TestNode testNode = MSTestTestNodeConverter.ToResultTestNode(testElement, unitTestResult, startTime, endTime, _isTrxEnabled, _settings);
-            Publish(testNode);
+            await PublishAsync(testNode).ConfigureAwait(false);
         }
 
         return isFailed;
     }
 
-    private void Publish(TestNode testNode)
-        => _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode)).GetAwaiter().GetResult();
+    private Task PublishAsync(TestNode testNode)
+        => _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode));
 }
 #endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpUnitTestElementSink.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpUnitTestElementSink.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// A Microsoft.Testing.Platform-native <see cref="IUnitTestElementSink"/> that publishes discovered tests directly
+/// as <see cref="TestNodeUpdateMessage"/>s on the platform message bus, without materializing a VSTest
+/// <c>TestCase</c> or going through the VSTest bridge.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MtpUnitTestElementSink : IUnitTestElementSink
+{
+    private readonly IMessageBus _messageBus;
+    private readonly IDataProducer _dataProducer;
+    private readonly SessionUid _sessionUid;
+    private readonly bool _isTrxEnabled;
+
+    public MtpUnitTestElementSink(IMessageBus messageBus, IDataProducer dataProducer, SessionUid sessionUid, bool isTrxEnabled)
+    {
+        _messageBus = messageBus;
+        _dataProducer = dataProducer;
+        _sessionUid = sessionUid;
+        _isTrxEnabled = isTrxEnabled;
+    }
+
+    public void SendTestElement(UnitTestElement testElement)
+    {
+        TestNode testNode = MSTestTestNodeConverter.ToDiscoveredTestNode(testElement, _isTrxEnabled);
+        _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode)).GetAwaiter().GetResult();
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpUnitTestElementSink.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpUnitTestElementSink.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
@@ -31,10 +31,10 @@ internal sealed class MtpUnitTestElementSink : IUnitTestElementSink
         _isTrxEnabled = isTrxEnabled;
     }
 
-    public void SendTestElement(UnitTestElement testElement)
+    public Task SendTestElementAsync(UnitTestElement testElement)
     {
         TestNode testNode = MSTestTestNodeConverter.ToDiscoveredTestNode(testElement, _isTrxEnabled);
-        _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode)).GetAwaiter().GetResult();
+        return _messageBus.PublishAsync(_dataProducer, new TestNodeUpdateMessage(_sessionUid, testNode));
     }
 }
 #endif

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -108,7 +108,7 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
             IUnitTestElementSink unitTestElementSink = elementSink ?? discoverySink!.ToUnitTestElementSink();
             if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext?.RunSettings?.SettingsXml, adapterLogger, configuration, _testSourceHandler))
             {
-                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, unitTestElementSink, discoveryContext?.RunSettings?.SettingsXml, new TestElementFilterProvider(discoveryContext), isMTP);
+                await new UnitTestDiscoverer(_testSourceHandler).DiscoverTestsAsync(sources, adapterLogger, unitTestElementSink, discoveryContext?.RunSettings?.SettingsXml, new TestElementFilterProvider(discoveryContext), isMTP).ConfigureAwait(false);
             }
         }
         finally

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestDiscoverer.cs
@@ -59,6 +59,31 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
 
     internal async Task DiscoverTestsAsync(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink, IConfiguration? configuration, bool isMTP)
     {
+        if (discoverySink is null)
+        {
+            throw new ArgumentNullException(nameof(discoverySink));
+        }
+
+        await DiscoverTestsCoreAsync(sources, discoveryContext, logger, elementSink: null, discoverySink, configuration, isMTP).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Discovers tests, reporting each discovered element directly to a platform-agnostic
+    /// <see cref="IUnitTestElementSink"/> (used by the native Microsoft.Testing.Platform integration, which
+    /// publishes test nodes itself and does not need a VSTest <see cref="ITestCaseDiscoverySink"/>).
+    /// </summary>
+    internal async Task DiscoverTestsAsync(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, IUnitTestElementSink elementSink, IConfiguration? configuration, bool isMTP)
+    {
+        if (elementSink is null)
+        {
+            throw new ArgumentNullException(nameof(elementSink));
+        }
+
+        await DiscoverTestsCoreAsync(sources, discoveryContext, logger, elementSink, discoverySink: null, configuration, isMTP).ConfigureAwait(false);
+    }
+
+    private async Task DiscoverTestsCoreAsync(IEnumerable<string> sources, IDiscoveryContext? discoveryContext, IMessageLogger logger, IUnitTestElementSink? elementSink, ITestCaseDiscoverySink? discoverySink, IConfiguration? configuration, bool isMTP)
+    {
         if (sources is null)
         {
             throw new ArgumentNullException(nameof(sources));
@@ -67,11 +92,6 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
         if (logger is null)
         {
             throw new ArgumentNullException(nameof(logger));
-        }
-
-        if (discoverySink is null)
-        {
-            throw new ArgumentNullException(nameof(discoverySink));
         }
 
         // Initialize telemetry collection if not already set (e.g. first call in the session).
@@ -85,9 +105,10 @@ internal sealed class MSTestDiscoverer : ITestDiscoverer
         try
         {
             IAdapterMessageLogger adapterLogger = logger.ToAdapterMessageLogger();
+            IUnitTestElementSink unitTestElementSink = elementSink ?? discoverySink!.ToUnitTestElementSink();
             if (MSTestDiscovererHelpers.InitializeDiscovery(sources, discoveryContext?.RunSettings?.SettingsXml, adapterLogger, configuration, _testSourceHandler))
             {
-                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, discoverySink.ToUnitTestElementSink(), discoveryContext?.RunSettings?.SettingsXml, new TestElementFilterProvider(discoveryContext), isMTP);
+                new UnitTestDiscoverer(_testSourceHandler).DiscoverTests(sources, adapterLogger, unitTestElementSink, discoveryContext?.RunSettings?.SettingsXml, new TestElementFilterProvider(discoveryContext), isMTP);
             }
         }
         finally

--- a/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
+++ b/src/Adapter/MSTest.TestAdapter/VSTestAdapter/MSTestExecutor.cs
@@ -177,7 +177,21 @@ internal sealed class MSTestExecutor : ITestExecutor
         return testElement;
     }
 
-    internal async Task RunTestsAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration, bool isMTP)
+    internal Task RunTestsAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, IConfiguration? configuration, bool isMTP)
+        => RunTestsFromSourcesCoreAsync(sources, runContext, frameworkHandle, settings => frameworkHandle!.ToTestResultRecorder(Environment.MachineName, settings), configuration, isMTP);
+
+    /// <summary>
+    /// Runs the tests from sources, reporting results to a caller-provided platform-agnostic
+    /// <see cref="ITestResultRecorder"/> (used by the native Microsoft.Testing.Platform integration, which
+    /// publishes test nodes itself instead of recording through the VSTest <see cref="IFrameworkHandle"/>).
+    /// The <paramref name="frameworkHandle"/> is still used for message logging and apartment-state handling.
+    /// The recorder is created via <paramref name="recorderFactory"/> after settings are resolved so it observes
+    /// the effective <see cref="MSTestSettings"/>.
+    /// </summary>
+    internal Task RunTestsAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, Func<MSTestSettings, ITestResultRecorder> recorderFactory, IConfiguration? configuration, bool isMTP)
+        => RunTestsFromSourcesCoreAsync(sources, runContext, frameworkHandle, recorderFactory, configuration, isMTP);
+
+    private async Task RunTestsFromSourcesCoreAsync(IEnumerable<string>? sources, IRunContext? runContext, IFrameworkHandle? frameworkHandle, Func<MSTestSettings, ITestResultRecorder> recorderFactory, IConfiguration? configuration, bool isMTP)
     {
         if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsInfoEnabled)
         {
@@ -215,9 +229,10 @@ internal sealed class MSTestExecutor : ITestExecutor
 
             sources = testSourceHandler.GetTestSources(sources);
 
-            // Translate the VSTest recorder into the platform-agnostic result recorder at this boundary; the
-            // execution engine reports results through this neutral recorder and never constructs VSTest results.
-            ITestResultRecorder testResultRecorder = frameworkHandle.ToTestResultRecorder(Environment.MachineName, MSTestSettings.CurrentSettings);
+            // Build the neutral result recorder now that settings have been resolved by InitializeDiscovery; the
+            // execution engine reports results through this recorder and never constructs VSTest results. For the
+            // VSTest path this wraps the framework handle; for the native MTP path it publishes test nodes directly.
+            ITestResultRecorder testResultRecorder = recorderFactory(MSTestSettings.CurrentSettings);
 
             // Extract the neutral run inputs (test-run directory + run settings XML) from the host run context at
             // this boundary so the execution engine no longer depends on the VSTest run context.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Discovery/UnitTestDiscoverer.cs
@@ -22,7 +22,7 @@ internal class UnitTestDiscoverer
     /// <param name="settingsXml"> The run settings XML, or <see langword="null"/> when none was provided. </param>
     /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
-    internal void DiscoverTests(
+    internal async Task DiscoverTestsAsync(
         IEnumerable<string> sources,
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
@@ -32,7 +32,7 @@ internal class UnitTestDiscoverer
     {
         foreach (string source in sources)
         {
-            DiscoverTestsInSource(source, logger, discoverySink, settingsXml, filterProvider, isMTP);
+            await DiscoverTestsInSourceAsync(source, logger, discoverySink, settingsXml, filterProvider, isMTP).ConfigureAwait(false);
         }
     }
 
@@ -45,7 +45,7 @@ internal class UnitTestDiscoverer
     /// <param name="settingsXml"> The run settings XML, or <see langword="null"/> when none was provided. </param>
     /// <param name="filterProvider">Provider for the test filter, or <see langword="null"/> for no filter.</param>
     /// <param name="isMTP">Flag set to true when the platform running discovery is MTP.</param>
-    internal virtual void DiscoverTestsInSource(
+    internal virtual async Task DiscoverTestsInSourceAsync(
         string source,
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
@@ -100,12 +100,12 @@ internal class UnitTestDiscoverer
                 source);
         }
 
-        SendTestCases(testElements, discoverySink, filterProvider, logger);
+        await SendTestCasesAsync(testElements, discoverySink, filterProvider, logger).ConfigureAwait(false);
     }
 
     private readonly ITestSourceHandler _testSource;
 
-    internal static void SendTestCases(IEnumerable<UnitTestElement> testElements, IUnitTestElementSink discoverySink, ITestElementFilterProvider? filterProvider, IAdapterMessageLogger logger)
+    internal static async Task SendTestCasesAsync(IEnumerable<UnitTestElement> testElements, IUnitTestElementSink discoverySink, ITestElementFilterProvider? filterProvider, IAdapterMessageLogger logger)
     {
         // Get filter and skip discovery in case filter expression has parsing error.
         bool filterHasError = false;
@@ -123,7 +123,7 @@ internal class UnitTestDiscoverer
                 continue;
             }
 
-            discoverySink.SendTestElement(testElement);
+            await discoverySink.SendTestElementAsync(testElement).ConfigureAwait(false);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestCaseDiscoverySink.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestCaseDiscoverySink.cs
@@ -24,6 +24,9 @@ internal sealed class TestCaseDiscoverySink : IUnitTestElementSink
     /// Collects the discovered test element.
     /// </summary>
     /// <param name="testElement"> The discovered test element. </param>
-    public void SendTestElement(UnitTestElement testElement)
-        => TestElements.Add(testElement);
+    public Task SendTestElementAsync(UnitTestElement testElement)
+    {
+        TestElements.Add(testElement);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.Runner.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution;
 
 internal partial class TestExecutionManager
 {
-    internal void SendTestResults(
+    internal async Task SendTestResultsAsync(
         UnitTestElement test,
         TestTools.UnitTesting.TestResult[] unitTestResults,
         DateTimeOffset startTime,
@@ -17,7 +17,7 @@ internal partial class TestExecutionManager
     {
         if (unitTestResults.Length == 0)
         {
-            testResultRecorder.RecordEmptyResult(test);
+            await testResultRecorder.RecordEmptyResultAsync(test).ConfigureAwait(false);
             return;
         }
 
@@ -26,12 +26,12 @@ internal partial class TestExecutionManager
             _testRunCancellationToken?.ThrowIfCancellationRequested();
 
 #if !WINDOWS_UWP && !WIN_UI
-            if (testResultRecorder.RecordResult(test, unitTestResult, startTime, endTime))
+            if (await testResultRecorder.RecordResultAsync(test, unitTestResult, startTime, endTime).ConfigureAwait(false))
             {
                 _hasAnyTestFailed = true;
             }
 #else
-            testResultRecorder.RecordResult(test, unitTestResult, startTime, endTime);
+            await testResultRecorder.RecordResultAsync(test, unitTestResult, startTime, endTime).ConfigureAwait(false);
 #endif
         }
     }
@@ -81,7 +81,7 @@ internal partial class TestExecutionManager
 
             // Report through the neutral recorder using the element itself; the adapter-side recorder resolves
             // the host test case (preserving host-injected TCM / data-collector properties) with full fidelity.
-            _testResultRecorder.RecordStart(currentTest);
+            await _testResultRecorder.RecordStartAsync(currentTest).ConfigureAwait(false);
 
             DateTimeOffset startTime = DateTimeOffset.Now;
 
@@ -119,7 +119,7 @@ internal partial class TestExecutionManager
 
             DateTimeOffset endTime = DateTimeOffset.Now;
 
-            SendTestResults(currentTest, unitTestResult, startTime, endTime, _testResultRecorder);
+            await SendTestResultsAsync(currentTest, unitTestResult, startTime, endTime, _testResultRecorder).ConfigureAwait(false);
         }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestExecutionManager.cs
@@ -138,7 +138,7 @@ internal partial class TestExecutionManager
             _testRunCancellationToken?.ThrowIfCancellationRequested();
 
             // discover the tests
-            GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSource(source, logger, discoverySink, deploymentContext.RunSettingsXml, filterProvider, isMTP);
+            await GetUnitTestDiscoverer(testSourceHandler).DiscoverTestsInSourceAsync(source, logger, discoverySink, deploymentContext.RunSettingsXml, filterProvider, isMTP).ConfigureAwait(false);
             tests.AddRange(discoverySink.TestElements);
 
             // Clear discoverSinksTests so that it just stores test for one source at one point of time

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/ITestResultRecorder.cs
@@ -25,13 +25,15 @@ internal interface ITestResultRecorder
     /// Signals that execution of the given test has started.
     /// </summary>
     /// <param name="testElement">The test whose execution is starting.</param>
-    void RecordStart(UnitTestElement testElement);
+    /// <returns>A task that completes once the start has been reported.</returns>
+    Task RecordStartAsync(UnitTestElement testElement);
 
     /// <summary>
     /// Signals that execution of the given test ended without producing any result.
     /// </summary>
     /// <param name="testElement">The test whose execution ended.</param>
-    void RecordEmptyResult(UnitTestElement testElement);
+    /// <returns>A task that completes once the empty result has been reported.</returns>
+    Task RecordEmptyResultAsync(UnitTestElement testElement);
 
     /// <summary>
     /// Reports a single framework <see cref="FrameworkTestResult"/> for the given test to the test host.
@@ -41,5 +43,5 @@ internal interface ITestResultRecorder
     /// <param name="startTime">The time at which the test started executing.</param>
     /// <param name="endTime">The time at which the test finished executing.</param>
     /// <returns><see langword="true"/> if the result was reported as a failure; otherwise, <see langword="false"/>.</returns>
-    bool RecordResult(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
+    Task<bool> RecordResultAsync(UnitTestElement testElement, FrameworkTestResult unitTestResult, DateTimeOffset startTime, DateTimeOffset endTime);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IUnitTestElementSink.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Interfaces/IUnitTestElementSink.cs
@@ -24,5 +24,6 @@ internal interface IUnitTestElementSink
     /// Reports a discovered <paramref name="testElement"/> to the running test host.
     /// </summary>
     /// <param name="testElement">The discovered test element.</param>
-    void SendTestElement(UnitTestElement testElement);
+    /// <returns>A task that completes once the element has been reported.</returns>
+    Task SendTestElementAsync(UnitTestElement testElement);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
@@ -23,7 +23,6 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     private readonly Func<IEnumerable<Assembly>> _getTestAssemblies;
     private readonly CountdownEvent _incomingRequestCounter = new(1);
     private bool _isDisposed;
-    private SessionUid? _sessionUid;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SynchronizedSingleSessionVSTestBridgedTestFramework"/> class.
@@ -52,6 +51,13 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     /// <inheritdoc />
     public sealed override string Version => _extension.Version;
 
+    /// <summary>
+    /// Gets the current test session UID, or <see langword="null"/> when no session is active. Exposed to the
+    /// (internals-visible) MSTest adapter so it can publish Microsoft.Testing.Platform test node updates natively
+    /// without routing through the VSTest bridge object model.
+    /// </summary>
+    internal SessionUid? SessionUid { get; private set; }
+
     /// <inheritdoc />
     public override async Task<bool> IsEnabledAsync() => await _extension.IsEnabledAsync().ConfigureAwait(false);
 
@@ -60,12 +66,12 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
-        if (_sessionUid is not null)
+        if (SessionUid is not null)
         {
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, _sessionUid.Value.Value));
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, SessionUid.Value.Value));
         }
 
-        _sessionUid = context.SessionUid;
+        SessionUid = context.SessionUid;
         return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
     }
 
@@ -77,7 +83,7 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
 
         // Wait for remaining request processing
         await _incomingRequestCounter.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-        _sessionUid = null;
+        SessionUid = null;
         return new CloseTestSessionResult { IsSuccess = true };
     }
 

--- a/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
+++ b/test/IntegrationTests/MSTest.IntegrationTests/Utilities/CLITestBase.discovery.cs
@@ -31,7 +31,7 @@ public abstract partial class CLITestBase
         string runSettingsXml = GetRunSettingsXml(string.Empty);
         var context = new InternalDiscoveryContext(runSettingsXml, testCaseFilter);
 
-        unitTestDiscoverer.DiscoverTestsInSource(assemblyPath, logger.ToAdapterMessageLogger(), sink.ToUnitTestElementSink(), runSettingsXml, new TestElementFilterProvider(context), false);
+        unitTestDiscoverer.DiscoverTestsInSourceAsync(assemblyPath, logger.ToAdapterMessageLogger(), sink.ToUnitTestElementSink(), runSettingsXml, new TestElementFilterProvider(context), false).GetAwaiter().GetResult();
 
         return sink.DiscoveredTests;
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Discovery/UnitTestDiscovererTests.cs
@@ -67,7 +67,7 @@ public class UnitTestDiscovererTests : TestContainer
         }
     }
 
-    public void DiscoverTestsShouldThrowOnFileNotFound()
+    public async Task DiscoverTestsShouldThrowOnFileNotFound()
     {
         string[] sources = ["DummyAssembly1.dll", "DummyAssembly2.dll"];
 
@@ -80,12 +80,12 @@ public class UnitTestDiscovererTests : TestContainer
                 .Returns(false);
         }
 
-        Action act = () => _unitTestDiscoverer.DiscoverTests(sources, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
-        act.Should().Throw<FileNotFoundException>()
+        Func<Task> act = async () => await _unitTestDiscoverer.DiscoverTestsAsync(sources, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
+        await act.Should().ThrowAsync<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, sources[0]));
     }
 
-    public void DiscoverTestsInSourceShouldThrowOnFileNotFound()
+    public async Task DiscoverTestsInSourceShouldThrowOnFileNotFound()
     {
         // Setup mocks.
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetFullFilePath(Source))
@@ -93,12 +93,12 @@ public class UnitTestDiscovererTests : TestContainer
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.DoesFileExist(Source))
             .Returns(false);
 
-        Action act = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
-        act.Should().Throw<FileNotFoundException>()
+        Func<Task> act = async () => await _unitTestDiscoverer.DiscoverTestsInSourceAsync(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
+        await act.Should().ThrowAsync<FileNotFoundException>()
             .WithMessage(string.Format(CultureInfo.CurrentCulture, Resource.TestAssembly_FileDoesNotExist, Source));
     }
 
-    public void DiscoverTestsInSourceShouldSendBackTestCasesDiscovered()
+    public async Task DiscoverTestsInSourceShouldSendBackTestCasesDiscovered()
     {
         // Setup mocks.
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetFullFilePath(Source))
@@ -125,13 +125,13 @@ public class UnitTestDiscovererTests : TestContainer
         MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object.RunSettings?.SettingsXml, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
+        await _unitTestDiscoverer.DiscoverTestsInSourceAsync(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.AtLeastOnce);
     }
 
-    public void DiscoverTestsInSourceShouldThrowWhenTreatDiscoveryWarningsAsErrorsIsTrue()
+    public async Task DiscoverTestsInSourceShouldThrowWhenTreatDiscoveryWarningsAsErrorsIsTrue()
     {
         // Setup mocks.
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetFullFilePath(Source))
@@ -160,10 +160,10 @@ public class UnitTestDiscovererTests : TestContainer
         MSTestSettings.PopulateSettings(_mockDiscoveryContext.Object.RunSettings?.SettingsXml, _mockMessageLogger.Object.ToAdapterMessageLogger(), null);
 
         // Act
-        Action action = () => _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
+        Func<Task> action = async () => await _unitTestDiscoverer.DiscoverTestsInSourceAsync(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Assert
-        action.Should().Throw<MSTestException>()
+        await action.Should().ThrowAsync<MSTestException>()
             .WithMessage($"*{Source}*");
 
         // Verify warning message was sent to logger (not error)
@@ -171,7 +171,7 @@ public class UnitTestDiscovererTests : TestContainer
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Never);
     }
 
-    public void DiscoverTestsInSourceShouldNotThrowWhenTreatDiscoveryWarningsAsErrorsIsFalse()
+    public async Task DiscoverTestsInSourceShouldNotThrowWhenTreatDiscoveryWarningsAsErrorsIsFalse()
     {
         // Setup mocks.
         _testablePlatformServiceProvider.MockFileOperations.Setup(fo => fo.GetFullFilePath(Source))
@@ -199,29 +199,29 @@ public class UnitTestDiscovererTests : TestContainer
 
         // Act & Assert
         // Should not throw an exception
-        _unitTestDiscoverer.DiscoverTestsInSource(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
+        await _unitTestDiscoverer.DiscoverTestsInSourceAsync(Source, _mockMessageLogger.Object.ToAdapterMessageLogger(), _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), _mockDiscoveryContext.Object.RunSettings?.SettingsXml, new TestElementFilterProvider(_mockDiscoveryContext.Object), false);
 
         // Verify warning message was sent to logger (not error)
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Warning, It.IsAny<string>()), Times.AtLeastOnce);
         _mockMessageLogger.Verify(lm => lm.SendMessage(TestMessageLevel.Error, It.IsAny<string>()), Times.Never);
     }
 
-    public void SendTestCasesShouldNotSendAnyTestCasesIfThereAreNoTestElements()
+    public async Task SendTestCasesShouldNotSendAnyTestCasesIfThereAreNoTestElements()
     {
         // There is a null check for testElements in the code flow before this function call. So not adding a unit test for that.
-        UnitTestDiscoverer.SendTestCases(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(new List<UnitTestElement> { }, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.IsAny<TestCase>()), Times.Never);
     }
 
-    public void SendTestCasesShouldSendAllTestCaseData()
+    public async Task SendTestCasesShouldSendAllTestCaseData()
     {
         var test1 = new UnitTestElement(CreateTestMethod("M1", "C", "A", displayName: null));
         var test2 = new UnitTestElement(CreateTestMethod("M2", "C", "A", displayName: null));
         var testElements = new List<UnitTestElement> { test1, test2 };
 
-        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(_mockDiscoveryContext.Object), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -231,7 +231,7 @@ public class UnitTestDiscovererTests : TestContainer
     /// <summary>
     /// Send test cases should send filtered test cases only.
     /// </summary>
-    public void SendTestCasesShouldSendFilteredTestCasesIfValidFilterExpression()
+    public async Task SendTestCasesShouldSendFilteredTestCasesIfValidFilterExpression()
     {
         TestableDiscoveryContextWithGetTestCaseFilter discoveryContext = new(() => new TestableTestCaseFilterExpression(p => p.DisplayName == "M1"));
 
@@ -240,7 +240,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -250,7 +250,7 @@ public class UnitTestDiscovererTests : TestContainer
     /// <summary>
     /// Send test cases should send all test cases if filter expression is null.
     /// </summary>
-    public void SendTestCasesShouldSendAllTestCasesIfNullFilterExpression()
+    public async Task SendTestCasesShouldSendAllTestCasesIfNullFilterExpression()
     {
         TestableDiscoveryContextWithGetTestCaseFilter discoveryContext = new(() => null!);
 
@@ -259,7 +259,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -269,7 +269,7 @@ public class UnitTestDiscovererTests : TestContainer
     /// <summary>
     /// Send test cases should send all test cases if GetTestCaseFilter method is not present in DiscoveryContext.
     /// </summary>
-    public void SendTestCasesShouldSendAllTestCasesIfGetTestCaseFilterNotPresent()
+    public async Task SendTestCasesShouldSendAllTestCasesIfGetTestCaseFilterNotPresent()
     {
         TestableDiscoveryContextWithoutGetTestCaseFilter discoveryContext = new();
 
@@ -278,7 +278,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Once);
@@ -288,7 +288,7 @@ public class UnitTestDiscovererTests : TestContainer
     /// <summary>
     /// Send test cases should not send any test cases if filter parsing error.
     /// </summary>
-    public void SendTestCasesShouldNotSendAnyTestCasesIfFilterError()
+    public async Task SendTestCasesShouldNotSendAnyTestCasesIfFilterError()
     {
         TestableDiscoveryContextWithGetTestCaseFilter discoveryContext = new(() => throw new TestPlatformFormatException("DummyException"));
 
@@ -297,7 +297,7 @@ public class UnitTestDiscovererTests : TestContainer
         var testElements = new List<UnitTestElement> { test1, test2 };
 
         // Action
-        UnitTestDiscoverer.SendTestCases(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
+        await UnitTestDiscoverer.SendTestCasesAsync(testElements, _mockTestCaseDiscoverySink.Object.ToUnitTestElementSink(), new TestElementFilterProvider(discoveryContext), _mockMessageLogger.Object.ToAdapterMessageLogger());
 
         // Assert.
         _mockTestCaseDiscoverySink.Verify(ds => ds.SendTestCase(It.Is<TestCase>(tc => tc.FullyQualifiedName == "C.M1")), Times.Never);
@@ -323,7 +323,7 @@ internal class DummyNavigationData
 
 internal class TestableUnitTestDiscoverer(ITestSourceHandler? testSourceHandler = null) : UnitTestDiscoverer(testSourceHandler ?? new TestSourceHandler())
 {
-    internal override void DiscoverTestsInSource(
+    internal override async Task DiscoverTestsInSourceAsync(
         string source,
         IAdapterMessageLogger logger,
         IUnitTestElementSink discoverySink,
@@ -333,8 +333,8 @@ internal class TestableUnitTestDiscoverer(ITestSourceHandler? testSourceHandler 
     {
         var testElement1 = new UnitTestElement(new TestMethod("A", "C", source, displayName: null));
         var testElement2 = new UnitTestElement(new TestMethod("B", "C", source, displayName: null));
-        discoverySink.SendTestElement(testElement1);
-        discoverySink.SendTestElement(testElement2);
+        await discoverySink.SendTestElementAsync(testElement1);
+        await discoverySink.SendTestElementAsync(testElement2);
     }
 }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestCaseDiscoverySinkTests.cs
@@ -22,24 +22,24 @@ public class TestCaseDiscoverySinkTests : TestContainer
         _testCaseDiscoverySink.TestElements.Count.Should().Be(0);
     }
 
-    public void SendTestElementShouldAddTheTestElement()
+    public async Task SendTestElementShouldAddTheTestElement()
     {
         var testElement = new UnitTestElement(new TestMethod("M", "C", "A", displayName: null));
 
-        _testCaseDiscoverySink.SendTestElement(testElement);
+        await _testCaseDiscoverySink.SendTestElementAsync(testElement);
 
         _testCaseDiscoverySink.TestElements.Should().NotBeNull();
         _testCaseDiscoverySink.TestElements.Count.Should().Be(1);
         _testCaseDiscoverySink.TestElements.ToArray()[0].Should().BeSameAs(testElement);
     }
 
-    public void SendTestElementShouldAddEachTestElementInOrder()
+    public async Task SendTestElementShouldAddEachTestElementInOrder()
     {
         var testElement1 = new UnitTestElement(new TestMethod("M1", "C", "A", displayName: null));
         var testElement2 = new UnitTestElement(new TestMethod("M2", "C", "A", displayName: null));
 
-        _testCaseDiscoverySink.SendTestElement(testElement1);
-        _testCaseDiscoverySink.SendTestElement(testElement2);
+        await _testCaseDiscoverySink.SendTestElementAsync(testElement1);
+        await _testCaseDiscoverySink.SendTestElementAsync(testElement2);
 
         _testCaseDiscoverySink.TestElements.Count.Should().Be(2);
         _testCaseDiscoverySink.TestElements.ToArray()[0].Should().BeSameAs(testElement1);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestExecutionManagerTests.cs
@@ -135,12 +135,12 @@ public class TestExecutionManagerTests : TestContainer
         expectedResultList.SequenceEqual(_frameworkHandle.ResultsList).Should().BeTrue();
     }
 
-    public void SendTestResults_WhenUnitTestResultsIsEmpty_RecordsEndWithoutResult()
+    public async Task SendTestResults_WhenUnitTestResultsIsEmpty_RecordsEndWithoutResult()
     {
         TestCase testCase = GetTestCase(typeof(DummyTestClass), "PassingTest");
         Microsoft.VisualStudio.TestTools.UnitTesting.TestResult[] unitTestResults = [];
 
-        _testExecutionManager.SendTestResults(ToUnitTestElement(testCase), unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
+        await _testExecutionManager.SendTestResultsAsync(ToUnitTestElement(testCase), unitTestResults, DateTimeOffset.Now, DateTimeOffset.Now, _frameworkHandle.ToTestResultRecorder(EnvironmentWrapper.Instance.MachineName, MSTestSettings.CurrentSettings));
 
         _frameworkHandle.TestCaseEndList.Should().Equal("PassingTest:None");
         _frameworkHandle.ResultsList.Should().BeEmpty();

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -239,13 +239,13 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     }
 
     // --- Seams ------------------------------------------------------------------------------------------------
-    public void MtpUnitTestElementSink_PublishesDiscoveredTestNode()
+    public async Task MtpUnitTestElementSink_PublishesDiscoveredTestNode()
     {
         var messageBus = new CapturingMessageBus();
         var sessionUid = new SessionUid("session-1");
         var sink = new MtpUnitTestElementSink(messageBus, new StubDataProducer(), sessionUid, isTrxEnabled: false);
 
-        sink.SendTestElement(CreateElement());
+        await sink.SendTestElementAsync(CreateElement());
 
         messageBus.Published.Should().ContainSingle();
         var message = (TestNodeUpdateMessage)messageBus.Published[0];
@@ -253,46 +253,46 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         message.TestNode.Properties.Any<DiscoveredTestNodeStateProperty>().Should().BeTrue();
     }
 
-    public void MtpTestResultRecorder_RecordStart_PublishesInProgressNode()
+    public async Task MtpTestResultRecorder_RecordStart_PublishesInProgressNode()
     {
         var messageBus = new CapturingMessageBus();
         var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
 
-        recorder.RecordStart(CreateElement());
+        await recorder.RecordStartAsync(CreateElement());
 
         var message = (TestNodeUpdateMessage)messageBus.Published.Single();
         message.TestNode.Properties.Any<InProgressTestNodeStateProperty>().Should().BeTrue();
     }
 
-    public void MtpTestResultRecorder_RecordEmptyResult_PublishesNothing()
+    public async Task MtpTestResultRecorder_RecordEmptyResult_PublishesNothing()
     {
         var messageBus = new CapturingMessageBus();
         var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
 
-        recorder.RecordEmptyResult(CreateElement());
+        await recorder.RecordEmptyResultAsync(CreateElement());
 
         messageBus.Published.Should().BeEmpty();
     }
 
-    public void MtpTestResultRecorder_RecordResult_PublishesResultNodeAndReturnsFailedFlag()
+    public async Task MtpTestResultRecorder_RecordResult_PublishesResultNodeAndReturnsFailedFlag()
     {
         var messageBus = new CapturingMessageBus();
         var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
         var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Failed, ExceptionMessage = "nope" };
 
-        bool isFailed = recorder.RecordResult(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now);
+        bool isFailed = await recorder.RecordResultAsync(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now);
 
         isFailed.Should().BeTrue();
         var message = (TestNodeUpdateMessage)messageBus.Published.Single();
         message.TestNode.Properties.Any<FailedTestNodeStateProperty>().Should().BeTrue();
     }
 
-    public void MtpTestResultRecorder_RecordResult_ReturnsFalse_ForPassedTest()
+    public async Task MtpTestResultRecorder_RecordResult_ReturnsFalse_ForPassedTest()
     {
         var messageBus = new CapturingMessageBus();
         var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
 
-        bool isFailed = recorder.RecordResult(CreateElement(), new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now);
+        bool isFailed = await recorder.RecordResultAsync(CreateElement(), new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now);
 
         isFailed.Should().BeFalse();
     }

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Extensions;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestFramework.ForTestingMSTest;
+
+using FrameworkTestResult = Microsoft.VisualStudio.TestTools.UnitTesting.TestResult;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests;
+
+/// <summary>
+/// Unit tests for <see cref="MSTestTestNodeConverter"/> and the Microsoft.Testing.Platform-native
+/// discovery/result seams (<see cref="MtpUnitTestElementSink"/>, <see cref="MtpTestResultRecorder"/>).
+/// </summary>
+public sealed class MSTestTestNodeConverterTests : TestContainer
+{
+    private static UnitTestElement CreateElement(string? managedMethodName = "MyMethod", string fullClassName = "MyNamespace.MyClass", string name = "MyMethod")
+    {
+        var testMethod = new TestMethod(managedMethodName, hierarchyValues: null, name, fullClassName, "MyAssembly.dll", displayName: null, parameterTypes: null);
+        return new UnitTestElement(testMethod);
+    }
+
+    // --- Discovery node ---------------------------------------------------------------------------------------
+    public void ToDiscoveredTestNode_SetsUidDisplayNameAndDiscoveredState()
+    {
+        UnitTestElement element = CreateElement();
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        node.Uid.Value.Should().Be(element.GetTestId().ToString());
+        node.DisplayName.Should().Be("MyMethod");
+        node.Properties.Any<DiscoveredTestNodeStateProperty>().Should().BeTrue();
+        node.Properties.Any<InProgressTestNodeStateProperty>().Should().BeFalse();
+    }
+
+    public void ToDiscoveredTestNode_UsesExplicitDisplayName_WhenProvided()
+    {
+        var testMethod = new TestMethod("MyMethod", hierarchyValues: null, "MyMethod", "MyNamespace.MyClass", "MyAssembly.dll", displayName: "Friendly name", parameterTypes: null);
+        var element = new UnitTestElement(testMethod);
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        node.DisplayName.Should().Be("Friendly name");
+    }
+
+    public void ToInProgressTestNode_AddsInProgressState()
+    {
+        TestNode node = MSTestTestNodeConverter.ToInProgressTestNode(CreateElement(), isTrxEnabled: false);
+
+        node.Properties.Any<InProgressTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void ToDiscoveredTestNode_AddsTestMethodIdentifier_FromManagedNames()
+    {
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(CreateElement(), isTrxEnabled: false);
+
+        TestMethodIdentifierProperty? identifier = node.Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        identifier.Should().NotBeNull();
+        identifier!.Namespace.Should().Be("MyNamespace");
+        identifier.TypeName.Should().Be("MyClass");
+        identifier.MethodName.Should().Be("MyMethod");
+        identifier.AssemblyFullName.Should().BeEmpty();
+        identifier.ReturnTypeFullName.Should().BeEmpty();
+    }
+
+    public void ToDiscoveredTestNode_DoesNotAddTestMethodIdentifier_WhenNoManagedMethodName()
+    {
+        UnitTestElement element = CreateElement(managedMethodName: null);
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        node.Properties.Any<TestMethodIdentifierProperty>().Should().BeFalse();
+    }
+
+    public void ToDiscoveredTestNode_AddsFileLocation_WhenDeclaringFileKnown()
+    {
+        UnitTestElement element = CreateElement();
+        element.DeclaringFilePath = "C:\\src\\MyClass.cs";
+        element.DeclaringLineNumber = 42;
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        TestFileLocationProperty? location = node.Properties.SingleOrDefault<TestFileLocationProperty>();
+        location.Should().NotBeNull();
+        location!.FilePath.Should().Be("C:\\src\\MyClass.cs");
+        location.LineSpan.Start.Line.Should().Be(42);
+    }
+
+    public void ToDiscoveredTestNode_DoesNotAddFileLocation_WhenDeclaringFileUnknown()
+    {
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(CreateElement(), isTrxEnabled: false);
+
+        node.Properties.Any<TestFileLocationProperty>().Should().BeFalse();
+    }
+
+    public void ToDiscoveredTestNode_AddsCategoriesAndTraitsAsMetadata()
+    {
+        UnitTestElement element = CreateElement();
+        element.TestCategory = ["CategoryA", "CategoryB"];
+        element.Traits = [new TestTrait("Owner", "Alice")];
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        TestMetadataProperty[] metadata = node.Properties.OfType<TestMetadataProperty>();
+        metadata.Should().Contain(p => p.Key == "CategoryA" && p.Value == string.Empty);
+        metadata.Should().Contain(p => p.Key == "CategoryB" && p.Value == string.Empty);
+        metadata.Should().Contain(p => p.Key == "Owner" && p.Value == "Alice");
+    }
+
+    public void ToDiscoveredTestNode_AddsTrxCategories_OnlyWhenTrxEnabled()
+    {
+        UnitTestElement element = CreateElement();
+        element.TestCategory = ["CategoryA"];
+
+        MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false)
+            .Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>().Should().BeFalse();
+
+        MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: true)
+            .Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>().Should().BeTrue();
+    }
+
+    // --- Result node: outcomes --------------------------------------------------------------------------------
+    public void ToResultTestNode_MapsPassedOutcome()
+    {
+        TestNode node = ResultNode(UnitTestOutcome.Passed);
+
+        node.Properties.Any<PassedTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void ToResultTestNode_MapsFailedOutcome_WithMessageAndStackTrace()
+    {
+        var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Failed, ExceptionMessage = "boom", ExceptionStackTrace = "at Some.Method()" };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        FailedTestNodeStateProperty? failed = node.Properties.SingleOrDefault<FailedTestNodeStateProperty>();
+        failed.Should().NotBeNull();
+        failed!.Exception!.Message.Should().Be("boom");
+        failed.Exception.StackTrace.Should().Be("at Some.Method()");
+    }
+
+    public void ToResultTestNode_MapsIgnoredOutcomeToSkipped()
+    {
+        TestNode node = ResultNode(UnitTestOutcome.Ignored);
+
+        node.Properties.Any<SkippedTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void ToResultTestNode_MapsNotFoundOutcomeToError()
+    {
+        TestNode node = ResultNode(UnitTestOutcome.NotFound);
+
+        node.Properties.Any<ErrorTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void ToResultTestNode_MapsInconclusiveToSkipped_ByDefault()
+    {
+        // Default MSTestSettings has MapInconclusiveToFailed = false.
+        TestNode node = ResultNode(UnitTestOutcome.Inconclusive);
+
+        node.Properties.Any<SkippedTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    // --- Result node: timing, output, attachments -------------------------------------------------------------
+    public void ToResultTestNode_AddsTimingProperty()
+    {
+        var start = new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero);
+        DateTimeOffset end = start.AddSeconds(2);
+        var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Passed, Duration = TimeSpan.FromSeconds(2) };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, start, end, isTrxEnabled: false, new MSTestSettings());
+
+        TimingProperty? timing = node.Properties.SingleOrDefault<TimingProperty>();
+        timing.Should().NotBeNull();
+        timing!.GlobalTiming.Duration.Should().Be(TimeSpan.FromSeconds(2));
+    }
+
+    public void ToResultTestNode_MapsLogOutputAndLogErrorToStandardStreams()
+    {
+        var result = new FrameworkTestResult
+        {
+            Outcome = UnitTestOutcome.Passed,
+            LogOutput = "hello out",
+            LogError = "hello err",
+        };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        node.Properties.SingleOrDefault<StandardOutputProperty>()!.StandardOutput.Should().Contain("hello out");
+        node.Properties.SingleOrDefault<StandardErrorProperty>()!.StandardError.Should().Contain("hello err");
+    }
+
+    public void ToResultTestNode_IncludesDebugTraceAndTestContextBannersInStandardOutput()
+    {
+        var result = new FrameworkTestResult
+        {
+            Outcome = UnitTestOutcome.Passed,
+            DebugTrace = "some trace",
+            TestContextMessages = "some context",
+        };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        string standardOutput = node.Properties.SingleOrDefault<StandardOutputProperty>()!.StandardOutput;
+        standardOutput.Should().Contain("Debug Trace:").And.Contain("some trace");
+        standardOutput.Should().Contain("TestContext Messages:").And.Contain("some context");
+    }
+
+    // --- Result node: TRX properties --------------------------------------------------------------------------
+    public void ToResultTestNode_AddsTrxProperties_WhenTrxEnabled()
+    {
+        var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Failed, ExceptionMessage = "boom", ExceptionStackTrace = "at X()" };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: true, new MSTestSettings());
+
+        node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxExceptionProperty>().Should().BeTrue();
+        node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxMessagesProperty>().Should().BeTrue();
+        Testing.Extensions.TrxReport.Abstractions.TrxFullyQualifiedTypeNameProperty? typeName =
+            node.Properties.SingleOrDefault<Testing.Extensions.TrxReport.Abstractions.TrxFullyQualifiedTypeNameProperty>();
+        typeName.Should().NotBeNull();
+        typeName!.FullyQualifiedTypeName.Should().Be("MyNamespace.MyClass");
+    }
+
+    public void ToResultTestNode_DoesNotAddTrxProperties_WhenTrxDisabled()
+    {
+        TestNode node = ResultNode(UnitTestOutcome.Passed);
+
+        node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxExceptionProperty>().Should().BeFalse();
+        node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxMessagesProperty>().Should().BeFalse();
+    }
+
+    // --- Seams ------------------------------------------------------------------------------------------------
+    public void MtpUnitTestElementSink_PublishesDiscoveredTestNode()
+    {
+        var messageBus = new CapturingMessageBus();
+        var sessionUid = new SessionUid("session-1");
+        var sink = new MtpUnitTestElementSink(messageBus, new StubDataProducer(), sessionUid, isTrxEnabled: false);
+
+        sink.SendTestElement(CreateElement());
+
+        messageBus.Published.Should().ContainSingle();
+        var message = (TestNodeUpdateMessage)messageBus.Published[0];
+        message.SessionUid.Value.Should().Be("session-1");
+        message.TestNode.Properties.Any<DiscoveredTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void MtpTestResultRecorder_RecordStart_PublishesInProgressNode()
+    {
+        var messageBus = new CapturingMessageBus();
+        var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
+
+        recorder.RecordStart(CreateElement());
+
+        var message = (TestNodeUpdateMessage)messageBus.Published.Single();
+        message.TestNode.Properties.Any<InProgressTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void MtpTestResultRecorder_RecordEmptyResult_PublishesNothing()
+    {
+        var messageBus = new CapturingMessageBus();
+        var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
+
+        recorder.RecordEmptyResult(CreateElement());
+
+        messageBus.Published.Should().BeEmpty();
+    }
+
+    public void MtpTestResultRecorder_RecordResult_PublishesResultNodeAndReturnsFailedFlag()
+    {
+        var messageBus = new CapturingMessageBus();
+        var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
+        var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Failed, ExceptionMessage = "nope" };
+
+        bool isFailed = recorder.RecordResult(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now);
+
+        isFailed.Should().BeTrue();
+        var message = (TestNodeUpdateMessage)messageBus.Published.Single();
+        message.TestNode.Properties.Any<FailedTestNodeStateProperty>().Should().BeTrue();
+    }
+
+    public void MtpTestResultRecorder_RecordResult_ReturnsFalse_ForPassedTest()
+    {
+        var messageBus = new CapturingMessageBus();
+        var recorder = new MtpTestResultRecorder(messageBus, new StubDataProducer(), new SessionUid("s"), isTrxEnabled: false, new MSTestSettings());
+
+        bool isFailed = recorder.RecordResult(CreateElement(), new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now);
+
+        isFailed.Should().BeFalse();
+    }
+
+    private static TestNode ResultNode(UnitTestOutcome outcome)
+        => MSTestTestNodeConverter.ToResultTestNode(CreateElement(), new FrameworkTestResult { Outcome = outcome }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        public List<IData> Published { get; } = [];
+
+        public Task PublishAsync(IDataProducer dataProducer, IData data)
+        {
+            Published.Add(data);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StubDataProducer : IDataProducer
+    {
+        public Type[] DataTypesProduced { get; } = [typeof(TestNodeUpdateMessage)];
+
+        public string Uid => "stub";
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => "Stub";
+
+        public string Description => "Stub data producer for tests.";
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    }
+}


### PR DESCRIPTION
## What

Works toward removing the `Microsoft.Testing.Extensions.VSTestBridge` dependency from MSTest's Microsoft.Testing.Platform (MTP) code path, so MSTest plugs into MTP natively. Delivered as a reviewable, phased series — all behind the opt-in `MSTEST_EXPERIMENTAL_NATIVE_MTP` switch, so the shipping default (the bridge) is unchanged.

- **RFC 018** — the roadmap/design (`docs/RFCs/018-...md`).
- **Phase 1** — native `TestNode` production seam (`MSTestTestNodeConverter`, `MtpUnitTestElementSink`, `MtpTestResultRecorder`).
- **Phase 2** — proved the seams by wiring them behind the flag (now superseded by the native framework).
- **Phases 3–5** — a native `MSTestTestFramework` that handles the MTP request directly: native filtering, runsettings/config, message logging, and session lifecycle. No VSTest bridge object-model adapters on the native request path.
- Review feedback addressed (async neutral seams, UTF-8 BOM, doc style).

## Why

On the MTP path, MSTest round-trips through the VSTest object model (context/filter/runsettings/handle/sink adapters) even though its engine already runs on neutral models. Going native removes that plumbing.

## Phases 3–5 in the latest commit

A native `MSTestTestFramework : ITestFramework, IDataProducer` replaces the bridge framework on the flag path and **reuses MSTest's existing `MSTestDiscoverer`/`MSTestExecutor` engine**. New (all `#if !WINDOWS_UWP`):

- **`MSTestFilterContext`** (`MSTestRunContext`/`MSTestDiscoveryContext`) — native `IRunContext`/`IDiscoveryContext` that builds the VSTest `ITestCaseFilterExpression` from the MTP `ITestExecutionFilter` + `--filter` + runsettings `<TestCaseFilter>` (reusing `Microsoft.TestPlatform.Filter.Source`, now referenced directly). MSTest's existing `TestMethodFilter` matching is unchanged.
- **`MSTestRunSettings`** — native `IRunSettings`: reads runsettings, patches MTP defaults (DesignMode/ResultsDirectory/`--test-parameter`), and warns on unsupported entries (reusing the bridge's already-localized `ExtensionResources`).
- **`MSTestFrameworkHandle`** — an `IFrameworkHandle` that only forwards messages to `IOutputDevice` (results flow through the native recorder).
- `AddMSTest` branches the framework factory on the flag; the bridge's shared command-line/config/env-var registrations are kept for now (retired with the dependency in the final step).

## Validation

- **Full `.\build.cmd` — 0 warnings, 0 errors** across all TFMs.
- **Unit tests:** 45 (`MSTestAdapter.UnitTests`) + 898 (`MSTestAdapter.PlatformServices.UnitTests`), all green.
- **Native path (flag on, acceptance):** **185** tests green — `FilterTests`, `RunsettingsTests` (incl. localization), `OutputTests`, `TrxReportTests`, `ThreadingTests` (STA), `ServerModeTests`, `DeploymentItem`, `DataSourceTests`, `Inconclusive`/`Ignore`, `TestRunParameters`, `TimeoutTests`.
- **Default bridge path (flag off, acceptance):** `FilterTests` + `RunsettingsTests` (45) — unchanged.

## Remaining — Phase 6 (separate, gated)

Flip the default to native and **drop the `VSTestBridge` dependency** from MSTest. This is gated on:
1. Full MSTest acceptance-suite parity on the native path (hundreds of tests — needs CI).
2. Native replacements for the bridge's remaining shared registrations (the `--filter`/`--settings`/`--test-parameter` option providers and the runsettings config/env-var providers), so the package reference can be removed.

The bridge package itself is **not** removed — NUnit/Expecto/3rd-party adapters still use it. Only MSTest stops depending on it.
