### PR TITLE
style: use range operators and is-null pattern in new PR files

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -150,8 +150,8 @@ internal static class MSTestTestNodeConverter
         parameterTypes ??= [];
 
         int lastIndexOfDot = managedType.LastIndexOf('.');
-        string @namespace = lastIndexOfDot == -1 ? string.Empty : managedType.Substring(0, lastIndexOfDot);
-        string typeName = lastIndexOfDot == -1 ? managedType : managedType.Substring(lastIndexOfDot + 1);
+        string @namespace = lastIndexOfDot == -1 ? string.Empty : managedType[..lastIndexOfDot];
+        string typeName = lastIndexOfDot == -1 ? managedType : managedType[(lastIndexOfDot + 1)..];
 
         // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to match
         // the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
@@ -305,7 +305,7 @@ internal static class MSTestTestNodeConverter
             return false;
         }
 
-        fullyQualifiedType = fullyQualifiedName.Substring(0, lastDotIndexBeforeOpenBracket);
+        fullyQualifiedType = fullyQualifiedName[..lastDotIndexBeforeOpenBracket];
         return true;
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.DataSource.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.DataSource.cs
@@ -52,7 +52,7 @@ internal sealed partial class TestMethodRunner
         try
         {
             IEnumerable<object>? dataRows = PlatformServiceProvider.Instance.TestDataSource.GetData(_testMethodInfo, _testContext);
-            if (dataRows == null)
+            if (dataRows is null)
             {
                 var inconclusiveResult = new TestResult
                 {


### PR DESCRIPTION
## Summary

Fixes #9734. Applies two `.editorconfig`-convention fixes to source files added in recent PRs.

### Changes

- `src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs` — 3× `String.Substring` calls replaced with C# range operators (IDE0057 / `csharp_style_prefer_range_operator`):
  - `managedType.Substring(0, lastIndexOfDot)` → `managedType[..lastIndexOfDot]`
  - `managedType.Substring(lastIndexOfDot + 1)` → `managedType[(lastIndexOfDot + 1)..]`
  - `fullyQualifiedName.Substring(0, lastDotIndexBeforeOpenBracket)` → `fullyQualifiedName[..lastDotIndexBeforeOpenBracket]`
- `src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodRunner.DataSource.cs` — `== null` replaced with `is null`.

### Multi-TFM

A full `build.cmd` succeeded with **0 warnings / 0 errors** across every target framework (net462, net472, net48, net8.0, net9.0, uap10.0, …). Range indexing on `string` is lowered by the C# compiler to `Substring`, so it works on all TFMs without any polyfill.

### Testing

- ✅ Full repo build succeeds, all TFMs, 0 warnings / 0 errors.
- No functional changes — range operators and `is null` are semantically equivalent to the originals.