### PR TITLE
Native MTP framework for MSTest — Phases 3–5 (native filter/runsettings/context, opt-in)

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -88,6 +88,11 @@
          reference is not added for UWP (see above), and PlatformServices no longer references the object model,
          so it is referenced explicitly here for UWP. -->
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Condition=" '$(TargetFramework)' == '$(UwpMinimum)' " />
+
+    <!-- The native Microsoft.Testing.Platform integration (TestingPlatformAdapter\MSTestFilterContext, guarded by
+         !WINDOWS_UWP) parses VSTest filter expressions via the Filter source package. It flows in transitively via
+         the VSTestBridge today (PrivateAssets=all there), so reference it explicitly where the native path builds. -->
+    <PackageReference Include="Microsoft.TestPlatform.Filter.Source" PrivateAssets="all" Condition=" '$(TargetFramework)' != '$(UwpMinimum)' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestBridgedTestFramework.cs
@@ -22,12 +22,6 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [StackTraceHidden]
 internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTestBridgedTestFramework
 {
-    // Opt-in switch for the experimental native Microsoft.Testing.Platform integration: when enabled, MSTest
-    // publishes test nodes directly from its neutral execution model instead of routing discovery and results
-    // through the VSTest bridge object model. Off by default, so the shipping behavior is unchanged.
-    private static readonly bool UseNativeMtpProduction =
-        Environment.GetEnvironmentVariable("MSTEST_EXPERIMENTAL_NATIVE_MTP") is "1" or "true" or "True";
-
     private readonly BridgedConfiguration? _configuration;
     private readonly ILoggerFactory _loggerFactory;
 
@@ -50,16 +44,7 @@ internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTe
             Debugger.Launch();
         }
 
-        var discoverer = new MSTestDiscoverer(new TestSourceHandler(), CreateTelemetrySender());
-        if (UseNativeMtpProduction && SessionUid is { } sessionUid)
-        {
-            // Publish discovered test nodes directly from the neutral model; the VSTest discovery sink in the
-            // request is bypassed (no VSTest TestCase materialization / ObjectModelConverters round-trip).
-            var elementSink = new MtpUnitTestElementSink(messageBus, this, sessionUid, IsTrxEnabled);
-            return discoverer.DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, elementSink, _configuration, isMTP: true);
-        }
-
-        return discoverer.DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, request.DiscoverySink, _configuration, isMTP: true);
+        return new MSTestDiscoverer(new TestSourceHandler(), CreateTelemetrySender()).DiscoverTestsAsync(request.AssemblyPaths, request.DiscoveryContext, request.MessageLogger, request.DiscoverySink, _configuration, isMTP: true);
     }
 
     /// <inheritdoc />
@@ -73,20 +58,6 @@ internal sealed class MSTestBridgedTestFramework : SynchronizedSingleSessionVSTe
         }
 
         MSTestExecutor testExecutor = new(cancellationToken, CreateTelemetrySender());
-        if (UseNativeMtpProduction && SessionUid is { } sessionUid)
-        {
-            // Report results directly as native test nodes; the framework handle is still used for message logging
-            // and apartment-state handling, but its VSTest RecordResult / ObjectModelConverters path is bypassed.
-            await testExecutor.RunTestsAsync(
-                request.AssemblyPaths,
-                request.RunContext,
-                request.FrameworkHandle,
-                settings => new MtpTestResultRecorder(messageBus, this, sessionUid, IsTrxEnabled, settings),
-                _configuration,
-                isMTP: true).ConfigureAwait(false);
-            return;
-        }
-
         await testExecutor.RunTestsAsync(request.AssemblyPaths, request.RunContext, request.FrameworkHandle, _configuration, isMTP: true).ConfigureAwait(false);
     }
 

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
@@ -166,7 +166,9 @@ internal abstract class MSTestFilterContextBase
                     case '=':
                     case '!':
                     case '~':
-                        if (i - 1 < 0 || currentTestNodeUid.Value[k - 1] != '\\')
+                        // Escape the special char if it is not already escaped. Note: index into k-1 (the previous
+                        // character in this UID value), not i-1.
+                        if (k - 1 < 0 || currentTestNodeUid.Value[k - 1] != '\\')
                         {
                             filter.Append('\\');
                         }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Requests;
