### PR TITLE
Native MTP integration for MSTest (Phase 6a): native providers, config, resources

### DIFF
--- a/eng/verify-nupkgs.ps1
+++ b/eng/verify-nupkgs.ps1
@@ -21,7 +21,7 @@ function Confirm-NugetPackages {
     $expectedNumOfFiles = @{
         "MSTest.Sdk"                                  = 15
         "MSTest.TestFramework"                        = 105
-        "MSTest.TestAdapter"                          = 53
+        "MSTest.TestAdapter"                          = 66
         "MSTest"                                      = 10
         "MSTest.Analyzers"                            = 56
     }

--- a/src/Adapter/MSTest.TestAdapter/Resources/PlatformAdapterResources.resx
+++ b/src/Adapter/MSTest.TestAdapter/Resources/PlatformAdapterResources.resx
@@ -1,0 +1,164 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RunsettingsFileCannotBeRead" xml:space="preserve">
+    <value>runsettings file '{0}' cannot be read</value>
+    <comment>0 is the {Locked="runsettings"} file path.</comment>
+  </data>
+  <data name="RunsettingsFileDoesNotExist" xml:space="preserve">
+    <value>runsettings file '{0}' does not exist</value>
+    <comment>0 is the {Locked="runsettings"} file path.</comment>
+  </data>
+  <data name="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage" xml:space="preserve">
+    <value>The bridged framework supports only one session at a time. A session with UID {0} is already open.</value>
+    <comment>{0} is the session {Locked="UID"}.</comment>
+  </data>
+  <data name="TestCaseFilterOptionDescription" xml:space="preserve">
+    <value>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</value>
+    <comment>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</comment>
+  </data>
+  <data name="RunSettingsOptionDescription" xml:space="preserve">
+    <value>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</value>
+    <comment>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</comment>
+  </data>
+  <data name="TestRunParameterOptionDescription" xml:space="preserve">
+    <value>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</value>
+    <comment>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</comment>
+  </data>
+  <data name="TestRunParameterOptionArgumentIsNotParameter" xml:space="preserve">
+    <value>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</value>
+    <comment>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</comment>
+  </data>
+  <data name="MissingRunSettingsAttribute" xml:space="preserve">
+    <value>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</value>
+    <comment>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</comment>
+  </data>
+  <data name="UnsupportedRunsettingsLoggers" xml:space="preserve">
+    <value>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</value>
+    <comment>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</comment>
+  </data>
+  <data name="UnsupportedRunsettingsDatacollectors" xml:space="preserve">
+    <value>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</value>
+    <comment>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</comment>
+  </data>
+  <data name="UnsupportedRunconfigurationSetting" xml:space="preserve">
+    <value>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</value>
+    <comment>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</comment>
+  </data>
+</root>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.cs.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.cs.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Neplatný soubor .runsettings. Chybí atribut &lt;RunSettings&gt;.</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Relativní nebo absolutní cesta k souboru .runsettings. Další informace a příklady konfigurace testovacího běhu najdete v tématu https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">Soubor runsettings „{0}“ nejde přečíst</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">Soubor runsettings „{0}“ neexistuje</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtruje testy pomocí daného výrazu. Další informace najdete v části s podrobnostmi o možnosti filtru. Další informace a příklady použití selektivního filtrování testů jednotek najdete v tématu https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">argument {0} není parametr. Argumenty parametrů odpovídají následujícímu vzoru key=value (klíč=hodnota).</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Zadejte nebo přepište parametr páru klíč-hodnota. Další informace a příklady najdete tady: https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform nepodporuje atribut Runsettings {0}. Bude ho proto ignorovat.</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform nepodporuje kolekce dat Runsettings. Bude je proto ignorovat.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform nepodporuje protokolovače Runsettings. Bude je proto ignorovat.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Přemostěná architektura podporuje najednou pouze jednu relaci. Relace s UID {0} je už otevřená.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.de.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.de.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Ungültige .runsettings-Datei, "&lt;RunSettings&gt;"-Attribut fehlt.</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Der relative oder absolute Pfad zur Datei „.runsettings“. Weitere Informationen und Beispiele zum Konfigurieren des Testlaufs finden Sie unter https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">runsettings-Datei „{0}“ kann nicht gelesen werden.</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">runsettings-Datei „{0}“ ist nicht vorhanden.</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtert Tests mithilfe des angegebenen Ausdrucks. Weitere Informationen finden Sie im Abschnitt „Filteroptionsdetails“. Weitere Informationen und Beispiele zur Verwendung der selektiven Komponententestfilterung finden Sie unter https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">Das Argument „{0}“ ist kein Parameter. Parameterargumente stimmen mit dem folgenden Muster „key=value“ überein.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Geben Sie einen Schlüssel-Wert-Paarparameter an, oder überschreiben Sie diesen. Weitere Informationen und Beispiele finden Sie unter https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings-Attribut "{0}" wird von Microsoft.Testing.Platform nicht unterstützt und wird ignoriert.</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings-Datacollectors werden von Microsoft.Testing.Platform nicht unterstützt und werden ignoriert.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings-Protokollierungen werden von Microsoft.Testing.Platform nicht unterstützt und werden ignoriert.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Das Brückenframework unterstützt jeweils nur eine Sitzung. Eine Sitzung mit UID {0} ist bereits geöffnet.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.es.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.es.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Archivo .runsettings no válido, falta el atributo "&lt;RunSettings&gt;"</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Ruta de acceso, relativa o absoluta, al archivo .runsettings. Para obtener más información y ejemplos sobre cómo configurar la serie de pruebas, consulte https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">No se puede leer el archivo '{0}' de runsettings</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">El archivo '{0}' de runsettings no existe</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtra las pruebas mediante la expresión especificada. Para obtener más información, consulte la sección Detalles de la opción Filtrar. Para obtener más información y ejemplos sobre cómo usar el filtrado de pruebas unitarias selectivas, consulte https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">el argumento "{0}" no es un parámetro. Los argumentos de parámetros coinciden con el patrón "key=value" siguiente.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Especifique o invalide un parámetro de par clave-valor. Para más información y ejemplos, consulte https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform no admite el atributo "{0}" de Runsettings y se omitirá</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform no admite los recopiladores de datos de Runsettings y se omitirán</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform no admite los registradores de Runsettings y se omitirán</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">El marco puente solo admite una sesión a la vez. Ya hay abierta una sesión con {0} UID.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.fr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.fr.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Fichier .runsettings non valide, « &lt;RunSettings&gt; » attribut est manquant</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Chemin d’accès, relatif ou absolu, au fichier .runsettings. Pour plus d’informations et d’exemples sur la configuration de la série de tests, consultez https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">impossible de lire le fichier runsettings « {0} »</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">Le fichier .runsettings n’existe pas sur « {0} »</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtre les tests à l’aide de l’expression donnée. Pour plus d’informations, consultez la section des détails de l’option Filtrer. Pour plus d’informations et d’exemples sur l’utilisation du filtrage sélectif des tests unitaires, consultez https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">l’argument « {0} » n’est pas un paramètre. Les arguments de paramètres correspondent au modèle suivant « key=value ».</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Spécifiez ou remplacez un paramètre de paire clé-valeur. Pour découvrir plus d’informations et d’exemples, voir https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Les attributs Runsettings « {0} » ne sont pas pris en charge par Microsoft.Testing.Platform et seront ignorés</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Les datacollecteurs Runsettings ne sont pas pris en charge par Microsoft.Testing.Platform et seront ignorés</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Les loggers Runsettings ne sont pas pris en charge par Microsoft.Testing.Platform et seront ignorés</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Le framework ponté ne prend en charge qu’une seule session à la fois. Une session avec UID {0} est déjà ouverte.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.it.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.it.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">File .runsettings non valido. Attributo '&lt;RunSettings&gt;' mancante</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Percorso, relativo o assoluto, del file .runsettings. Per altre informazioni ed esempi su come configurare l'esecuzione dei test, vedere https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">Non è possibile leggere il file runsettings '{0}'</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">Il file runsettings '{0}' non esiste</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtra i test usando l'espressione specificata. Per ulteriori informazioni, vedere la sezione dei dettagli dell'opzione Filtro. Per altre informazioni ed esempi su come usare il filtro selettivo unit test, vedere https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">l'argomento '{0}' non è un parametro. Gli argomenti dei parametri corrispondono al criterio 'key=value' seguente.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Specificare o eseguire l'override di un parametro di coppia chiave-valore. Per altre informazioni ed esempi, vedere https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">L’attributo Runsettings ‘{0}’ non è supportato da Microsoft.Testing.Platform e verrà ignorato</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">I datacollector Runsettings non sono supportati da Microsoft.Testing.Platform e verranno ignorati</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">I logger Runsettings non sono supportati da Microsoft.Testing.Platform e verranno ignorati</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Il framework bridged supporta solo una sessione alla volta. Una sessione con UID {0} è già aperta.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ja.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ja.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">.runsettings ファイルが無効です。'&lt;RunSettings&gt;' 属性がありません</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">.runsettings ファイルへの相対パスまたは絶対パス。テストの実行を構成する方法の詳細と例については、https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file を参照してください</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">runsettings ファイル '{0}' を読み取れません</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">runsettings ファイル '{0}' が存在しません</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">指定された式を使用してテストをフィルター処理します。詳細については、「フィルター オプションの詳細」セクションを参照してください。選択的単体テスト フィルターの使用方法の詳細と例については、https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests を参照してください。</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">引数 '{0}' はパラメーターではありません。パラメーター引数は、次のパターン 'key=value' と一致しています。</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">キーと値のペア パラメーターを指定またはオーバーライドします。詳細情報と例については、「https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters」を参照してください。</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 属性 '{0}' は Microsoft.Testing.Platform でサポートされていないため、無視されます</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings datacollectors は Microsoft.Testing.Platform でサポートされていないため、無視されます</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings loggers は Microsoft.Testing.Platform でサポートされていないため、無視されます</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">ブリッジ されたフレームワークは、一度に 1 つのセッションのみをサポートします。UID{0} のセッションは既に開かれています。</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ko.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ko.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">.runsettings 파일이 잘못되었습니다. '&lt;RunSettings&gt;' 특성이 없습니다.</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">.runsettings 파일에 대한 상대 또는 절대 경로입니다. 테스트 실행을 구성하는 방법에 관한 자세한 내용 및 예시는 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file을 참조하세요.</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">runsettings 파일 '{0}'을(를) 읽을 수 없습니다.</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">runsettings 파일 '{0}'이(가) 없습니다.</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">지정된 식을 사용하여 테스트를 필터링합니다. 자세한 내용은 필터 옵션 세부 정보 섹션을 참조하세요. 선택적 단위 테스트 필터링을 사용하는 방법에 관한 자세한 내용과 예시는 https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests를 참조하세요.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">'{0}' 인수는 매개 변수가 아닙니다. 매개 변수 인수가 다음 패턴 'key=value'와 일치합니다.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">키-값 쌍 매개 변수를 지정하거나 재정의합니다. 자세한 내용 및 예제는 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters를 참조하세요.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 특성 '{0}'은(는) Microsoft.Testing.Platform에서 지원되지 않으며 무시됩니다.</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings datacollectors는 Microsoft.Testing.Platform에서 지원되지 않으며 무시됩니다.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 로거는 Microsoft.Testing.Platform에서 지원되지 않으며 무시됩니다.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">브리지된 프레임워크는 한 번에 하나의 세션만 지원합니다. UID가 {0}인 세션이 이미 열려 있습니다.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.pl.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.pl.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Nieprawidłowy plik .runsettings, brak atrybutu „&lt;RunSettings&gt;”</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Ścieżka względna lub bezwzględna pliku .runsettings. Aby uzyskać więcej informacji i przykładów dotyczących konfigurowania przebiegu testu, zobacz: https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">nie można odczytać pliku runsettings „{0}”</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">plik runsettings „{0}” nie istnieje</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtruje testy przy użyciu danego wyrażenia. Aby uzyskać więcej informacji, zobacz sekcję szczegółów opcji filtru. Aby uzyskać więcej informacji i przykładów dotyczących używania selektywnego filtrowania testów jednostkowych, zobacz: https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">argument „{0}” nie jest parametrem. Argumenty parametrów pasują do następującego wzorca „key=value”.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Określ lub zastąp parametr pary klucz-wartość. Aby uzyskać więcej informacji i przykładów, zobacz stronę https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Atrybut Runsettings „{0}” nie jest obsługiwany przez element Microsoft.Testing.Platform i zostanie zignorowany.</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Kolektory danych Runsettings nie są obsługiwane przez element Microsoft.Testing.Platform i będą ignorowane</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Rejestratory Runsettings nie są obsługiwane przez element Microsoft.Testing.Platform i będą ignorowane.</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Platforma mostkowania obsługuje tylko jedną sesję naraz. Sesja z identyfikatorem UID {0} jest już otwarta.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.pt-BR.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.pt-BR.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Arquivo .runsettings inválido, o atributo "&lt;RunSettings&gt;" está ausente</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">O caminho, relativo ou absoluto, para o arquivo .runsettings. Para obter mais informações e exemplos sobre como configurar a execução de teste, consulte https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">o arquivo runsettings "{0}" não pode ser lido</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">o arquivo runsettings "{0}" não existe</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Filtra testes usando a expressão fornecida. Para obter mais informações, consulte a seção detalhes da opção Filtro. Para obter mais informações e exemplos sobre como usar a filtragem de teste de unidade seletiva, consulte https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">o argumento '{0}' não é um parâmetro. Os argumentos de parâmetros correspondem ao padrão 'key=value' a seguir.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Especifique ou substitua um parâmetro de par chave-valor. Para obter mais informações e exemplos, consulte https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">O atributo Runsettings "{0}" não tem suporte no Microsoft.Testing.Platform e será ignorado</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Os coletores de dados de arquivos Runsettings não são compatíveis com Microsoft.Testing.Platform e serão ignorados</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Os registradores de arquivos Runsettings não têm suporte no Microsoft.Testing.Platform e serão ignorados</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">A estrutura em ponte dá suporte a apenas uma sessão por vez. Uma sessão com UID {0} já está aberta.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ru.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.ru.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Недопустимый файл .runsettings, отсутствует атрибут "&lt;RunSettings&gt;"</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">Относительный или абсолютный путь к файлу .runsettings. Дополнительные сведения и примеры настройки тестового запуска см. на странице https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">не удается прочитать файл runsettings "{0}"</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">файл runsettings "{0}" не существует</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Фильтрация тестов с использованием заданного выражения. Дополнительные сведения см. в разделе сведений о параметрах фильтра. Дополнительные сведения и примеры использования выборочной фильтрации модульных тестов см. на странице https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">аргумент "{0}" не является параметром. Аргументы параметров соответствуют следующему шаблону: "key=value".</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Укажите или переопределите параметр пары "ключ-значение". Дополнительные сведения и примеры см. на странице https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Атрибут Runsettings "{0}" не поддерживается в Microsoft.Testing.Platform и будет пропущен</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Сборщики данных Runsettings не поддерживаются в Microsoft.Testing.Platform и будут пропущены</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Средства ведения журналов Runsettings не поддерживаются в Microsoft.Testing.Platform и будут пропущены</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Интегрированная среда Bridged Framework поддерживает только один сеанс одновременно. Сеанс с UID {0} уже открыт.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.tr.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.tr.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">Geçersiz .runsettings dosyası, '&lt;RunSettings&gt;' özniteliği eksik</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">.runsettings dosyasının göreli veya mutlak yolu. Test çalıştırmasını yapılandırma hakkında daha fazla bilgi ve örnek için şu sayfaya bakın: https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">'{0}' runsettings dosyası okunamıyor</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">'{0}' runsettings dosyası mevcut değil</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">Belirtilen ifadeyi kullanarak testleri filtreler. Daha fazla bilgi için Filtre seçeneği ayrıntıları bölümüne bakın. Seçici birim testi filtreleme hakkında daha fazla bilgi ve örnek için şu sayfaya bakın: https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">'{0}' bağımsız değişkeni bir parametre değil. Parametre bağımsız değişkenleri aşağıdaki 'key=value' deseniyle eşleşiyor.</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">Anahtar-değer çifti parametresi belirtin veya geçersiz kılın. Daha fazla bilgi ve örnek için şu sayfaya bakın: https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">'{0}' Runsettings özniteliği Microsoft.Testing.Platform tarafından desteklenmiyor ve yoksayılacak</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings veri toplayıcıları Microsoft.Testing.Platform tarafından desteklenmiyor ve yoksayılacak</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings günlükçüleri Microsoft.Testing.Platform tarafından desteklenmiyor ve yoksayılacak</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">Köprülü çerçeve aynı anda yalnızca bir oturumu destekler. UID'si {0} olan bir oturum zaten açık.</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.zh-Hans.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.zh-Hans.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">.runsettings 文件无效，缺少 '&lt;RunSettings&gt;' 属性</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">.runsettings 文件的相对路径或绝对路径。有关如何配置测试运行的详细信息和示例，请参阅 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">无法读取 runsettings 文件“{0}”</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">runsettings 文件“{0}”不存在</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">使用给定的表达式筛选测试。有关详细信息，请参阅“筛选器选项详细信息”部分。有关如何使用选择性单元测试筛选的详细信息和示例，请参阅 https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests。</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">自变量“{0}”不是参数。参数自变量与以下模式“key=value”相匹配。</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">指定或替代键值对参数。有关详细信息和示例，请参阅 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform 不支持 Runsettings 属性“{0}”，将被忽略</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform 不支持 Runsettings 数据收集器，将被忽略</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Microsoft.Testing.Platform 不支持 Runsettings 记录器，将被忽略</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">桥接框架一次仅支持一个会话。已打开具有 UID {0} 的会话。</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.zh-Hant.xlf
+++ b/src/Adapter/MSTest.TestAdapter/Resources/xlf/PlatformAdapterResources.zh-Hant.xlf
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../PlatformAdapterResources.resx">
+    <body>
+      <trans-unit id="MissingRunSettingsAttribute">
+        <source>Invalid .runsettings file, '&lt;RunSettings&gt;' attribute is missing</source>
+        <target state="translated">.runsettings 檔案無效，遺漏 '&lt;RunSettings&gt;' 屬性</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or element {Locked="&lt;RunSettings&gt;"}.</note>
+      </trans-unit>
+      <trans-unit id="RunSettingsOptionDescription">
+        <source>The path, relative or absolute, to the .runsettings file. For more information and examples on how to configure test run, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</source>
+        <target state="translated">.runsettings 檔案的相對或絕對路徑。如需如何設定測試回合的詳細資訊和範例，請參閱 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file</target>
+        <note>Do not localize file extension {Locked=".runsettings"} or link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#the-runsettings-file"}.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileCannotBeRead">
+        <source>runsettings file '{0}' cannot be read</source>
+        <target state="translated">無法讀取 runsettings 檔案 '{0}'</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="RunsettingsFileDoesNotExist">
+        <source>runsettings file '{0}' does not exist</source>
+        <target state="translated">.runsettings 檔案 '{0}' 不存在</target>
+        <note>0 is the {Locked="runsettings"} file path.</note>
+      </trans-unit>
+      <trans-unit id="TestCaseFilterOptionDescription">
+        <source>Filters tests using the given expression. For more information, see the Filter option details section. For more information and examples on how to use selective unit test filtering, see https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests.</source>
+        <target state="translated">使用指定運算式的篩選測試。如需詳細資訊，請參閱篩選選項詳細資料區段。如需如何使用選擇性單元測試篩選的詳細資訊和範例，請參閱 https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests。</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/dotnet/core/testing/selective-unit-tests"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionArgumentIsNotParameter">
+        <source>argument '{0}' is not a parameter. Parameters arguments are matching the following pattern 'key=value'.</source>
+        <target state="translated">引數 '{0}' 不是參數。參數引數符合下列模式 'key=value'。</target>
+        <note>0 is the invalid argument. Do not localize pattern {Locked="key=value"}.</note>
+      </trans-unit>
+      <trans-unit id="TestRunParameterOptionDescription">
+        <source>Specify or override a key-value pair parameter. For more information and examples, see https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</source>
+        <target state="translated">指定或覆寫機碼值組參數。如需詳細資訊和範例，請參閱 https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters</target>
+        <note>Do not localize link {Locked="https://learn.microsoft.com/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file#testrunparameters"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunconfigurationSetting">
+        <source>Runsettings attribute '{0}' is not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 屬性 '{0}' 不受 Microsoft.Testing.Platform 支援，將會予以忽略</target>
+        <note>0 is the unsupported {Locked="Runsettings"} attribute name. Do not localize {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsDatacollectors">
+        <source>Runsettings datacollectors are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 資料收集器不受 Microsoft.Testing.Platform 支援，將會予以忽略</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="UnsupportedRunsettingsLoggers">
+        <source>Runsettings loggers are not supported by Microsoft.Testing.Platform and will be ignored</source>
+        <target state="translated">Runsettings 記錄器不受 Microsoft.Testing.Platform 支援，將會予以忽略</target>
+        <note>Do not localize {Locked="Runsettings"} or {Locked="Microsoft.Testing.Platform"}.</note>
+      </trans-unit>
+      <trans-unit id="VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage">
+        <source>The bridged framework supports only one session at a time. A session with UID {0} is already open.</source>
+        <target state="translated">橋接器架構一次只支援一個工作階段。已開啟具有 UID {0} 的工作階段。</target>
+        <note>{0} is the session {Locked="UID"}.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/IMSTestTrxReportCapability.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/IMSTestTrxReportCapability.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native TRX report capability that also exposes whether TRX reporting has been enabled for the run.
+/// This mirrors the VSTest bridge's internal capability so the native framework can determine TRX enablement
+/// without depending on the bridge.
+/// </summary>
+internal interface IMSTestTrxReportCapability : ITrxReportCapability
+{
+    bool IsTrxEnabled { get; }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestFilterContext.cs
@@ -26,8 +26,8 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatform
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal abstract class MSTestFilterContextBase
 {
-    // Keep in sync with the bridge's TestCaseFilterCommandLineOptionsProvider.TestCaseFilterOptionName.
-    private const string TestCaseFilterOptionName = "filter";
+    // References the native --filter option provider's name.
+    private const string TestCaseFilterOptionName = MSTestTestCaseFilterCommandLineOptionsProvider.TestCaseFilterOptionName;
 
     protected MSTestFilterContextBase(ICommandLineOptions commandLineOptions, IRunSettings runSettings, ITestExecutionFilter filter)
     {

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
-using Microsoft.Testing.Extensions.VSTestBridge.Resources;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.Platform.TestHost;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 
@@ -24,10 +24,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatform
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 internal sealed class MSTestRunSettings : IRunSettings
 {
-    // Keep in sync with the bridge's option provider constants (options are still registered by the bridge).
-    private const string RunSettingsOptionName = "settings";
-    private const string TestRunParameterOptionName = "test-parameter";
-
     private static readonly char[] TestRunParameterSeparator = ['='];
 
     private static readonly string[] UnsupportedRunConfigurationSettings =
@@ -49,7 +45,8 @@ internal sealed class MSTestRunSettings : IRunSettings
         IClientInfo client,
         IMessageLogger messageLogger)
     {
-        string runSettingsXml = ReadRunSettings(commandLineOptions, fileSystem);
+        _ = commandLineOptions.TryGetOptionArgumentList(MSTestRunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? fileNames);
+        string runSettingsXml = ReadRunSettings(fileNames, fileSystem);
 
         XDocument runSettingsDocument = Patch(runSettingsXml, configuration, client, commandLineOptions);
         WarnOnUnsupportedEntries(runSettingsDocument, messageLogger);
@@ -62,13 +59,11 @@ internal sealed class MSTestRunSettings : IRunSettings
     // Not used by MSTest (matches the bridge's RunSettingsAdapter).
     public ISettingsProvider? GetSettings(string? settingsName) => throw new NotImplementedException();
 
-    internal static string ReadRunSettings(ICommandLineOptions commandLineOptions, IFileSystem fileSystem)
+    internal static string ReadRunSettings(string[]? fileNames, IFileSystem fileSystem)
     {
-        _ = commandLineOptions.TryGetOptionArgumentList(RunSettingsOptionName, out string[]? fileNames);
-
-        // Match the runsettings environment-variable provider (which reads the same --settings option): use the
-        // first provided path rather than requiring exactly one, so a valid value is not ignored when more than
-        // one argument is present.
+        // Use the first provided --settings path rather than requiring exactly one, matching the runsettings
+        // environment-variable provider that reads the same option, so a valid value is not ignored when more
+        // than one argument is present.
         if (fileNames is { Length: > 0 } && fileSystem.ExistFile(fileNames[0]))
         {
             return fileSystem.ReadAllText(fileNames[0]);
@@ -106,7 +101,7 @@ internal sealed class MSTestRunSettings : IRunSettings
         var document = XDocument.Parse(runSettingsXml);
         if (document.Element("RunSettings") is not { } runSettingsElement)
         {
-            throw new InvalidOperationException(ExtensionResources.MissingRunSettingsAttribute);
+            throw new InvalidOperationException(PlatformAdapterResources.MissingRunSettingsAttribute);
         }
 
         bool isPatchingCommentAdded = false;
@@ -156,7 +151,7 @@ internal sealed class MSTestRunSettings : IRunSettings
 
     private static void PatchTestRunParameters(XDocument runSettingsDocument, ICommandLineOptions commandLineOptions)
     {
-        if (!commandLineOptions.TryGetOptionArgumentList(TestRunParameterOptionName, out string[]? testRunParameters))
+        if (!commandLineOptions.TryGetOptionArgumentList(MSTestTestRunParametersCommandLineOptionsProvider.TestRunParameterOptionName, out string[]? testRunParameters))
         {
             return;
         }
@@ -196,12 +191,12 @@ internal sealed class MSTestRunSettings : IRunSettings
 
         if (runSettingsElement.Element("LoggerRunSettings") is not null)
         {
-            messageLogger.SendMessage(TestMessageLevel.Warning, ExtensionResources.UnsupportedRunsettingsLoggers);
+            messageLogger.SendMessage(TestMessageLevel.Warning, PlatformAdapterResources.UnsupportedRunsettingsLoggers);
         }
 
         if (runSettingsElement.Element("DataCollectionRunSettings") is not null)
         {
-            messageLogger.SendMessage(TestMessageLevel.Warning, ExtensionResources.UnsupportedRunsettingsDatacollectors);
+            messageLogger.SendMessage(TestMessageLevel.Warning, PlatformAdapterResources.UnsupportedRunsettingsDatacollectors);
         }
 
         if (runSettingsElement.Element("RunConfiguration") is not { } runConfigurationElement)
@@ -211,7 +206,7 @@ internal sealed class MSTestRunSettings : IRunSettings
 
         foreach (string unsupportedRunConfigurationSetting in UnsupportedRunConfigurationSettings.Where(setting => runConfigurationElement.Element(setting) is not null))
         {
-            messageLogger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, ExtensionResources.UnsupportedRunconfigurationSetting, unsupportedRunConfigurationSetting));
+            messageLogger.SendMessage(TestMessageLevel.Warning, string.Format(CultureInfo.InvariantCulture, PlatformAdapterResources.UnsupportedRunconfigurationSetting, unsupportedRunConfigurationSetting));
         }
     }
 }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsCommandLineOptionsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsCommandLineOptionsProvider.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
+
+using IFileSystem = Microsoft.Testing.Platform.Helpers.IFileSystem;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native command-line provider for the VSTest <c>--settings</c> (.runsettings) option. Mirrors the VSTest
+/// bridge's <c>RunSettingsCommandLineOptionsProvider</c> (identical option name, description and validation) so the
+/// <c>--help</c> surface is unchanged.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestRunSettingsCommandLineOptionsProvider : CommandLineOptionsProviderBase
+{
+    public const string RunSettingsOptionName = "settings";
+    private readonly IFileSystem _fileSystem;
+
+    public MSTestRunSettingsCommandLineOptionsProvider(IExtension extension)
+        : this(extension, new SystemFileSystem())
+    {
+    }
+
+    internal MSTestRunSettingsCommandLineOptionsProvider(IExtension extension, IFileSystem fileSystem)
+        : base(extension, [new CommandLineOption(RunSettingsOptionName, PlatformAdapterResources.RunSettingsOptionDescription, ArgumentArity.ExactlyOne, false)])
+        => _fileSystem = fileSystem;
+
+    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
+    {
+        string filePath = arguments[0];
+
+        return !_fileSystem.ExistFile(filePath)
+            ? ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, PlatformAdapterResources.RunsettingsFileDoesNotExist, filePath))
+            : !CanReadFile(filePath)
+                ? ValidationResult.InvalidTask(string.Format(CultureInfo.InvariantCulture, PlatformAdapterResources.RunsettingsFileCannotBeRead, filePath))
+                : ValidationResult.ValidTask;
+    }
+
+    private bool CanReadFile(string filePath)
+    {
+        try
+        {
+            using IFileStream stream = _fileSystem.NewFileStream(filePath, FileMode.Open, FileAccess.Read);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsConfigurationProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsConfigurationProvider.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+
+using IFileSystem = Microsoft.Testing.Platform.Helpers.IFileSystem;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native configuration source that bridges the <c>&lt;ResultsDirectory&gt;</c> from a .runsettings file into
+/// the Microsoft.Testing.Platform configuration model. Mirrors the VSTest bridge's
+/// <c>RunSettingsConfigurationProvider</c> without depending on the bridge.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestRunSettingsConfigurationProvider : IConfigurationSource, IConfigurationProvider
+{
+    private readonly IExtension _extension;
+    private readonly IFileSystem _fileSystem;
+    private string? _runSettingsFileContent;
+
+    public MSTestRunSettingsConfigurationProvider(IExtension extension, IFileSystem fileSystem)
+    {
+        _extension = extension;
+        _fileSystem = fileSystem;
+    }
+
+    public string Uid => nameof(MSTestRunSettingsConfigurationProvider);
+
+    public string Version => _extension.Version;
+
+    public string DisplayName => "MSTest: runsettings configuration";
+
+    public string Description => "Configuration source to bridge VSTest xml runsettings configuration into Microsoft Testing Platform configuration model.";
+
+    public int Order => 2;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task LoadAsync() => Task.CompletedTask;
+
+    public bool TryGet(string key, out string? value)
+    {
+        if (string.IsNullOrEmpty(_runSettingsFileContent))
+        {
+            value = null;
+            return false;
+        }
+
+        if (key == PlatformConfigurationConstants.PlatformResultDirectory)
+        {
+            var document = XDocument.Parse(_runSettingsFileContent);
+            value = document.Element("RunSettings")?.Element("RunConfiguration")?.Element("ResultsDirectory")?.Value;
+            if (value is not null)
+            {
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    public Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult)
+    {
+        _ = commandLineParseResult.TryGetOptionArgumentList(MSTestRunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? fileNames);
+        _runSettingsFileContent = MSTestRunSettings.ReadRunSettings(fileNames, _fileSystem);
+        return Task.FromResult<IConfigurationProvider>(this);
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsEnvironmentVariableProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettingsEnvironmentVariableProvider.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+
+using IEnvironment = Microsoft.Testing.Platform.Helpers.IEnvironment;
+using IFileStream = Microsoft.Testing.Platform.Helpers.IFileStream;
+using IFileSystem = Microsoft.Testing.Platform.Helpers.IFileSystem;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native test host environment-variable provider that applies the <c>&lt;EnvironmentVariables&gt;</c> from a
+/// .runsettings file to the test host. Mirrors the VSTest bridge's <c>RunSettingsEnvironmentVariableProvider</c>
+/// without depending on the bridge.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestRunSettingsEnvironmentVariableProvider : ITestHostEnvironmentVariableProvider
+{
+    private readonly IExtension _extension;
+    private readonly ICommandLineOptions _commandLineOptions;
+    private readonly IFileSystem _fileSystem;
+    private readonly IEnvironment _environment;
+    private XDocument? _runSettings;
+
+    public MSTestRunSettingsEnvironmentVariableProvider(IExtension extension, ICommandLineOptions commandLineOptions, IFileSystem fileSystem, IEnvironment environment)
+    {
+        _extension = extension;
+        _commandLineOptions = commandLineOptions;
+        _fileSystem = fileSystem;
+        _environment = environment;
+    }
+
+    public string Uid => _extension.Uid;
+
+    public string Version => _extension.Version;
+
+    public string DisplayName => _extension.DisplayName;
+
+    public string Description => _extension.Description;
+
+    public async Task<bool> IsEnabledAsync()
+    {
+        string? runSettingsFilePath = null;
+        string? runSettingsContent = null;
+
+        if (_commandLineOptions.TryGetOptionArgumentList(MSTestRunSettingsCommandLineOptionsProvider.RunSettingsOptionName, out string[]? runsettings)
+            && runsettings.Length > 0
+            && _fileSystem.ExistFile(runsettings[0]))
+        {
+            runSettingsFilePath = runsettings[0];
+        }
+
+        if (runSettingsFilePath is null)
+        {
+            runSettingsContent = _environment.GetEnvironmentVariable("TESTINGPLATFORM_EXPERIMENTAL_VSTEST_RUNSETTINGS");
+        }
+
+        if (runSettingsFilePath is null && string.IsNullOrEmpty(runSettingsContent))
+        {
+            string? envVarFilePath = _environment.GetEnvironmentVariable("TESTINGPLATFORM_VSTESTBRIDGE_RUNSETTINGS_FILE");
+            if (!string.IsNullOrEmpty(envVarFilePath) && _fileSystem.ExistFile(envVarFilePath!))
+            {
+                runSettingsFilePath = envVarFilePath;
+            }
+        }
+
+        if (runSettingsFilePath is not null)
+        {
+            using IFileStream fileStream = _fileSystem.NewFileStream(runSettingsFilePath, FileMode.Open, FileAccess.Read);
+#if NETCOREAPP
+            _runSettings = await XDocument.LoadAsync(fileStream.Stream, LoadOptions.None, CancellationToken.None).ConfigureAwait(false);
+#else
+            using StreamReader streamReader = new(fileStream.Stream);
+            _runSettings = XDocument.Parse(await streamReader.ReadToEndAsync().ConfigureAwait(false));
+#endif
+        }
+        else if (!string.IsNullOrEmpty(runSettingsContent))
+        {
+            _runSettings = XDocument.Parse(runSettingsContent);
+        }
+        else
+        {
+            return false;
+        }
+
+        return _runSettings.Element("RunSettings")?.Element("RunConfiguration")?.Element("EnvironmentVariables") is not null;
+    }
+
+    public Task UpdateAsync(IEnvironmentVariables environmentVariables)
+    {
+        foreach (XElement element in _runSettings!.Element("RunSettings")!.Element("RunConfiguration")!.Element("EnvironmentVariables")!.Elements())
+        {
+            environmentVariables.SetVariable(new(element.Name.ToString(), element.Value, true, true));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<ValidationResult> ValidateTestHostEnvironmentVariablesAsync(IReadOnlyEnvironmentVariables environmentVariables)
+        => ValidationResult.ValidTask;
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestCaseFilterCommandLineOptionsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestCaseFilterCommandLineOptionsProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native command-line provider for the VSTest <c>--filter</c> (test case filter) option. Mirrors the VSTest
+/// bridge's <c>TestCaseFilterCommandLineOptionsProvider</c> (identical option name and description).
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestTestCaseFilterCommandLineOptionsProvider : CommandLineOptionsProviderBase
+{
+    public const string TestCaseFilterOptionName = "filter";
+
+    public MSTestTestCaseFilterCommandLineOptionsProvider(IExtension extension)
+        : base(extension, [new CommandLineOption(TestCaseFilterOptionName, PlatformAdapterResources.TestCaseFilterOptionDescription, ArgumentArity.ExactlyOne, false)])
+    {
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestFramework.cs
@@ -3,8 +3,6 @@
 
 #if !WINDOWS_UWP
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
-using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
-using Microsoft.Testing.Extensions.VSTestBridge.Resources;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
@@ -16,6 +14,7 @@ using Microsoft.Testing.Platform.Services;
 using Microsoft.Testing.Platform.Telemetry;
 using Microsoft.Testing.Platform.TestHost;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
@@ -79,7 +78,7 @@ internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisp
     ];
 
     private bool IsTrxEnabled
-        => _isTrxEnabled ??= _trxReportCapability is IInternalVSTestBridgeTrxReportCapability internalCapability
+        => _isTrxEnabled ??= _trxReportCapability is IMSTestTrxReportCapability internalCapability
             ? internalCapability.IsTrxEnabled
             : _trxReportCapability is { IsSupported: true };
 
@@ -91,7 +90,7 @@ internal sealed class MSTestTestFramework : ITestFramework, IDataProducer, IDisp
 
         if (_sessionUid is not null)
         {
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, _sessionUid.Value.Value));
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, PlatformAdapterResources.VSTestBridgedTestFrameworkSessionAlreadyCreatedErrorMessage, _sessionUid.Value.Value));
         }
 
         _sessionUid = context.SessionUid;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestRunParametersCommandLineOptionsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestRunParametersCommandLineOptionsProvider.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
+
+/// <summary>
+/// MSTest-native command-line provider for the VSTest <c>--test-parameter</c> (TestRunParameters) option. Mirrors
+/// the VSTest bridge's <c>TestRunParametersCommandLineOptionsProvider</c> (identical option name, description and
+/// validation).
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
+internal sealed class MSTestTestRunParametersCommandLineOptionsProvider : CommandLineOptionsProviderBase
+{
+    public const string TestRunParameterOptionName = "test-parameter";
+
+    public MSTestTestRunParametersCommandLineOptionsProvider(IExtension extension)
+        : base(extension, [new CommandLineOption(TestRunParameterOptionName, PlatformAdapterResources.TestRunParameterOptionDescription, ArgumentArity.OneOrMore, false)])
+    {
+    }
+
+    public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
+    {
+        foreach (string argument in arguments)
+        {
+            if (!argument.Contains('='))
+            {
+                return ValidationResult.InvalidTask(string.Format(CultureInfo.CurrentCulture, PlatformAdapterResources.TestRunParameterOptionArgumentIsNotParameter, argument));
+            }
+        }
+
+        return ValidationResult.ValidTask;
+    }
+}
+#endif

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
@@ -4,11 +4,11 @@
 #if !WINDOWS_UWP
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Extensions.VSTestBridge.Capabilities;
-using Microsoft.Testing.Extensions.VSTestBridge.Helpers;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Services;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -18,9 +18,11 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
 public static class TestApplicationBuilderExtensions
 {
-    // NOTE: We intentionally use this class and not VSTestBridgeExtensionBaseCapabilities because
-    // we don't want MSTest to use vstestProvider capability
-    private sealed class MSTestCapabilities : IInternalVSTestBridgeTrxReportCapability
+    // NOTE: We intentionally do not use the bridge's VSTestBridgeExtensionBaseCapabilities because we don't want
+    // MSTest to use the vstestProvider capability. This implements BOTH the bridge's TRX capability interface (read
+    // by MSTestBridgedTestFramework, the current default) and MSTest's native one (read by MSTestTestFramework), so
+    // both frameworks observe the same TRX enablement.
+    private sealed class MSTestCapabilities : IInternalVSTestBridgeTrxReportCapability, IMSTestTrxReportCapability
     {
         public bool IsTrxEnabled { get; private set; }
 
@@ -38,11 +40,21 @@ public static class TestApplicationBuilderExtensions
     public static void AddMSTest(this ITestApplicationBuilder testApplicationBuilder, Func<IEnumerable<Assembly>> getTestAssemblies)
     {
         MSTestExtension extension = new();
-        testApplicationBuilder.AddRunSettingsService(extension);
-        testApplicationBuilder.AddTestCaseFilterService(extension);
-        testApplicationBuilder.AddTestRunParametersService(extension);
+
+        // Register MSTest's own command-line options, runsettings configuration source and environment-variable
+        // provider natively (identical option names/descriptions to the VSTest bridge), so both the native and the
+        // bridged framework read them by name.
+        if (testApplicationBuilder is TestApplicationBuilder concreteBuilder)
+        {
+            concreteBuilder.Configuration.AddConfigurationSource(() => new MSTestRunSettingsConfigurationProvider(extension, new SystemFileSystem()));
+        }
+
+        testApplicationBuilder.CommandLine.AddProvider(() => new MSTestRunSettingsCommandLineOptionsProvider(extension));
+        testApplicationBuilder.CommandLine.AddProvider(() => new MSTestTestCaseFilterCommandLineOptionsProvider(extension));
+        testApplicationBuilder.CommandLine.AddProvider(() => new MSTestTestRunParametersCommandLineOptionsProvider(extension));
         testApplicationBuilder.AddMaximumFailedTestsService(extension);
-        testApplicationBuilder.AddRunSettingsEnvironmentVariableProvider(extension);
+        testApplicationBuilder.TestHostControllers.AddEnvironmentVariableProvider(serviceProvider
+            => new MSTestRunSettingsEnvironmentVariableProvider(extension, serviceProvider.GetCommandLineOptions(), serviceProvider.GetFileSystem(), serviceProvider.GetEnvironment()));
 
         // When the experimental native MTP integration is enabled, MSTest plugs into Microsoft.Testing.Platform
         // directly (no VSTest bridge object model on the request path). Off by default, so shipping behavior is

--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -48,13 +48,29 @@
 
   <Target Name="GetMSTestV2CultureHierarchy" Returns="@(MSTestV2Files)">
     <!--
+      MTP scenario (EnableMSTestRunner): the UI language is chosen at runtime (for example via
+      TESTINGPLATFORM_UI_LANGUAGE / DOTNET_CLI_UI_LANGUAGE), so the build-machine culture is irrelevant.
+      Every localized satellite must be copied to the output directory so any culture can be resolved at run time.
+      -->
+    <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' ">
+      <MSTestV2Files Include="$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\_localization'))\**\*.dll" />
+      <!-- Set UICulture from the satellite's culture folder. This is done via Update (not inline on Include) because
+           the well-known %(RecursiveDir) metadata is only available on items after they have been created. -->
+      <MSTestV2Files Update="@(MSTestV2Files)">
+        <UICulture>%(RecursiveDir)</UICulture>
+      </MSTestV2Files>
+    </ItemGroup>
+
+    <!--
+      VSTest scenario: the UI language is fixed to the build-machine culture, so only that culture's hierarchy
+      is copied to keep the output directory slim.
       Only traversing 5 levels in the culture hierarchy. This is the maximum length for all cultures and should be sufficient
       to get to a culture name that maps to a resource folder we package.
       The root culture name for all cultures is invariant whose name is '' (empty) and the parent for invariant culture is
       invariant itself. (https://msdn.microsoft.com/library/system.globalization.cultureinfo.parent.aspx)
       So the below code should not break build in any case.
       -->
-    <ItemGroup>
+    <ItemGroup Condition=" '$(EnableMSTestRunner)' != 'true' ">
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Name)" />
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Name)' != '' "/>
       <CurrentUICultureHierarchy Include="$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Name)"  Condition=" '$([System.Globalization.CultureInfo]::CurrentUICulture.Parent.Parent.Name)' != '' "/>
@@ -67,9 +83,9 @@
       This is populated here (rather than inside CopyMSTestV2Resources) so the item group is available when the
       Inputs/Outputs of CopyMSTestV2Resources are evaluated for incremental build.
     -->
-    <ItemGroup>
+    <ItemGroup Condition=" '$(EnableMSTestRunner)' != 'true' ">
       <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
-        <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
+        <UICulture>%(CurrentUICultureHierarchy.Identity)\</UICulture>
       </MSTestV2Files>
     </ItemGroup>
   </Target>
@@ -79,12 +95,12 @@
           Condition=" '$(EnableMSTestV2CopyResources)' == 'true' "
           DependsOnTargets="GetMSTestV2CultureHierarchy"
           Inputs="@(MSTestV2Files)"
-          Outputs="@(MSTestV2Files->'$(TargetDir)%(UICulture)\%(FileName)%(Extension)')">
+          Outputs="@(MSTestV2Files->'$(TargetDir)%(UICulture)%(FileName)%(Extension)')">
 
     <ItemGroup>
       <!-- Add the localization file as content so it gets copied from nuget to bin folder. -->
       <Content Include="@(MSTestV2Files->'%(FullPath)')">
-        <Link>%(MSTestV2Files.UICulture)\%(FileName).dll</Link>
+        <Link>%(MSTestV2Files.UICulture)%(FileName).dll</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <BaseAssemblyFullPath>%(FullPath)</BaseAssemblyFullPath>
         <Visible>False</Visible>


### PR DESCRIPTION
## What

Continues the removal of the `Microsoft.Testing.Extensions.VSTestBridge` dependency from MSTest's Microsoft.Testing.Platform (MTP) path (RFC 018). This phase makes the **experimental native MTP path fully self-contained on the request/registration side**, without changing shipping behavior: the VSTest bridge remains the default (behind the `MSTEST_EXPERIMENTAL_NATIVE_MTP` opt-in) and stays referenced. The risky default-flip + bridge-reference removal becomes a trivial, CI-gated follow-up (Phase 6b).

## Changes

- **Native option providers / config / env-var**: register MSTest's own command-line option providers, runsettings configuration source, and environment-variable provider natively (identical option names and descriptions to the bridge), replacing the bridge `Helpers`. Both frameworks read options by name, so the registration swap is safe for the default bridged path too.
- **Native TRX capability**: add `IMSTestTrxReportCapability`. `MSTestCapabilities` implements both it and the bridge's `IInternalVSTestBridgeTrxReportCapability`, so both frameworks observe the same TRX enablement.
- **Native localized resources**: own the user-facing strings via `PlatformAdapterResources` (resx + 13 xlf, copied from the bridge's `ExtensionResources`) instead of reading the bridge's resources.
- **Runtime localization fix**: `MSTest.TestAdapter` slims localized satellites to the *build-machine* culture (correct for VSTest, where the UI language is fixed at build time). For MTP the UI language is chosen at **run time** (e.g. `TESTINGPLATFORM_UI_LANGUAGE`), so copy every culture's satellite to the output when `EnableMSTestRunner` is `true`; keep the slim behavior otherwise. This keeps VSTest consumers' output unchanged.
- Bump the `MSTest.TestAdapter` expected package file count in `verify-nupkgs.ps1` for the added satellites.

## Validation

- Full build clean (warnings-as-errors).
- Unit tests: `MSTestAdapter.UnitTests` (45) and `MSTestAdapter.PlatformServices.UnitTests` (898) pass.
- Native-path acceptance sweep green: runsettings (including the `_Localization` cases), filter, help/info, TRX, threading; full `MSTest.Acceptance` = 784 passed / 3 skipped.
- Default bridged path unaffected (representative slice 54/54).
- The only failures are 3 pre-existing `NativeAot` smoke tests, which **also fail on the untouched default path** (VSTest ObjectModel trim warnings-as-errors in this environment) — not a regression.

## Follow-up (Phase 6b, separate PR)

Flip the default to native, remove the `MSTEST_EXPERIMENTAL_NATIVE_MTP` flag and `MSTestBridgedTestFramework`/`BridgedConfiguration`, drop the `Microsoft.Testing.Extensions.VSTestBridge` ProjectReference, and add direct refs to `TrxReport.Abstractions` + `Microsoft.TestPlatform.ObjectModel`.

Co-authored-by: Copilot App &lt;223556219+Copilot@users.noreply.github.com&gt;