### PR TITLE
Remove duplicated #if NETCOREAPP / #else primitives in BaseSerializer

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter.PlatformServicesConfigurationAdapter(Microsoft.Testing.Platform.Configurations.IConfiguration! configuration) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter.this[string! key].get -> string?

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
-using System.Buffers;
-#endif
-
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Testing.Platform.IPC.Serializers;
@@ -22,170 +18,26 @@ internal abstract class BaseSerializer
     protected static void DebugAssert(bool condition, string message)
         => Debug.Assert(condition, message);
 
-    // Internal invariant-violation diagnostic for "impossible" states (e.g. BitConverter.TryWriteBytes into a
-    // correctly-sized buffer). Kept self-contained (no ApplicationStateGuard) so this file shares as source.
+    // Internal invariant-violation diagnostic for "impossible" states (e.g. GetSize<T> called with an
+    // unsupported type). Kept self-contained (no ApplicationStateGuard) so this file shares as source.
     private static InvalidOperationException Unreachable([CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
         => new(string.Format(CultureInfo.InvariantCulture, "This program location is thought to be unreachable. File='{0}' Line={1}", path, line));
 
-#if NETCOREAPP
-    protected static string ReadString(Stream stream)
-    {
-        Span<byte> len = stackalloc byte[sizeof(int)];
-        stream.ReadExactly(len);
-        int stringLen = BitConverter.ToInt32(len);
-        byte[] bytes = ArrayPool<byte>.Shared.Rent(stringLen);
-        try
-        {
-            stream.ReadExactly(bytes, 0, stringLen);
-            return Encoding.UTF8.GetString(bytes, 0, stringLen);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(bytes);
-        }
-    }
-
-    protected static string ReadStringValue(Stream stream, int size)
-    {
-        byte[] bytes = ArrayPool<byte>.Shared.Rent(size);
-        try
-        {
-            stream.ReadExactly(bytes, 0, size);
-            return Encoding.UTF8.GetString(bytes, 0, size);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(bytes);
-        }
-    }
-
-    protected static void WriteString(Stream stream, string str)
-    {
-        int stringutf8TotalBytes = Encoding.UTF8.GetByteCount(str);
-        byte[] bytes = ArrayPool<byte>.Shared.Rent(stringutf8TotalBytes);
-        try
-        {
-            Span<byte> len = stackalloc byte[sizeof(int)];
-            if (!BitConverter.TryWriteBytes(len, stringutf8TotalBytes))
-            {
-                throw Unreachable();
-            }
-
-            stream.Write(len);
-
-            Encoding.UTF8.GetBytes(str, bytes);
-            stream.Write(bytes, 0, stringutf8TotalBytes);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(bytes);
-        }
-    }
-
-    protected static void WriteSize<T>(Stream stream)
-        where T : struct
-    {
-        int sizeInBytes = GetSize<T>();
-        Span<byte> len = stackalloc byte[sizeof(int)];
-
-        if (!BitConverter.TryWriteBytes(len, sizeInBytes))
-        {
-            throw Unreachable();
-        }
-
-        stream.Write(len);
-    }
-
-    protected static void WriteInt(Stream stream, int value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(int)];
-        if (!BitConverter.TryWriteBytes(bytes, value))
-        {
-            throw Unreachable();
-        }
-
-        stream.Write(bytes);
-    }
-
-    protected static void WriteLong(Stream stream, long value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(long)];
-        if (!BitConverter.TryWriteBytes(bytes, value))
-        {
-            throw Unreachable();
-        }
-
-        stream.Write(bytes);
-    }
-
-    protected static void WriteUShort(Stream stream, ushort value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
-        if (!BitConverter.TryWriteBytes(bytes, value))
-        {
-            throw Unreachable();
-        }
-
-        stream.Write(bytes);
-    }
-
-    protected static void WriteBool(Stream stream, bool value)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(bool)];
-        if (!BitConverter.TryWriteBytes(bytes, value))
-        {
-            throw Unreachable();
-        }
-
-        stream.Write(bytes);
-    }
-
-    protected static int ReadInt(Stream stream)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(int)];
-        stream.ReadExactly(bytes);
-        return BitConverter.ToInt32(bytes);
-    }
-
-    protected static long ReadLong(Stream stream)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(long)];
-        stream.ReadExactly(bytes);
-        return BitConverter.ToInt64(bytes);
-    }
-
-    protected static ushort ReadUShort(Stream stream)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
-        stream.ReadExactly(bytes);
-        return BitConverter.ToUInt16(bytes);
-    }
-
-    protected static bool ReadBool(Stream stream)
-    {
-        Span<byte> bytes = stackalloc byte[sizeof(bool)];
-        stream.ReadExactly(bytes);
-        return BitConverter.ToBoolean(bytes);
-    }
-
-#else
     protected static string ReadString(Stream stream)
     {
         byte[] len = new byte[sizeof(int)];
-        _ = stream.Read(len, 0, len.Length);
+        ReadExactly(stream, len, 0, len.Length);
         int length = BitConverter.ToInt32(len, 0);
         byte[] bytes = new byte[length];
-        _ = stream.Read(bytes, 0, bytes.Length);
-
-        return Encoding.UTF8.GetString(bytes);
+        ReadExactly(stream, bytes, 0, length);
+        return Encoding.UTF8.GetString(bytes, 0, length);
     }
 
     protected static string ReadStringValue(Stream stream, int size)
     {
         byte[] bytes = new byte[size];
-        _ = stream.Read(bytes, 0, bytes.Length);
-
-        return Encoding.UTF8.GetString(bytes);
+        ReadExactly(stream, bytes, 0, size);
+        return Encoding.UTF8.GetString(bytes, 0, size);
     }
 
     protected static void WriteString(Stream stream, string str)
