### PR TITLE
Align CTRF report writer overwrite behavior and add public IArtifactNamingService

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileWriter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.FileWriter.cs
@@ -7,72 +7,19 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 
 internal sealed partial class CtrfReportEngine
 {
-    private async Task<(string FileName, string? Warning)> WriteWithRetryAsync(string finalPath, byte[] bytes, bool fileNameExplicitlyProvided)
+    private async Task<(string FileName, string? Warning)> WriteAsync(string finalPath, byte[] bytes)
     {
-        // Explicit file names: use FileMode.Create (overwrite). Default-generated file
-        // names: use FileMode.CreateNew but retry with disambiguating suffixes when the
-        // file already exists, so concurrent runs (or two runs within the same second
-        // sharing the result directory) don't fail with IOException.
-        if (fileNameExplicitlyProvided)
-        {
-            bool willOverwrite = _fileSystem.ExistFile(finalPath);
-            await WriteBytesAsync(finalPath, FileMode.Create, bytes).ConfigureAwait(false);
-            return (
-                finalPath,
-                willOverwrite
-                    ? string.Format(CultureInfo.InvariantCulture, ExtensionResources.CtrfReportFileExistsAndWillBeOverwritten, finalPath)
-                    : null);
-        }
-
-        DateTimeOffset firstTry = _clock.UtcNow;
-        string directory = Path.GetDirectoryName(finalPath) ?? string.Empty;
-        string fileName = Path.GetFileName(finalPath);
-        SplitCtrfExtension(fileName, out string baseName, out string extension);
-        string candidate = finalPath;
-        int attempt = 0;
-
-        while (true)
-        {
-            _cancellationToken.ThrowIfCancellationRequested();
-
-            try
-            {
-                await WriteBytesAsync(candidate, FileMode.CreateNew, bytes).ConfigureAwait(false);
-                return (candidate, null);
-            }
-            catch (IOException) when (_fileSystem.ExistFile(candidate))
-            {
-                // The IOException was caused by the file already existing. Try a
-                // suffixed name. Any other IOException (disk full, permission, path
-                // too long, etc.) is not caught here and will propagate to the caller.
-                // Bound by both wall-clock (5s) and attempt count (1000) so we never
-                // spin forever in pathological cases like a clock that doesn't advance.
-                if (_clock.UtcNow - firstTry > TimeSpan.FromSeconds(5) || attempt >= 1_000)
-                {
-                    throw;
-                }
-
-                attempt++;
-                candidate = Path.Combine(directory, $"{baseName}_{attempt}{extension}");
-            }
-        }
-    }
-
-    // Split a file name into base + extension while preserving the CTRF
-    // double-extension convention (`*.ctrf.json`). The disambiguation suffix
-    // must land before `.ctrf.json` so that downstream CTRF readers continue to
-    // recognize the file by its conventional extension.
-    private static void SplitCtrfExtension(string fileName, out string baseName, out string extension)
-    {
-        const string ctrfJsonSuffix = ".ctrf.json";
-        if (fileName.EndsWith(ctrfJsonSuffix, StringComparison.OrdinalIgnoreCase) && fileName.Length > ctrfJsonSuffix.Length)
-        {
-            baseName = fileName.Substring(0, fileName.Length - ctrfJsonSuffix.Length);
-            extension = fileName.Substring(fileName.Length - ctrfJsonSuffix.Length);
-            return;
-        }
-
-        baseName = Path.GetFileNameWithoutExtension(fileName);
-        extension = Path.GetExtension(fileName);
+        // Always overwrite (FileMode.Create), regardless of whether the file name was explicitly
+        // provided or generated from the default
+        // <user>_<machine>_<asm>_<tfm>_<timestamp>.ctrf.json shape. Emit a warning when overwriting
+        // so users have a single, predictable rule to reason about — matching the TRX, HTML and
+        // JUnit report extensions.
+        bool willOverwrite = _fileSystem.ExistFile(finalPath);
+        await WriteBytesAsync(finalPath, FileMode.Create, bytes).ConfigureAwait(false);
+        return (
+            finalPath,
+            willOverwrite
+                ? string.Format(CultureInfo.InvariantCulture, ExtensionResources.CtrfReportFileExistsAndWillBeOverwritten, finalPath)
+                : null);
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.cs
@@ -19,12 +19,12 @@ internal sealed partial class CtrfReportEngine : ReportEngineBase
 
     private async Task<(string FileName, string? Warning)> GenerateReportCoreAsync(CapturedTestResult[] results, DateTimeOffset finishTime)
     {
-        (string finalPath, bool fileNameExplicitlyProvided) = ResolveOutputPath(
+        (string finalPath, _) = ResolveOutputPath(
             CtrfReportGeneratorCommandLine.CtrfReportFileNameOptionName,
             () => BuildDefaultFileName(finishTime));
 
         byte[] bytes = BuildCtrfJson(results, finishTime);
 
-        return await WriteWithRetryAsync(finalPath, bytes, fileNameExplicitlyProvided).ConfigureAwait(false);
+        return await WriteAsync(finalPath, bytes).ConfigureAwait(false);
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
@@ -64,7 +64,7 @@ internal sealed partial class TestHostBuilder
         serviceProvider.TryAddService(_testApplicationModuleInfo);
         serviceProvider.TryAddService(testHostControllerInfo);
         serviceProvider.TryAddService(systemClock);
-
+        serviceProvider.TryAddService(new ArtifactNamingService(_testApplicationModuleInfo, systemEnvironment, systemClock));
         SystemMonitor systemMonitor = new();
         serviceProvider.TryAddService(systemMonitor);
         SystemMonitorAsyncFactory systemMonitorAsyncFactory = new();

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer
+Microsoft.Testing.Platform.Services.ArtifactNamingService
+Microsoft.Testing.Platform.Services.ArtifactNamingService.ArtifactNamingService(Microsoft.Testing.Platform.Services.ITestApplicationModuleInfo! testApplicationModuleInfo, Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Helpers.IClock! clock) -> void
+Microsoft.Testing.Platform.Services.ArtifactNamingService.ResolveFileName(string! template) -> string!
+static Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(string! fileName) -> string!

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Microsoft.Testing.Platform.Services.IArtifactNamingService
+Microsoft.Testing.Platform.Services.IArtifactNamingService.ResolveFileName(string! template) -> string!
+static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetArtifactNamingService(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Services.IArtifactNamingService!

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.Services;
+
+// Mirrors the extension-side Microsoft.Testing.Extensions.ReportFileNameSanitizer (linked source in
+// src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs). The extension copy has SHIPPED
+// InternalAPI entries in five extensions, so it cannot be moved without churn/risk. This core-internal
+// copy exists pending future consolidation of the two.
+internal static partial class ArtifactFileNameSanitizer
+{
+    private const char ReplacementChar = '_';
+    private static readonly Regex ReservedFileNamesRegex = BuildReservedFileNameRegex();
+
+    internal static string ReplaceInvalidFileNameChars(string fileName)
+    {
+        char[] result = new char[fileName.Length];
+
+        for (int i = 0; i < fileName.Length; ++i)
+        {
+            result[i] = IsInvalidFileNameChar(fileName[i]) ? ReplacementChar : fileName[i];
+        }
+
+        string replaced = new string(result).TrimEnd();
+        ArgumentGuard.Ensure(replaced.Length > 0, nameof(fileName), $"File name {fileName} is empty after sanitizing invalid characters.");
+
+        if (IsReservedFileName(replaced))
+        {
+            replaced = ReplacementChar + replaced; // Cannot add to the end because it can have extensions.
+        }
+
+        return replaced;
+    }
+
+    private static bool IsInvalidFileNameChar(char c)
+        => c is < ' ' or '"' or '<' or '>' or '|' or ':' or '*' or '?' or '\\' or '/' or '@' or '(' or ')' or '^' or ' ';
+
+    private static bool IsReservedFileName(string fileName) =>
+        // CreateFile:
+        // The following reserved device names cannot be used as the name of a file:
+        // CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+        // LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
+        // Also avoid these names followed by an extension, for example, NUL.tx7.
+        // Windows NT: CLOCK$ is also a reserved device name.
+        ReservedFileNamesRegex.IsMatch(fileName);
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$", RegexOptions.None, "en-150")]
+    private static partial Regex BuildReservedFileNameRegex();
+#else
+    private static Regex BuildReservedFileNameRegex() => new(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$");
+#endif
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.Services;
+
+internal sealed class ArtifactNamingService : IArtifactNamingService
+{
+    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    private readonly IEnvironment _environment;
+    private readonly IClock _clock;
+
+    public ArtifactNamingService(ITestApplicationModuleInfo testApplicationModuleInfo, IEnvironment environment, IClock clock)
+    {
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _environment = environment;
+        _clock = clock;
+    }
+
+    public string ResolveFileName(string template)
+    {
+        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
+        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Dictionary<string, string> replacements = ArtifactNamingHelper.GetStandardReplacements(processName, processId, _clock.UtcNow);
+        string resolved = ArtifactNamingHelper.ResolveTemplate(template, replacements);
+
+        string directoryPart = Path.GetDirectoryName(resolved) ?? string.Empty;
+        string sanitized = ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(Path.GetFileName(resolved));
+
+        return directoryPart.Length == 0 ? sanitized : Path.Combine(directoryPart, sanitized);
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/IArtifactNamingService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IArtifactNamingService.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Services;
+
+/// <summary>
+/// Provides file-name templating for artifacts produced by the test platform and its extensions.
+/// </summary>
+/// <remarks>
+/// The service expands the standard placeholders and sanitizes the resulting leaf file name so it is
+/// valid on the current operating system. It is registered as a common service and can be resolved
+/// through <see cref="ServiceProviderExtensions.GetArtifactNamingService(System.IServiceProvider)"/>.
+/// </remarks>
+public interface IArtifactNamingService
+{
+    /// <summary>
+    /// Resolves a file-name template into a concrete file name.
+    /// </summary>
+    /// <param name="template">
+    /// The template to resolve. The following placeholders are expanded:
+    /// <list type="bullet">
+    /// <item><description><c>{pname}</c> — the current test application process name.</description></item>
+    /// <item><description><c>{pid}</c> — the current process id.</description></item>
+    /// <item><description><c>{asm}</c> — the entry assembly name.</description></item>
+    /// <item><description><c>{tfm}</c> — the short target framework moniker (including platform).</description></item>
+    /// <item><description><c>{arch}</c> — the process architecture.</description></item>
+    /// <item><description><c>{time}</c> — the current UTC timestamp.</description></item>
+    /// </list>
+    /// Unknown placeholders are preserved as-is. Any directory portion of the template is preserved
+    /// while only the leaf file name is sanitized.
+    /// </param>
+    /// <returns>The resolved file name, with the leaf sanitized to be valid for the current file system.</returns>
+    string ResolveFileName(string template);
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -72,6 +72,14 @@ public static class ServiceProviderExtensions
         => serviceProvider.GetRequiredService<IConfiguration>();
 
     /// <summary>
+    /// Gets the artifact naming service from the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The artifact naming service.</returns>
+    public static IArtifactNamingService GetArtifactNamingService(this IServiceProvider serviceProvider)
+        => serviceProvider.GetRequiredService<IArtifactNamingService>();
+
+    /// <summary>
     /// Gets the command line options from the <see cref="IServiceProvider"/>.
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -393,7 +393,7 @@ public class CtrfReportEngineTests
     {
         string? pathSeen = null;
         _ = _fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);
-        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.CreateNew))
+        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.Create))
             .Returns<string, FileMode>((path, _) =>
             {
                 pathSeen = path;
@@ -485,20 +485,19 @@ public class CtrfReportEngineTests
     }
 
     [TestMethod]
-    public async Task GenerateReportAsync_AppendsDisambiguatingSuffix_When_DefaultFileExists()
+    public async Task GenerateReportAsync_OverwritesAndWarns_When_DefaultFileExists()
     {
-        var bytesSeen = new List<string>();
-        int callCount = 0;
-        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.CreateNew))
+        // Default-name path uses the same overwrite-and-warn semantics as the explicit-name
+        // path: a single, predictable rule. When the file already exists, the engine
+        // overwrites it (FileMode.Create) and surfaces the CtrfReportFileExistsAndWillBeOverwritten
+        // warning.
+        string? pathSeen = null;
+        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.Create))
             .Returns<string, FileMode>((path, _) =>
             {
-                callCount++;
-                bytesSeen.Add(path);
-                return callCount == 1
-                    ? throw new IOException("file exists")
-                    : new MemoryFileStream();
+                pathSeen = path;
+                return new MemoryFileStream();
             });
-
         _ = _fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(true);
 
         _ = _configurationMock.SetupGet(_ => _[It.IsAny<string>()]).Returns(string.Empty);
@@ -522,18 +521,22 @@ public class CtrfReportEngineTests
             0,
             CancellationToken.None));
 
-        (string finalPath, _) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
+        (string finalPath, string? warning) = await engine.GenerateReportAsync([Captured("a", "A", "passed")]);
 
-        Assert.AreEqual(2, callCount);
-        Assert.AreEqual(bytesSeen[1], finalPath);
-        Assert.Contains("_1.ctrf.json", finalPath);
+        Assert.AreEqual(pathSeen, finalPath);
+        Assert.DoesNotContain("_1.ctrf.json", finalPath);
+        Assert.IsNotNull(warning);
+        Assert.Contains(finalPath, warning!);
     }
 
     [TestMethod]
-    public async Task GenerateReportAsync_PropagatesIOException_When_FileDoesNotExist()
+    public async Task GenerateReportAsync_PropagatesIOException_When_WriteFails()
     {
+        // An IOException during the write (e.g. disk full, permission denied, path too
+        // long) must propagate to the caller — there is no longer any disambiguation
+        // loop that could mask such failures behind a retry budget.
         int callCount = 0;
-        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.CreateNew))
+        _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.Create))
             .Returns<string, FileMode>((path, _) =>
             {
                 callCount++;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ArtifactNamingServiceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ArtifactNamingServiceTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests.Services;
+
+[TestClass]
+public sealed class ArtifactNamingServiceTests
+{
+    private readonly Mock<ITestApplicationModuleInfo> _moduleInfoMock = new();
+    private readonly Mock<IEnvironment> _environmentMock = new();
+    private readonly Mock<IClock> _clockMock = new();
+
+    private ArtifactNamingService CreateService(string modulePath = "MyApp.dll", int processId = 4242)
+    {
+        _ = _moduleInfoMock.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns(modulePath);
+        _ = _environmentMock.SetupGet(x => x.ProcessId).Returns(processId);
+        _ = _clockMock.SetupGet(x => x.UtcNow).Returns(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero));
+        return new ArtifactNamingService(_moduleInfoMock.Object, _environmentMock.Object, _clockMock.Object);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_ExpandsStandardPlaceholders()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "MyApp.dll"), processId: 4242);
+
+        string result = service.ResolveFileName("{pname}_{pid}_{time}.json");
+
+        Assert.StartsWith("MyApp_4242_", result);
+        Assert.Contains("2026-01-02_03-04-05", result);
+        Assert.EndsWith(".json", result);
+        Assert.DoesNotContain("{pname}", result);
+        Assert.DoesNotContain("{pid}", result);
+        Assert.DoesNotContain("{time}", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_SanitizesInvalidCharactersInExpandedName()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "My*App.dll"));
+
+        string result = service.ResolveFileName("{pname}.json");
+
+        Assert.AreEqual("My_App.json", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_PreservesDirectoryPortionAndSanitizesLeaf()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "My*App.dll"));
+
+        string template = Path.Combine("sub", "dir", "{pname}.json");
+        string result = service.ResolveFileName(template);
+
+        Assert.AreEqual(Path.Combine("sub", "dir", "My_App.json"), result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_LeavesUnknownPlaceholderAsIs()
+    {
+        ArtifactNamingService service = CreateService();
+
+        string result = service.ResolveFileName("{unknown}_{pname}.json");
+
+        Assert.Contains("{unknown}", result);
+        Assert.Contains("MyApp", result);
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes to MTP report file naming.

### 1. Align CTRF report writer to overwrite + warn (matches TRX/HTML/JUnit)

`CtrfReportEngine` was the only report extension that, for a **default-generated** file name, used `FileMode.CreateNew` plus a `_1`/`_2` disambiguating-suffix retry loop instead of overwriting. This change aligns it with the shared rule already used by the TRX, HTML and JUnit report extensions: **always overwrite (`FileMode.Create`) and emit a warning when the file already existed**, giving users a single, predictable rule.

- `CtrfReportEngine.FileWriter.cs`: replaced `WriteWithRetryAsync` (and the `SplitCtrfExtension` helper) with a small `WriteAsync` that mirrors `HtmlReportEngine`.
- `CtrfReportEngine.cs`: `GenerateReportCoreAsync` now calls `WriteAsync` and no longer threads the `fileNameExplicitlyProvided` flag.
- `CtrfReportEngineTests.cs`: default-name test now expects `FileMode.Create`; `GenerateReportAsync_AppendsDisambiguatingSuffix_When_DefaultFileExists` was replaced by `GenerateReportAsync_OverwritesAndWarns_When_DefaultFileExists`, and the IOException test was renamed to `..._When_WriteFails` — both mirroring the `HtmlReportEngineTests` equivalents. (27/27 passing.)

The `CtrfReportFileExistsAndWillBeOverwritten` resource already existed, so no resx/xlf changes were needed.

### 2. New public, injectable `IArtifactNamingService` in MTP core

Exposes file-name templating as a public, injectable core service so it can be consumed outside the existing linked-source (`[Embedded]` helper) pattern.

- `IArtifactNamingService` (public) — single member `ResolveFileName(string template)`; expands the standard placeholders (`{pname}`, `{pid}`, `{asm}`, `{tfm}`, `{arch}`, `{time}`) and sanitizes the leaf file name while preserving any directory portion.
- `ArtifactNamingService` (internal) — wraps the existing `ArtifactNamingHelper` templating with process/name/time resolution from `ITestApplicationModuleInfo`/`IEnvironment`/`IClock`.
- `ArtifactFileNameSanitizer` (internal) — a core-internal copy of the invalid-char/reserved-name sanitization from the extension-side `ReportFileNameSanitizer` (which has shipped InternalAPI entries and is intentionally left in place; the two are marked for future consolidation).
- Registered as a common service in `TestHostBuilder.CommonServices.cs` and resolvable via a new public `ServiceProviderExtensions.GetArtifactNamingService(...)` accessor.
- Public/internal API tracking files updated; new `ArtifactNamingServiceTests` (4/4 passing) cover placeholder expansion, sanitization, directory preservation, and unknown-placeholder passthrough.

## Verification

Built `Microsoft.Testing.Platform.UnitTests` and `Microsoft.Testing.Extensions.UnitTests` and ran the targeted filters:
- `ArtifactNamingService` — 4/4 passing
- `CtrfReportEngineTests` — 27/27 passing

## ⚠️ Heads-up: pre-existing, unrelated baseline break

There is a pre-existing repo-wide build break introduced by #9774 that is **not** addressed here and needs a separate fix: `IPC/Serializers/BaseSerializer.cs` gained two `protected static` methods (`ReadFields`, `WriteListPayload`) but no matching `InternalAPI.Unshipped.txt` entries were added, so analyzer **RS0051** fails as an error in every project that links that source (Microsoft.Testing.Platform and the HangDump / MSBuild / Retry / TrxReport extensions). A transient local workaround was applied only to verify this PR and then reverted, so it is intentionally not part of this change.