### PR TITLE
Bump .NET SDK to 11.0.100-preview.7.26359.110

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.5.26302.115",
+    "dotnet": "11.0.100-preview.7.26359.110",
     "runtimes": {
       "dotnet": [
         "8.0.28",
@@ -24,7 +24,7 @@
     }
   },
   "sdk": {
-    "version": "11.0.100-preview.5.26302.115",
+    "version": "11.0.100-preview.7.26359.110",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
Bumps the .NET SDK used by the repo to the latest nightly preview from the `11.0.1xx` daily channel.

- `global.json`: `tools.dotnet` and `sdk.version` updated from `11.0.100-preview.5.26302.115` → `11.0.100-preview.7.26359.110`.

Verified locally: the nightly SDK installs via `restore.cmd`, restore completes with 0 warnings / 0 errors, and `dotnet --version` reports the new build.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>