+using Microsoft.VisualStudio.TestPlatform.Common.Filtering;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// A native Microsoft.Testing.Platform (MTP) filter context for MSTest. It builds a VSTest
+/// <see cref="ITestCaseFilterExpression"/> (which MSTest's <c>TestMethodFilter</c> evaluates over
+/// <c>UnitTestElement</c>s) directly from the MTP <see cref="ITestExecutionFilter"/>, the <c>--filter</c>
+/// command-line option and the runsettings <c>&lt;TestCaseFilter&gt;</c> — without going through the VSTest bridge's
+/// context adapters.
+/// </summary>
+/// <remarks>
+/// This mirrors, for the MSTest native path, what <c>ContextAdapterBase</c> / <c>RunContextAdapter</c> /
+/// <c>DiscoveryContextAdapter</c> do in <c>Microsoft.Testing.Extensions.VSTestBridge</c>. The filter-expression
+/// parsing itself reuses the VSTest <c>Microsoft.TestPlatform.Filter.Source</c> package, exactly like the bridge.
+/// </remarks>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal abstract class MSTestFilterContextBase
+{
+    // Keep in sync with the bridge's TestCaseFilterCommandLineOptionsProvider.TestCaseFilterOptionName.
+    private const string TestCaseFilterOptionName = "filter";
+
+    protected MSTestFilterContextBase(ICommandLineOptions commandLineOptions, IRunSettings runSettings, ITestExecutionFilter filter)
+    {
+        RunSettings = runSettings;
+
+        string? filterFromRunsettings = runSettings.SettingsXml is null
+            ? null
+            : XDocument.Parse(runSettings.SettingsXml).Element("RunSettings")?.Element("RunConfiguration")?.Element("TestCaseFilter")?.Value;
+
+        string? filterFromCommandLineOption = null;
+        if (commandLineOptions.TryGetOptionArgumentList(TestCaseFilterOptionName, out string[]? filterExpressions)
+            && filterExpressions is not null
+            && filterExpressions.Length == 1)
+        {
+            filterFromCommandLineOption = filterExpressions[0];
+        }
+
+        HandleFilter(filter, filterFromRunsettings, filterFromCommandLineOption);
+    }
+
+    public IRunSettings? RunSettings { get; }
+
+    private FilterExpressionWrapper? FilterExpressionWrapper { get; set; }
+
+    private sealed class MSTestFilterExpression : ITestCaseFilterExpression
+    {
+        private readonly TestCaseFilterExpression _testCaseFilterExpression;
+
+        public MSTestFilterExpression(TestCaseFilterExpression testCaseFilterExpression)
+            => _testCaseFilterExpression = testCaseFilterExpression;
+
+        public string TestCaseFilterValue
+            => _testCaseFilterExpression.TestCaseFilterValue;
+
+        public bool MatchTestCase(TestCase testCase, Func<string, object?> propertyValueProvider)
+            => _testCaseFilterExpression.MatchTestCase(propertyValueProvider);
+    }
+
+    // NOTE: MSTest.TestAdapter's TestMethodFilter accesses this method via reflection on the discovery context
+    // (see GetTestCaseFilterFromDiscoveryContext) and directly on the run context.
+#pragma warning disable IDE0060 // Remove unused parameter - kept for the VSTest GetTestCaseFilter contract shape.
+    public ITestCaseFilterExpression? GetTestCaseFilter(
+        IEnumerable<string>? supportedProperties,
+        Func<string, TestProperty?> propertyProvider)
+#pragma warning restore IDE0060
+        => FilterExpressionWrapper is null
+            ? null
+            : !string.IsNullOrEmpty(FilterExpressionWrapper.ParseError)
+                ? throw new TestPlatformFormatException(FilterExpressionWrapper.ParseError, FilterExpressionWrapper.FilterString)
+                : new MSTestFilterExpression(new TestCaseFilterExpression(FilterExpressionWrapper));
+
+    private void HandleFilter(ITestExecutionFilter? filter, string? filterFromRunsettings, string? filterFromCommandLineOption)
+    {
+        if (filter is null or NopFilter
+            && filterFromRunsettings is null
+            && filterFromCommandLineOption is null)
+        {
+            return;
+        }
+
+        var filterBuilder = new StringBuilder();
+
+        AppendFilter(filterFromRunsettings, filterBuilder);
+        AppendFilter(filterFromCommandLineOption, filterBuilder);
+
+        if (filter is TestNodeUidListFilter testNodeUidListFilter)
+        {
+            StartFilter(filterBuilder);
+            BuildFilter(testNodeUidListFilter.TestNodeUids, filterBuilder);
+            EndFilter(filterBuilder);
+        }
+
+        if (filterBuilder.Length > 0)
+        {
+            FilterExpressionWrapper = new FilterExpressionWrapper(filterBuilder.ToString());
+        }
+
+        static void AppendFilter(string? filter, StringBuilder builder)
+        {
+            if (filter is null)
+            {
+                return;
+            }
+
+            StartFilter(builder);
+            builder.Append(filter);
+            EndFilter(builder);
+        }
+
+        static void StartFilter(StringBuilder builder)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(" & (");
+            }
+            else
+            {
+                builder.Append('(');
+            }
+        }
+
+        static void EndFilter(StringBuilder builder)
+            => builder.Append(')');
+    }
+
+    // Heuristic borrowed from the bridge: a GUID TestNodeUid maps to a VSTest Id filter, everything else to a
+    // (escaped) FullyQualifiedName filter.
+    private static void BuildFilter(TestNodeUid[] testNodesUid, StringBuilder filter)
+    {
+        for (int i = 0; i < testNodesUid.Length; i++)
+        {
+            if (i > 0)
+            {
+                filter.Append('|');
+            }
+
+            if (Guid.TryParse(testNodesUid[i].Value, out Guid guid))
+            {
+                filter.Append("Id=");
+                filter.Append(guid.ToString());
+                continue;
+            }
+
+            TestNodeUid currentTestNodeUid = testNodesUid[i];
+            filter.Append("FullyQualifiedName=");
+            for (int k = 0; k < currentTestNodeUid.Value.Length; k++)
+            {
+                char currentChar = currentTestNodeUid.Value[k];
+                switch (currentChar)
+                {
+                    case '\\':
+                    case '(':
+                    case ')':
+                    case '&':
+                    case '|':
+                    case '=':
+                    case '!':
+                    case '~':
+                        if (i - 1 < 0 || currentTestNodeUid.Value[k - 1] != '\\')
+                        {
+                            filter.Append('\\');
+                        }
+
+                        filter.Append(currentChar);
+                        break;
+
+                    default:
+                        filter.Append(currentChar);
+                        break;
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Native MTP implementation of the VSTest <see cref="IRunContext"/> for the MSTest native path.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestRunContext : MSTestFilterContextBase, IRunContext
+{
+    public MSTestRunContext(ICommandLineOptions commandLineOptions, IRunSettings runSettings, ITestExecutionFilter filter)
+        : base(commandLineOptions, runSettings, filter)
+        => TestRunDirectory = runSettings.SettingsXml is null
+            ? null
+            : XDocument.Parse(runSettings.SettingsXml).Element("RunSettings")?.Element("RunConfiguration")?.Element("ResultsDirectory")?.Value;
+
+    // TPv2-oriented flags that do not apply to the platform adapter (mirrors RunContextAdapter).
+    public bool KeepAlive { get; }
+
+    public bool InIsolation { get; }
+
+    public bool IsDataCollectionEnabled { get; }
+
+    public bool IsBeingDebugged => Debugger.IsAttached;
+
+    public string? TestRunDirectory { get; }
+
+    public string? SolutionDirectory { get; }
+}
+
+/// <summary>
+/// Native MTP implementation of the VSTest <see cref="IDiscoveryContext"/> for the MSTest native path.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestDiscoveryContext : MSTestFilterContextBase, IDiscoveryContext
+{
+    public MSTestDiscoveryContext(ICommandLineOptions commandLineOptions, IRunSettings runSettings, ITestExecutionFilter filter)
+        : base(commandLineOptions, runSettings, filter)
+    {
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// A native Microsoft.Testing.Platform (MTP) <see cref="IFrameworkHandle"/> for the MSTest native path. It only
+/// forwards diagnostic messages to the MTP <see cref="IOutputDevice"/>; test results are reported natively through
+/// the <c>MtpTestResultRecorder</c>, so the VSTest result-recording members are intentionally no-ops.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestFrameworkHandle : IFrameworkHandle, IOutputDeviceDataProducer
+{
+    private readonly IOutputDevice _outputDevice;
+    private readonly IExtension _extension;
+    private readonly CancellationToken _cancellationToken;
+
+    public MSTestFrameworkHandle(IOutputDevice outputDevice, IExtension extension, CancellationToken cancellationToken)
+    {
+        _outputDevice = outputDevice;
+        _extension = extension;
+        _cancellationToken = cancellationToken;
+    }
+
+    public bool EnableShutdownAfterTestRun { get; set; }
+
+    string IExtension.Uid => _extension.Uid;
+
+    string IExtension.Version => _extension.Version;
+
+    string IExtension.DisplayName => _extension.DisplayName;
+
+    string IExtension.Description => _extension.Description;
+
+    public int LaunchProcessWithDebuggerAttached(string filePath, string? workingDirectory, string? arguments, IDictionary<string, string?>? environmentVariables)
+        => -1;
+
+    // Results are reported natively through the recorder; the VSTest recording members are not used.
+    public void RecordResult(TestResult testResult)
+    {
+    }
+
+    public void RecordStart(TestCase testCase)
+    {
+    }
+
+    public void RecordEnd(TestCase testCase, TestOutcome outcome)
+    {
+    }
+
+    public void RecordAttachments(IList<AttachmentSet> attachmentSets)
+    {
+    }
+
+    public void SendMessage(TestMessageLevel testMessageLevel, string message)
+    {
+        IOutputDeviceData data = testMessageLevel switch
+        {
+            TestMessageLevel.Informational => new TextOutputDeviceData(message),
+            TestMessageLevel.Warning => new WarningMessageOutputDeviceData(message),
+            TestMessageLevel.Error => new ErrorMessageOutputDeviceData(message),
+            _ => throw new NotSupportedException($"Unsupported logging level '{testMessageLevel}'."),
+        };
+
+        _outputDevice.DisplayAsync(this, data, _cancellationToken).GetAwaiter().GetResult();
+    }
+
+    Task<bool> IExtension.IsEnabledAsync() => _extension.IsEnabledAsync();
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFrameworkHandle.cs
@@ -70,7 +70,7 @@ internal sealed class MSTestFrameworkHandle : IFrameworkHandle, IOutputDeviceDat
             _ => throw new NotSupportedException($"Unsupported logging level '{testMessageLevel}'."),
         };
 
-        _outputDevice.DisplayAsync(this, data, _cancellationToken).GetAwaiter().GetResult();
+        _outputDevice.DisplayAsync(this, data, _cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     Task<bool> IExtension.IsEnabledAsync() => _extension.IsEnabledAsync();

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Extensions.VSTestBridge.Resources;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+
+using IFileSystem = Microsoft.Testing.Platform.Helpers.IFileSystem;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// A native Microsoft.Testing.Platform (MTP) implementation of the VSTest <see cref="IRunSettings"/> for the MSTest
+/// native path. It reads the runsettings XML (from the <c>--settings</c> option or the runsettings environment
+/// variables), patches it with MTP defaults (design mode, results directory, <c>--test-parameter</c> overrides) and
+/// warns on entries MTP does not support — mirroring the VSTest bridge's <c>RunSettingsAdapter</c> /
+/// <c>RunSettingsPatcher</c> / <c>RunSettingsHelpers</c> without depending on the bridge.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestRunSettings : IRunSettings
+{
+    // Keep in sync with the bridge's option provider constants (options are still registered by the bridge).
+    private const string RunSettingsOptionName = "settings";
+    private const string TestRunParameterOptionName = "test-parameter";
+
+    private static readonly char[] TestRunParameterSeparator = ['='];
+
+    private static readonly string[] UnsupportedRunConfigurationSettings =
+    [
+        "DotnetHostPath",
+        "MaxCpuCount",
+        "TargetFrameworkVersion",
+        "TargetPlatform",
+        "TestAdaptersPaths",
+        "TestSessionTimeout",
+        "TreatNoTestsAsError",
+        "TreatTestAdapterErrorsAsWarnings",
+    ];
+
+    public MSTestRunSettings(
+        ICommandLineOptions commandLineOptions,
+        IFileSystem fileSystem,
+        IConfiguration configuration,
+        IClientInfo client,
+        IMessageLogger messageLogger)
+    {
+        string runSettingsXml = ReadRunSettings(commandLineOptions, fileSystem);
+
+        XDocument runSettingsDocument = Patch(runSettingsXml, configuration, client, commandLineOptions);
+        WarnOnUnsupportedEntries(runSettingsDocument, messageLogger);
+
+        SettingsXml = runSettingsDocument.ToString();
+    }
+
+    public string? SettingsXml { get; }
+
+    // Not used by MSTest (matches the bridge's RunSettingsAdapter).
+    public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
+
+    internal static string ReadRunSettings(ICommandLineOptions commandLineOptions, IFileSystem fileSystem)
+    {
+        _ = commandLineOptions.TryGetOptionArgumentList(RunSettingsOptionName, out string[]? fileNames);
+
+        if (fileNames is { Length: 1 } && fileSystem.ExistFile(fileNames[0]))
+        {
+            return fileSystem.ReadAllText(fileNames[0]);
+        }
+
+        string? envVariableRunSettings = Environment.GetEnvironmentVariable("TESTINGPLATFORM_EXPERIMENTAL_VSTEST_RUNSETTINGS");
+        if (!string.IsNullOrEmpty(envVariableRunSettings))
+        {
+            return envVariableRunSettings;
+        }
+
+        string? runSettingsFilePath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_VSTESTBRIDGE_RUNSETTINGS_FILE");
+        return !string.IsNullOrEmpty(runSettingsFilePath) && fileSystem.ExistFile(runSettingsFilePath)
+            ? fileSystem.ReadAllText(runSettingsFilePath)
+            : string.Empty;
+    }
+
+    private static XDocument Patch(string? runSettingsXml, IConfiguration configuration, IClientInfo client, ICommandLineOptions commandLineOptions)
+    {
+        XDocument runSettingsDocument = PatchSettingsWithDefaults(runSettingsXml, isDesignMode: client.Id == WellKnownClients.VisualStudio, configuration);
+        PatchTestRunParameters(runSettingsDocument, commandLineOptions);
+        return runSettingsDocument;
+    }
+
+    private static XDocument PatchSettingsWithDefaults(string? runSettingsXml, bool isDesignMode, IConfiguration configuration)
+    {
+        if (string.IsNullOrWhiteSpace(runSettingsXml))
+        {
+            runSettingsXml = """
+                <RunSettings>
+                </RunSettings>
+                """;
+        }
+
+        var document = XDocument.Parse(runSettingsXml);
+        if (document.Element("RunSettings") is not { } runSettingsElement)
+        {
+            throw new InvalidOperationException(ExtensionResources.MissingRunSettingsAttribute);
+        }
+
+        bool isPatchingCommentAdded = false;
+        if (runSettingsElement.Element("RunConfiguration") is not { } runConfigurationElement)
+        {
+            runConfigurationElement = new XElement("RunConfiguration");
+            AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);
+            runSettingsElement.AddFirst(runConfigurationElement);
+        }
+
+        if (runConfigurationElement.Element("DesignMode") is null)
+        {
+            AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);
+            runConfigurationElement.Add(new XElement("DesignMode", isDesignMode));
+        }
+
+        if (runConfigurationElement.Element("CollectSourceInformation") is null)
+        {
+            AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);
+            runConfigurationElement.Add(new XElement("CollectSourceInformation", false));
+        }
+
+        if (runConfigurationElement.Element("ResultsDirectory") is null)
+        {
+            AddPatchingCommentIfNeeded(runConfigurationElement, ref isPatchingCommentAdded);
+            runConfigurationElement.Add(new XElement("ResultsDirectory", configuration.GetTestResultDirectory()));
+        }
+
+        if (isPatchingCommentAdded)
+        {
+            runConfigurationElement.Add(new XComment("End"));
+        }
+
+        return document;
+    }
+
+    private static void AddPatchingCommentIfNeeded(XElement element, ref bool isPatchingCommentAdded)
+    {
+        if (isPatchingCommentAdded)
+        {
+            return;
+        }
+
+        element.Add(new XComment("Default configuration added by Microsoft Testing Platform"));
+        isPatchingCommentAdded = true;
+    }
+
+    private static void PatchTestRunParameters(XDocument runSettingsDocument, ICommandLineOptions commandLineOptions)
+    {
+        if (!commandLineOptions.TryGetOptionArgumentList(TestRunParameterOptionName, out string[]? testRunParameters))
+        {
+            return;
+        }
+
+        XElement runSettingsElement = runSettingsDocument.Element("RunSettings")!;
+        XElement? testRunParametersElement = runSettingsElement.Element("TestRunParameters");
+        if (testRunParametersElement is null)
+        {
+            testRunParametersElement = new XElement("TestRunParameters");
+            runSettingsElement.Add(testRunParametersElement);
+        }
+
+        XElement[] testRunParametersNodes = [.. testRunParametersElement.Nodes().OfType<XElement>()];
+        foreach (string testRunParameter in testRunParameters)
+        {
+            string[] parts = testRunParameter.Split(TestRunParameterSeparator, 2);
+            string name = parts[0];
+            string value = parts[1];
+            XElement? existingElement = testRunParametersNodes.FirstOrDefault(x => x.Attribute("name")?.Value == name);
+            if (existingElement is not null)
+            {
+                existingElement.Attribute("value")!.Value = value;
+            }
+            else
+            {
+                var parameterElement = new XElement("Parameter");
+                parameterElement.Add(new XAttribute("name", name));
+                parameterElement.Add(new XAttribute("value", value));
+                testRunParametersElement.Add(parameterElement);
+            }
+        }
+    }
+
+    private static void WarnOnUnsupportedEntries(XDocument document, IMessageLogger messageLogger)
+    {
+        XElement runSettingsElement = document.Element("RunSettings")!;
+
+        if (runSettingsElement.Element("LoggerRunSettings") is not null)
+        {
+            messageLogger.SendMessage(TestMessageLevel.Warning, ExtensionResources.UnsupportedRunsettingsLoggers);
+        }
+
+        if (runSettingsElement.Element("DataCollectionRunSettings") is not null)
+        {
+            messageLogger.SendMessage(TestMessageLevel.Warning, ExtensionResources.UnsupportedRunsettingsDatacollectors);
+        }
+
+        if (runSettingsElement.Element("RunConfiguration") is not { } runConfigurationElement)
+        {
+            return;
+        }
+
+        foreach (string unsupportedRunConfigurationSetting in UnsupportedRunConfigurationSettings)
+        {
+            if (runConfigurationElement.Element(unsupportedRunConfigurationSetting) is not null)
+            {
+                messageLogger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, ExtensionResources.UnsupportedRunconfigurationSetting, unsupportedRunConfigurationSetting));
+            }
+        }
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -66,7 +66,10 @@ internal sealed class MSTestRunSettings : IRunSettings
     {
         _ = commandLineOptions.TryGetOptionArgumentList(RunSettingsOptionName, out string[]? fileNames);
 
-        if (fileNames is { Length: 1 } && fileSystem.ExistFile(fileNames[0]))
+        // Match the runsettings environment-variable provider (which reads the same --settings option): use the
+        // first provided path rather than requiring exactly one, so a valid value is not ignored when more than
+        // one argument is present.
+        if (fileNames is { Length: > 0 } && fileSystem.ExistFile(fileNames[0]))
         {
             return fileSystem.ReadAllText(fileNames[0]);
         }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
@@ -206,12 +206,9 @@ internal sealed class MSTestRunSettings : IRunSettings
             return;
         }
 
-        foreach (string unsupportedRunConfigurationSetting in UnsupportedRunConfigurationSettings)
+        foreach (string unsupportedRunConfigurationSetting in UnsupportedRunConfigurationSettings.Where(setting => runConfigurationElement.Element(setting) is not null))
         {
-            if (runConfigurationElement.Element(unsupportedRunConfigurationSetting) is not null)
-            {
-                messageLogger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, ExtensionResources.UnsupportedRunconfigurationSetting, unsupportedRunConfigurationSetting));
-            }
+            messageLogger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, ExtensionResources.UnsupportedRunconfigurationSetting, unsupportedRunConfigurationSetting));
         }
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
@@ -4,6 +4,7 @@
 #if !WINDOWS_UWP
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
+using Microsoft.Testing.Extensions.VSTestBridge.Resources;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
@@ -90,7 +91,7 @@ internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisp
 
         if (_sessionUid is not null)
         {
-            throw new InvalidOperationException($"A test session '{_sessionUid.Value.Value}' was already created.");
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, _sessionUid.Value.Value));
         }
 
         _sessionUid = context.SessionUid;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.Requests;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.Telemetry;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
