### PR TITLE
Fix broken main: declare new BaseSerializer helper members in InternalAPI

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter.PlatformServicesConfigurationAdapter(Microsoft.Testing.Platform.Configurations.IConfiguration! configuration) -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.PlatformServicesConfigurationAdapter.this[string! key].get -> string?

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void


### PR DESCRIPTION
## Problem

`main` is broken. The [official build 3018307](https://dnceng.visualstudio.com/internal/_build/results?buildId=3018307&view=results) failed with `RS0051` on **all** target frameworks of `Microsoft.Testing.Platform` (netstandard2.0, net8.0, net9.0):

```
src\Platform\Microsoft.Testing.Platform\IPC\Serializers\BaseSerializer.cs(359,27): error RS0051:
  Symbol 'static ...BaseSerializer.ReadFields(...) -> void' is not part of the declared API
src\Platform\Microsoft.Testing.Platform\IPC\Serializers\BaseSerializer.cs(380,27): error RS0051:
  Symbol 'static ...BaseSerializer.WriteListPayload<T>(...) -> void' is not part of the declared API
```

The downstream "Publish Test Results / binlogs" and "OneLocBuild (testsuite not found)" failures are just consequences — the failed build produced no packages/artifacts for those later steps to consume.

## Root cause

Two recent changes landed close together:

- **#9774** ("Deduplicate DotnetTest IPC serializer 3-phase boilerplate") added the `protected static` helpers `ReadFields` and `WriteListPayload<T>` to `BaseSerializer`.
- **#9752** ("Add InternalAPI tracking to all projects with PublicAPI") turned on the internal/public API analyzer for these projects.

The new members were never added to `InternalAPI.Unshipped.txt`, so the analyzer rejected them.

## Fix

`BaseSerializer.cs` is compiled as shared source (`<Compile Include=... Link=... />`) into several projects that each have InternalAPI (RS0051) tracking. The two new members are declared in every one of them:

- `Microsoft.Testing.Platform` (both the netstandard2.0 root and `net/` variants)
- `Microsoft.Testing.Extensions.HangDump`
- `Microsoft.Testing.Extensions.Retry`
- `Microsoft.Testing.Extensions.TrxReport`
- `Microsoft.Testing.Extensions.MSBuild`

(`Microsoft.Testing.Platform.MSBuild` also compiles the file but has no InternalAPI tracking, so it needs no entry.)

## Verification

Release builds of `Microsoft.Testing.Platform` and all four tracked extensions succeed with **0 warnings, 0 errors** across net8.0, net9.0, and netstandard2.0.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>