### PR TITLE
Normalize array initialization in DotnetTest IPC serializers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/CommandLineOptionMessagesSerializer.cs
@@ -43,7 +43,7 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
     protected override CommandLineOptionMessages DeserializeCore(Stream stream)
     {
         string? moduleName = null;
-        CommandLineOptionMessage[]? commandLineOptionMessages = null;
+        CommandLineOptionMessage[]? commandLineOptionMessages = [];
 
         ReadFields(stream, (fieldId, fieldSize) =>
         {
@@ -62,7 +62,7 @@ internal sealed class CommandLineOptionMessagesSerializer : NamedPipeSerializer<
             }
         });
 
-        return new(moduleName, commandLineOptionMessages ?? []);
+        return new(moduleName, commandLineOptionMessages);
     }
 
     private static CommandLineOptionMessage[] ReadCommandLineOptionMessagesPayload(Stream stream)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -56,7 +56,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     {
         string? executionId = null;
         string? instanceId = null;
-        FileArtifactMessage[]? fileArtifactMessages = null;
+        FileArtifactMessage[]? fileArtifactMessages = [];
 
         ReadFields(stream, (fieldId, fieldSize) =>
         {
@@ -79,7 +79,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
             }
         });
 
-        return new(executionId, instanceId, fileArtifactMessages ?? []);
+        return new(executionId, instanceId, fileArtifactMessages);
     }
 
     private static FileArtifactMessage[] ReadFileArtifactMessagesPayload(Stream stream)

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -111,8 +111,8 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
     {
         string? executionId = null;
         string? instanceId = null;
-        SuccessfulTestResultMessage[]? successfulTestResultMessages = null;
-        FailedTestResultMessage[]? failedTestResultMessages = null;
+        SuccessfulTestResultMessage[]? successfulTestResultMessages = [];
+        FailedTestResultMessage[]? failedTestResultMessages = [];
 
         ReadFields(stream, (fieldId, fieldSize) =>
         {
@@ -142,8 +142,8 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
         return new(
             executionId,
             instanceId,
-            successfulTestResultMessages ?? [],
-            failedTestResultMessages ?? []);
+            successfulTestResultMessages,
+            failedTestResultMessages);
     }
 
     private static SuccessfulTestResultMessage[] ReadSuccessfulTestMessagesPayload(Stream stream)


### PR DESCRIPTION
Fixes #9786.

## Summary

Follow-up to #9774. PR #9774 introduced two different empty-array initialization styles across the DotnetTest IPC serializers. This normalizes the three inconsistent files to the `= []` pattern used by `DiscoveredTestMessagesSerializer` and `TestInProgressMessagesSerializer`, removing the nullable `= null` initializer and the `?? []` null-coalescing at the return site.

### Files changed

- `CommandLineOptionMessagesSerializer.cs`
- `FileArtifactMessagesSerializer.cs`
- `TestResultMessagesSerializer.cs`

### Notes

The missing `InternalAPI.Unshipped.txt` declarations (`ReadFields`/`WriteListPayload` and `PlatformServicesConfigurationAdapter`) referenced in the issue are already present on `main`, so no InternalAPI changes were needed.

No functional changes — behavior is identical.

## Testing

- ✅ `Microsoft.Testing.Platform` builds cleanly (0 warnings, 0 errors).