+
+using CreateTestSessionContext = Microsoft.Testing.Platform.Extensions.TestFramework.CreateTestSessionContext;
+
+namespace Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// A native Microsoft.Testing.Platform (MTP) test framework for MSTest. Unlike <see cref="MSTestBridgedTestFramework"/>
+/// it does not derive from the VSTest bridge: it handles the MTP discovery/run requests directly, builds the run
+/// context, filter and runsettings natively (see <see cref="MSTestRunContext"/> / <see cref="MSTestDiscoveryContext"/>
+/// / <see cref="MSTestRunSettings"/>), and publishes test nodes through the native <see cref="MtpUnitTestElementSink"/>
+/// / <see cref="MtpTestResultRecorder"/>. It reuses MSTest's existing <see cref="MSTestDiscoverer"/> /
+/// <see cref="MSTestExecutor"/> engine.
+/// </summary>
+/// <remarks>
+/// This is opt-in (behind <c>MSTEST_EXPERIMENTAL_NATIVE_MTP</c>) while the native path reaches full parity with the
+/// bridge. It still relies on the bridge only for the shared command-line options (<c>--filter</c>, <c>--settings</c>,
+/// <c>--test-parameter</c>) and the runsettings configuration/environment-variable providers; retiring those and the
+/// bridge package reference is the final step of the migration.
+/// </remarks>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+[StackTraceHidden]
+internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisposable
+{
+    private readonly MSTestExtension _extension;
+    private readonly Func<IEnumerable<Assembly>> _getTestAssemblies;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ITrxReportCapability? _trxReportCapability;
+    private readonly BridgedConfiguration _configuration;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly CountdownEvent _incomingRequestCounter = new(1);
+    private bool? _isTrxEnabled;
+    private bool _isDisposed;
+    private SessionUid? _sessionUid;
+
+    public MSTestTestFramework(MSTestExtension extension, Func<IEnumerable<Assembly>> getTestAssemblies,
+        IServiceProvider serviceProvider, ITestFrameworkCapabilities capabilities)
+    {
+        _extension = extension;
+        _getTestAssemblies = getTestAssemblies;
+        _serviceProvider = serviceProvider;
+        _trxReportCapability = capabilities.GetCapability<ITrxReportCapability>();
+        _configuration = new(serviceProvider.GetConfiguration());
+        _loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        PlatformServiceProvider.Instance.AdapterTraceLogger = new MTPTraceLogger(_loggerFactory.CreateLogger("mstest-trace"));
+    }
+
+    public string Uid => _extension.Uid;
+
+    public string Version => _extension.Version;
+
+    public string DisplayName => _extension.DisplayName;
+
+    public string Description => _extension.Description;
+
+    public Type[] DataTypesProduced { get; } =
+    [
+        typeof(TestNodeUpdateMessage),
+        typeof(SessionFileArtifact),
+    ];
+
+    private bool IsTrxEnabled
+        => _isTrxEnabled ??= _trxReportCapability is IInternalVSTestBridgeTrxReportCapability internalCapability
+            ? internalCapability.IsTrxEnabled
+            : _trxReportCapability is { IsSupported: true };
+
+    public Task<bool> IsEnabledAsync() => _extension.IsEnabledAsync();
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+        _sessionUid = context.SessionUid;
+        return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
+    }
+
+    public async Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+    {
+        _incomingRequestCounter.Signal();
+        await _incomingRequestCounter.WaitAsync(context.CancellationToken).ConfigureAwait(false);
+        _sessionUid = null;
+        return new CloseTestSessionResult { IsSuccess = true };
+    }
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        _incomingRequestCounter.AddCount();
+        try
+        {
+            switch (context.Request)
+            {
+                case DiscoverTestExecutionRequest discoverRequest:
+                    await DiscoverTestsAsync(discoverRequest, context.MessageBus, context.CancellationToken).ConfigureAwait(false);
+                    break;
+
+                case RunTestExecutionRequest runRequest:
+                    await RunTestsAsync(runRequest, context.MessageBus, context.CancellationToken).ConfigureAwait(false);
+                    break;
+            }
+        }
+        finally
+        {
+            _incomingRequestCounter.Signal();
+            context.Complete();
+        }
+    }
+
+    private async Task DiscoverTestsAsync(DiscoverTestExecutionRequest request, IMessageBus messageBus, CancellationToken cancellationToken)
+    {
+        if (Environment.GetEnvironmentVariable("MSTEST_DEBUG_DISCOVERTESTS") == "1" && !Debugger.IsAttached)
+        {
+            Debugger.Launch();
+        }
+
+        SessionUid sessionUid = _sessionUid!.Value;
+        string[] assemblyPaths = GetAssemblyPaths();
+        var handle = new MSTestFrameworkHandle(_serviceProvider.GetOutputDevice(), _extension, cancellationToken);
+        MSTestRunSettings runSettings = CreateRunSettings(handle);
+        var discoveryContext = new MSTestDiscoveryContext(_serviceProvider.GetCommandLineOptions(), runSettings, request.Filter);
+        var elementSink = new MtpUnitTestElementSink(messageBus, this, sessionUid, IsTrxEnabled);
+
+        await new MSTestDiscoverer(new TestSourceHandler(), CreateTelemetrySender())
+            .DiscoverTestsAsync(assemblyPaths, discoveryContext, handle, elementSink, _configuration, isMTP: true)
+            .ConfigureAwait(false);
+    }
+
+    private async Task RunTestsAsync(RunTestExecutionRequest request, IMessageBus messageBus, CancellationToken cancellationToken)
+    {
+        if (Environment.GetEnvironmentVariable("MSTEST_DEBUG_RUNTESTS") == "1" && !Debugger.IsAttached)
+        {
+            Debugger.Launch();
+        }
+
+        SessionUid sessionUid = _sessionUid!.Value;
+        string[] assemblyPaths = GetAssemblyPaths();
+        var handle = new MSTestFrameworkHandle(_serviceProvider.GetOutputDevice(), _extension, cancellationToken);
+        MSTestRunSettings runSettings = CreateRunSettings(handle);
+        var runContext = new MSTestRunContext(_serviceProvider.GetCommandLineOptions(), runSettings, request.Filter);
+
+        await new MSTestExecutor(cancellationToken, CreateTelemetrySender())
+            .RunTestsAsync(
+                assemblyPaths,
+                runContext,
+                handle,
+                settings => new MtpTestResultRecorder(messageBus, this, sessionUid, IsTrxEnabled, settings),
+                _configuration,
+                isMTP: true)
+            .ConfigureAwait(false);
+    }
+
+    private MSTestRunSettings CreateRunSettings(MSTestFrameworkHandle handle)
+        => new(
+            _serviceProvider.GetCommandLineOptions(),
+            _serviceProvider.GetFileSystem(),
+            _serviceProvider.GetConfiguration(),
+            _serviceProvider.GetClientInfo(),
+            handle);
+
+    private string[] GetAssemblyPaths()
+        => [.. _getTestAssemblies().Select(GetAssemblyPath)];
+
+    [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "Empty Assembly.Location is handled explicitly by falling back to the assembly simple name.")]
+    private static string GetAssemblyPath(Assembly assembly)
+    {
+        string location = assembly.Location;
+        if (!string.IsNullOrEmpty(location))
+        {
+            return location;
+        }
+
+        string name = assembly.GetName().Name
+            ?? throw new InvalidOperationException($"Cannot determine the name of assembly '{assembly}'.");
+
+        return name + ".dll";
+    }
+
+    private Func<string, IDictionary<string, object>, Task>? CreateTelemetrySender()
+    {
+        ITelemetryInformation telemetryInformation = _serviceProvider.GetTelemetryInformation();
+        if (!telemetryInformation.IsEnabled)
+        {
+            return null;
+        }
+
+        ITelemetryCollector telemetryCollector = _serviceProvider.GetTelemetryCollector();
+        return (eventName, metrics) => telemetryCollector.LogEventAsync(eventName, metrics, CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        if (!_isDisposed)
+        {
+            _incomingRequestCounter.Dispose();
+            _isDisposed = true;
+        }
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
@@ -87,6 +87,12 @@ internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisp
     public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
     {
         context.CancellationToken.ThrowIfCancellationRequested();
+
+        if (_sessionUid is not null)
+        {
+            throw new InvalidOperationException($"A test session '{_sessionUid.Value.Value}' was already created.");
+        }
+
         _sessionUid = context.SessionUid;
         return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
     }
@@ -113,6 +119,9 @@ internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisp
                 case RunTestExecutionRequest runRequest:
                     await RunTestsAsync(runRequest, context.MessageBus, context.CancellationToken).ConfigureAwait(false);
                     break;
+
+                default:
+                    throw new NotSupportedException($"The native MSTest framework does not support requests of type '{context.Request.GetType()}'.");
             }
         }
         finally

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -43,12 +43,20 @@ public static class TestApplicationBuilderExtensions
         testApplicationBuilder.AddTestRunParametersService(extension);
         testApplicationBuilder.AddMaximumFailedTestsService(extension);
         testApplicationBuilder.AddRunSettingsEnvironmentVariableProvider(extension);
