### PR TITLE
Deduplicate fixture lifecycle analyzers via shared registration helper

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyCleanupShouldBeValidAnalyzer.cs
@@ -33,10 +33,11 @@ public sealed class AssemblyCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterAssemblyFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute,
             Rule,
+            FixtureKind.Assembly,
             FixtureParameterMode.OptionalTestContext);
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyInitializeShouldBeValidAnalyzer.cs
@@ -33,10 +33,11 @@ public sealed class AssemblyInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterAssemblyFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyInitializeAttribute,
             Rule,
+            FixtureKind.Assembly,
             FixtureParameterMode.MustHaveTestContext);
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassCleanupShouldBeValidAnalyzer.cs
@@ -33,10 +33,11 @@ public sealed class ClassCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterClassFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassCleanupAttribute,
             Rule,
+            FixtureKind.Class,
             FixtureParameterMode.OptionalTestContext);
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ClassInitializeShouldBeValidAnalyzer.cs
@@ -16,8 +16,7 @@ namespace MSTest.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class ClassInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
 {
-    /// <inheritdoc cref="Resources.ClassInitializeShouldBeValidTitle" />
-    public static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
         DiagnosticIds.ClassInitializeShouldBeValidRuleId,
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.ClassInitializeShouldBeValidTitle)),
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.ClassInitializeShouldBeValidMessageFormat)),
@@ -34,10 +33,11 @@ public sealed class ClassInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterClassFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingClassInitializeAttribute,
             Rule,
+            FixtureKind.Class,
             FixtureParameterMode.MustHaveTestContext);
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureKind.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureKind.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace MSTest.Analyzers.Helpers;
+
+/// <summary>
+/// Identifies the lifecycle scope of a fixture method, controlling which validation is applied when
+/// registering a fixture-method analyzer through <see cref="FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer"/>.
+/// </summary>
+internal enum FixtureKind
+{
+    /// <summary>
+    /// An instance fixture method, e.g. <c>[TestInitialize]</c> or <c>[TestCleanup]</c>.
+    /// </summary>
+    Instance,
+
+    /// <summary>
+    /// A class fixture method, e.g. <c>[ClassInitialize]</c> or <c>[ClassCleanup]</c>.
+    /// </summary>
+    Class,
+
+    /// <summary>
+    /// An assembly fixture method, e.g. <c>[AssemblyInitialize]</c> or <c>[AssemblyCleanup]</c>.
+    /// </summary>
+    Assembly,
+}

--- a/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/FixtureMethodAnalyzerHelper.cs
@@ -38,12 +38,44 @@ internal static class FixtureMethodAnalyzerHelper
     }
 
     /// <summary>
+    /// Registers the symbol analysis for a fixture-lifecycle analyzer based on <paramref name="kind"/>, so that
+    /// <paramref name="rule"/> is reported for methods carrying <paramref name="fixtureAttributeMetadataName"/>
+    /// that do not have a valid fixture signature. This is the shared entry point used by the near-identical
+    /// fixture analyzers (<c>TestInitialize</c>/<c>TestCleanup</c>, <c>ClassInitialize</c>/<c>ClassCleanup</c>,
+    /// <c>AssemblyInitialize</c>/<c>AssemblyCleanup</c>). Callers remain responsible for
+    /// <c>ConfigureGeneratedCodeAnalysis</c> / <c>EnableConcurrentExecution</c> as required by the RS1025/RS1026
+    /// analyzers.
+    /// </summary>
+    internal static void RegisterFixtureAnalyzer(
+        AnalysisContext context,
+        string fixtureAttributeMetadataName,
+        DiagnosticDescriptor rule,
+        FixtureKind kind,
+        FixtureParameterMode parameterMode = FixtureParameterMode.MustNotHaveTestContext)
+    {
+        switch (kind)
+        {
+            case FixtureKind.Instance:
+                RegisterInstanceFixtureAnalyzer(context, fixtureAttributeMetadataName, rule);
+                break;
+
+            case FixtureKind.Class:
+                RegisterClassFixtureAnalyzer(context, fixtureAttributeMetadataName, rule, parameterMode);
+                break;
+
+            default:
+                RegisterAssemblyFixtureAnalyzer(context, fixtureAttributeMetadataName, rule, parameterMode);
+                break;
+        }
+    }
+
+    /// <summary>
     /// Registers the standard symbol analysis for an instance fixture method (e.g. <c>[TestInitialize]</c> or
     /// <c>[TestCleanup]</c>): reports <paramref name="rule"/> for methods that do not have a valid instance
     /// fixture signature. Callers remain responsible for <c>ConfigureGeneratedCodeAnalysis</c> /
     /// <c>EnableConcurrentExecution</c> as required by the RS1025/RS1026 analyzers.
     /// </summary>
-    internal static void RegisterInstanceFixtureAnalyzer(
+    private static void RegisterInstanceFixtureAnalyzer(
         AnalysisContext context,
         string fixtureAttributeMetadataName,
         DiagnosticDescriptor rule)
@@ -114,7 +146,7 @@ internal static class FixtureMethodAnalyzerHelper
             SymbolKind.Method);
     }
 
