### PR TITLE
Clean up structural noise in integration test asset csprojs

### DIFF
--- a/test/IntegrationTests/TestAssets/DataSourceTestProject/DataSourceTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/DataSourceTestProject/DataSourceTestProject.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,10 +11,6 @@
     <None Update="a.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/IntegrationTests/TestAssets/DiscoverInternalsProject/DiscoverInternalsProject.csproj
+++ b/test/IntegrationTests/TestAssets/DiscoverInternalsProject/DiscoverInternalsProject.csproj
@@ -1,15 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/IntegrationTests/TestAssets/DoNotParallelizeTestProject/DoNotParallelizeTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/DoNotParallelizeTestProject/DoNotParallelizeTestProject.csproj
@@ -1,15 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/IntegrationTests/TestAssets/TestCategoriesFromTestDataRowProject/TestCategoriesFromTestDataRowProject.csproj
+++ b/test/IntegrationTests/TestAssets/TestCategoriesFromTestDataRowProject/TestCategoriesFromTestDataRowProject.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/TestProject/TestProjectForDiscovery.csproj
+++ b/test/IntegrationTests/TestAssets/TestProject/TestProjectForDiscovery.csproj
@@ -4,18 +4,6 @@
     <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework\TestFramework.csproj" />
     <ProjectReference Include="$(RepoRoot)test\IntegrationTests\TestAssets\SampleFrameworkExtensions\SampleFrameworkExtensions.csproj" />


### PR DESCRIPTION
Part of #9715 (structural / legacy cleanup).

This PR fixes the structural mistakes and legacy artifacts in a focused set of `test/IntegrationTests/TestAssets/*.csproj` files, and fully cleans those files so a follow-up bulk-sweep PR won't touch them (avoids merge conflicts).

### Changes
- **Task 3 — legacy VS `<Service Include>` removal**: dropped the no-op `<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />` node from `DataSourceTestProject`, `DiscoverInternalsProject`, and `DoNotParallelizeTestProject`.
- **Task 4 — plural → singular TFM**: `TestCategoriesFromTestDataRowProject` now uses `<TargetFramework>` (single TFM) instead of `<TargetFrameworks>`.
- **Task 5 — legacy IDE props**: `TestProjectForDiscovery` no longer carries the IDE-only `<PropertyGroup>` (`ErrorReport`, `WarningLevel`, `IsCodedUITest`, `TestProjectType`, redundant `TRACE`) nor the SDK-implicit `<Reference Include="System" />`.
- For the five files above, also replaced hardcoded `net462` with `$(NetFrameworkMinimum)` and removed the redundant `<IsPackable>false</IsPackable>` (already set by `test/Directory.Build.props`).

The remaining ~21 asset projects get the same TFM/`IsPackable` sweep in a separate PR.

### Verification
- `restore.cmd` succeeds.
- All 5 changed projects build with **0 warnings / 0 errors**.
- `dotnet msbuild -getProperty:TargetFramework` resolves to `net462` for each, confirming semantic equivalence.