### PR TITLE
Support managed identity auth in AzureFoundry provider

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,6 +78,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
@@ -43,6 +43,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Testing.Extensions.AzureFoundry;
 /// </summary>
 internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
 {
+    // DefaultAzureCredential caches tokens on the instance and probes the whole credential chain
+    // (env vars, workload identity, managed identity via IMDS, Azure CLI, ...) on first use, which
+    // can be expensive. Reuse a single instance so the token cache and chain discovery are shared.
+    private static readonly Lazy<DefaultAzureCredential> DefaultCredential = new(() => new DefaultAzureCredential());
+
     /// <inheritdoc />
     public bool IsAvailable =>
         !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
@@ -50,7 +55,7 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
         // authentication via DefaultAzureCredential. This keeps the provider secure-by-default for
         // Azure-hosted scenarios where distributing API keys is undesirable.
         AzureOpenAIClient client = RoslynString.IsNullOrEmpty(apiKey)
-            ? new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+            ? new AzureOpenAIClient(new Uri(endpoint), DefaultCredential.Value)
             : new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey));
 
         return Task.FromResult(client.GetChatClient(deploymentName).AsIChatClient());

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
@@ -4,6 +4,7 @@
 using System.ClientModel;
 
 using Azure.AI.OpenAI;
+using Azure.Identity;
 
 using Microsoft.Extensions.AI;
 using Microsoft.Testing.Extensions.AzureFoundry.Resources;
@@ -20,8 +21,7 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
     /// <inheritdoc />
     public bool IsAvailable =>
         !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
-        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")) &&
-        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY"));
+        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME"));
 
     /// <inheritdoc />
     public bool HasToolsCapability => true;
@@ -46,14 +46,12 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExtensionResources.EnvironmentVariableNotSet, "AZURE_OPENAI_DEPLOYMENT_NAME"));
         }
 
-        if (RoslynString.IsNullOrEmpty(apiKey))
-        {
-            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExtensionResources.EnvironmentVariableNotSet, "AZURE_OPENAI_API_KEY"));
-        }
-
-        var client = new AzureOpenAIClient(
-            new Uri(endpoint),
-            new ApiKeyCredential(apiKey));
+        // Prefer an explicit API key when provided, otherwise fall back to Entra ID / managed identity
+        // authentication via DefaultAzureCredential. This keeps the provider secure-by-default for
+        // Azure-hosted scenarios where distributing API keys is undesirable.
+        AzureOpenAIClient client = RoslynString.IsNullOrEmpty(apiKey)
+            ? new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+            : new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey));
 
         return Task.FromResult(client.GetChatClient(deploymentName).AsIChatClient());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
@@ -23,6 +23,22 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
     // can be expensive. Reuse a single instance so the token cache and chain discovery are shared.
     private static readonly Lazy<DefaultAzureCredential> DefaultCredential = new(() => new DefaultAzureCredential());
 
+    /// <summary>
+    /// The authentication mode used to create the Azure OpenAI client.
+    /// </summary>
+    internal enum AuthenticationMode
+    {
+        /// <summary>
+        /// Authenticate with an explicit API key (<c>AZURE_OPENAI_API_KEY</c>).
+        /// </summary>
+        ApiKey,
+
+        /// <summary>
+        /// Authenticate with Entra ID / managed identity via <see cref="DefaultAzureCredential"/>.
+        /// </summary>
+        DefaultAzureCredential,
+    }
+
     /// <inheritdoc />
     public bool IsAvailable =>
         !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
@@ -33,6 +49,14 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
 
     /// <inheritdoc />
     public string ModelName => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "unknown";
+
+    // Prefer an explicit API key when provided, otherwise fall back to Entra ID / managed identity
+    // authentication via DefaultAzureCredential. This keeps the provider secure-by-default for
+    // Azure-hosted scenarios where distributing API keys is undesirable.
+    internal static AuthenticationMode GetAuthenticationMode(string? apiKey)
+        => RoslynString.IsNullOrEmpty(apiKey)
+            ? AuthenticationMode.DefaultAzureCredential
+            : AuthenticationMode.ApiKey;
 
     /// <inheritdoc />
     public Task<IChatClient> CreateChatClientAsync(CancellationToken cancellationToken)
@@ -51,12 +75,11 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExtensionResources.EnvironmentVariableNotSet, "AZURE_OPENAI_DEPLOYMENT_NAME"));
         }
 
-        // Prefer an explicit API key when provided, otherwise fall back to Entra ID / managed identity
-        // authentication via DefaultAzureCredential. This keeps the provider secure-by-default for
-        // Azure-hosted scenarios where distributing API keys is undesirable.
-        AzureOpenAIClient client = RoslynString.IsNullOrEmpty(apiKey)
-            ? new AzureOpenAIClient(new Uri(endpoint), DefaultCredential.Value)
-            : new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey));
+        AzureOpenAIClient client = GetAuthenticationMode(apiKey) switch
+        {
+            AuthenticationMode.ApiKey => new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey!)),
+            _ => new AzureOpenAIClient(new Uri(endpoint), DefaultCredential.Value),
+        };
 
         return Task.FromResult(client.GetChatClient(deploymentName).AsIChatClient());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
