### PR TITLE
test: MSTEST0029 — add edge case tests for virtual/override and make-private fixer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PublicMethodShouldBeTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PublicMethodShouldBeTestMethodAnalyzerTests.cs
@@ -244,13 +244,89 @@ public sealed class PublicMethodShouldBeTestMethodAnalyzerTests
             [TestClass]
             public class MyTestClass
             {
-                [TestInitialize]
+                [TestCleanup]
                 public void TestCleanup()
                 {
                 }
             }
             """;
         await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicVirtualMethodInTestClass_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public virtual void MyTestMethod()
+                {
+                }
+            }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenPublicOverrideMethodInTestClass_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Base
+            {
+                public virtual void MyTestMethod()
+                {
+                }
+            }
+
+            [TestClass]
+            public class MyTestClass : Base
+            {
+                public override void MyTestMethod()
+                {
+                }
+            }
+            """;
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodIsPublicAndNotMarkedAsTestMethod_ChangeToPrivateFix()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public void [|MyTestMethod|]()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            CodeActionIndex = 1,
+        }.RunAsync();
     }
 
     [TestMethod]


### PR DESCRIPTION
Fixes #9758.

Improves test coverage for `PublicMethodShouldBeTestMethodAnalyzer` (MSTEST0029) by closing gaps in the existing test suite.

## Changes

`test/UnitTests/MSTest.Analyzers.UnitTests/PublicMethodShouldBeTestMethodAnalyzerTests.cs`

- **Add** `WhenPublicVirtualMethodInTestClass_NoDiagnostic` — exercises the `IsVirtual` early-return path: a public virtual method in a `[TestClass]` that does not implement any interface should produce no diagnostic.
- **Add** `WhenPublicOverrideMethodInTestClass_NoDiagnostic` — exercises the `IsOverride` early-return path: a public override of a non-interface base-class method in a `[TestClass]` should produce no diagnostic.
- **Add** `WhenMethodIsPublicAndNotMarkedAsTestMethod_ChangeToPrivateFix` — exercises `CodeActionIndex = 1`, the "Change accessibility to private" code fix offered by `PublicMethodShouldBeTestMethodFixer`, which was previously untested.
- **Fix** `WhenMethodIsPublicAndMarkedAsTestCleanup_NoDiagnostic` — the test body used `[TestInitialize]` instead of `[TestCleanup]`, making it a duplicate of the `TestInitialize` test and leaving the `[TestCleanup]` suppression path untested.

## Test status

Pure test additions — no production code changed. All 19 `PublicMethodShouldBeTestMethodAnalyzerTests` pass:

```
Test run summary: Passed!
  total: 19, failed: 0, succeeded: 19, skipped: 0
```