### PR TITLE
perf: cache bool.Parse results in InvokeTestingPlatformTask

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
@@ -27,7 +27,7 @@ public partial class InvokeTestingPlatformTask
     /// <inheritdoc />
     protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
     {
-        if (!bool.Parse(TestingPlatformCaptureOutput.ItemSpec))
+        if (!_captureOutput)
         {
             Log.LogMessage(MessageImportance.High, singleLine);
         }
@@ -67,6 +67,12 @@ public partial class InvokeTestingPlatformTask
     /// <inheritdoc />
     public override bool Execute()
     {
+        // These [Required] task items are set once by MSBuild before Execute() is called and never
+        // change during the run. Parse them once here (before base.Execute() starts the process and
+        // begins streaming output) instead of re-parsing on every output line / failed-test request.
+        _captureOutput = bool.Parse(TestingPlatformCaptureOutput.ItemSpec);
+        _showTestsFailure = bool.Parse(TestingPlatformShowTestsFailure.ItemSpec);
+
         bool returnValue = base.Execute();
         if (_toolCommand is not null)
         {
@@ -170,7 +176,7 @@ public partial class InvokeTestingPlatformTask
         if (request is FailedTestInfoRequest failedTestInfoRequest)
         {
             // TestingPlatformShowTestsFailure is not enabled, don't write errors to output.
-            if (!bool.Parse(TestingPlatformShowTestsFailure.ItemSpec))
+            if (!_showTestsFailure)
             {
                 return Task.FromResult<IResponse>(VoidResponse.CachedInstance);
             }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -39,6 +39,8 @@ public partial class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisp
     private string? _outputFileName;
     private StreamWriter? _outputFileStream;
     private string? _toolCommand;
+    private bool _captureOutput;
+    private bool _showTestsFailure;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="InvokeTestingPlatformTask"/> class.


### PR DESCRIPTION
Fixes #9806

## Summary

`InvokeTestingPlatformTask` bridges MSBuild and the test process via a named pipe and streams every line of test-process output through `LogEventsFromTextOutput`. That method was calling `bool.Parse(TestingPlatformCaptureOutput.ItemSpec)` on **every line**, re-parsing the same constant string for the whole run. `HandleRequestAsync` had the same pattern with `bool.Parse(TestingPlatformShowTestsFailure.ItemSpec)` on every `FailedTestInfoRequest`.

Both properties are `[Required]` `ITaskItem`s set once by MSBuild before `Execute()` and never change during a run, so re-parsing is pure overhead.

## Changes

- Added two private `bool` fields (`_captureOutput`, `_showTestsFailure`).
- Initialized them at the start of `Execute()`, **before** `base.Execute()` starts the process and background connection loop.
- Replaced the two `bool.Parse(...)` call-sites with the cached field reads.

## Verification

- `.\build.cmd -c Release` for `Microsoft.Testing.Platform.MSBuild` — succeeded (0 warnings, 0 errors).

No behavioral change; only redundant string parsing on the hot output path is removed.