@@ -33,6 +33,8 @@ When `AZURE_OPENAI_API_KEY` is not set, the provider authenticates with [`Defaul
 
 To target a specific user-assigned managed identity, set the `AZURE_CLIENT_ID` environment variable to its client ID; `DefaultAzureCredential` honors it automatically. Because credentials are resolved lazily, authentication problems (for example, an identity that lacks access to the Azure OpenAI resource) surface on the first chat request rather than when the provider is configured.
 
+> **Note:** In local development, `DefaultAzureCredential` can take several seconds on first use because it probes a chain of credential sources (Managed Identity, Workload Identity, Azure CLI, Visual Studio, etc.) until one succeeds. Setting `AZURE_OPENAI_API_KEY` avoids this delay by using key-based authentication directly.
+
 This package is a reference implementation of the [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/Microsoft.Testing.Platform.AI) abstractions.
 
 ## Related packages

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
@@ -31,6 +31,8 @@ The provider is configured through the following environment variables:
 
 When `AZURE_OPENAI_API_KEY` is not set, the provider authenticates with [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential), which is recommended for Azure-hosted scenarios so that no secret has to be provisioned or distributed. Provide `AZURE_OPENAI_API_KEY` only when you explicitly want key-based authentication.
 
+To target a specific user-assigned managed identity, set the `AZURE_CLIENT_ID` environment variable to its client ID; `DefaultAzureCredential` honors it automatically. Because credentials are resolved lazily, authentication problems (for example, an identity that lacks access to the Azure OpenAI resource) surface on the first chat request rather than when the provider is configured.
+
 This package is a reference implementation of the [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/Microsoft.Testing.Platform.AI) abstractions.
 
 ## Related packages

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
@@ -17,6 +17,19 @@ This package extends Microsoft.Testing.Platform with:
 - **Azure AI Foundry integration**: provides an `IChatClientProvider` implementation backed by Azure OpenAI
 - **Provider implementation**: supplies chat client capabilities to extensions using `Microsoft.Testing.Platform.AI`
 - **Environment-based configuration**: reads Azure OpenAI settings from environment variables
+- **Flexible authentication**: uses Microsoft Entra ID / managed identity (`DefaultAzureCredential`) by default and falls back to an API key when one is provided
+
+## Configuration
+
+The provider is configured through the following environment variables:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `AZURE_OPENAI_ENDPOINT` | Yes | The Azure OpenAI resource endpoint, for example `https://my-resource.openai.azure.com`. |
+| `AZURE_OPENAI_DEPLOYMENT_NAME` | Yes | The name of the model deployment to use. |
+| `AZURE_OPENAI_API_KEY` | No | An API key for the resource. When omitted, authentication uses `DefaultAzureCredential` (Managed Identity, Workload Identity, Azure CLI, Visual Studio, etc.). |
+
+When `AZURE_OPENAI_API_KEY` is not set, the provider authenticates with [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential), which is recommended for Azure-hosted scenarios so that no secret has to be provisioned or distributed. Provide `AZURE_OPENAI_API_KEY` only when you explicitly want key-based authentication.
 
 This package is a reference implementation of the [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/Microsoft.Testing.Platform.AI) abstractions.
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
@@ -118,6 +118,10 @@ public sealed class AzureFoundryChatClientProviderTests
 
         var provider = new AzureOpenAIChatClientProvider();
 
+        // The selection logic must resolve to the API-key path when a key is present...
+        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret"));
+
+        // ...and the client must be constructed without throwing.
         IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
 
         Assert.IsNotNull(client);
@@ -132,11 +136,25 @@ public sealed class AzureFoundryChatClientProviderTests
         var provider = new AzureOpenAIChatClientProvider();
 
         // No AZURE_OPENAI_API_KEY is set, so the provider must fall back to DefaultAzureCredential.
+        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null));
+
         // Credential resolution is lazy, so client construction must not throw even without a live identity.
         IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
 
         Assert.IsNotNull(client);
     }
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithApiKey_ReturnsApiKey()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret"));
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithoutApiKey_ReturnsDefaultAzureCredential()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null));
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithEmptyApiKey_ReturnsDefaultAzureCredential()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(string.Empty));
 
     [TestMethod]
     public async Task CreateChatClientAsync_WhenEndpointMissing_Throws()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Testing.Extensions.AzureFoundry;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+// The provider reads process-wide AZURE_OPENAI_* environment variables, so these tests must not run