+
+        // When the experimental native MTP integration is enabled, MSTest plugs into Microsoft.Testing.Platform
+        // directly (no VSTest bridge object model on the request path). Off by default, so shipping behavior is
+        // the bridged framework.
+        bool useNativeMtp = Environment.GetEnvironmentVariable("MSTEST_EXPERIMENTAL_NATIVE_MTP") is "1" or "true" or "True";
+
         testApplicationBuilder.RegisterTestFramework(
             serviceProvider => new TestFrameworkCapabilities(
                 new MSTestCapabilities(),
                 new MSTestBannerCapability(serviceProvider.GetRequiredService<IPlatformInformation>()),
                 MSTestGracefulStopTestExecutionCapability.Instance),
-            (capabilities, serviceProvider) => new MSTestBridgedTestFramework(extension, getTestAssemblies, serviceProvider, capabilities));
+            (capabilities, serviceProvider) => useNativeMtp
+                ? new MSTestTestFramework(extension, getTestAssemblies, serviceProvider, capabilities)
+                : new MSTestBridgedTestFramework(extension, getTestAssemblies, serviceProvider, capabilities));
     }
 }
 #endif

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/SynchronizedSingleSessionVSTestAndTestAnywhereAdapter.cs
@@ -23,6 +23,7 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     private readonly Func<IEnumerable<Assembly>> _getTestAssemblies;
     private readonly CountdownEvent _incomingRequestCounter = new(1);
     private bool _isDisposed;