@@ -213,7 +65,7 @@ internal abstract class BaseSerializer
     protected static int ReadInt(Stream stream)
     {
         byte[] bytes = new byte[sizeof(int)];
-        _ = stream.Read(bytes, 0, bytes.Length);
+        ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToInt32(bytes, 0);
     }
 
@@ -223,23 +75,23 @@ internal abstract class BaseSerializer
         stream.Write(bytes, 0, bytes.Length);
     }
 
+    protected static long ReadLong(Stream stream)
+    {
+        byte[] bytes = new byte[sizeof(long)];
+        ReadExactly(stream, bytes, 0, bytes.Length);
+        return BitConverter.ToInt64(bytes, 0);
+    }
+
     protected static void WriteUShort(Stream stream, ushort value)
     {
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
     }
 
-    protected static long ReadLong(Stream stream)
-    {
-        byte[] bytes = new byte[sizeof(long)];
-        _ = stream.Read(bytes, 0, bytes.Length);
-        return BitConverter.ToInt64(bytes, 0);
-    }
-
     protected static ushort ReadUShort(Stream stream)
     {
         byte[] bytes = new byte[sizeof(ushort)];
-        _ = stream.Read(bytes, 0, bytes.Length);
+        ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToUInt16(bytes, 0);
     }
 
@@ -252,10 +104,32 @@ internal abstract class BaseSerializer
     protected static bool ReadBool(Stream stream)
     {
         byte[] bytes = new byte[sizeof(bool)];
-        _ = stream.Read(bytes, 0, bytes.Length);
+        ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToBoolean(bytes, 0);
     }