+// concurrently with each other. Each test snapshots and restores the variables to avoid leaking state.
+[TestClass]
+[DoNotParallelize]
+public sealed class AzureFoundryChatClientProviderTests
+{
+    private const string EndpointVariable = "AZURE_OPENAI_ENDPOINT";
+    private const string DeploymentVariable = "AZURE_OPENAI_DEPLOYMENT_NAME";
+    private const string ApiKeyVariable = "AZURE_OPENAI_API_KEY";
+
+    private string? _originalEndpoint;
+    private string? _originalDeployment;
+    private string? _originalApiKey;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _originalEndpoint = Environment.GetEnvironmentVariable(EndpointVariable);
+        _originalDeployment = Environment.GetEnvironmentVariable(DeploymentVariable);
+        _originalApiKey = Environment.GetEnvironmentVariable(ApiKeyVariable);
+
+        Environment.SetEnvironmentVariable(EndpointVariable, null);
+        Environment.SetEnvironmentVariable(DeploymentVariable, null);
+        Environment.SetEnvironmentVariable(ApiKeyVariable, null);
+    }
+
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, _originalEndpoint);
+        Environment.SetEnvironmentVariable(DeploymentVariable, _originalDeployment);
+        Environment.SetEnvironmentVariable(ApiKeyVariable, _originalApiKey);
+    }
+
+    [TestMethod]
+    public void IsAvailable_WhenEndpointAndDeploymentSetWithoutApiKey_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.IsTrue(provider.IsAvailable);
+    }
+
+    [TestMethod]
+    public void IsAvailable_WhenApiKeyAlsoSet_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+        Environment.SetEnvironmentVariable(ApiKeyVariable, "secret");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.IsTrue(provider.IsAvailable);
+    }
+
+    [TestMethod]
+    public void IsAvailable_WhenEndpointMissing_ReturnsFalse()
+    {
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.IsFalse(provider.IsAvailable);
+    }
+
+    [TestMethod]
+    public void IsAvailable_WhenDeploymentMissing_ReturnsFalse()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.IsFalse(provider.IsAvailable);
+    }
+
+    [TestMethod]
+    public void ModelName_ReturnsDeploymentName()
+    {
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.AreEqual("gpt-4o", provider.ModelName);
+    }
+
+    [TestMethod]
+    public void ModelName_WhenDeploymentMissing_ReturnsUnknown()
+    {
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.AreEqual("unknown", provider.ModelName);
+    }
+
+    [TestMethod]
+    public void HasToolsCapability_ReturnsTrue()
+    {
+        var provider = new AzureOpenAIChatClientProvider();
+
+        Assert.IsTrue(provider.HasToolsCapability);
+    }
+
+    [TestMethod]
+    public async Task CreateChatClientAsync_WithApiKey_UsesApiKeyPathAndReturnsClient()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+        Environment.SetEnvironmentVariable(ApiKeyVariable, "secret");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
+
+        Assert.IsNotNull(client);
+    }
+
+    [TestMethod]
+    public async Task CreateChatClientAsync_WithoutApiKey_UsesEntraPathAndReturnsClient()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        // No AZURE_OPENAI_API_KEY is set, so the provider must fall back to DefaultAzureCredential.
+        // Credential resolution is lazy, so client construction must not throw even without a live identity.
+        IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
+
+        Assert.IsNotNull(client);
+    }
+
+    [TestMethod]
+    public async Task CreateChatClientAsync_WhenEndpointMissing_Throws()
+    {
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => provider.CreateChatClientAsync(CancellationToken.None));
+
+        Assert.Contains(EndpointVariable, exception.Message);
+    }
+
+    [TestMethod]
+    public async Task CreateChatClientAsync_WhenDeploymentMissing_Throws()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => provider.CreateChatClientAsync(CancellationToken.None));
+
+        Assert.Contains(DeploymentVariable, exception.Message);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
@@ -52,6 +52,9 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.Logging\Microsoft.Testing.Extensions.Logging.csproj">
       <SetTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.AzureFoundry\Microsoft.Testing.Extensions.AzureFoundry.csproj">
+      <SetTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #8412

## Summary
`Microsoft.Testing.Extensions.AzureFoundry` previously hard-required `AZURE_OPENAI_API_KEY` and always constructed `AzureOpenAIClient` with `ApiKeyCredential`, with no managed-identity / Entra path. This made the only built-in AI provider not secure-by-default for Azure-hosted scenarios.

## Changes
- `IsAvailable` now only requires `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_DEPLOYMENT_NAME`; the API key is no longer mandatory.
- `CreateChatClientAsync` prefers an explicit `AZURE_OPENAI_API_KEY` when present, otherwise falls back to `DefaultAzureCredential` (managed identity, workload identity, Azure CLI, Visual Studio, …).
- Added the `Azure.Identity` package reference (version pinned in `Directory.Packages.props`).
- Updated `PACKAGE.md` with a configuration table documenting both authentication modes.

## Notes
- No `.resx`/`.xlf` changes were needed — the existing `EnvironmentVariableNotSet` string is still used for the endpoint/deployment checks.
- Built cleanly (netstandard2.0, net8.0, net9.0) with 0 warnings/0 errors.