### PR TITLE
Make Azure.Identity optional in AzureFoundry via injectable TokenCredential

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,7 +78,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageVersion Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Core" Version="1.44.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Shipped.txt
@@ -3,8 +3,6 @@ Microsoft.CodeAnalysis.EmbeddedAttribute
 Microsoft.CodeAnalysis.EmbeddedAttribute.EmbeddedAttribute() -> void
 Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider
 Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
-Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey = 0 -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
-Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential = 1 -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
 Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AzureOpenAIChatClientProvider() -> void
 Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.CreateChatClientAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.IChatClient!>!
 Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.HasToolsCapability.get -> bool
@@ -13,7 +11,7 @@ Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.ModelNam
 Microsoft.Testing.Platform.RoslynString
 Polyfills.Polyfill
 Polyfills.Polyfill.extension(System.OperatingSystem)
-static Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.GetAuthenticationMode(string? apiKey) -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
+static Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.GetAuthenticationMode(string? apiKey, Azure.Core.TokenCredential? credential) -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
 static Microsoft.Testing.Platform.RoslynString.IsNullOrEmpty(string? value) -> bool
 static Microsoft.Testing.Platform.RoslynString.IsNullOrWhiteSpace(string? value) -> bool
 static Polyfills.Polyfill.extension(System.OperatingSystem).IsAndroid() -> bool

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey = 1 -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
+Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode.None = 0 -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
+Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode.TokenCredential = 2 -> Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AuthenticationMode
+Microsoft.Testing.Extensions.AzureFoundry.AzureOpenAIChatClientProvider.AzureOpenAIChatClientProvider(Azure.Core.TokenCredential! credential) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" />
-    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/OpenAIChatClientProvider.cs
@@ -4,7 +4,7 @@
 using System.ClientModel;
 
 using Azure.AI.OpenAI;
-using Azure.Identity;
+using Azure.Core;
 
 using Microsoft.Extensions.AI;
 using Microsoft.Testing.Extensions.AzureFoundry.Resources;
@@ -18,10 +18,27 @@ namespace Microsoft.Testing.Extensions.AzureFoundry;
 /// </summary>
 internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
 {
-    // DefaultAzureCredential caches tokens on the instance and probes the whole credential chain
-    // (env vars, workload identity, managed identity via IMDS, Azure CLI, ...) on first use, which
-    // can be expensive. Reuse a single instance so the token cache and chain discovery are shared.
-    private static readonly Lazy<DefaultAzureCredential> DefaultCredential = new(() => new DefaultAzureCredential());
+    // Optional credential used for Entra ID / managed identity authentication. When null, the provider
+    // can only authenticate with an API key. Keeping the credential injectable means the core package does
+    // not need a dependency on Azure.Identity (and its MSAL graph); consumers that want managed identity
+    // reference Azure.Identity themselves and pass a credential (for example new DefaultAzureCredential()).
+    private readonly TokenCredential? _credential;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureOpenAIChatClientProvider"/> class that authenticates
+    /// with an API key read from the <c>AZURE_OPENAI_API_KEY</c> environment variable.
+    /// </summary>
+    public AzureOpenAIChatClientProvider()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureOpenAIChatClientProvider"/> class that authenticates
+    /// with the provided <see cref="TokenCredential"/> when no API key is available.
+    /// </summary>
+    /// <param name="credential">The credential used for Entra ID / managed identity authentication.</param>
+    public AzureOpenAIChatClientProvider(TokenCredential credential)
+        => _credential = credential ?? throw new ArgumentNullException(nameof(credential));
 
     /// <summary>
     /// The authentication mode used to create the Azure OpenAI client.
@@ -29,20 +46,26 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
     internal enum AuthenticationMode
     {
         /// <summary>
+        /// No authentication is available (neither an API key nor a credential was provided).
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Authenticate with an explicit API key (<c>AZURE_OPENAI_API_KEY</c>).
         /// </summary>
         ApiKey,
 
         /// <summary>
-        /// Authenticate with Entra ID / managed identity via <see cref="DefaultAzureCredential"/>.
+        /// Authenticate with an injected <see cref="Azure.Core.TokenCredential"/> (for example Entra ID / managed identity).
         /// </summary>
-        DefaultAzureCredential,
+        TokenCredential,
     }
 
     /// <inheritdoc />
     public bool IsAvailable =>
         !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")) &&
-        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME"));
+        !RoslynString.IsNullOrEmpty(Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")) &&
+        GetAuthenticationMode(Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY"), _credential) != AuthenticationMode.None;
 
     /// <inheritdoc />
     public bool HasToolsCapability => true;
@@ -50,13 +73,14 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
     /// <inheritdoc />
     public string ModelName => Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME") ?? "unknown";
 
-    // Prefer an explicit API key when provided, otherwise fall back to Entra ID / managed identity
-    // authentication via DefaultAzureCredential. This keeps the provider secure-by-default for
-    // Azure-hosted scenarios where distributing API keys is undesirable.
-    internal static AuthenticationMode GetAuthenticationMode(string? apiKey)
-        => RoslynString.IsNullOrEmpty(apiKey)
-            ? AuthenticationMode.DefaultAzureCredential
-            : AuthenticationMode.ApiKey;
+    // Prefer an explicit API key when provided, otherwise fall back to the injected credential (if any).
+    // When neither is available the provider cannot authenticate, so the caller must supply a credential.
+    internal static AuthenticationMode GetAuthenticationMode(string? apiKey, TokenCredential? credential)
+        => !RoslynString.IsNullOrEmpty(apiKey)
+            ? AuthenticationMode.ApiKey
+            : credential is not null
+                ? AuthenticationMode.TokenCredential
+                : AuthenticationMode.None;
 
     /// <inheritdoc />
     public Task<IChatClient> CreateChatClientAsync(CancellationToken cancellationToken)
@@ -75,10 +99,11 @@ internal sealed class AzureOpenAIChatClientProvider : IChatClientProvider
             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ExtensionResources.EnvironmentVariableNotSet, "AZURE_OPENAI_DEPLOYMENT_NAME"));
         }
 
