### PR TITLE
Deduplicate DotnetTest IPC serializer 3-phase boilerplate

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -350,6 +350,55 @@ internal abstract class BaseSerializer
         SetPosition(stream, currentPosition);
     }
 
+    /// <summary>
+    /// Reads the standard field envelope (a <c>ushort</c> field count followed by that many
+    /// <c>[ushort id][int size][payload]</c> triples) and dispatches each field to <paramref name="tryReadField"/>.
+    /// When the callback returns <see langword="false"/> (an unrecognized field id), the field payload is skipped so
+    /// that the reader stays aligned and remains forward-compatible with newer producers.
+    /// </summary>
+    protected static void ReadFields(Stream stream, Func<ushort, int, bool> tryReadField)
+    {
+        ushort fieldCount = ReadUShort(stream);
+        for (int i = 0; i < fieldCount; i++)
+        {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+            if (!tryReadField(fieldId, fieldSize))
+            {
+                // If we don't recognize the field id, skip the payload corresponding to that field.
+                SetPosition(stream, stream.Position + fieldSize);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a length-prefixed list payload using the deferred-size-backfill protocol: the field id, a reserved
+    /// 4-byte size slot, the element count, then each element via <paramref name="writeItem"/>. The reserved slot is
+    /// finally patched with the payload size. A <see langword="null"/> or empty list writes nothing.
+    /// </summary>
+    /// <typeparam name="T">The element type of the list being serialized.</typeparam>
+    protected static void WriteListPayload<T>(Stream stream, ushort fieldId, T[]? list, Action<Stream, T> writeItem)
+    {
+        if (list is null || list.Length == 0)
+        {
+            return;
+        }
+
+        WriteUShort(stream, fieldId);
+        // We will reserve an int (4 bytes) so that we fill the size later, once we write the payload.
+        WriteInt(stream, 0);
+        long before = stream.Position;
+        WriteInt(stream, list.Length);
+        foreach (T item in list)
+        {
+            writeItem(stream, item);
+        }
+
+        // NOTE: We are able to seek only if we are using a MemoryStream
+        // thus, the seek operation is fast as we are only changing the value of a property.
+        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
+    }
+
     private static int GetSize<T>() => typeof(T) switch
     {
         Type type when type == typeof(int) => sizeof(int),

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/AzureDevOpsLogMessageSerializer.cs
@@ -31,33 +31,26 @@ internal sealed class AzureDevOpsLogMessageSerializer : NamedPipeSerializer<Azur
         string? instanceId = null;
         string? logText = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            ushort fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case AzureDevOpsLogMessageFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case AzureDevOpsLogMessageFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case AzureDevOpsLogMessageFieldsId.LogText:
                     logText = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(executionId, instanceId, logText);
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -45,29 +45,22 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
         string? moduleName = null;
         CommandLineOptionMessage[]? commandLineOptionMessages = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            int fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case CommandLineOptionMessagesFieldsId.ModulePath:
                     moduleName = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case CommandLineOptionMessagesFieldsId.CommandLineOptionMessageList:
                     commandLineOptionMessages = ReadCommandLineOptionMessagesPayload(stream);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(moduleName, commandLineOptionMessages ?? []);
     }
@@ -82,36 +75,30 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
             string? name = null, description = null;
             bool? isHidden = null, isBuiltIn = null;
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case CommandLineOptionMessageFieldsId.Name:
                         name = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case CommandLineOptionMessageFieldsId.Description:
                         description = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case CommandLineOptionMessageFieldsId.IsHidden:
                         isHidden = ReadBool(stream);
-                        break;
+                        return true;
 
                     case CommandLineOptionMessageFieldsId.IsBuiltIn:
                         isBuiltIn = ReadBool(stream);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             commandLineOptionMessages[i] = new CommandLineOptionMessage(name, description, isHidden, isBuiltIn);
         }
@@ -130,34 +117,15 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
     }
 
     private static void WriteCommandLineOptionMessagesPayload(Stream stream, CommandLineOptionMessage[]? commandLineOptionMessageList)
-    {
-        if (commandLineOptionMessageList is null || commandLineOptionMessageList.Length == 0)
+        => WriteListPayload(stream, CommandLineOptionMessagesFieldsId.CommandLineOptionMessageList, commandLineOptionMessageList, static (s, commandLineOptionMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(commandLineOptionMessage));
 
-        WriteUShort(stream, CommandLineOptionMessagesFieldsId.CommandLineOptionMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, commandLineOptionMessageList.Length);
-        foreach (CommandLineOptionMessage commandLineOptionMessage in commandLineOptionMessageList)
-        {
-            WriteUShort(stream, GetFieldCount(commandLineOptionMessage));
-
-            WriteField(stream, CommandLineOptionMessageFieldsId.Name, commandLineOptionMessage.Name);
-            WriteField(stream, CommandLineOptionMessageFieldsId.Description, commandLineOptionMessage.Description);
-            WriteField(stream, CommandLineOptionMessageFieldsId.IsHidden, commandLineOptionMessage.IsHidden);
-            WriteField(stream, CommandLineOptionMessageFieldsId.IsBuiltIn, commandLineOptionMessage.IsBuiltIn);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, CommandLineOptionMessageFieldsId.Name, commandLineOptionMessage.Name);
+            WriteField(s, CommandLineOptionMessageFieldsId.Description, commandLineOptionMessage.Description);
+            WriteField(s, CommandLineOptionMessageFieldsId.IsHidden, commandLineOptionMessage.IsHidden);
+            WriteField(s, CommandLineOptionMessageFieldsId.IsBuiltIn, commandLineOptionMessage.IsBuiltIn);
+        });
 
     private static ushort GetFieldCount(CommandLineOptionMessages commandLineOptionMessages) =>
         (ushort)((commandLineOptionMessages.ModulePath is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -85,33 +85,26 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
         string? instanceId = null;
         DiscoveredTestMessage[]? discoveredTestMessages = [];
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            int fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case DiscoveredTestMessagesFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case DiscoveredTestMessagesFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList:
                     discoveredTestMessages = ReadDiscoveredTestMessagesPayload(stream);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(executionId, instanceId, discoveredTestMessages);
     }
@@ -132,56 +125,50 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
             TraitMessage[] traits = [];
             string[] parameterTypeFullNames = [];
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case DiscoveredTestMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.FilePath:
                         filePath = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.LineNumber:
                         lineNumber = ReadInt(stream);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.Namespace:
                         @namespace = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.TypeName:
                         typeName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.MethodName:
                         methodName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.Traits:
                         traits = ReadTraitsPayload(stream);
-                        break;
+                        return true;
 
                     case DiscoveredTestMessageFieldsId.ParameterTypeFullNames:
                         parameterTypeFullNames = ReadParameterTypeFullNamesPayload(stream);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             discoveredTestMessages[i] = new DiscoveredTestMessage(uid, displayName, filePath, lineNumber, @namespace, typeName, methodName, parameterTypeFullNames, traits);
         }
@@ -210,28 +197,23 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
         {
             string? key = null;
             string? value = null;
-            int fieldCount = ReadUShort(stream);
 
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case TraitMessageFieldsId.Key:
                         key = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case TraitMessageFieldsId.Value:
                         value = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             _ = key ?? throw new InvalidOperationException("Trait key is required.");
             _ = value ?? throw new InvalidOperationException("Trait value is required.");
@@ -253,92 +235,32 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
     }
 
     private static void WriteDiscoveredTestMessagesPayload(Stream stream, DiscoveredTestMessage[]? discoveredTestMessageList)
-    {
-        if (discoveredTestMessageList is null || discoveredTestMessageList.Length == 0)
+        => WriteListPayload(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList, discoveredTestMessageList, static (s, discoveredTestMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(discoveredTestMessage));
 
-        WriteUShort(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, discoveredTestMessageList.Length);
-        foreach (DiscoveredTestMessage discoveredTestMessage in discoveredTestMessageList)
-        {
-            WriteUShort(stream, GetFieldCount(discoveredTestMessage));
-
-            WriteField(stream, DiscoveredTestMessageFieldsId.Uid, discoveredTestMessage.Uid);
-            WriteField(stream, DiscoveredTestMessageFieldsId.DisplayName, discoveredTestMessage.DisplayName);
-            WriteField(stream, DiscoveredTestMessageFieldsId.FilePath, discoveredTestMessage.FilePath);
-            WriteField(stream, DiscoveredTestMessageFieldsId.LineNumber, discoveredTestMessage.LineNumber);
-            WriteField(stream, DiscoveredTestMessageFieldsId.Namespace, discoveredTestMessage.Namespace);
-            WriteField(stream, DiscoveredTestMessageFieldsId.TypeName, discoveredTestMessage.TypeName);
-            WriteField(stream, DiscoveredTestMessageFieldsId.MethodName, discoveredTestMessage.MethodName);
-            WriteParameterTypeFullNamesPayload(stream, discoveredTestMessage.ParameterTypeFullNames);
-            WriteTraitsPayload(stream, discoveredTestMessage.Traits);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, DiscoveredTestMessageFieldsId.Uid, discoveredTestMessage.Uid);
+            WriteField(s, DiscoveredTestMessageFieldsId.DisplayName, discoveredTestMessage.DisplayName);
+            WriteField(s, DiscoveredTestMessageFieldsId.FilePath, discoveredTestMessage.FilePath);
+            WriteField(s, DiscoveredTestMessageFieldsId.LineNumber, discoveredTestMessage.LineNumber);
+            WriteField(s, DiscoveredTestMessageFieldsId.Namespace, discoveredTestMessage.Namespace);
+            WriteField(s, DiscoveredTestMessageFieldsId.TypeName, discoveredTestMessage.TypeName);
+            WriteField(s, DiscoveredTestMessageFieldsId.MethodName, discoveredTestMessage.MethodName);
+            WriteParameterTypeFullNamesPayload(s, discoveredTestMessage.ParameterTypeFullNames);
+            WriteTraitsPayload(s, discoveredTestMessage.Traits);
+        });
 
     private static void WriteTraitsPayload(Stream stream, TraitMessage[]? traits)
-    {
-        if (traits is null || traits.Length == 0)
+        => WriteListPayload(stream, DiscoveredTestMessageFieldsId.Traits, traits, static (s, trait) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(trait));
 
-        WriteUShort(stream, DiscoveredTestMessageFieldsId.Traits);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, traits.Length);
-        foreach (TraitMessage trait in traits)
-        {
-            WriteUShort(stream, GetFieldCount(trait));
-
-            WriteField(stream, TraitMessageFieldsId.Key, trait.Key);
-            WriteField(stream, TraitMessageFieldsId.Value, trait.Value);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, TraitMessageFieldsId.Key, trait.Key);
+            WriteField(s, TraitMessageFieldsId.Value, trait.Value);
+        });
 
     private static void WriteParameterTypeFullNamesPayload(Stream stream, string[]? parameterTypeFullNames)
