### PR TITLE
Use $(NetFrameworkMinimum) and drop redundant IsPackable across integration test assets

### DIFF
--- a/test/IntegrationTests/TestAssets/ClsTestProject/ClsTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/ClsTestProject/ClsTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DataRowTestProject/DataRowTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/DataRowTestProject/DataRowTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DeploymentTestProject.Never/DeploymentTestProject.Never.csproj
+++ b/test/IntegrationTests/TestAssets/DeploymentTestProject.Never/DeploymentTestProject.Never.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>$(NetFrameworkMinimum);net8.0</TargetFrameworks>
     <DependencyCopyBehavior>Never</DependencyCopyBehavior>
   </PropertyGroup>
 

--- a/test/IntegrationTests/TestAssets/DeploymentTestProject.PreserveNewest/DeploymentTestProject.PreserveNewest.csproj
+++ b/test/IntegrationTests/TestAssets/DeploymentTestProject.PreserveNewest/DeploymentTestProject.PreserveNewest.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>$(NetFrameworkMinimum);net8.0</TargetFrameworks>
     <DependencyCopyBehavior>PreserveNewest</DependencyCopyBehavior>
   </PropertyGroup>
 

--- a/test/IntegrationTests/TestAssets/DesktopTestProjectx64Debug/DesktopTestProjectx64Debug.csproj
+++ b/test/IntegrationTests/TestAssets/DesktopTestProjectx64Debug/DesktopTestProjectx64Debug.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DesktopTestProjectx64Release/DesktopTestProjectx64Release.csproj
+++ b/test/IntegrationTests/TestAssets/DesktopTestProjectx64Release/DesktopTestProjectx64Release.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DesktopTestProjectx86Debug/DesktopTestProjectx86Debug.csproj
+++ b/test/IntegrationTests/TestAssets/DesktopTestProjectx86Debug/DesktopTestProjectx86Debug.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DesktopTestProjectx86Release/DesktopTestProjectx86Release.csproj
+++ b/test/IntegrationTests/TestAssets/DesktopTestProjectx86Release/DesktopTestProjectx86Release.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/DynamicDataTestProject/DynamicDataTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/DynamicDataTestProject/DynamicDataTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/FixturesTestProject/FixturesTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/FixturesTestProject/FixturesTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/FxExtensibilityTestProject/FxExtensibilityTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/FxExtensibilityTestProject/FxExtensibilityTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/HierarchyProject/HierarchyProject.csproj
+++ b/test/IntegrationTests/TestAssets/HierarchyProject/HierarchyProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/LibProjectReferencedByDataSourceTest/LibProjectReferencedByDataSourceTest.csproj
+++ b/test/IntegrationTests/TestAssets/LibProjectReferencedByDataSourceTest/LibProjectReferencedByDataSourceTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/IntegrationTests/TestAssets/OutputTestProject/OutputTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/OutputTestProject/OutputTestProject.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/ParallelTestClass/ParallelClassesTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/ParallelTestClass/ParallelClassesTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/ParallelTestMethods/ParallelMethodsTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/ParallelTestMethods/ParallelMethodsTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/SampleProjectForAssemblyResolution/SampleProjectForAssemblyResolution.csproj
+++ b/test/IntegrationTests/TestAssets/SampleProjectForAssemblyResolution/SampleProjectForAssemblyResolution.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/SuiteLifeCycleTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/SuiteLifeCycleTestProject/SuiteLifeCycleTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>$(NetFrameworkMinimum);net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/TestIdProject.DefaultStrategy/TestIdProject.DefaultStrategy.csproj
+++ b/test/IntegrationTests/TestAssets/TestIdProject.DefaultStrategy/TestIdProject.DefaultStrategy.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/IntegrationTests/TestAssets/TestIdProject.FullyQualifiedTestStrategy/TestIdProject.FullyQualifiedStrategy.csproj
+++ b/test/IntegrationTests/TestAssets/TestIdProject.FullyQualifiedTestStrategy/TestIdProject.FullyQualifiedStrategy.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
-    <IsPackable>false</IsPackable>
+    <TargetFramework>$(NetFrameworkMinimum)</TargetFramework>
     <DefineConstants>$(DefineConstants);FULLY_QUALIFIED_ID</DefineConstants>
   </PropertyGroup>
 

--- a/test/IntegrationTests/TestAssets/TimeoutTestProject/TimeoutTestProject.csproj
+++ b/test/IntegrationTests/TestAssets/TimeoutTestProject/TimeoutTestProject.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>$(NetFrameworkMinimum);net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of #9715 (tasks 1 & 2, bulk sweep). Companion to #9745.

This is the bulk sweep of the remaining integration test asset `.csproj` files under `test/IntegrationTests/TestAssets/`. For each of the 21 projects, two transformations were applied:

1. Replaced the hardcoded `net462` TFM with the central `$(NetFrameworkMinimum)` property:
   - Single-TFM: `<TargetFramework>net462</TargetFramework>` → `<TargetFramework>$(NetFrameworkMinimum)</TargetFramework>`
   - Multi-TFM: `<TargetFrameworks>net462;net8.0</TargetFrameworks>` → `<TargetFrameworks>$(NetFrameworkMinimum);net8.0</TargetFrameworks>`
2. Removed the redundant `<IsPackable>false</IsPackable>` line (inherited from `test/Directory.Build.props`).

No other changes were made — item groups (ProjectReference/PackageReference/Content/Compile/None) are untouched.

### Verification
- `.\.dotnet\dotnet.exe msbuild <proj> -getProperty:TargetFramework` prints `net462` for changed projects, confirming the property resolves.
- Built representative projects with 0 errors: `ClsTestProject` (single-TFM), `DesktopTestProjectx64Debug` (Desktop variant), and `TimeoutTestProject` (multi-TFM).
- Confirmed none of the 21 files still contain `IsPackable` or a hardcoded `>net462<`.

### Files (21)
Single-TFM: ClsTestProject, DataRowTestProject, DesktopTestProjectx64Debug, DesktopTestProjectx64Release, DesktopTestProjectx86Debug, DesktopTestProjectx86Release, DynamicDataTestProject, FixturesTestProject, FxExtensibilityTestProject, HierarchyProject, LibProjectReferencedByDataSourceTest, OutputTestProject, ParallelClassesTestProject, ParallelMethodsTestProject, SampleProjectForAssemblyResolution, TestIdProject.DefaultStrategy, TestIdProject.FullyQualifiedStrategy.

Multi-TFM: DeploymentTestProject.Never, DeploymentTestProject.PreserveNewest, SuiteLifeCycleTestProject, TimeoutTestProject.