### PR TITLE
Post-release: mark 4.3.0 / 2.3.1 changelogs as released

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -16,8 +16,6 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 ## <a name="2.3.1" />[2.3.1] - 2026-07-08
 
-See full log [of v4.3.0...v4.3.1](https://github.com/microsoft/testfx/compare/v4.3.0...v4.3.1)
-
 ### Fixed
 
 * Fix forward-compat crash (`MissingMethodException`) loading old 2.x extensions (Telemetry, TrxReport, VSTestBridge) on .NET Framework by @Evangelink in [#9739](https://github.com/microsoft/testfx/pull/9739)

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -14,7 +14,7 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
 * Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
 
-## <a name="2.3.1" />[2.3.1] - UNRELEASED
+## <a name="2.3.1" />[2.3.1] - 2026-07-08
 
 See full log [of v4.3.0...v4.3.1](https://github.com/microsoft/testfx/compare/v4.3.0...v4.3.1)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,7 +12,7 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
 
-## <a name="4.3.0" />[4.3.0] - UNRELEASED
+## <a name="4.3.0" />[4.3.0] - 2026-07-08
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)
 


### PR DESCRIPTION
Post-release activities for the 4.3.0 (MSTest) / 2.3.1 (Microsoft.Testing.Platform) release.

## Changes
- `docs/Changelog.md`: mark `[4.3.0]` as released (`2026-07-08`).
- `docs/Changelog-Platform.md`: mark `[2.3.1]` as released (`2026-07-08`).

## Notes
- Public APIs are **already shipped** on `main` (running `eng/mark-shipped.ps1` produced no diffs), and `AnalyzerReleases.Unshipped.md` is already empty (content previously moved into `Release 4.3.0`). No API/analyzer changes were needed here.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>