-    {
-        if (parameterTypeFullNames is null || parameterTypeFullNames.Length == 0)
-        {
-            return;
-        }
-
-        WriteUShort(stream, DiscoveredTestMessageFieldsId.ParameterTypeFullNames);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, parameterTypeFullNames.Length);
-        foreach (string parameterTypeFullName in parameterTypeFullNames)
-        {
-            WriteString(stream, parameterTypeFullName);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+        => WriteListPayload(stream, DiscoveredTestMessageFieldsId.ParameterTypeFullNames, parameterTypeFullNames, static (s, parameterTypeFullName) => WriteString(s, parameterTypeFullName));
 
     private static ushort GetFieldCount(DiscoveredTestMessages discoveredTestMessages) =>
         (ushort)((discoveredTestMessages.ExecutionId is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DisplayMessageSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DisplayMessageSerializer.cs
@@ -36,22 +36,17 @@ internal sealed class DisplayMessageSerializer : NamedPipeSerializer<DisplayMess
         byte level = DisplayMessageLevels.Information;
         string? text = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            ushort fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case DisplayMessageFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case DisplayMessageFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case DisplayMessageFieldsId.Level:
                     level = ReadByte(stream);
@@ -64,18 +59,16 @@ internal sealed class DisplayMessageSerializer : NamedPipeSerializer<DisplayMess
                         SetPosition(stream, stream.Position + (fieldSize - 1));
                     }
 
-                    break;
+                    return true;
 
                 case DisplayMessageFieldsId.Text:
                     text = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(executionId, instanceId, level, text);
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -58,33 +58,26 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
         string? instanceId = null;
         FileArtifactMessage[]? fileArtifactMessages = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            int fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case FileArtifactMessagesFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case FileArtifactMessagesFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case FileArtifactMessagesFieldsId.FileArtifactMessageList:
                     fileArtifactMessages = ReadFileArtifactMessagesPayload(stream);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(executionId, instanceId, fileArtifactMessages ?? []);
     }
@@ -98,44 +91,38 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
         {
             string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null;
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case FileArtifactMessageFieldsId.FullPath:
                         fullPath = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FileArtifactMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FileArtifactMessageFieldsId.Description:
                         description = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FileArtifactMessageFieldsId.TestUid:
                         testUid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FileArtifactMessageFieldsId.TestDisplayName:
                         testDisplayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FileArtifactMessageFieldsId.SessionUid:
                         sessionUid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             fileArtifactMessages[i] = new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid);
         }
