### PR TITLE
Update changelogs for MTP 2.3 / MSTest 4.3 release

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## <a name="2.3.0" />[2.3.0] - UNRELEASED
+## <a name="2.4.0" />[2.4.0] - UNRELEASED
+
+See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.0...v4.4.0)
+
+### Added
+
+* Add `--report-azdo-groups <on|off>` and `--report-azdo-annotations <on|off>` toggles to Azure DevOps report extension by @Evangelink in [#9542](https://github.com/microsoft/testfx/pull/9542)
+* Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
+* Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
+
+## <a name="2.3.0" />[2.3.0] - 2026-07-07
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
 
@@ -44,9 +54,6 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Forward Azure DevOps logging commands over the dotnet test pipe for multi-assembly test runs by @Evangelink in [#9463](https://github.com/microsoft/testfx/pull/9463)
 * Add `PropertyBag.FirstOrDefault<TProperty>()` for efficient single-property lookup without per-call array allocation by @Evangelink in [#9488](https://github.com/microsoft/testfx/pull/9488)
 * Add experimental `Microsoft.Testing.Extensions.GitHubActionsReport` extension emitting GitHub Actions workflow commands (per-assembly log groups, failure annotations, job summary, slow-test notices) by @azat-msft in [#9541](https://github.com/microsoft/testfx/pull/9541)
-* Add `--report-azdo-groups <on|off>` and `--report-azdo-annotations <on|off>` toggles to Azure DevOps report extension by @Evangelink in [#9542](https://github.com/microsoft/testfx/pull/9542)
-* Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
-* Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
 * Emit `::warning` annotations for skipped tests in `Microsoft.Testing.Extensions.GitHubActionsReport` by @Evangelink in [#9641](https://github.com/microsoft/testfx/pull/9641)
 
 ### Fixed
@@ -86,6 +93,18 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Fix --list-tests json output under --server mode by streaming discovered tests to the SDK over the dotnet-test pipe by @Evangelink in [#9192](https://github.com/microsoft/testfx/pull/9192)
 * Make AzureDevOps summary report file name unique per assembly by @Evangelink in [#9264](https://github.com/microsoft/testfx/pull/9264)
 * Fix `--treenode-filter` + `--filter-uid` mutual exclusion: validated during command-line validation (proper `InvalidCommandLine` exit code) instead of a late `NotSupportedException`; documentation gaps for the `!` NOT operator and property-filter semantics addressed by @Evangelink in [#9458](https://github.com/microsoft/testfx/pull/9458)
+
+### Artifacts
+
+* Microsoft.Testing.Platform: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Platform/2.3.0)
+* Microsoft.Testing.Platform.MSBuild: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild/2.3.0)
+* Microsoft.Testing.Extensions.CrashDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CrashDump/2.3.0)
+* Microsoft.Testing.Extensions.HangDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump/2.3.0)
+* Microsoft.Testing.Extensions.HotReload: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/2.3.0)
+* Microsoft.Testing.Extensions.Retry: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/2.3.0)
+* Microsoft.Testing.Extensions.Telemetry: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Telemetry/2.3.0)
+* Microsoft.Testing.Extensions.TrxReport: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/2.3.0)
+* Microsoft.Testing.Extensions.TrxReport.Abstractions: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport.Abstractions/2.3.0)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -14,6 +14,14 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
 * Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
 
+## <a name="2.3.1" />[2.3.1] - UNRELEASED
+
+See full log [of v4.3.0...v4.3.1](https://github.com/microsoft/testfx/compare/v4.3.0...v4.3.1)
+
+### Fixed
+
+* Fix forward-compat crash (`MissingMethodException`) loading old 2.x extensions (Telemetry, TrxReport, VSTestBridge) on .NET Framework by @Evangelink in [#9739](https://github.com/microsoft/testfx/pull/9739)
+
 ## <a name="2.3.0" />[2.3.0] - 2026-07-07
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -106,6 +106,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 
 * Microsoft.Testing.Platform: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Platform/2.3.0)
 * Microsoft.Testing.Platform.MSBuild: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Platform.MSBuild/2.3.0)
+* Microsoft.Testing.Extensions.AzureDevOpsReport: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.AzureDevOpsReport/2.3.0)
 * Microsoft.Testing.Extensions.CrashDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CrashDump/2.3.0)
 * Microsoft.Testing.Extensions.HangDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump/2.3.0)
 * Microsoft.Testing.Extensions.HotReload: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/2.3.0)
@@ -114,6 +115,7 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Microsoft.Testing.Extensions.Telemetry: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Telemetry/2.3.0)
 * Microsoft.Testing.Extensions.TrxReport: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/2.3.0)
 * Microsoft.Testing.Extensions.TrxReport.Abstractions: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport.Abstractions/2.3.0)
+* Microsoft.Testing.Extensions.VSTestBridge: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VSTestBridge/2.3.0)
 * Microsoft.Testing.Extensions.CtrfReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CtrfReport/1.0.0-alpha.26357.13)
 * Microsoft.Testing.Extensions.GitHubActionsReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport/1.0.0-alpha.26357.13)
 * Microsoft.Testing.Extensions.JUnitReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.JUnitReport/1.0.0-alpha.26357.13)

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -101,10 +101,17 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Microsoft.Testing.Extensions.CrashDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CrashDump/2.3.0)
 * Microsoft.Testing.Extensions.HangDump: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HangDump/2.3.0)
 * Microsoft.Testing.Extensions.HotReload: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HotReload/2.3.0)