+    private SessionUid? _sessionUid;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SynchronizedSingleSessionVSTestBridgedTestFramework"/> class.
@@ -51,13 +52,6 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     /// <inheritdoc />
     public sealed override string Version => _extension.Version;
 
-    /// <summary>
-    /// Gets the current test session UID, or <see langword="null"/> when no session is active. Exposed to the
-    /// (internals-visible) MSTest adapter so it can publish Microsoft.Testing.Platform test node updates natively
-    /// without routing through the VSTest bridge object model.
-    /// </summary>
-    internal SessionUid? SessionUid { get; private set; }
-
     /// <inheritdoc />
     public override async Task<bool> IsEnabledAsync() => await _extension.IsEnabledAsync().ConfigureAwait(false);
 
@@ -66,12 +60,12 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
-        if (SessionUid is not null)
+        if (_sessionUid is not null)
         {
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, SessionUid.Value.Value));
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, _sessionUid.Value.Value));
         }
 
-        SessionUid = context.SessionUid;
+        _sessionUid = context.SessionUid;
         return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
     }
 
@@ -83,7 +77,7 @@ public abstract class SynchronizedSingleSessionVSTestBridgedTestFramework : VSTe
 
         // Wait for remaining request processing
         await _incomingRequestCounter.WaitAsync(context.CancellationToken).ConfigureAwait(false);