@@ -155,36 +142,17 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     }
 
     private static void WriteFileArtifactMessagesPayload(Stream stream, FileArtifactMessage[]? fileArtifactMessageList)
-    {
-        if (fileArtifactMessageList is null || fileArtifactMessageList.Length == 0)
+        => WriteListPayload(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList, fileArtifactMessageList, static (s, fileArtifactMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(fileArtifactMessage));
 
-        WriteUShort(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, fileArtifactMessageList.Length);
-        foreach (FileArtifactMessage fileArtifactMessage in fileArtifactMessageList)
-        {
-            WriteUShort(stream, GetFieldCount(fileArtifactMessage));
-
-            WriteField(stream, FileArtifactMessageFieldsId.FullPath, fileArtifactMessage.FullPath);
-            WriteField(stream, FileArtifactMessageFieldsId.DisplayName, fileArtifactMessage.DisplayName);
-            WriteField(stream, FileArtifactMessageFieldsId.Description, fileArtifactMessage.Description);
-            WriteField(stream, FileArtifactMessageFieldsId.TestUid, fileArtifactMessage.TestUid);
-            WriteField(stream, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
-            WriteField(stream, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, FileArtifactMessageFieldsId.FullPath, fileArtifactMessage.FullPath);
+            WriteField(s, FileArtifactMessageFieldsId.DisplayName, fileArtifactMessage.DisplayName);
+            WriteField(s, FileArtifactMessageFieldsId.Description, fileArtifactMessage.Description);
+            WriteField(s, FileArtifactMessageFieldsId.TestUid, fileArtifactMessage.TestUid);
+            WriteField(s, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
+            WriteField(s, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
+        });
 
     private static ushort GetFieldCount(FileArtifactMessages fileArtifactMessages) =>
         (ushort)((fileArtifactMessages.ExecutionId is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -42,33 +42,26 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
         string? instanceId = null;
         TestInProgressMessage[]? inProgressMessages = [];
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            int fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case TestInProgressMessagesFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case TestInProgressMessagesFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case TestInProgressMessagesFieldsId.TestInProgressMessageList:
                     inProgressMessages = ReadInProgressMessagesPayload(stream);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(executionId, instanceId, inProgressMessages);
     }
@@ -82,28 +75,22 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
             string? uid = null;
             string? displayName = null;
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case TestInProgressMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case TestInProgressMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             inProgressMessages[i] = new TestInProgressMessage(uid, displayName);
         }
@@ -123,32 +110,13 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
     }
 
     private static void WriteInProgressMessagesPayload(Stream stream, TestInProgressMessage[]? inProgressMessageList)
-    {
-        if (inProgressMessageList is null || inProgressMessageList.Length == 0)
+        => WriteListPayload(stream, TestInProgressMessagesFieldsId.TestInProgressMessageList, inProgressMessageList, static (s, inProgressMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(inProgressMessage));
 
-        WriteUShort(stream, TestInProgressMessagesFieldsId.TestInProgressMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, inProgressMessageList.Length);
-        foreach (TestInProgressMessage inProgressMessage in inProgressMessageList)
-        {
-            WriteUShort(stream, GetFieldCount(inProgressMessage));
-
-            WriteField(stream, TestInProgressMessageFieldsId.Uid, inProgressMessage.Uid);
-            WriteField(stream, TestInProgressMessageFieldsId.DisplayName, inProgressMessage.DisplayName);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, TestInProgressMessageFieldsId.Uid, inProgressMessage.Uid);
+            WriteField(s, TestInProgressMessageFieldsId.DisplayName, inProgressMessage.DisplayName);
+        });
 
     private static ushort GetFieldCount(TestInProgressMessages inProgressMessages) =>
         (ushort)((inProgressMessages.ExecutionId is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -114,37 +114,30 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
         SuccessfulTestResultMessage[]? successfulTestResultMessages = null;
         FailedTestResultMessage[]? failedTestResultMessages = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            int fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case TestResultMessagesFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case TestResultMessagesFieldsId.InstanceId:
                     instanceId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case TestResultMessagesFieldsId.SuccessfulTestMessageList:
                     successfulTestResultMessages = ReadSuccessfulTestMessagesPayload(stream);
-                    break;
+                    return true;
 
                 case TestResultMessagesFieldsId.FailedTestMessageList:
                     failedTestResultMessages = ReadFailedTestMessagesPayload(stream);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(
             executionId,
@@ -163,52 +156,46 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
             byte? state = null;
             long? duration = null;
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case SuccessfulTestResultMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.State:
                         state = ReadByte(stream);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.Duration:
                         duration = ReadLong(stream);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.Reason:
                         reason = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.StandardOutput:
                         standardOutput = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.ErrorOutput:
                         errorOutput = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case SuccessfulTestResultMessageFieldsId.SessionUid:
                         sessionUid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             successfulTestResultMessages[i] = new SuccessfulTestResultMessage(uid, displayName, state, duration, reason, standardOutput, errorOutput, sessionUid);
         }
@@ -227,56 +214,50 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
             byte? state = null;
             long? duration = null;
 
-            int fieldCount = ReadUShort(stream);
-
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case FailedTestResultMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.State:
                         state = ReadByte(stream);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.Duration:
                         duration = ReadLong(stream);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.Reason:
                         reason = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.ExceptionMessageList:
                         exceptionMessages = ReadExceptionMessagesPayload(stream);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.StandardOutput:
                         standardOutput = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.ErrorOutput:
                         errorOutput = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case FailedTestResultMessageFieldsId.SessionUid:
                         sessionUid = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             failedTestResultMessages[i] = new FailedTestResultMessage(uid, displayName, state, duration, reason, exceptionMessages, standardOutput, errorOutput, sessionUid);
         }
@@ -291,36 +272,30 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
 
         for (int i = 0; i < length; i++)
         {
-            int fieldCount = ReadUShort(stream);
-
             string? errorMessage = null;
             string? errorType = null;
             string? stackTrace = null;
 
-            for (int j = 0; j < fieldCount; j++)
+            ReadFields(stream, (fieldId, fieldSize) =>
             {
-                int fieldId = ReadUShort(stream);
-                int fieldSize = ReadInt(stream);
-
                 switch (fieldId)
                 {
                     case ExceptionMessageFieldsId.ErrorMessage:
                         errorMessage = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case ExceptionMessageFieldsId.ErrorType:
                         errorType = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     case ExceptionMessageFieldsId.StackTrace:
                         stackTrace = ReadStringValue(stream, fieldSize);
-                        break;
+                        return true;
 
                     default:
-                        SetPosition(stream, stream.Position + fieldSize);
-                        break;
+                        return false;
                 }
-            }
+            });
 
             exceptionMessages[i] = new ExceptionMessage(errorMessage, errorType, stackTrace);
         }
@@ -341,102 +316,45 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
     }
 
     private static void WriteSuccessfulTestMessagesPayload(Stream stream, SuccessfulTestResultMessage[]? successfulTestResultMessages)
-    {
-        if (successfulTestResultMessages is null || successfulTestResultMessages.Length == 0)
+        => WriteListPayload(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList, successfulTestResultMessages, static (s, successfulTestResultMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(successfulTestResultMessage));
 
-        WriteUShort(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, successfulTestResultMessages.Length);
-        foreach (SuccessfulTestResultMessage successfulTestResultMessage in successfulTestResultMessages)
-        {
-            WriteUShort(stream, GetFieldCount(successfulTestResultMessage));
-
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.State, successfulTestResultMessage.State);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.Duration, successfulTestResultMessage.Duration);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.Reason, successfulTestResultMessage.Reason);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.StandardOutput, successfulTestResultMessage.StandardOutput);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.ErrorOutput, successfulTestResultMessage.ErrorOutput);
-            WriteField(stream, SuccessfulTestResultMessageFieldsId.SessionUid, successfulTestResultMessage.SessionUid);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, SuccessfulTestResultMessageFieldsId.Uid, successfulTestResultMessage.Uid);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.DisplayName, successfulTestResultMessage.DisplayName);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.State, successfulTestResultMessage.State);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.Duration, successfulTestResultMessage.Duration);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.Reason, successfulTestResultMessage.Reason);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.StandardOutput, successfulTestResultMessage.StandardOutput);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.ErrorOutput, successfulTestResultMessage.ErrorOutput);
+            WriteField(s, SuccessfulTestResultMessageFieldsId.SessionUid, successfulTestResultMessage.SessionUid);
+        });
 
     private static void WriteFailedTestMessagesPayload(Stream stream, FailedTestResultMessage[]? failedTestResultMessages)
