### PR TITLE
test: add edge case tests for AvoidOutRefTestMethodParametersAnalyzer (MSTEST0062)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -232,7 +232,7 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenTestMethodHasDerivedTestMethodAttributeAndOutParam_Diagnostic()
+    public async Task WhenTestMethodHasDerivedTestMethodAttributeAndOutParameter_Diagnostic()
     {
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -274,7 +274,7 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenTestMethodOutsideTestClassHasOutParam_Diagnostic()
+    public async Task WhenTestMethodOutsideTestClassHasOutParameter_Diagnostic()
     {
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -230,4 +230,98 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasDerivedTestMethodAttributeAndOutParam_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public sealed class MyCustomTestMethodAttribute : TestMethodAttribute
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyCustomTestMethod]
+                public void [|TestMethod1|](out string s)
+                {
+                    s = "";
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public sealed class MyCustomTestMethodAttribute : TestMethodAttribute
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyCustomTestMethod]
+                public void TestMethod1(string s)
+                {
+                    s = "";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodOutsideTestClassHasOutParam_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void [|TestMethod1|](out string s)
+                {
+                    s = "";
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1(string s)
+                {
+                    s = "";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasInParameter_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DataRow("Hello")]
+                public void TestMethod1(in string s)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
Fixes #9716

Adds three additive tests covering previously-untested paths in `AvoidOutRefTestMethodParametersAnalyzer` (MSTEST0062). No production code changes.

| Test | Covers |
|------|--------|
| `WhenTestMethodHasDerivedTestMethodAttributeAndOutParam_Diagnostic` | Analyzer fires + fixer removes `out` when a custom attribute derived from `TestMethodAttribute` is used; exercises the `attr.AttributeClass.Inherits(...)` branch |
| `WhenTestMethodOutsideTestClassHasOutParam_Diagnostic` | Analyzer fires even when the containing class lacks `[TestClass]` (no TestClass guard) |
| `WhenTestMethodHasInParameter_NoDiagnostic` | `in` parameters are not flagged — the analyzer checks only `RefKind.Out`/`RefKind.Ref` |

### Test status
Debug build: 0 warnings, 0 errors. `MSTest.Analyzers.UnitTests` pass on both `net472` and `net8.0` (7 pre-existing + 3 new).