-        AzureOpenAIClient client = GetAuthenticationMode(apiKey) switch
+        AzureOpenAIClient client = GetAuthenticationMode(apiKey, _credential) switch
         {
             AuthenticationMode.ApiKey => new AzureOpenAIClient(new Uri(endpoint), new ApiKeyCredential(apiKey!)),
-            _ => new AzureOpenAIClient(new Uri(endpoint), DefaultCredential.Value),
+            AuthenticationMode.TokenCredential => new AzureOpenAIClient(new Uri(endpoint), _credential!),
+            _ => throw new InvalidOperationException(ExtensionResources.NoAuthenticationConfigured),
         };
 
         return Task.FromResult(client.GetChatClient(deploymentName).AsIChatClient());

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PACKAGE.md
@@ -17,7 +17,7 @@ This package extends Microsoft.Testing.Platform with:
 - **Azure AI Foundry integration**: provides an `IChatClientProvider` implementation backed by Azure OpenAI
 - **Provider implementation**: supplies chat client capabilities to extensions using `Microsoft.Testing.Platform.AI`
 - **Environment-based configuration**: reads Azure OpenAI settings from environment variables
-- **Flexible authentication**: uses Microsoft Entra ID / managed identity (`DefaultAzureCredential`) by default and falls back to an API key when one is provided
+- **Flexible authentication**: authenticates with an API key out of the box, or with any Azure `TokenCredential` (for example Microsoft Entra ID / managed identity) that the consumer supplies
 
 ## Configuration
 
@@ -27,13 +27,27 @@ The provider is configured through the following environment variables:
 | --- | --- | --- |
 | `AZURE_OPENAI_ENDPOINT` | Yes | The Azure OpenAI resource endpoint, for example `https://my-resource.openai.azure.com`. |
 | `AZURE_OPENAI_DEPLOYMENT_NAME` | Yes | The name of the model deployment to use. |
-| `AZURE_OPENAI_API_KEY` | No | An API key for the resource. When omitted, authentication uses `DefaultAzureCredential` (Managed Identity, Workload Identity, Azure CLI, Visual Studio, etc.). |
+| `AZURE_OPENAI_API_KEY` | Conditional | An API key for the resource. Required unless a `TokenCredential` is supplied in code (see below). |
 