-        SessionUid = null;
+        _sessionUid = null;
         return new CloseTestSessionResult { IsSuccess = true };
     }
 


### PR DESCRIPTION
Follow-up to #9706 (RFC 018 + Phases 1–2, merged). Continues retiring the `Microsoft.Testing.Extensions.VSTestBridge` dependency from MSTest's Microsoft.Testing.Platform (MTP) code path. Everything is behind the opt-in `MSTEST_EXPERIMENTAL_NATIVE_MTP` switch, so the shipping default (the bridge) is unchanged.

## What

A native **`MSTestTestFramework : ITestFramework, IDataProducer`** that handles the MTP discovery/run request directly and **reuses MSTest's existing `MSTestDiscoverer`/`MSTestExecutor` engine** — removing all VSTest bridge object-model adapters (`RunContextAdapter`, `DiscoveryContextAdapter`, `FrameworkHandlerAdapter`, `RunSettingsAdapter`, `TestCaseDiscoverySinkAdapter`, `MessageLoggerAdapter`) from the native request path.

New (all `#if !WINDOWS_UWP`):

- **`MSTestFilterContext`** (`MSTestRunContext` / `MSTestDiscoveryContext`) — native `IRunContext` / `IDiscoveryContext` that builds the VSTest `ITestCaseFilterExpression` from the MTP `ITestExecutionFilter` + `--filter` + runsettings `<TestCaseFilter>` (reusing `Microsoft.TestPlatform.Filter.Source`, now referenced directly). MSTest's existing `TestMethodFilter` matching is unchanged.
- **`MSTestRunSettings`** — native `IRunSettings`: reads runsettings, patches MTP defaults (DesignMode / ResultsDirectory / `--test-parameter`), and warns on unsupported entries (reusing the bridge's already-localized `ExtensionResources`).
- **`MSTestFrameworkHandle`** — an `IFrameworkHandle` that only forwards messages to `IOutputDevice` (results flow through the native `MtpTestResultRecorder`).
- **`MSTestTestFramework`** — session lifecycle + request handling; drives discovery/execution through the native seams from #9706.

`AddMSTest` branches the framework factory on the flag. The bridge's shared command-line/config/env-var registrations are kept for now (retired with the dependency in the final step). `MSTestBridgedTestFramework` reverts to pure-bridge (native production now lives in the native framework), and the now-unused Phase 2 `SessionUid` helper is removed from the bridge base.

## Validation

- **Full `.\build.cmd` — 0 warnings, 0 errors** across all TFMs (rebased onto current `main`).
- **Unit tests:** 45 (`MSTestAdapter.UnitTests`) + 898 (`MSTestAdapter.PlatformServices.UnitTests`), all green.
- **Native path (flag on, acceptance):** **185** tests green — `FilterTests`, `RunsettingsTests` (incl. localization), `OutputTests`, `TrxReportTests`, `ThreadingTests` (STA), `ServerModeTests`, `DeploymentItem`, `DataSourceTests`, `Inconclusive`/`Ignore`, `TestRunParameters`, `TimeoutTests`.
- **Default bridge path (flag off, acceptance):** `FilterTests` + `RunsettingsTests` (45) — unchanged.

## Remaining — Phase 6 (separate, gated)

Flip the default to native and **drop the `VSTestBridge` dependency** from MSTest. Gated on (1) full MSTest acceptance-suite parity on the native path (needs CI) and (2) native replacements for the bridge's remaining shared registrations (the `--filter`/`--settings`/`--test-parameter` option providers and the runsettings config/env-var providers) so the package reference can be removed.

The bridge package itself is **not** removed — NUnit/Expecto/3rd-party adapters still use it.