-    {
-        if (failedTestResultMessages is null || failedTestResultMessages.Length == 0)
+        => WriteListPayload(stream, TestResultMessagesFieldsId.FailedTestMessageList, failedTestResultMessages, static (s, failedTestResultMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(failedTestResultMessage));
 
-        WriteUShort(stream, TestResultMessagesFieldsId.FailedTestMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, failedTestResultMessages.Length);
-        foreach (FailedTestResultMessage failedTestResultMessage in failedTestResultMessages)
-        {
-            WriteUShort(stream, GetFieldCount(failedTestResultMessage));
-
-            WriteField(stream, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
-            WriteField(stream, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
-            WriteField(stream, FailedTestResultMessageFieldsId.State, failedTestResultMessage.State);
-            WriteField(stream, FailedTestResultMessageFieldsId.Duration, failedTestResultMessage.Duration);
-            WriteField(stream, FailedTestResultMessageFieldsId.Reason, failedTestResultMessage.Reason);
-            WriteExceptionMessagesPayload(stream, failedTestResultMessage.Exceptions);
-            WriteField(stream, FailedTestResultMessageFieldsId.StandardOutput, failedTestResultMessage.StandardOutput);
-            WriteField(stream, FailedTestResultMessageFieldsId.ErrorOutput, failedTestResultMessage.ErrorOutput);
-            WriteField(stream, FailedTestResultMessageFieldsId.SessionUid, failedTestResultMessage.SessionUid);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, FailedTestResultMessageFieldsId.Uid, failedTestResultMessage.Uid);
+            WriteField(s, FailedTestResultMessageFieldsId.DisplayName, failedTestResultMessage.DisplayName);
+            WriteField(s, FailedTestResultMessageFieldsId.State, failedTestResultMessage.State);
+            WriteField(s, FailedTestResultMessageFieldsId.Duration, failedTestResultMessage.Duration);
+            WriteField(s, FailedTestResultMessageFieldsId.Reason, failedTestResultMessage.Reason);
+            WriteExceptionMessagesPayload(s, failedTestResultMessage.Exceptions);
+            WriteField(s, FailedTestResultMessageFieldsId.StandardOutput, failedTestResultMessage.StandardOutput);
+            WriteField(s, FailedTestResultMessageFieldsId.ErrorOutput, failedTestResultMessage.ErrorOutput);
+            WriteField(s, FailedTestResultMessageFieldsId.SessionUid, failedTestResultMessage.SessionUid);
+        });
 
     private static void WriteExceptionMessagesPayload(Stream stream, ExceptionMessage[]? exceptionMessages)
-    {
-        if (exceptionMessages is null || exceptionMessages.Length == 0)
+        => WriteListPayload(stream, FailedTestResultMessageFieldsId.ExceptionMessageList, exceptionMessages, static (s, exceptionMessage) =>
         {
-            return;
-        }
+            WriteUShort(s, GetFieldCount(exceptionMessage));
 
-        WriteUShort(stream, FailedTestResultMessageFieldsId.ExceptionMessageList);
-
-        // We will reserve an int (4 bytes)
-        // so that we fill the size later, once we write the payload
-        WriteInt(stream, 0);
-
-        long before = stream.Position;
-        WriteInt(stream, exceptionMessages.Length);
-        foreach (ExceptionMessage exceptionMessage in exceptionMessages)
-        {
-            WriteUShort(stream, GetFieldCount(exceptionMessage));
-
-            WriteField(stream, ExceptionMessageFieldsId.ErrorMessage, exceptionMessage.ErrorMessage);
-            WriteField(stream, ExceptionMessageFieldsId.ErrorType, exceptionMessage.ErrorType);
-            WriteField(stream, ExceptionMessageFieldsId.StackTrace, exceptionMessage.StackTrace);
-        }
-
-        // NOTE: We are able to seek only if we are using a MemoryStream
-        // thus, the seek operation is fast as we are only changing the value of a property
-        WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
-    }
+            WriteField(s, ExceptionMessageFieldsId.ErrorMessage, exceptionMessage.ErrorMessage);
+            WriteField(s, ExceptionMessageFieldsId.ErrorType, exceptionMessage.ErrorType);
+            WriteField(s, ExceptionMessageFieldsId.StackTrace, exceptionMessage.StackTrace);
+        });
 
     private static ushort GetFieldCount(TestResultMessages testResultMessages) =>
         (ushort)((testResultMessages.ExecutionId is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestSessionEventSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestSessionEventSerializer.cs
@@ -31,33 +31,26 @@ internal sealed class TestSessionEventSerializer : NamedPipeSerializer<TestSessi
         string? sessionUid = null;
         string? executionId = null;
 
-        ushort fieldCount = ReadUShort(stream);
-
-        for (int i = 0; i < fieldCount; i++)
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
-            ushort fieldId = ReadUShort(stream);
-            int fieldSize = ReadInt(stream);
-
             switch (fieldId)
             {
                 case TestSessionEventFieldsId.SessionType:
                     type = ReadByte(stream);
-                    break;
+                    return true;
 
                 case TestSessionEventFieldsId.SessionUid:
                     sessionUid = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 case TestSessionEventFieldsId.ExecutionId:
                     executionId = ReadStringValue(stream, fieldSize);
-                    break;
+                    return true;
 
                 default:
-                    // If we don't recognize the field id, skip the payload corresponding to that field
-                    SetPosition(stream, stream.Position + fieldSize);
-                    break;
+                    return false;
             }
-        }
+        });
 
         return new(type, sessionUid, executionId);
     }