-When `AZURE_OPENAI_API_KEY` is not set, the provider authenticates with [`DefaultAzureCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential), which is recommended for Azure-hosted scenarios so that no secret has to be provisioned or distributed. Provide `AZURE_OPENAI_API_KEY` only when you explicitly want key-based authentication.
+### Authentication
 
-To target a specific user-assigned managed identity, set the `AZURE_CLIENT_ID` environment variable to its client ID; `DefaultAzureCredential` honors it automatically. Because credentials are resolved lazily, authentication problems (for example, an identity that lacks access to the Azure OpenAI resource) surface on the first chat request rather than when the provider is configured.
+By default the provider authenticates with the API key from `AZURE_OPENAI_API_KEY`:
 
-> **Note:** In local development, `DefaultAzureCredential` can take several seconds on first use because it probes a chain of credential sources (Managed Identity, Workload Identity, Azure CLI, Visual Studio, etc.) until one succeeds. Setting `AZURE_OPENAI_API_KEY` avoids this delay by using key-based authentication directly.
+```csharp
+builder.AddAzureOpenAIChatClientProvider();
+```
+
+To use Microsoft Entra ID / managed identity instead, reference the [`Azure.Identity`](https://www.nuget.org/packages/Azure.Identity) package in your test project and pass a credential. The API key still takes precedence when `AZURE_OPENAI_API_KEY` is set:
+
+```csharp
+using Azure.Identity;
+
+builder.AddAzureOpenAIChatClientProvider(new DefaultAzureCredential());
+```
+
+This keeps `Azure.Identity` (and its MSAL dependency graph) out of the package for consumers who only use API keys — they pull no managed-identity assemblies. Consumers who opt into Entra ID reference `Azure.Identity` explicitly.
+
+> **Note:** `DefaultAzureCredential` can take several seconds on first use because it probes a chain of credential sources (Managed Identity, Workload Identity, Azure CLI, Visual Studio, etc.) until one succeeds. Because credentials are resolved lazily, authentication problems (for example, an identity that lacks access to the Azure OpenAI resource) surface on the first chat request rather than when the provider is configured. To target a specific user-assigned managed identity, set the `AZURE_CLIENT_ID` environment variable to its client ID; `DefaultAzureCredential` honors it automatically.
 
 This package is a reference implementation of the [Microsoft.Testing.Platform.AI](https://www.nuget.org/packages/Microsoft.Testing.Platform.AI) abstractions.
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+[TPEXP]static Microsoft.Testing.Extensions.AzureFoundry.TestApplicationBuilderExtensions.AddAzureOpenAIChatClientProvider(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! testApplicationBuilder, Azure.Core.TokenCredential! credential) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Resources/ExtensionResources.resx
@@ -121,4 +121,7 @@
     <value>Environment variable '{0}' is not set.</value>
     <comment>{0} is the environment variable name.</comment>
   </data>
+  <data name="NoAuthenticationConfigured" xml:space="preserve">
+    <value>No authentication is configured for the Azure OpenAI chat client provider. Set the 'AZURE_OPENAI_API_KEY' environment variable, or reference the 'Azure.Identity' package and pass a credential (for example 'new DefaultAzureCredential()') to 'AddAzureOpenAIChatClientProvider'.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Azure.Core;
+
 using Microsoft.Testing.Platform.AI;
 using Microsoft.Testing.Platform.Builder;
 
@@ -13,9 +15,28 @@ namespace Microsoft.Testing.Extensions.AzureFoundry;
 public static class TestApplicationBuilderExtensions
 {
     /// <summary>
-    /// Adds the Azure OpenAI chat client provider to the test application.
+    /// Adds the Azure OpenAI chat client provider to the test application. The provider authenticates with
+    /// the API key from the <c>AZURE_OPENAI_API_KEY</c> environment variable.
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
+    /// <remarks>
+    /// To authenticate with Entra ID / managed identity, reference the <c>Azure.Identity</c> package and use
+    /// the <see cref="AddAzureOpenAIChatClientProvider(ITestApplicationBuilder, TokenCredential)"/> overload,
+    /// passing, for example, <c>new DefaultAzureCredential()</c>.
+    /// </remarks>
     public static void AddAzureOpenAIChatClientProvider(this ITestApplicationBuilder testApplicationBuilder)
         => testApplicationBuilder.AddChatClientProvider(_ => new AzureOpenAIChatClientProvider());
+
+    /// <summary>
+    /// Adds the Azure OpenAI chat client provider to the test application. The provider prefers the API key from
+    /// the <c>AZURE_OPENAI_API_KEY</c> environment variable when set, otherwise authenticates with the supplied
+    /// <paramref name="credential"/>.
+    /// </summary>
+    /// <param name="testApplicationBuilder">The test application builder.</param>
+    /// <param name="credential">
+    /// The credential used for Entra ID / managed identity authentication, for example
+    /// <c>new DefaultAzureCredential()</c> from the <c>Azure.Identity</c> package.
+    /// </param>
+    public static void AddAzureOpenAIChatClientProvider(this ITestApplicationBuilder testApplicationBuilder, TokenCredential credential)
+        => testApplicationBuilder.AddChatClientProvider(_ => new AzureOpenAIChatClientProvider(credential));
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureFoundryChatClientProviderTests.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Azure.Core;
+
 using Microsoft.Extensions.AI;
 using Microsoft.Testing.Extensions.AzureFoundry;
+
+using Moq;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
 
@@ -41,13 +45,26 @@ public sealed class AzureFoundryChatClientProviderTests
     }
 
     [TestMethod]
-    public void IsAvailable_WhenEndpointAndDeploymentSetWithoutApiKey_ReturnsTrue()
+    public void IsAvailable_WhenEndpointAndDeploymentSetWithoutApiKeyOrCredential_ReturnsFalse()
     {
         Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
         Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
 
         var provider = new AzureOpenAIChatClientProvider();
 
+        // Without an API key and without an injected credential, the provider cannot authenticate.
+        Assert.IsFalse(provider.IsAvailable);
+    }
+
+    [TestMethod]
+    public void IsAvailable_WhenEndpointAndDeploymentSetWithCredential_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider(Mock.Of<TokenCredential>());
+
+        // An injected credential makes the provider available even without an API key.
         Assert.IsTrue(provider.IsAvailable);
     }
 
@@ -67,6 +84,7 @@ public sealed class AzureFoundryChatClientProviderTests
     public void IsAvailable_WhenEndpointMissing_ReturnsFalse()
     {
         Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+        Environment.SetEnvironmentVariable(ApiKeyVariable, "secret");
 
         var provider = new AzureOpenAIChatClientProvider();
 
@@ -77,6 +95,7 @@ public sealed class AzureFoundryChatClientProviderTests
     public void IsAvailable_WhenDeploymentMissing_ReturnsFalse()
     {
         Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(ApiKeyVariable, "secret");
 
         var provider = new AzureOpenAIChatClientProvider();
 
@@ -119,7 +138,7 @@ public sealed class AzureFoundryChatClientProviderTests
         var provider = new AzureOpenAIChatClientProvider();
 
         // The selection logic must resolve to the API-key path when a key is present...
-        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret"));
+        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret", null));
 
         // ...and the client must be constructed without throwing.
         IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
@@ -128,15 +147,16 @@ public sealed class AzureFoundryChatClientProviderTests
     }
 
     [TestMethod]
-    public async Task CreateChatClientAsync_WithoutApiKey_UsesEntraPathAndReturnsClient()
+    public async Task CreateChatClientAsync_WithCredentialAndNoApiKey_UsesCredentialPathAndReturnsClient()
     {
         Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
         Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
 
-        var provider = new AzureOpenAIChatClientProvider();
+        TokenCredential credential = Mock.Of<TokenCredential>();
+        var provider = new AzureOpenAIChatClientProvider(credential);
 
-        // No AZURE_OPENAI_API_KEY is set, so the provider must fall back to DefaultAzureCredential.
-        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null));
+        // No AZURE_OPENAI_API_KEY is set, so the provider must use the injected credential.
+        Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.TokenCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null, credential));
 
         // Credential resolution is lazy, so client construction must not throw even without a live identity.
         IChatClient client = await provider.CreateChatClientAsync(CancellationToken.None);
@@ -145,16 +165,47 @@ public sealed class AzureFoundryChatClientProviderTests
     }
 
     [TestMethod]
+    public async Task CreateChatClientAsync_WithoutApiKeyOrCredential_Throws()
+    {
+        Environment.SetEnvironmentVariable(EndpointVariable, "https://contoso.openai.azure.com");
+        Environment.SetEnvironmentVariable(DeploymentVariable, "gpt-4o");
+
+        var provider = new AzureOpenAIChatClientProvider();
+
+        // Neither an API key nor a credential is available, so the provider cannot authenticate.
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => provider.CreateChatClientAsync(CancellationToken.None));
+
+        Assert.Contains(ApiKeyVariable, exception.Message);
+    }
+
+    [TestMethod]
+    public void Constructor_WithNullCredential_Throws()
+        => Assert.ThrowsExactly<ArgumentNullException>(() => new AzureOpenAIChatClientProvider(null!));
+
+    [TestMethod]
     public void GetAuthenticationMode_WithApiKey_ReturnsApiKey()
-        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret"));
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret", null));
 
     [TestMethod]
-    public void GetAuthenticationMode_WithoutApiKey_ReturnsDefaultAzureCredential()
-        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null));
+    public void GetAuthenticationMode_WithApiKeyAndCredential_ReturnsApiKey()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.ApiKey, AzureOpenAIChatClientProvider.GetAuthenticationMode("secret", Mock.Of<TokenCredential>()));
 
     [TestMethod]
-    public void GetAuthenticationMode_WithEmptyApiKey_ReturnsDefaultAzureCredential()
-        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.DefaultAzureCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(string.Empty));
+    public void GetAuthenticationMode_WithCredentialAndNoApiKey_ReturnsTokenCredential()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.TokenCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(null, Mock.Of<TokenCredential>()));
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithEmptyApiKeyAndCredential_ReturnsTokenCredential()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.TokenCredential, AzureOpenAIChatClientProvider.GetAuthenticationMode(string.Empty, Mock.Of<TokenCredential>()));
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithoutApiKeyOrCredential_ReturnsNone()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.None, AzureOpenAIChatClientProvider.GetAuthenticationMode(null, null));
+
+    [TestMethod]
+    public void GetAuthenticationMode_WithEmptyApiKeyAndNoCredential_ReturnsNone()
+        => Assert.AreEqual(AzureOpenAIChatClientProvider.AuthenticationMode.None, AzureOpenAIChatClientProvider.GetAuthenticationMode(string.Empty, null));
 
     [TestMethod]
     public async Task CreateChatClientAsync_WhenEndpointMissing_Throws()


### PR DESCRIPTION
Fixes #9712

## Summary

Implements the `TokenCredential`-injection option from #9712 so that `Microsoft.Testing.Extensions.AzureFoundry` no longer carries a hard dependency on `Azure.Identity` (and its heavyweight MSAL graph). API-key users pull **zero** managed-identity assemblies; Entra ID / managed identity remains fully supported but is now **opt-in** — the consumer references `Azure.Identity` themselves and passes a credential.

This reworks the authentication added in #9707. It is **not** a revert: the managed-identity capability is preserved, only the `Azure.Identity` reference and the `new DefaultAzureCredential()` call move out of the package and into the caller (the idiomatic Azure SDK pattern that `Azure.AI.OpenAI` itself follows).

## Changes

- **`OpenAIChatClientProvider.cs`** — removed the static `Lazy<DefaultAzureCredential>` and `using Azure.Identity`. Added an optional injected `TokenCredential` (new constructor overload), an `AuthenticationMode` of `None`/`ApiKey`/`TokenCredential`, and `GetAuthenticationMode(apiKey, credential)`. `IsAvailable` now also requires an API key **or** an injected credential; when neither is present `CreateChatClientAsync` throws a clear `InvalidOperationException`.
- **`TestApplicationBuilderExtensions.cs`** — new `AddAzureOpenAIChatClientProvider(this ITestApplicationBuilder, TokenCredential)` overload (the parameterless API-key/auto-registered overload is kept).
- **`.csproj` + `Directory.Packages.props`** — dropped `Azure.Identity`; added `Azure.Core` (1.44.1, already the transitive floor from `Azure.AI.OpenAI`) since `TokenCredential` now appears in the public API.
- **PublicAPI / InternalAPI** — declared the new overload and reconciled the internal-API tracking files.
- **Resources** — added the `NoAuthenticationConfigured` string.
- **`PACKAGE.md`** — documented the opt-in Entra ID model.
- **Unit tests** — updated/added coverage for API-key, injected-credential, no-auth-throws, precedence, and null-credential cases.

## Behavioral change (needs sign-off)

This drops #9707's **zero-config** `DefaultAzureCredential` fallback: Entra users now reference `Azure.Identity` and pass a credential explicitly. This is exactly the dependency-footprint tradeoff #9712 asks to weigh before GA, surfaced here as a concrete diff for the team to review.

```csharp
// API-key users: no Azure.Identity dependency at all
builder.AddAzureOpenAIChatClientProvider();

// Managed-identity users: reference Azure.Identity and pass the credential
builder.AddAzureOpenAIChatClientProvider(new DefaultAzureCredential());
```

## Verification

- AzureFoundry project builds clean (0 warnings / 0 errors) and unit tests pass (20/20) — verified prior to a local-worktree file-loss incident; the committed content is byte-identical to the verified changes.

## Notes

- **xlf not modified:** the package is `IsShipping=false`, and Arcade's `Localization.targets` only wires XliffTasks for shipping assemblies, so `UpdateXlf` is unavailable and CI does not validate xlf for this project. Per the repo rule against hand-editing xlf, the `.xlf` files are left untouched; the loc pipeline will regenerate them when the package flips to shipping.
- Also worth confirming at GA (per #9712): whether the pinned Azure SDK versions are still current/supported.