+* Microsoft.Testing.Extensions.HtmlReport: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.HtmlReport/2.3.0)
 * Microsoft.Testing.Extensions.Retry: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/2.3.0)
 * Microsoft.Testing.Extensions.Telemetry: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Telemetry/2.3.0)
 * Microsoft.Testing.Extensions.TrxReport: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/2.3.0)
 * Microsoft.Testing.Extensions.TrxReport.Abstractions: [2.3.0](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport.Abstractions/2.3.0)
+* Microsoft.Testing.Extensions.CtrfReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.CtrfReport/1.0.0-alpha.26357.13)
+* Microsoft.Testing.Extensions.GitHubActionsReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.GitHubActionsReport/1.0.0-alpha.26357.13)
+* Microsoft.Testing.Extensions.JUnitReport: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.JUnitReport/1.0.0-alpha.26357.13)
+* Microsoft.Testing.Extensions.Logging: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Logging/1.0.0-alpha.26357.13)
+* Microsoft.Testing.Extensions.PackagedApp: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.PackagedApp/1.0.0-alpha.26357.13)
+* Microsoft.Testing.Extensions.VideoRecorder: [1.0.0-alpha.26357.13](https://www.nuget.org/packages/Microsoft.Testing.Extensions.VideoRecorder/1.0.0-alpha.26357.13)
 
 ## <a name="2.2.3" />[2.2.3] - 2026-05-14
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,10 +12,6 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
 
-### Changed
-
-* Lower `MSTEST0050` (`GlobalTestFixtureShouldBeValidAnalyzer`) severity from `Error` to `Warning`, matching the six peer fixture analyzers (MSTEST0008–0013) by @Evangelink in [#9670](https://github.com/microsoft/testfx/pull/9670)
-
 ## <a name="4.3.0" />[4.3.0] - UNRELEASED
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
@@ -65,6 +61,10 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Remove redundant `actual type:` line from Assert.Throws\* failure message by @Evangelink in [#9195](https://github.com/microsoft/testfx/pull/9195)
 * Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages by @Evangelink in [#9212](https://github.com/microsoft/testfx/pull/9212)
 * Fix `[ClassCleanup]` resource leak when `ITestFilter` drops the last test of an initialized class by @Evangelink in [#9503](https://github.com/microsoft/testfx/pull/9503)
+
+### Changed
+
+* Lower `MSTEST0050` (`GlobalTestFixtureShouldBeValidAnalyzer`) severity from `Error` to `Warning`, matching the six peer fixture analyzers (MSTEST0008–0013) by @Evangelink in [#9670](https://github.com/microsoft/testfx/pull/9670)
 
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## <a name="4.4.0" />[4.4.0] - UNRELEASED
+
+See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.0...v4.4.0)
+
+### Fixed
+
+* Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
+
+### Changed
+
+* Lower `MSTEST0050` (`GlobalTestFixtureShouldBeValidAnalyzer`) severity from `Error` to `Warning`, matching the six peer fixture analyzers (MSTEST0008–0013) by @Evangelink in [#9670](https://github.com/microsoft/testfx/pull/9670)
+
 ## <a name="4.3.0" />[4.3.0] - UNRELEASED
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
@@ -53,11 +65,6 @@ See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4
 * Remove redundant `actual type:` line from Assert.Throws\* failure message by @Evangelink in [#9195](https://github.com/microsoft/testfx/pull/9195)
 * Include full exception (stack trace + inner exceptions) in Assert.Throws\* failure messages by @Evangelink in [#9212](https://github.com/microsoft/testfx/pull/9212)
 * Fix `[ClassCleanup]` resource leak when `ITestFilter` drops the last test of an initialized class by @Evangelink in [#9503](https://github.com/microsoft/testfx/pull/9503)
-* Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
-
-### Changed
-
-* Lower `MSTEST0050` (`GlobalTestFixtureShouldBeValidAnalyzer`) severity from `Error` to `Warning`, matching the six peer fixture analyzers (MSTEST0008–0013) by @Evangelink in [#9670](https://github.com/microsoft/testfx/pull/9670)
 
 ## <a name="4.2.3" />[4.2.3] - 2026-05-14
 


### PR DESCRIPTION
## What

Reconcile `main`'s changelogs with what actually shipped in the 2.3 / 4.3 release, using `rel/4.3` as the source of truth, and stage the follow-up servicing/next-version entries.

## Details

### Entries moved (not present on `rel/4.3` → next version)
- MTP (`Changelog-Platform.md`): #9542, #9545, #9549 → **2.4.0**
- MSTest (`Changelog.md`): #9581 (Fixed) → **4.4.0**

> #9670 was initially moved to 4.4.0 but is being backported to `rel/4.3`, so it stays under MSTest **4.3.0** (Changed).

### MTP `2.3.0` finalized
- Marked released (`2026-07-07`).
- Artifacts list expanded beyond the previous 9-package template to reflect what actually ships:
  - **Stable (2.3.0):** core packages + `AzureDevOpsReport`, `HtmlReport`, `VSTestBridge` (all inherit the default `TestingPlatformVersionPrefix`, packable, no override).
  - **Experimental (1.0.0-alpha.26357.13):** `CtrfReport`, `GitHubActionsReport`, `JUnitReport`, `Logging`, `PackagedApp`, `VideoRecorder` (independently/alpha versioned).

### MTP `2.3.1` (new, UNRELEASED)
- Servicing section for the `MissingMethodException` regression from 2.3.0 (#9710), fixed by #9739 and backported to `rel/4.3` via #9740.

### MSTest `4.3.0`
- Kept `UNRELEASED` (about to release).

## Notes
- `AzureFoundry`, `OpenTelemetry`, and `Platform.AI` are excluded from the 2.3.0 artifacts (`AzureFoundry` is `IsShipping=false`; the other two aren't referenced by any 2.3 changelog entry).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>