### PR TITLE
Simplify TestRunParameters argument validation with LINQ (PR #9748 follow-up)

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestRunParametersCommandLineOptionsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestRunParametersCommandLineOptionsProvider.cs
@@ -26,15 +26,10 @@ internal sealed class MSTestTestRunParametersCommandLineOptionsProvider : Comman
 
     public override Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
     {
-        foreach (string argument in arguments)
-        {
-            if (!argument.Contains('='))
-            {
-                return ValidationResult.InvalidTask(string.Format(CultureInfo.CurrentCulture, PlatformAdapterResources.TestRunParameterOptionArgumentIsNotParameter, argument));
-            }
-        }
-
-        return ValidationResult.ValidTask;
+        string? invalidArgument = arguments.FirstOrDefault(argument => !argument.Contains('='));
+        return invalidArgument is not null
+            ? ValidationResult.InvalidTask(string.Format(CultureInfo.CurrentCulture, PlatformAdapterResources.TestRunParameterOptionArgumentIsNotParameter, invalidArgument))
+            : ValidationResult.ValidTask;
     }
 }
 #endif


### PR DESCRIPTION
## What

Follow-up to the merged #9748 (Phase 6a), addressing the review feedback on that PR.

## Change

The `github-code-quality` bot flagged that `MSTestTestRunParametersCommandLineOptionsProvider.ValidateOptionArgumentsAsync` used a `foreach` that implicitly filters its sequence. Replaced it with an explicit `FirstOrDefault` filter:

```csharp
string? invalidArgument = arguments.FirstOrDefault(argument => !argument.Contains('='));
return invalidArgument is not null
    ? ValidationResult.InvalidTask(string.Format(CultureInfo.CurrentCulture, PlatformAdapterResources.TestRunParameterOptionArgumentIsNotParameter, invalidArgument))
    : ValidationResult.ValidTask;
```

No behavior change — it still reports the first argument missing `=` with the same localized message, and returns valid when all arguments contain `=`.

## Not addressed here (deferred/informational)

The expert-review summary on #9748 raised two *informational, non-blocking* notes that are intentionally left out of this PR:
- **`MSTEST_EXPERIMENTAL_NATIVE_MTP` casing** (`is "1" or "true" or "True"` won't match `"TRUE"`) — the reviewer explicitly suggested harmonizing this when the flag is promoted in **Phase 6b**, so it's folded into that work.
- **`MSTestRunSettingsConfigurationProvider.TryGet()` re-parsing the XDocument** — a cold path; caching is optional and not warranted yet.

## Validation

- Full build clean (warnings-as-errors).
- `MSTestAdapter.UnitTests` (45) pass.

Co-authored-by: Copilot App &lt;223556219+Copilot@users.noreply.github.com&gt;