### PR TITLE
[link-checker] Fix broken documentation link in Changelog.md

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1109,7 +1109,7 @@ See full log [of v3.6.3...v3.6.4](https://github.com/microsoft/testfx/compare/v3
 ### Fixed
 
 * Bump MS CC to 17.13.0 by @Evangelink in [#4212](https://github.com/microsoft/testfx/pull/4212)
-* Bump vulnerable deps by @Evangelink in [#4218)(https://github.com/microsoft/testfx/pull/4218)
+* Bump vulnerable deps by @Evangelink in [#4218](https://github.com/microsoft/testfx/pull/4218)
 
 ### Artifacts
 


### PR DESCRIPTION
## Summary

Fixes #9732

Corrects a malformed markdown link in `docs/Changelog.md` (line 1112). The link for PR #4218 used `)` instead of `]` to close the link text portion, making it invalid markdown and causing the link checker to flag it as broken.

- Before: `[#4218)(https://github.com/microsoft/testfx/pull/4218)`
- After: `[#4218](https://github.com/microsoft/testfx/pull/4218)`

All other links flagged by the daily link check were confirmed as false positives or unfixable (localhost URLs, non-existent repos/tags, NuGet firewall blocks, badge parsing artifacts).