-    internal static void RegisterClassFixtureAnalyzer(
+    private static void RegisterClassFixtureAnalyzer(
         AnalysisContext context,
         string fixtureAttributeMetadataName,
         DiagnosticDescriptor rule,
@@ -126,7 +158,7 @@ internal static class FixtureMethodAnalyzerHelper
             (rule, parameterMode),
             requireTestContextSymbol: parameterMode == FixtureParameterMode.MustHaveTestContext);
 
-    internal static void RegisterAssemblyFixtureAnalyzer(
+    private static void RegisterAssemblyFixtureAnalyzer(
         AnalysisContext context,
         string fixtureAttributeMetadataName,
         DiagnosticDescriptor rule,

--- a/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestCleanupShouldBeValidAnalyzer.cs
@@ -16,8 +16,7 @@ namespace MSTest.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class TestCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
 {
-    /// <inheritdoc cref="Resources.TestCleanupShouldBeValidTitle" />
-    public static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
         DiagnosticIds.TestCleanupShouldBeValidRuleId,
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.TestCleanupShouldBeValidTitle)),
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.TestCleanupShouldBeValidMessageFormat)),
@@ -34,9 +33,10 @@ public sealed class TestCleanupShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterInstanceFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestCleanupAttribute,
-            Rule);
+            Rule,
+            FixtureKind.Instance);
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestInitializeShouldBeValidAnalyzer.cs
@@ -16,8 +16,7 @@ namespace MSTest.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class TestInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
 {
-    /// <inheritdoc cref="Resources.TestInitializeShouldBeValidTitle" />
-    public static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
         DiagnosticIds.TestInitializeShouldBeValidRuleId,
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.TestInitializeShouldBeValidTitle)),
         FixtureMethodAnalyzerHelper.CreateResourceString(nameof(Resources.TestInitializeShouldBeValidMessageFormat)),
@@ -34,9 +33,10 @@ public sealed class TestInitializeShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        FixtureMethodAnalyzerHelper.RegisterInstanceFixtureAnalyzer(
+        FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(
             context,
             WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestInitializeAttribute,
-            Rule);
+            Rule,
+            FixtureKind.Instance);
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ClassInitializeShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ClassInitializeShouldBeValidAnalyzerTests.cs
@@ -148,7 +148,7 @@ public sealed class ClassInitializeShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic(ClassInitializeShouldBeValidAnalyzer.Rule)
+            VerifyCS.Diagnostic()
                 .WithLocation(0)
                 .WithArguments("ClassInitialize"),
             fixedCode);

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestCleanupShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestCleanupShouldBeValidAnalyzerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
@@ -85,7 +85,7 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.Rule)
+            VerifyCS.Diagnostic()
                 .WithLocation(0)
                 .WithArguments("TestCleanup"),
             fixedCode);
@@ -126,7 +126,7 @@ public sealed class TestCleanupShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic(TestCleanupShouldBeValidAnalyzer.Rule)
+            VerifyCS.Diagnostic()
                 .WithLocation(0)
                 .WithArguments("TestCleanup"),
             fixedCode);

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestInitializeShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestInitializeShouldBeValidAnalyzerTests.cs
@@ -146,7 +146,7 @@ public sealed class TestInitializeShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic(TestInitializeShouldBeValidAnalyzer.Rule)
+            VerifyCS.Diagnostic()
                 .WithLocation(0)
                 .WithArguments("TestInitialize"),
             fixedCode);


### PR DESCRIPTION
Fixes #9721

## Summary

The six fixture-lifecycle analyzers were structurally near-identical, differing by only a few tokens each. This PR consolidates their registration logic and removes copy-paste drift.

## Changes

- **Shared entry point** — Added `FixtureMethodAnalyzerHelper.RegisterFixtureAnalyzer(context, attribute, rule, kind, parameterMode)` plus a new `FixtureKind` enum (`Instance` / `Class` / `Assembly`). Each analyzer's `Initialize` now delegates its registration to this single method instead of branching to three different helpers.
- **Reduced surface** — The three per-scope helpers (`RegisterInstanceFixtureAnalyzer`, `RegisterClassFixtureAnalyzer`, `RegisterAssemblyFixtureAnalyzer`) are now `private` implementation details behind the shared entry point.
- **Fixed visibility drift** — Standardized the `Rule` descriptor to `internal` across all six analyzers. Previously `TestInitialize`/`TestCleanup`/`ClassInitialize` were `public` while `ClassCleanup`/`AssemblyInitialize`/`AssemblyCleanup` were `internal` — a copy-paste inconsistency called out in the issue. Chose `internal` to keep public API surface minimal. Updated the three affected unit tests to the parameterless `VerifyCS.Diagnostic()` form already used by the internal-rule analyzer tests.

### Notes

- `context.ConfigureGeneratedCodeAnalysis(...)` and `context.EnableConcurrentExecution()` are intentionally kept inline in each `Initialize` — the RS1025/RS1026 analyzers require these calls to appear directly in `Initialize` and reject them when moved into a helper.
- The six code-fixer classes already share `FixtureMethodSignatureFixerBase` and were left unchanged (verified they still compile).

## Validation

- `MSTest.Analyzers` and `MSTest.Analyzers.UnitTests` build clean (0 warnings, 0 errors).
- All 366 `*ShouldBeValidAnalyzerTests` pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>