### PR DESCRIPTION
## Summary

Deduplicates the 3-phase read/write wire-protocol boilerplate that was copy-pasted across the 8 DotnetTest IPC serializers under `src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/`.

Two helpers are added to the shared `BaseSerializer` and every serializer is refactored to use them:

- `ReadFields(Stream, Func<ushort, int, bool>)` — encapsulates the `field-count` loop that reads each `[id][size][payload]` triple and skips unrecognized fields (the forward-compatibility fallback), replacing the identical loop in every `DeserializeCore` and per-list-item reader.
- `WriteListPayload<T>(Stream, ushort, T[]?, Action<Stream, T>)` — encapsulates the deferred-size-backfill list protocol (reserve size slot, write count, write items, patch size), replacing the copy-pasted `before`/`WriteAtPosition` sequence.

Refactored serializers: `AzureDevOpsLogMessage`, `TestSessionEvent`, `DisplayMessage`, `CommandLineOptionMessages`, `TestInProgressMessages`, `FileArtifactMessages`, `DiscoveredTestMessages`, `TestResultMessages`.

Net change: **+237 / −465** lines.

## Wire compatibility

No wire-format change. Per-field write order and the skip-unknown/backfill semantics are preserved verbatim (including `DisplayMessage`'s `Level` size-honoring read and `DiscoveredTestMessages`' required trait key/value validation).

## Validation

- `Microsoft.Testing.Platform` + the 4 shared-source extensions (HangDump, Retry, TrxReport, MSBuild) build with 0 warnings / 0 errors.
- `DotnetTestProtocolContract.UnitTests` round-trip tests: **63/63** pass (net462/net8.0/net9.0).
- IPC `Protocol` tests in `Microsoft.Testing.Platform.UnitTests`: **33/33** pass.

Fixes #9764