+
+    // Reads exactly 'count' bytes into 'buffer' starting at 'offset', looping until the request is
+    // satisfied or the end of the stream is reached. This centralizes the previously duplicated
+    // per-primitive read logic and fixes the historical short-read bug on the non-NETCOREAPP path,
+    // where a single Stream.Read could return fewer bytes than requested and silently corrupt data.
+    private static void ReadExactly(Stream stream, byte[] buffer, int offset, int count)
+    {
+#if NETCOREAPP
+        stream.ReadExactly(buffer, offset, count);
+#else
+        int totalRead = 0;
+        while (totalRead < count)
+        {
+            int read = stream.Read(buffer, offset + totalRead, count - totalRead);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            totalRead += read;
+        }
 #endif
+    }
 
     protected static byte ReadByte(Stream stream) => (byte)stream.ReadByte();
 

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPartialReadTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPartialReadTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC.Models;
+using Microsoft.Testing.Platform.IPC.Serializers;
+
+using static Microsoft.Testing.Platform.UnitTests.ProtocolSerializerTestHelper;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+/// <summary>
+/// Guards the <c>BaseSerializer.ReadExactly</c> behavior against regressions. The other serializer round-trip tests
+/// only exercise <see cref="MemoryStream"/>, which always satisfies a read request in a single call and therefore
+/// never triggers the short-read handling. These tests deserialize through a stream that intentionally returns
+/// fewer bytes than requested (partial reads) and through a truncated stream (premature EOF), which are exactly the
+/// conditions the centralized read helper exists to handle. On non-NETCOREAPP target frameworks (for example the
+/// net462 test run) this exercises the hand-written read-until-complete loop; on NETCOREAPP it exercises the
+/// framework <c>Stream.ReadExactly</c> path.
+/// </summary>
+[TestClass]
+public sealed class BaseSerializerPartialReadTests
+{
+    [TestMethod]
+    public void Deserialize_WhenStreamReturnsOneBytePerRead_RoundTripsCorrectly()
+    {
+        object serializer = new AzureDevOpsLogMessageSerializer();
+        var message = new AzureDevOpsLogMessage("MyExecId", "MyInstId", "##[group]A reasonably long log line so several primitive reads span multiple partial reads.");
+
+        byte[] payload = SerializeToBytes(serializer, message);
+
+        // Wrap the payload in a stream that hands back at most one byte per Read call, forcing every primitive read
+        // (length prefixes, field ids, and string payloads) to loop until it has the full value.
+        using var partialReadStream = new PartialReadStream(new MemoryStream(payload), maxBytesPerRead: 1);
+        var actual = (AzureDevOpsLogMessage)Deserialize(serializer, partialReadStream);
+
+        Assert.AreEqual(message.ExecutionId, actual.ExecutionId);
+        Assert.AreEqual(message.InstanceId, actual.InstanceId);
+        Assert.AreEqual(message.LogText, actual.LogText);
+    }
+
+    [TestMethod]
+    public void Deserialize_WhenStreamIsTruncated_ThrowsEndOfStreamException()
+    {
+        object serializer = new AzureDevOpsLogMessageSerializer();
+        var message = new AzureDevOpsLogMessage("MyExecId", "MyInstId", "##[group]A reasonably long log line that will be cut off mid-read to force an end-of-stream.");
+
+        byte[] payload = SerializeToBytes(serializer, message);
+
+        // Cut the payload in half so a length-prefixed read claims more bytes than are available, driving the reader
+        // to the end of the stream before the request is satisfied.
+        byte[] truncated = new byte[payload.Length / 2];
+        Array.Copy(payload, truncated, truncated.Length);
+
+        using var truncatedStream = new MemoryStream(truncated);
+        TargetInvocationException wrapper = Assert.ThrowsExactly<TargetInvocationException>(
+            () => Deserialize(serializer, truncatedStream));
+        Assert.IsInstanceOfType<EndOfStreamException>(wrapper.InnerException);
+    }
+
+    private static byte[] SerializeToBytes<TMessage>(object serializer, TMessage message)
+    {
+        using var stream = new MemoryStream();
+        Serialize(serializer, message, stream);
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// A read-only stream decorator that never returns more than <c>maxBytesPerRead</c> bytes from a single
+    /// <see cref="Read(byte[], int, int)"/> call, simulating streams (such as network/pipe streams) that satisfy a
+    /// read request incrementally. All other stream operations delegate to the wrapped stream.
+    /// </summary>
+    private sealed class PartialReadStream(Stream inner, int maxBytesPerRead) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+
+        public override bool CanSeek => inner.CanSeek;
+
+        public override bool CanWrite => false;
+
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => inner.Read(buffer, offset, Math.Min(count, maxBytesPerRead));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #9765.

BaseSerializer.cs previously implemented every read/write primitive **twice** — once under `#if NETCOREAPP` (`Span<byte>` / `ArrayPool<byte>` / `ReadExactly`) and once under `#else` (heap `byte[]` + `stream.Read`). The two branches were structurally identical, so adding or fixing a primitive meant editing both.

This collapses the 12 duplicated primitives into a **single `byte[]`-based implementation**. The only remaining conditional is a small private `ReadExactly` helper:

- On `NETCOREAPP` it delegates to the framework `Stream.ReadExactly`.
- Otherwise it loops until the requested byte count is read, throwing `EndOfStreamException` on premature EOF.

## Why byte[] instead of Span everywhere

`Microsoft.Testing.Platform` intentionally does **not** reference `System.Memory` (dropped in #4652), and this file is shared as source into several other projects. `Span`/`ArrayPool` are therefore unavailable on the `netstandard2.0` target, so the unified path stays `byte[]`-based.

## Bug fix included

The old `#else` branch used single `stream.Read(...)` calls that ignored short reads, which could silently return fewer bytes than requested and corrupt data on the .NET Framework / netstandard2.0 path. Routing all reads through `ReadExactly` fixes this.

## Tests

Added `BaseSerializerPartialReadTests`, which deserialize through a stream that returns one byte per `Read` (forcing every length prefix / field id / string payload through the `ReadExactly` loop) and through a truncated stream (asserting `EndOfStreamException`). These run on net8.0/net9.0 (framework `Stream.ReadExactly` path) and net462 (the hand-written loop).

## InternalAPI baseline changes (to unblock CI — not part of the refactor)

> ⚠️ These `InternalAPI.Unshipped.txt` edits are **not** part of the BaseSerializer refactor. They declare internal symbols that recently landed on `main` (via #9752 InternalAPI tracking + #9774 DotnetTest serializer dedup) but were left undeclared, so `RS0051` currently fails on `main` and is inherited by every PR. They are included here only to keep this PR's CI green:

- `BaseSerializer.ReadFields` / `WriteListPayload` — declared in Platform, Extensions.HangDump, Extensions.MSBuild, Extensions.Retry, Extensions.TrxReport (each compiles `BaseSerializer.cs` as shared source).
- `PlatformServicesConfigurationAdapter` — declared in MSTest.TestAdapter. This one is **unrelated** to this change and was pulled in via the merge with `main`; happy to split it (and the other baseline updates) into a dedicated PR if preferred.

## Validation

- Full solution build passes with 0 code errors across `net8.0`, `net9.0`, and `netstandard2.0` (all previously-failing `RS0051` errors resolved).
- No behavioral public/protected **member** changes to `BaseSerializer` (bodies only); the API-baseline files above are updated purely to declare pre-existing-on-`main` symbols.