### PR TITLE
perf: cache JsonSerializerOptions in performance runner steps

### DIFF
--- a/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
@@ -31,6 +31,8 @@ namespace MSTest.Performance.Runner.Steps;
 /// </remarks>
 internal class DotnetTestProcess : IStep<BuildArtifact, Files>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
     private readonly string _reportFileName;
     private readonly BuildConfiguration _buildConfiguration;
     private readonly int _numberOfRun;
@@ -117,11 +119,9 @@ internal class DotnetTestProcess : IStep<BuildArtifact, Files>
             results.Add(result);
         }
 
-#pragma warning disable CA1869 // Cache and reuse 'JsonSerializerOptions' instances
         await File.AppendAllTextAsync(
             Path.Combine(Path.GetDirectoryName(payload.TestHost.FullName)!, "Result.json"),
-            JsonSerializer.Serialize(results, new JsonSerializerOptions { WriteIndented = true }));
-#pragma warning restore CA1869
+            JsonSerializer.Serialize(results, JsonOptions));
 
         string sample = Path.Combine(Path.GetTempPath(), _reportFileName);
         File.Delete(sample);


### PR DESCRIPTION
Fixes #9714

## Summary

Cache the `JsonSerializerOptions { WriteIndented = true }` instance as a `private static readonly` field in `DotnetTestProcess`, and remove the `CA1869` pragma suppression that was previously hiding the repeated-construction anti-pattern.

`JsonSerializerOptions` construction triggers reflection-based scanning of converter types and type metadata. Constructing a new instance on every `ExecuteAsync()` call repeats this work unnecessarily — a benchmark tool that measures performance should not itself incur avoidable overhead.

## Changes

| File | Change |
|------|--------|
| `test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs` | Added `private static readonly JsonSerializerOptions JsonOptions`; removed `#pragma warning disable/restore CA1869` pair |

Note: `PlainProcess.cs` already had an equivalent cached `JsonOptions` field on this branch, so no change was needed there. The new field uses the same `JsonOptions` name for consistency.

## Trade-offs

None. Purely mechanical — same behaviour and output, no logic changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>