### PR TITLE
Stabilize extension UIDs and add naming governance (#9757)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsCommandLineProvider.cs
@@ -55,7 +55,8 @@ internal sealed class AzureDevOpsCommandLineProvider : CommandLineOptionsProvide
 
     public AzureDevOpsCommandLineProvider()
         : base(
-            nameof(AzureDevOpsCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "AzureDevOpsCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
             AzureDevOpsResources.DisplayName,
             AzureDevOpsResources.Description,

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/CrashDumpCommandLineProvider.cs
@@ -23,7 +23,8 @@ internal sealed class CrashDumpCommandLineProvider : CommandLineOptionsProviderB
 
     public CrashDumpCommandLineProvider()
         : base(
-            nameof(CrashDumpCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "CrashDumpCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
             CrashDumpResources.CrashDumpDisplayName,
             CrashDumpResources.CrashDumpDescription,

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGeneratorCommandLine.cs
@@ -12,7 +12,8 @@ internal sealed class CtrfReportGeneratorCommandLine : ReportGeneratorCommandLin
 
     public CtrfReportGeneratorCommandLine()
         : base(
-            nameof(CtrfReportGeneratorCommandLine),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "CtrfReportGeneratorCommandLine",
             ExtensionResources.CtrfReportGeneratorDisplayName,
             ExtensionResources.CtrfReportGeneratorDescription,
             CtrfReportOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/GitHubActionsCommandLineProvider.cs
@@ -13,7 +13,8 @@ internal sealed class GitHubActionsCommandLineProvider : CommandLineOptionsProvi
 {
     public GitHubActionsCommandLineProvider()
         : base(
-            nameof(GitHubActionsCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "GitHubActionsCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
             GitHubActionsResources.DisplayName,
             GitHubActionsResources.Description,

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpCommandLineProvider.cs
@@ -51,7 +51,8 @@ internal sealed class HangDumpCommandLineProvider : CommandLineOptionsProviderBa
 
     public HangDumpCommandLineProvider()
         : base(
-            nameof(HangDumpCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "HangDumpCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
             ExtensionResources.HangDumpExtensionDisplayName,
             ExtensionResources.HangDumpExtensionDescription,

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGeneratorCommandLine.cs
@@ -12,7 +12,8 @@ internal sealed class HtmlReportGeneratorCommandLine : ReportGeneratorCommandLin
 
     public HtmlReportGeneratorCommandLine()
         : base(
-            nameof(HtmlReportGeneratorCommandLine),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "HtmlReportGeneratorCommandLine",
             ExtensionResources.HtmlReportGeneratorDisplayName,
             ExtensionResources.HtmlReportGeneratorDescription,
             HtmlReportOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGeneratorCommandLine.cs
@@ -12,7 +12,8 @@ internal sealed class JUnitReportGeneratorCommandLine : ReportGeneratorCommandLi
 
     public JUnitReportGeneratorCommandLine()
         : base(
-            nameof(JUnitReportGeneratorCommandLine),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "JUnitReportGeneratorCommandLine",
             ExtensionResources.JUnitReportGeneratorDisplayName,
             ExtensionResources.JUnitReportGeneratorDescription,
             JUnitReportOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildCommandLineProvider.cs
@@ -15,9 +15,10 @@ internal sealed class MSBuildCommandLineProvider : CommandLineOptionsProviderBas
 
     public MSBuildCommandLineProvider()
         : base(
-            nameof(MSBuildCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "MSBuildCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
-            nameof(MSBuildCommandLineProvider),
+            Resources.ExtensionResources.MSBuildCommandLineProviderDisplayName,
             Resources.ExtensionResources.MSBuildExtensionsDescription,
             CachedCommandLineOptions)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/ExtensionResources.resx
@@ -121,4 +121,8 @@
     <value>Extension used to pass parameters from MSBuild node and the hosts</value>
     <comment>Do not localize {Locked="MSBuild"}.</comment>
   </data>
+  <data name="MSBuildCommandLineProviderDisplayName" xml:space="preserve">
+    <value>MSBuild integration</value>
+    <comment>Do not localize {Locked="MSBuild"}.</comment>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Rozšíření používané k předání parametrů z uzlu MSBuild a hostitelů</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Erweiterung, die zum Übergeben von Parametern vom MSBuild-Knoten und den Hosts verwendet wird.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Extensión usada para pasar parámetros desde el nodo de MSBuild y los hosts</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Extension utilisée pour passer des paramètres entre le nœud MSBuild et les hôtes</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Estensione usata per passare parametri dal nodo MSBuild e dagli host</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">MSBuild ノードおよびホストからパラメーターを渡すために使用される拡張機能</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">MSBuild 노드 및 호스트에서 매개 변수를 전달하는 데 사용되는 확장</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Rozszerzenie używane do przekazywania parametrów z węzła MSBuild i hostów</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Extensão usada para passar parâmetros do nó do MSBuild e dos hosts</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">Расширение, используемое для передачи параметров с узла MSBuild и из основных элементов</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">MSBuild düğümünden ve konaklardan parametreleri geçirmek için kullanılan uzantı</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">用于从 MSBuild 节点和主机传递参数的扩展</target>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="MSBuildCommandLineProviderDisplayName">
+        <source>MSBuild integration</source>
+        <target state="new">MSBuild integration</target>
+        <note>Do not localize {Locked="MSBuild"}.</note>
+      </trans-unit>
       <trans-unit id="MSBuildExtensionsDescription">
         <source>Extension used to pass parameters from MSBuild node and the hosts</source>
         <target state="translated">用於從 MSBuild 節點和主機傳遞參數的延伸模組</target>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryCommandLineOptionsProvider.cs
@@ -19,7 +19,8 @@ internal sealed class RetryCommandLineOptionsProvider : CommandLineOptionsProvid
 
     public RetryCommandLineOptionsProvider()
         : base(
-            nameof(RetryCommandLineOptionsProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "RetryCommandLineOptionsProvider",
             ExtensionVersion.DefaultSemVer,
             ExtensionResources.RetryFailedTestsExtensionDisplayName,
             ExtensionResources.RetryFailedTestsExtensionDescription,

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCommandLine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxCommandLine.cs
@@ -12,7 +12,8 @@ internal sealed class TrxReportGeneratorCommandLine : ReportGeneratorCommandLine
 
     public TrxReportGeneratorCommandLine()
         : base(
-            nameof(TrxReportGeneratorCommandLine),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "TrxReportGeneratorCommandLine",
             ExtensionResources.TrxReportGeneratorDisplayName,
             ExtensionResources.TrxReportGeneratorDescription,
             TrxReportOptionName,

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderCommandLineProvider.cs
@@ -49,7 +49,8 @@ internal sealed class VideoRecorderCommandLineProvider : CommandLineOptionsProvi
 
     public VideoRecorderCommandLineProvider()
         : base(
-            nameof(VideoRecorderCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "VideoRecorderCommandLineProvider",
             ExtensionVersion.DefaultSemVer,
             VideoRecorderResources.ExtensionDisplayName,
             VideoRecorderResources.CommandLineProviderDescription,

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/PlatformCommandLineProvider.cs
@@ -86,7 +86,8 @@ internal sealed class PlatformCommandLineProvider : CommandLineOptionsProviderBa
 
     public PlatformCommandLineProvider()
         : base(
-            nameof(PlatformCommandLineProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "PlatformCommandLineProvider",
             PlatformVersion.Version,
             PlatformResources.PlatformCommandLineProviderDisplayName,
             PlatformResources.PlatformCommandLineProviderDescription,

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IExtension.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IExtension.cs
@@ -12,6 +12,17 @@ public interface IExtension
     /// <summary>
     /// Gets the unique identifier for the extension.
     /// </summary>
+    /// <remarks>
+    /// The value must be a <b>stable</b> string constant that survives class renames. It is SHA-256-hashed
+    /// for telemetry, displayed verbatim in <c>--info</c> output and error messages, embedded in artifact
+    /// metadata, and used for feature detection, so changing it silently breaks telemetry continuity and any
+    /// consumer relying on the previous value.
+    /// <para>
+    /// Do <b>not</b> derive the value from <c>nameof(ImplementingClass)</c>: an IDE "Rename Symbol" refactor
+    /// would then change the UID without any visible diff at the call site. Use an explicit string literal or
+    /// <c>const</c> instead, even if its initial value happens to match the class name.
+    /// </para>
+    /// </remarks>
     string Uid { get; }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
@@ -27,7 +27,8 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : CommandLi
 
     public TerminalTestReporterCommandLineOptionsProvider()
         : base(
-            nameof(TerminalTestReporterCommandLineOptionsProvider),
+            // Stable extension UID. Do not change: it feeds telemetry, --info output, and artifact metadata.
+            "TerminalTestReporterCommandLineOptionsProvider",
             PlatformVersion.Version,
             TerminalResources.TerminalTestReporterDisplayName,
             TerminalResources.TerminalTestReporterDescription,

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -642,7 +642,7 @@ Registered command line providers:
         Supports the following placeholders: {pname} (test application name), {pid} (process ID), {asm} (entry assembly name), {tfm} (target framework moniker), {arch} (process architecture), {time} (timestamp).
         Example: MyReport_{tfm}.xml
   MSBuildCommandLineProvider
-    Name: MSBuildCommandLineProvider
+    Name: MSBuild integration
     Version: *
     Description: Extension used to pass parameters from MSBuild node and the hosts
     Options:

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/WellKnownExtensionUidTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/WellKnownExtensionUidTests.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+/// <summary>
+/// Snapshot of the well-known extension UIDs owned by Microsoft.Testing.Platform.
+/// These UIDs are SHA-256-hashed for telemetry, printed verbatim in <c>--info</c> output,
+/// and embedded in artifact metadata, so they must stay stable across class renames.
+/// If one of these assertions fails because a class was renamed, do NOT update the literal:
+/// keep the UID stable (as an explicit string constant) so telemetry and consumers keep working.
+/// </summary>
+[TestClass]
+public sealed class WellKnownExtensionUidTests
+{
+    [TestMethod]
+    public void PlatformCommandLineProvider_HasStableUid()
+        => Assert.AreEqual("PlatformCommandLineProvider", new PlatformCommandLineProvider().Uid);
+
+    [TestMethod]
+    public void TerminalTestReporterCommandLineOptionsProvider_HasStableUid()
+        => Assert.AreEqual("TerminalTestReporterCommandLineOptionsProvider", new TerminalTestReporterCommandLineOptionsProvider().Uid);
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/NopPlatformOutputDeviceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/NopPlatformOutputDeviceTests.cs
@@ -24,8 +24,10 @@ public sealed class NopPlatformOutputDeviceTests
     {
         var device = new NopPlatformOutputDevice();
 
-        Assert.AreEqual(nameof(NopPlatformOutputDevice), device.Uid);
-        Assert.AreEqual(nameof(NopPlatformOutputDevice), device.DisplayName);
+        // Assert the stable UID/DisplayName as string literals (not nameof) so that renaming
+        // NopPlatformOutputDevice trips this test instead of silently changing the runtime value.
+        Assert.AreEqual("NopPlatformOutputDevice", device.Uid);
+        Assert.AreEqual("NopPlatformOutputDevice", device.DisplayName);
 
         // NopPlatformOutputDevice.Version returns the Platform assembly's PlatformVersion.Version.
         // We can't assert equality against this test assembly's PlatformVersion.Version because it


### PR DESCRIPTION
Fixes #9757.

Every MTP extension / command-line provider exposes `IExtension.Uid`, which is SHA-256-hashed for telemetry, printed verbatim in `--info`, embedded in artifact metadata, and used for feature detection. Many providers derived that value from `nameof(ClassName)`, so an IDE "Rename Symbol" refactor would silently change the UID. This PR addresses all five tasks in the issue.

### Changes

**Task 1 — Document the stability requirement**
- `IExtension.Uid` XML doc now states the value must be a stable string constant that survives class renames and must **not** use `nameof(ImplementingClass)`.

**Task 2 — Fix `MSBuildCommandLineProvider` DisplayName**
- The provider passed `nameof(MSBuildCommandLineProvider)` as both `uid` **and** `displayName`, so `--info` leaked the internal class name. Added a localized `MSBuildCommandLineProviderDisplayName` = "MSBuild integration" resource (xlf regenerated) and use it as the display name. UID is unchanged.

**Task 3 — Replace `nameof()` UIDs with stable literals**
- Converted the UID/`providerName` argument to an explicit string literal (same value) in the 12 remaining well-known command-line providers: `PlatformCommandLineProvider`, `TerminalTestReporterCommandLineOptionsProvider`, `CrashDumpCommandLineProvider`, `HangDumpCommandLineProvider`, `RetryCommandLineOptionsProvider`, the four report generators (Trx/JUnit/Html/Ctrf), `AzureDevOpsCommandLineProvider`, `GitHubActionsCommandLineProvider`, and `VideoRecorderCommandLineProvider`. Each carries a short "do not change" comment. **No UID values change**, so telemetry continuity is preserved.

**Task 4 — Fix `NopPlatformOutputDeviceTests`**
- The identity test asserted `nameof(NopPlatformOutputDevice)` on both sides, so a rename would silently update rather than fail. It now asserts the string literal directly, turning a rename into a conspicuous failure.

**Task 5 — UID snapshot coverage**
- The existing `--info` acceptance tests already assert provider UIDs as section headers. Added `WellKnownExtensionUidTests` as a fast, dependency-free unit-test tripwire pinning the platform-owned provider UIDs.

### Validation
- Built the platform, all touched extensions, and the unit-test project — 0 warnings / 0 errors.
- `WellKnownExtensionUidTests` + `NopPlatformOutputDeviceTests` pass (5/5).
- Updated the `--info` all-extensions acceptance expectation (`HelpInfoAllExtensionsTests`) so `Name: MSBuild integration` matches the new display name.

> 🤖 Generated with GitHub Copilot