### PR TITLE
Prefer Assert.IsEmpty over Assert.HasCount(0, collection)

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.HasCount.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.HasCount.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace MSTest.Analyzers;
+
+public sealed partial class UseProperAssertMethodsAnalyzer
+{
+    private static void AnalyzeHasCountInvocation(OperationAnalysisContext context, IOperation expectedArgument)
+    {
+        // We want to flag Assert.HasCount(0, collection) and suggest Assert.IsEmpty(collection).
+        var invocation = (IInvocationOperation)context.Operation;
+        IMethodSymbol targetMethod = invocation.TargetMethod;
+
+        // HasCount overloads are HasCount(int expected, TCollection collection, ...), so the
+        // collection is the second parameter (ordinal 1).
+        if (targetMethod.Parameters.Length < 2)
+        {
+            return;
+        }
+
+        // Assert.IsEmpty only has IEnumerable-based overloads. The Span/ReadOnlySpan/Memory/ReadOnlyMemory
+        // HasCount overloads have no IsEmpty equivalent, so we must not suggest a fix that would not compile.
+        if (IsSpanOrMemoryType(targetMethod.Parameters[1].Type))
+        {
+            return;
+        }
+
+        // Only suggest IsEmpty when the expected count is the constant 0.
+        if (!expectedArgument.ConstantValue.HasValue ||
+            expectedArgument.ConstantValue.Value is not int expectedCount ||
+            expectedCount != 0)
+        {
+            return;
+        }
+
+        // Assert.HasCount(0, collection) -> Assert.IsEmpty(collection).
+        // The codefix removes the expected (0) argument and renames HasCount to IsEmpty.
+        ImmutableDictionary<string, string?>.Builder properties = ImmutableDictionary.CreateBuilder<string, string?>();
+        properties.Add(ProperAssertMethodNameKey, "IsEmpty");
+        properties.Add(CodeFixModeKey, CodeFixModeRemoveArgument);
+        context.ReportDiagnostic(context.Operation.CreateDiagnostic(
+            Rule,
+            additionalLocations: ImmutableArray.Create(expectedArgument.Syntax.GetLocation()),
+            properties: properties.ToImmutable(),
+            "IsEmpty",
+            "HasCount"));
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
@@ -114,6 +114,11 @@ namespace MSTest.Analyzers;
 /// <code>Assert.IsFalse(myEnumerable.Contains(item, comparer))</code>
 /// </description>
 /// </item>
+/// <item>
+/// <description>
+/// <code>Assert.HasCount(0, myCollection)</code>
+/// </description>
+/// </item>
 /// </list>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
@@ -297,6 +302,10 @@ public sealed partial class UseProperAssertMethodsAnalyzer : DiagnosticAnalyzer
 
             case "AreNotEqual":
                 AnalyzeAreEqualOrAreNotEqualInvocation(context, firstArgument, isAreEqualInvocation: false, assertTypeSymbol, objectTypeSymbol, enumerableTypeSymbol);
+                break;
+
+            case "HasCount":
+                AnalyzeHasCountInvocation(context, firstArgument);
                 break;
         }
     }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseProperAssertMethodsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseProperAssertMethodsAnalyzerTests.cs
@@ -2285,6 +2285,154 @@ public sealed class UseProperAssertMethodsAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenAssertHasCountZero_IsEmpty()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var list = new List<int>();
+                    {|#0:Assert.HasCount(0, list)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var list = new List<int>();
+                    Assert.IsEmpty(list);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            // /0/Test0.cs(11,9): info MSTEST0037: Use 'Assert.IsEmpty' instead of 'Assert.HasCount'
+            VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("IsEmpty", "HasCount"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertHasCountZeroWithMessage_IsEmpty()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var list = new List<int>();
+                    {|#0:Assert.HasCount(0, list, "Collection should be empty")|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var list = new List<int>();
+                    Assert.IsEmpty(list, "Collection should be empty");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            // /0/Test0.cs(11,9): info MSTEST0037: Use 'Assert.IsEmpty' instead of 'Assert.HasCount'
+            VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("IsEmpty", "HasCount"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertHasCountZeroWithNonGenericEnumerable_IsEmpty()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var hashtable = new Hashtable();
+                    {|#0:Assert.HasCount(0, hashtable)|};
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var hashtable = new Hashtable();
+                    Assert.IsEmpty(hashtable);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            // /0/Test0.cs(11,9): info MSTEST0037: Use 'Assert.IsEmpty' instead of 'Assert.HasCount'
+            VerifyCS.DiagnosticIgnoringAdditionalLocations().WithLocation(0).WithArguments("IsEmpty", "HasCount"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertHasCountNonZero_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+            using System.Collections.Generic;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    var list = new List<int> { 1, 2, 3 };
+                    Assert.HasCount(3, list);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenAssertAreEqualWithCollectionCountUsingCustomCollection()
     {
         string code = """
@@ -4973,6 +5121,30 @@ public sealed class UseProperAssertMethodsAnalyzerTests
                     int? nullableCount = 3;
                     Assert.AreEqual(longCount, span.Length);
                     Assert.AreEqual(nullableCount, span.Length);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertHasCountZeroWithSpan_NoDiagnostic()
+    {
+        // Span/Memory have no IsEmpty overload, so Assert.HasCount(0, span) must NOT be rewritten
+        // to Assert.IsEmpty(span).
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Span<int> span = new int[] { 1, 2, 3 };
+                    Assert.HasCount(0, span);
                 }
             }
             """;


### PR DESCRIPTION
Fixes #9788

## What

Extends the `MSTEST0037` ("Use proper 'Assert' methods") analyzer to recognize `Assert.HasCount(0, collection)` and suggest the more expressive `Assert.IsEmpty(collection)`, with an accompanying code fix.

```csharp
// Before
Assert.HasCount(0, list);
Assert.HasCount(0, list, "should be empty");

// After (code fix)
Assert.IsEmpty(list);
Assert.IsEmpty(list, "should be empty");
```

## How

- New `AnalyzeHasCountInvocation` handler (in `UseProperAssertMethodsAnalyzer.HasCount.cs`) hooked into the `HasCount` case of the invocation switch.
- Only fires when the expected count is the constant `0`.
- Reuses the existing `CodeFixModeRemoveArgument` fixer mode (remove the `0` argument, rename `HasCount` → `IsEmpty`), so any trailing message argument is preserved.
- **Span/Memory `HasCount` overloads are intentionally skipped**, because `Assert.IsEmpty` has no `Span`/`ReadOnlySpan`/`Memory`/`ReadOnlyMemory` overload — suggesting `IsEmpty` there would not compile.

## Tests

Added coverage to `UseProperAssertMethodsAnalyzerTests`:
- `HasCount(0, list)` → `IsEmpty(list)`
- `HasCount(0, list, "msg")` → `IsEmpty(list, "msg")`
- `HasCount(0, hashtable)` (non-generic `IEnumerable`) → `IsEmpty(hashtable)`
- `HasCount(3, list)` — no diagnostic
- `HasCount(0, span)` — no diagnostic (no matching `IsEmpty` overload)

All 131 `UseProperAssertMethodsAnalyzerTests` pass.