### PR TITLE
Add public injectable IArtifactNamingService to Microsoft.Testing.Platform

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/TestHostBuilder.CommonServices.cs
@@ -64,6 +64,7 @@ internal sealed partial class TestHostBuilder
         serviceProvider.TryAddService(_testApplicationModuleInfo);
         serviceProvider.TryAddService(testHostControllerInfo);
         serviceProvider.TryAddService(systemClock);
+        serviceProvider.TryAddService(new ArtifactNamingService(_testApplicationModuleInfo, systemEnvironment, systemClock));
 
         SystemMonitor systemMonitor = new();
         serviceProvider.TryAddService(systemMonitor);

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -4,6 +4,10 @@ Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.init -> void
+Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer
+Microsoft.Testing.Platform.Services.ArtifactNamingService
+Microsoft.Testing.Platform.Services.ArtifactNamingService.ArtifactNamingService(Microsoft.Testing.Platform.Services.ITestApplicationModuleInfo! testApplicationModuleInfo, Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Helpers.IClock! clock) -> void
+Microsoft.Testing.Platform.Services.ArtifactNamingService.ResolveFileName(string! template) -> string!
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.<Clone>$() -> Microsoft.Testing.Platform.Services.ClientCapabilitiesService!
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool IsStateful) -> void
@@ -18,11 +22,12 @@ Microsoft.Testing.Platform.Services.ClientInfoService.Deconstruct(out string! Id
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.GetHashCode() -> int
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ToString() -> string!
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void
+static Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(string! fileName) -> string!
 static Microsoft.Testing.Platform.Services.ClientCapabilitiesService.operator !=(Microsoft.Testing.Platform.Services.ClientCapabilitiesService? left, Microsoft.Testing.Platform.Services.ClientCapabilitiesService? right) -> bool
 static Microsoft.Testing.Platform.Services.ClientCapabilitiesService.operator ==(Microsoft.Testing.Platform.Services.ClientCapabilitiesService? left, Microsoft.Testing.Platform.Services.ClientCapabilitiesService? right) -> bool
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider) -> void
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientInfoService.ClientInfoService(string! Id, string! Version) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientInfoService.Deconstruct(out string! Id, out string! Version) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -2,3 +2,6 @@
 [TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities
 [TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool
 [TPEXP]Microsoft.Testing.Platform.Services.IClientInfo.Capabilities.get -> Microsoft.Testing.Platform.Services.IClientCapabilities!
+Microsoft.Testing.Platform.Services.IArtifactNamingService
+Microsoft.Testing.Platform.Services.IArtifactNamingService.ResolveFileName(string! template) -> string!
+static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetArtifactNamingService(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Services.IArtifactNamingService!

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.Services;
+
+// Mirrors the extension-side Microsoft.Testing.Extensions.ReportFileNameSanitizer (linked source in
+// src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs). The extension copy has SHIPPED
+// InternalAPI entries in five extensions, so it cannot be moved without churn/risk. This core-internal
+// copy exists pending future consolidation of the two.
+internal static partial class ArtifactFileNameSanitizer
+{
+    private const char ReplacementChar = '_';
+    private static readonly Regex ReservedFileNamesRegex = BuildReservedFileNameRegex();
+
+    internal static string ReplaceInvalidFileNameChars(string fileName)
+    {
+        char[] result = new char[fileName.Length];
+
+        for (int i = 0; i < fileName.Length; ++i)
+        {
+            result[i] = IsInvalidFileNameChar(fileName[i]) ? ReplacementChar : fileName[i];
+        }
+
+        string replaced = new string(result).TrimEnd();
+        ArgumentGuard.Ensure(replaced.Length > 0, nameof(fileName), $"File name {fileName} is empty after sanitizing invalid characters.");
+
+        if (IsReservedFileName(replaced))
+        {
+            replaced = ReplacementChar + replaced; // Cannot add to the end because it can have extensions.
+        }
+
+        return replaced;
+    }
+
+    private static bool IsInvalidFileNameChar(char c)
+        => c is < ' ' or '"' or '<' or '>' or '|' or ':' or '*' or '?' or '\\' or '/' or '@' or '(' or ')' or '^' or ' ';
+
+    private static bool IsReservedFileName(string fileName) =>
+        // CreateFile:
+        // The following reserved device names cannot be used as the name of a file:
+        // CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+        // LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
+        // Also avoid these names followed by an extension, for example, NUL.tx7.
+        // Windows NT: CLOCK$ is also a reserved device name.
+        ReservedFileNamesRegex.IsMatch(fileName);
+
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$", RegexOptions.None, "en-150")]
+    private static partial Regex BuildReservedFileNameRegex();
+#else
+    private static Regex BuildReservedFileNameRegex() => new(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$");
+#endif
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.Services;
+
+internal sealed class ArtifactNamingService : IArtifactNamingService
+{
+    private readonly ITestApplicationModuleInfo _testApplicationModuleInfo;
+    private readonly IEnvironment _environment;
+    private readonly IClock _clock;
+
+    public ArtifactNamingService(ITestApplicationModuleInfo testApplicationModuleInfo, IEnvironment environment, IClock clock)
+    {
+        _testApplicationModuleInfo = testApplicationModuleInfo;
+        _environment = environment;
+        _clock = clock;
+    }
+
+    public string ResolveFileName(string template)
+    {
+        string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
+        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        Dictionary<string, string> replacements = ArtifactNamingHelper.GetStandardReplacements(processName, processId, _clock.UtcNow);
+        string resolved = ArtifactNamingHelper.ResolveTemplate(template, replacements);
+
+        string directoryPart = Path.GetDirectoryName(resolved) ?? string.Empty;
+        string leafName = Path.GetFileName(resolved);
+        if (leafName.Length == 0)
+        {
+            throw new ArgumentException("The resolved template must produce a file name, not just a directory path.", nameof(template));
+        }
+
+        string sanitized = ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(leafName);
+
+        return directoryPart.Length == 0 ? sanitized : Path.Combine(directoryPart, sanitized);
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/IArtifactNamingService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IArtifactNamingService.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Services;
+
+/// <summary>
+/// Provides file-name templating for artifacts produced by the test platform and its extensions.
+/// </summary>
+/// <remarks>
+/// The service expands the standard placeholders and sanitizes the resulting leaf file name so it is
+/// valid on the current operating system. It is registered as a common service and can be resolved
+/// through <see cref="ServiceProviderExtensions.GetArtifactNamingService(System.IServiceProvider)"/>.
+/// </remarks>
+public interface IArtifactNamingService
+{
+    /// <summary>
+    /// Resolves a file-name template into a concrete file name.
+    /// </summary>
+    /// <param name="template">
+    /// The template to resolve. The following placeholders are expanded:
+    /// <list type="bullet">
+    /// <item><description><c>{pname}</c> — the current test application process name.</description></item>
+    /// <item><description><c>{pid}</c> — the current process id.</description></item>
+    /// <item><description><c>{asm}</c> — the entry assembly name (or <c>unknown</c> if not available).</description></item>
+    /// <item><description><c>{tfm}</c> — the short target framework moniker including platform (or <c>unknown</c> if not available).</description></item>
+    /// <item><description><c>{arch}</c> — the process architecture.</description></item>
+    /// <item><description><c>{time}</c> — the current UTC timestamp.</description></item>
+    /// </list>
+    /// Unknown placeholders are preserved as-is. Any directory portion of the template is preserved
+    /// while only the leaf file name is sanitized.
+    /// </param>
+    /// <returns>The resolved file name, with the leaf sanitized to be valid for the current file system.</returns>
+    string ResolveFileName(string template);
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -72,6 +72,14 @@ public static class ServiceProviderExtensions
         => serviceProvider.GetRequiredService<IConfiguration>();
 
     /// <summary>
+    /// Gets the artifact naming service from the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The artifact naming service.</returns>
+    public static IArtifactNamingService GetArtifactNamingService(this IServiceProvider serviceProvider)
+        => serviceProvider.GetRequiredService<IArtifactNamingService>();
+
+    /// <summary>
     /// Gets the command line options from the <see cref="IServiceProvider"/>.
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ArtifactNamingServiceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ArtifactNamingServiceTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests.Services;
+
+[TestClass]
+public sealed class ArtifactNamingServiceTests
+{
+    private readonly Mock<ITestApplicationModuleInfo> _moduleInfoMock = new();
+    private readonly Mock<IEnvironment> _environmentMock = new();
+    private readonly Mock<IClock> _clockMock = new();
+
+    private ArtifactNamingService CreateService(string modulePath = "MyApp.dll", int processId = 4242)
+    {
+        _ = _moduleInfoMock.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns(modulePath);
+        _ = _environmentMock.SetupGet(x => x.ProcessId).Returns(processId);
+        _ = _clockMock.SetupGet(x => x.UtcNow).Returns(new DateTimeOffset(2026, 1, 2, 3, 4, 5, TimeSpan.Zero));
+        return new ArtifactNamingService(_moduleInfoMock.Object, _environmentMock.Object, _clockMock.Object);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_ExpandsStandardPlaceholders()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "MyApp.dll"), processId: 4242);
+
+        string result = service.ResolveFileName("{pname}_{pid}_{time}.json");
+
+        Assert.StartsWith("MyApp_4242_", result);
+        Assert.Contains("2026-01-02_03-04-05", result);
+        Assert.EndsWith(".json", result);
+        Assert.DoesNotContain("{pname}", result);
+        Assert.DoesNotContain("{pid}", result);
+        Assert.DoesNotContain("{time}", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_SanitizesInvalidCharactersInExpandedName()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "My*App.dll"));
+
+        string result = service.ResolveFileName("{pname}.json");
+
+        Assert.AreEqual("My_App.json", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_PrefixesReservedDeviceName()
+    {
+        // A {pname} that resolves to a reserved Windows device name (CON/PRN/NUL/COM1/...)
+        // must be prefixed with '_' by the sanitizer so it is a valid file name.
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "CON.dll"));
+
+        string result = service.ResolveFileName("{pname}.json");
+
+        Assert.AreEqual("_CON.json", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_PreservesDirectoryPortionAndSanitizesLeaf()
+    {
+        ArtifactNamingService service = CreateService(modulePath: Path.Combine("dir", "My*App.dll"));
+
+        string template = Path.Combine("sub", "dir", "{pname}.json");
+        string result = service.ResolveFileName(template);
+
+        Assert.AreEqual(Path.Combine("sub", "dir", "My_App.json"), result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_LeavesUnknownPlaceholderAsIs()
+    {
+        ArtifactNamingService service = CreateService();
+
+        string result = service.ResolveFileName("{unknown}_{pname}.json");
+
+        Assert.Contains("{unknown}", result);
+        Assert.Contains("MyApp", result);
+    }
+
+    [TestMethod]
+    public void ResolveFileName_ThrowsWhenTemplateHasNoLeafFileName()
+    {
+        // A template that resolves to a directory path only (no leaf file name, e.g. ending in a
+        // directory separator) is rejected with a clear ArgumentException at the service boundary.
+        ArtifactNamingService service = CreateService();
+
+        string template = "outdir" + Path.DirectorySeparatorChar;
+
+        Assert.ThrowsExactly<ArgumentException>(() => service.ResolveFileName(template));
+    }
+}


### PR DESCRIPTION
## Summary

Exposes file-name templating as a public, injectable core service in Microsoft.Testing.Platform, so it can be consumed outside the existing linked-source (`[Embedded]` helper) pattern.

### Changes
- **`IArtifactNamingService`** (public) — single member `string ResolveFileName(string template)`. Expands the standard placeholders (`{pname}`, `{pid}`, `{asm}`, `{tfm}`, `{arch}`, `{time}`) and sanitizes the leaf file name while preserving any directory portion of the template.
- **`ArtifactNamingService`** (internal) — implementation that wraps the existing `ArtifactNamingHelper` templating with process name/id/timestamp resolved from `ITestApplicationModuleInfo`, `IEnvironment` and `IClock`.
- **`ArtifactFileNameSanitizer`** (internal) — a core-internal copy of the invalid-char / reserved-name (CON/PRN/AUX/NUL/COM1-9/LPT1-9/CLOCK$) sanitization from the extension-side `ReportFileNameSanitizer`. The extension copy has shipped InternalAPI entries and is intentionally left in place; a comment marks the two for future consolidation.
- Registered as a common service in `TestHostBuilder.CommonServices.cs` and resolvable via a new public `ServiceProviderExtensions.GetArtifactNamingService(this IServiceProvider)` accessor.
- Public/internal API tracking files updated.
- New `ArtifactNamingServiceTests` cover placeholder expansion, invalid-char sanitization, directory-portion preservation, and unknown-placeholder passthrough.

## Verification
Built `Microsoft.Testing.Platform.UnitTests` and ran `--filter "FullyQualifiedName~ArtifactNamingService"` — 4/4 passing.

## Note
This is one of two PRs split out from #9780 (the other, #9782, aligns the CTRF report writer overwrite behavior).

The pre-existing RS0051 InternalAPI baseline break from #9774 (`BaseSerializer.ReadFields`/`WriteListPayload` missing InternalAPI entries) that previously blocked the build has since been fixed on `main`; this branch was rebased onto that fix, so the two BaseSerializer entries now appear alongside the new service entries in `InternalAPI.Unshipped.txt`.
