### PR TITLE
Deduplicate ExecutionId/InstanceId envelope across DotnetTest IPC serializers

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -273,17 +273,19 @@ internal abstract class BaseSerializer
         WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
     }
 
-    // ExecutionId and InstanceId are the two leading fields shared verbatim by every "execution-scoped" message
-    // envelope on the 'dotnet test' protocol (DiscoveredTestMessages, TestResultMessages, TestInProgressMessages,
-    // FileArtifactMessages). Their wire ids are pinned to 1 and 2 for all of those serializers and MUST NOT change.
+    // ExecutionId and InstanceId are the two leading fields shared verbatim by the four 'dotnet test' collection
+    // message envelopes that carry a list payload (DiscoveredTestMessages, TestResultMessages, TestInProgressMessages,
+    // FileArtifactMessages). Their wire ids are pinned to 1 and 2 for those serializers and MUST NOT change. Note that
+    // AzureDevOpsLogMessage/DisplayMessage also place ExecutionId/InstanceId at ids 1/2, but they carry scalar payloads
+    // rather than a message list, so they do not use these helpers.
     private const ushort ExecutionScopedExecutionIdFieldId = 1;
     private const ushort ExecutionScopedInstanceIdFieldId = 2;
 
     /// <summary>
-    /// Reads the shared execution-scoped message envelope: the leading <c>ExecutionId</c> (id 1) and
-    /// <c>InstanceId</c> (id 2) string fields common to every 'dotnet test' messages payload, delegating any other
-    /// field id to <paramref name="tryReadPayloadField"/> (the type-specific message-list reader). Returns the two
-    /// envelope values so the caller can build its concrete message object.
+    /// Reads the shared collection-envelope prefix: the leading <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2)
+    /// string fields common to the four 'dotnet test' list-carrying messages payloads, delegating any other field id to
+    /// <paramref name="tryReadPayloadField"/> (the type-specific message-list reader). Returns the two envelope values
+    /// so the caller can build its concrete message object.
     /// </summary>
     protected static (string? ExecutionId, string? InstanceId) ReadExecutionScopedFields(Stream stream, Func<ushort, int, bool> tryReadPayloadField)
     {
@@ -311,7 +313,7 @@ internal abstract class BaseSerializer
     }
 
     /// <summary>
-    /// Writes the shared execution-scoped message envelope: a field-count prefix (the <c>ExecutionId</c> and
+    /// Writes the shared collection-envelope prefix: a field-count prefix (the <c>ExecutionId</c> and
     /// <c>InstanceId</c> fields when non-<see langword="null"/> plus <paramref name="payloadFieldCount"/>), followed by
     /// the <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2) fields, then <paramref name="writePayload"/> which
     /// appends the type-specific message list(s).

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -282,43 +282,38 @@ internal abstract class BaseSerializer
     private const ushort ExecutionScopedInstanceIdFieldId = 2;
 
     /// <summary>
-    /// Reads the shared collection-envelope prefix: the leading <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2)
-    /// string fields common to the four 'dotnet test' list-carrying messages payloads, delegating any other field id to
-    /// <paramref name="tryReadPayloadField"/> (the type-specific message-list reader). Returns the two envelope values
-    /// so the caller can build its concrete message object.
+    /// Matches the two leading collection-envelope fields (<c>ExecutionId</c> id 1 / <c>InstanceId</c> id 2) shared by
+    /// the four 'dotnet test' list-carrying messages payloads, assigning the value into <paramref name="executionId"/>
+    /// or <paramref name="instanceId"/> and returning <see langword="true"/> when the field is one of them. The caller
+    /// invokes this from its own single <see cref="ReadFields"/> callback and handles its type-specific message-list
+    /// field ids when this returns <see langword="false"/>. Kept as a <see langword="ref"/>-based matcher (rather than a
+    /// wrapping callback) so it adds no closure/delegate allocation on the hot per-test IPC read path.
     /// </summary>
-    protected static (string? ExecutionId, string? InstanceId) ReadExecutionScopedFields(Stream stream, Func<ushort, int, bool> tryReadPayloadField)
+    protected static bool TryReadExecutionScopedField(Stream stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId)
     {
-        string? executionId = null;
-        string? instanceId = null;
-
-        ReadFields(stream, (fieldId, fieldSize) =>
+        switch (fieldId)
         {
-            switch (fieldId)
-            {
-                case ExecutionScopedExecutionIdFieldId:
-                    executionId = ReadStringValue(stream, fieldSize);
-                    return true;
+            case ExecutionScopedExecutionIdFieldId:
+                executionId = ReadStringValue(stream, fieldSize);
+                return true;
 
-                case ExecutionScopedInstanceIdFieldId:
-                    instanceId = ReadStringValue(stream, fieldSize);
-                    return true;
+            case ExecutionScopedInstanceIdFieldId:
+                instanceId = ReadStringValue(stream, fieldSize);
+                return true;
 
-                default:
-                    return tryReadPayloadField(fieldId, fieldSize);
-            }
-        });
-
-        return (executionId, instanceId);
+            default:
+                return false;
+        }
     }
 
     /// <summary>
-    /// Writes the shared collection-envelope prefix: a field-count prefix (the <c>ExecutionId</c> and
-    /// <c>InstanceId</c> fields when non-<see langword="null"/> plus <paramref name="payloadFieldCount"/>), followed by
-    /// the <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2) fields, then <paramref name="writePayload"/> which
-    /// appends the type-specific message list(s).
+    /// Writes the shared collection-envelope header: a field-count prefix (the <c>ExecutionId</c> and <c>InstanceId</c>
+    /// fields when non-<see langword="null"/> plus <paramref name="payloadFieldCount"/>), followed by the
+    /// <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2) fields. The caller writes its type-specific message
+    /// list(s) directly afterwards. Kept callback-free so it adds no closure/delegate allocation on the hot per-test
+    /// IPC write path.
     /// </summary>
-    protected static void WriteExecutionScopedFields(Stream stream, string? executionId, string? instanceId, ushort payloadFieldCount, Action<Stream> writePayload)
+    protected static void WriteExecutionScopedHeader(Stream stream, string? executionId, string? instanceId, ushort payloadFieldCount)
     {
         DebugAssert(stream.CanSeek, "We expect a seekable stream.");
 
@@ -326,7 +321,6 @@ internal abstract class BaseSerializer
 
         WriteField(stream, ExecutionScopedExecutionIdFieldId, executionId);
         WriteField(stream, ExecutionScopedInstanceIdFieldId, instanceId);
-        writePayload(stream);
     }
 
     private static int GetSize<T>() => typeof(T) switch

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -273,6 +273,60 @@ internal abstract class BaseSerializer
         WriteAtPosition(stream, (int)(stream.Position - before), before - sizeof(int));
     }
 
+    // ExecutionId and InstanceId are the two leading fields shared verbatim by every "execution-scoped" message
+    // envelope on the 'dotnet test' protocol (DiscoveredTestMessages, TestResultMessages, TestInProgressMessages,
+    // FileArtifactMessages). Their wire ids are pinned to 1 and 2 for all of those serializers and MUST NOT change.
+    private const ushort ExecutionScopedExecutionIdFieldId = 1;
+    private const ushort ExecutionScopedInstanceIdFieldId = 2;
+
+    /// <summary>
+    /// Reads the shared execution-scoped message envelope: the leading <c>ExecutionId</c> (id 1) and
+    /// <c>InstanceId</c> (id 2) string fields common to every 'dotnet test' messages payload, delegating any other
+    /// field id to <paramref name="tryReadPayloadField"/> (the type-specific message-list reader). Returns the two
+    /// envelope values so the caller can build its concrete message object.
+    /// </summary>
+    protected static (string? ExecutionId, string? InstanceId) ReadExecutionScopedFields(Stream stream, Func<ushort, int, bool> tryReadPayloadField)
+    {
+        string? executionId = null;
+        string? instanceId = null;
+
+        ReadFields(stream, (fieldId, fieldSize) =>
+        {
+            switch (fieldId)
+            {
+                case ExecutionScopedExecutionIdFieldId:
+                    executionId = ReadStringValue(stream, fieldSize);
+                    return true;
+
+                case ExecutionScopedInstanceIdFieldId:
+                    instanceId = ReadStringValue(stream, fieldSize);
+                    return true;
+
+                default:
+                    return tryReadPayloadField(fieldId, fieldSize);
+            }
+        });
+
+        return (executionId, instanceId);
+    }
+
+    /// <summary>
+    /// Writes the shared execution-scoped message envelope: a field-count prefix (the <c>ExecutionId</c> and
+    /// <c>InstanceId</c> fields when non-<see langword="null"/> plus <paramref name="payloadFieldCount"/>), followed by
+    /// the <c>ExecutionId</c> (id 1) and <c>InstanceId</c> (id 2) fields, then <paramref name="writePayload"/> which
+    /// appends the type-specific message list(s).
+    /// </summary>
+    protected static void WriteExecutionScopedFields(Stream stream, string? executionId, string? instanceId, ushort payloadFieldCount, Action<Stream> writePayload)
+    {
+        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
+
+        WriteUShort(stream, (ushort)((executionId is null ? 0 : 1) + (instanceId is null ? 0 : 1) + payloadFieldCount));
+
+        WriteField(stream, ExecutionScopedExecutionIdFieldId, executionId);
+        WriteField(stream, ExecutionScopedInstanceIdFieldId, instanceId);
+        writePayload(stream);
+    }
+
     private static int GetSize<T>() => typeof(T) switch
     {
         Type type when type == typeof(int) => sizeof(int),

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -24,9 +24,9 @@ Microsoft.Testing.Platform.Services.ClientInfoService.Deconstruct(out string! Id
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.GetHashCode() -> int
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ToString() -> string!
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void
 static Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(string! fileName) -> string!
 static Microsoft.Testing.Platform.Services.ClientCapabilitiesService.operator !=(Microsoft.Testing.Platform.Services.ClientCapabilitiesService? left, Microsoft.Testing.Platform.Services.ClientCapabilitiesService? right) -> bool

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -24,7 +24,9 @@ Microsoft.Testing.Platform.Services.ClientInfoService.Deconstruct(out string! Id
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Equals(object? obj) -> bool
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.GetHashCode() -> int
 override Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ToString() -> string!
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void
 static Microsoft.Testing.Platform.Services.ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(string! fileName) -> string!
 static Microsoft.Testing.Platform.Services.ClientCapabilitiesService.operator !=(Microsoft.Testing.Platform.Services.ClientCapabilitiesService? left, Microsoft.Testing.Platform.Services.ClientCapabilitiesService? right) -> bool

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
-static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/net/InternalAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadExecutionScopedFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadPayloadField) -> (string? ExecutionId, string? InstanceId)
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
+static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedFields(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount, System.Action<System.IO.Stream!>! writePayload) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayload<T>(System.IO.Stream! stream, ushort fieldId, T[]? list, System.Action<System.IO.Stream!, T>! writeItem) -> void

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -81,29 +81,17 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
 
     protected override DiscoveredTestMessages DeserializeCore(Stream stream)
     {
-        string? executionId = null;
-        string? instanceId = null;
         DiscoveredTestMessage[]? discoveredTestMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
         {
-            switch (fieldId)
+            if (fieldId == DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList)
             {
-                case DiscoveredTestMessagesFieldsId.ExecutionId:
-                    executionId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case DiscoveredTestMessagesFieldsId.InstanceId:
-                    instanceId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList:
-                    discoveredTestMessages = ReadDiscoveredTestMessagesPayload(stream);
-                    return true;
-
-                default:
-                    return false;
+                discoveredTestMessages = ReadDiscoveredTestMessagesPayload(stream);
+                return true;
             }
+
+            return false;
         });
 
         return new(executionId, instanceId, discoveredTestMessages);
@@ -224,15 +212,12 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
     }
 
     protected override void SerializeCore(DiscoveredTestMessages objectToSerialize, Stream stream)
-    {
-        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
-
-        WriteUShort(stream, GetFieldCount(objectToSerialize));
-
-        WriteField(stream, DiscoveredTestMessagesFieldsId.ExecutionId, objectToSerialize.ExecutionId);
-        WriteField(stream, DiscoveredTestMessagesFieldsId.InstanceId, objectToSerialize.InstanceId);
-        WriteDiscoveredTestMessagesPayload(stream, objectToSerialize.DiscoveredMessages);
-    }
+        => WriteExecutionScopedFields(
+            stream,
+            objectToSerialize.ExecutionId,
+            objectToSerialize.InstanceId,
+            (ushort)(IsNullOrEmpty(objectToSerialize.DiscoveredMessages) ? 0 : 1),
+            s => WriteDiscoveredTestMessagesPayload(s, objectToSerialize.DiscoveredMessages));
 
     private static void WriteDiscoveredTestMessagesPayload(Stream stream, DiscoveredTestMessage[]? discoveredTestMessageList)
         => WriteListPayload(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList, discoveredTestMessageList, static (s, discoveredTestMessage) =>
@@ -261,11 +246,6 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
 
     private static void WriteParameterTypeFullNamesPayload(Stream stream, string[]? parameterTypeFullNames)
         => WriteListPayload(stream, DiscoveredTestMessageFieldsId.ParameterTypeFullNames, parameterTypeFullNames, static (s, parameterTypeFullName) => WriteString(s, parameterTypeFullName));
-
-    private static ushort GetFieldCount(DiscoveredTestMessages discoveredTestMessages) =>
-        (ushort)((discoveredTestMessages.ExecutionId is null ? 0 : 1) +
-        (discoveredTestMessages.InstanceId is null ? 0 : 1) +
-        (IsNullOrEmpty(discoveredTestMessages.DiscoveredMessages) ? 0 : 1));
 
     private static ushort GetFieldCount(DiscoveredTestMessage discoveredTestMessage) =>
         (ushort)((discoveredTestMessage.Uid is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -81,10 +81,17 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
 
     protected override DiscoveredTestMessages DeserializeCore(Stream stream)
     {
+        string? executionId = null;
+        string? instanceId = null;
         DiscoveredTestMessage[]? discoveredTestMessages = [];
 
-        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
+            if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
+            {
+                return true;
+            }
+
             if (fieldId == DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList)
             {
                 discoveredTestMessages = ReadDiscoveredTestMessagesPayload(stream);
@@ -212,12 +219,15 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
     }
 
     protected override void SerializeCore(DiscoveredTestMessages objectToSerialize, Stream stream)
-        => WriteExecutionScopedFields(
+    {
+        WriteExecutionScopedHeader(
             stream,
             objectToSerialize.ExecutionId,
             objectToSerialize.InstanceId,
-            (ushort)(IsNullOrEmpty(objectToSerialize.DiscoveredMessages) ? 0 : 1),
-            s => WriteDiscoveredTestMessagesPayload(s, objectToSerialize.DiscoveredMessages));
+            (ushort)(IsNullOrEmpty(objectToSerialize.DiscoveredMessages) ? 0 : 1));
+
+        WriteDiscoveredTestMessagesPayload(stream, objectToSerialize.DiscoveredMessages);
+    }
 
     private static void WriteDiscoveredTestMessagesPayload(Stream stream, DiscoveredTestMessage[]? discoveredTestMessageList)
         => WriteListPayload(stream, DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList, discoveredTestMessageList, static (s, discoveredTestMessage) =>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -54,29 +54,17 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
 
     protected override FileArtifactMessages DeserializeCore(Stream stream)
     {
-        string? executionId = null;
-        string? instanceId = null;
         FileArtifactMessage[]? fileArtifactMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
         {
-            switch (fieldId)
+            if (fieldId == FileArtifactMessagesFieldsId.FileArtifactMessageList)
             {
-                case FileArtifactMessagesFieldsId.ExecutionId:
-                    executionId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case FileArtifactMessagesFieldsId.InstanceId:
-                    instanceId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case FileArtifactMessagesFieldsId.FileArtifactMessageList:
-                    fileArtifactMessages = ReadFileArtifactMessagesPayload(stream);
-                    return true;
-
-                default:
-                    return false;
+                fileArtifactMessages = ReadFileArtifactMessagesPayload(stream);
+                return true;
             }
+
+            return false;
         });
 
         return new(executionId, instanceId, fileArtifactMessages);
@@ -131,15 +119,12 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     }
 
     protected override void SerializeCore(FileArtifactMessages objectToSerialize, Stream stream)
-    {
-        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
-
-        WriteUShort(stream, GetFieldCount(objectToSerialize));
-
-        WriteField(stream, FileArtifactMessagesFieldsId.ExecutionId, objectToSerialize.ExecutionId);
-        WriteField(stream, FileArtifactMessagesFieldsId.InstanceId, objectToSerialize.InstanceId);
-        WriteFileArtifactMessagesPayload(stream, objectToSerialize.FileArtifacts);
-    }
+        => WriteExecutionScopedFields(
+            stream,
+            objectToSerialize.ExecutionId,
+            objectToSerialize.InstanceId,
+            (ushort)(IsNullOrEmpty(objectToSerialize.FileArtifacts) ? 0 : 1),
+            s => WriteFileArtifactMessagesPayload(s, objectToSerialize.FileArtifacts));
 
     private static void WriteFileArtifactMessagesPayload(Stream stream, FileArtifactMessage[]? fileArtifactMessageList)
         => WriteListPayload(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList, fileArtifactMessageList, static (s, fileArtifactMessage) =>
@@ -153,11 +138,6 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
             WriteField(s, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
             WriteField(s, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
         });
-
-    private static ushort GetFieldCount(FileArtifactMessages fileArtifactMessages) =>
-        (ushort)((fileArtifactMessages.ExecutionId is null ? 0 : 1) +
-        (fileArtifactMessages.InstanceId is null ? 0 : 1) +
-        (IsNullOrEmpty(fileArtifactMessages.FileArtifacts) ? 0 : 1));
 
     private static ushort GetFieldCount(FileArtifactMessage fileArtifactMessage) =>
         (ushort)((fileArtifactMessage.FullPath is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -54,10 +54,17 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
 
     protected override FileArtifactMessages DeserializeCore(Stream stream)
     {
+        string? executionId = null;
+        string? instanceId = null;
         FileArtifactMessage[]? fileArtifactMessages = [];
 
-        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
+            if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
+            {
+                return true;
+            }
+
             if (fieldId == FileArtifactMessagesFieldsId.FileArtifactMessageList)
             {
                 fileArtifactMessages = ReadFileArtifactMessagesPayload(stream);
@@ -119,12 +126,15 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
     }
 
     protected override void SerializeCore(FileArtifactMessages objectToSerialize, Stream stream)
-        => WriteExecutionScopedFields(
+    {
+        WriteExecutionScopedHeader(
             stream,
             objectToSerialize.ExecutionId,
             objectToSerialize.InstanceId,
-            (ushort)(IsNullOrEmpty(objectToSerialize.FileArtifacts) ? 0 : 1),
-            s => WriteFileArtifactMessagesPayload(s, objectToSerialize.FileArtifacts));
+            (ushort)(IsNullOrEmpty(objectToSerialize.FileArtifacts) ? 0 : 1));
+
+        WriteFileArtifactMessagesPayload(stream, objectToSerialize.FileArtifacts);
+    }
 
     private static void WriteFileArtifactMessagesPayload(Stream stream, FileArtifactMessage[]? fileArtifactMessageList)
         => WriteListPayload(stream, FileArtifactMessagesFieldsId.FileArtifactMessageList, fileArtifactMessageList, static (s, fileArtifactMessage) =>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -38,29 +38,17 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
 
     protected override TestInProgressMessages DeserializeCore(Stream stream)
     {
-        string? executionId = null;
-        string? instanceId = null;
         TestInProgressMessage[]? inProgressMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
         {
-            switch (fieldId)
+            if (fieldId == TestInProgressMessagesFieldsId.TestInProgressMessageList)
             {
-                case TestInProgressMessagesFieldsId.ExecutionId:
-                    executionId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case TestInProgressMessagesFieldsId.InstanceId:
-                    instanceId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case TestInProgressMessagesFieldsId.TestInProgressMessageList:
-                    inProgressMessages = ReadInProgressMessagesPayload(stream);
-                    return true;
-
-                default:
-                    return false;
+                inProgressMessages = ReadInProgressMessagesPayload(stream);
+                return true;
             }
+
+            return false;
         });
 
         return new(executionId, instanceId, inProgressMessages);
@@ -99,15 +87,12 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
     }
 
     protected override void SerializeCore(TestInProgressMessages objectToSerialize, Stream stream)
-    {
-        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
-
-        WriteUShort(stream, GetFieldCount(objectToSerialize));
-
-        WriteField(stream, TestInProgressMessagesFieldsId.ExecutionId, objectToSerialize.ExecutionId);
-        WriteField(stream, TestInProgressMessagesFieldsId.InstanceId, objectToSerialize.InstanceId);
-        WriteInProgressMessagesPayload(stream, objectToSerialize.InProgressMessages);
-    }
+        => WriteExecutionScopedFields(
+            stream,
+            objectToSerialize.ExecutionId,
+            objectToSerialize.InstanceId,
+            (ushort)(IsNullOrEmpty(objectToSerialize.InProgressMessages) ? 0 : 1),
+            s => WriteInProgressMessagesPayload(s, objectToSerialize.InProgressMessages));
 
     private static void WriteInProgressMessagesPayload(Stream stream, TestInProgressMessage[]? inProgressMessageList)
         => WriteListPayload(stream, TestInProgressMessagesFieldsId.TestInProgressMessageList, inProgressMessageList, static (s, inProgressMessage) =>
@@ -117,11 +102,6 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
             WriteField(s, TestInProgressMessageFieldsId.Uid, inProgressMessage.Uid);
             WriteField(s, TestInProgressMessageFieldsId.DisplayName, inProgressMessage.DisplayName);
         });
-
-    private static ushort GetFieldCount(TestInProgressMessages inProgressMessages) =>
-        (ushort)((inProgressMessages.ExecutionId is null ? 0 : 1) +
-        (inProgressMessages.InstanceId is null ? 0 : 1) +
-        (IsNullOrEmpty(inProgressMessages.InProgressMessages) ? 0 : 1));
 
     private static ushort GetFieldCount(TestInProgressMessage inProgressMessage) =>
         (ushort)((inProgressMessage.Uid is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -38,10 +38,17 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
 
     protected override TestInProgressMessages DeserializeCore(Stream stream)
     {
+        string? executionId = null;
+        string? instanceId = null;
         TestInProgressMessage[]? inProgressMessages = [];
 
-        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
+            if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
+            {
+                return true;
+            }
+
             if (fieldId == TestInProgressMessagesFieldsId.TestInProgressMessageList)
             {
                 inProgressMessages = ReadInProgressMessagesPayload(stream);
@@ -87,12 +94,15 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
     }
 
     protected override void SerializeCore(TestInProgressMessages objectToSerialize, Stream stream)
-        => WriteExecutionScopedFields(
+    {
+        WriteExecutionScopedHeader(
             stream,
             objectToSerialize.ExecutionId,
             objectToSerialize.InstanceId,
-            (ushort)(IsNullOrEmpty(objectToSerialize.InProgressMessages) ? 0 : 1),
-            s => WriteInProgressMessagesPayload(s, objectToSerialize.InProgressMessages));
+            (ushort)(IsNullOrEmpty(objectToSerialize.InProgressMessages) ? 0 : 1));
+
+        WriteInProgressMessagesPayload(stream, objectToSerialize.InProgressMessages);
+    }
 
     private static void WriteInProgressMessagesPayload(Stream stream, TestInProgressMessage[]? inProgressMessageList)
         => WriteListPayload(stream, TestInProgressMessagesFieldsId.TestInProgressMessageList, inProgressMessageList, static (s, inProgressMessage) =>

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -109,23 +109,13 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
 
     protected override TestResultMessages DeserializeCore(Stream stream)
     {
-        string? executionId = null;
-        string? instanceId = null;
         SuccessfulTestResultMessage[]? successfulTestResultMessages = [];
         FailedTestResultMessage[]? failedTestResultMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
         {
             switch (fieldId)
             {
-                case TestResultMessagesFieldsId.ExecutionId:
-                    executionId = ReadStringValue(stream, fieldSize);
-                    return true;
-
-                case TestResultMessagesFieldsId.InstanceId:
-                    instanceId = ReadStringValue(stream, fieldSize);
-                    return true;
-
                 case TestResultMessagesFieldsId.SuccessfulTestMessageList:
                     successfulTestResultMessages = ReadSuccessfulTestMessagesPayload(stream);
                     return true;
@@ -304,16 +294,17 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
     }
 
     protected override void SerializeCore(TestResultMessages objectToSerialize, Stream stream)
-    {
-        DebugAssert(stream.CanSeek, "We expect a seekable stream.");
-
-        WriteUShort(stream, GetFieldCount(objectToSerialize));
-
-        WriteField(stream, TestResultMessagesFieldsId.ExecutionId, objectToSerialize.ExecutionId);
-        WriteField(stream, TestResultMessagesFieldsId.InstanceId, objectToSerialize.InstanceId);
-        WriteSuccessfulTestMessagesPayload(stream, objectToSerialize.SuccessfulTestMessages);
-        WriteFailedTestMessagesPayload(stream, objectToSerialize.FailedTestMessages);
-    }
+        => WriteExecutionScopedFields(
+            stream,
+            objectToSerialize.ExecutionId,
+            objectToSerialize.InstanceId,
+            (ushort)((IsNullOrEmpty(objectToSerialize.SuccessfulTestMessages) ? 0 : 1) +
+                (IsNullOrEmpty(objectToSerialize.FailedTestMessages) ? 0 : 1)),
+            s =>
+            {
+                WriteSuccessfulTestMessagesPayload(s, objectToSerialize.SuccessfulTestMessages);
+                WriteFailedTestMessagesPayload(s, objectToSerialize.FailedTestMessages);
+            });
 
     private static void WriteSuccessfulTestMessagesPayload(Stream stream, SuccessfulTestResultMessage[]? successfulTestResultMessages)
         => WriteListPayload(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList, successfulTestResultMessages, static (s, successfulTestResultMessage) =>
@@ -355,12 +346,6 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
             WriteField(s, ExceptionMessageFieldsId.ErrorType, exceptionMessage.ErrorType);
             WriteField(s, ExceptionMessageFieldsId.StackTrace, exceptionMessage.StackTrace);
         });
-
-    private static ushort GetFieldCount(TestResultMessages testResultMessages) =>
-        (ushort)((testResultMessages.ExecutionId is null ? 0 : 1) +
-        (testResultMessages.InstanceId is null ? 0 : 1) +
-        (IsNullOrEmpty(testResultMessages.SuccessfulTestMessages) ? 0 : 1) +
-        (IsNullOrEmpty(testResultMessages.FailedTestMessages) ? 0 : 1));
 
     private static ushort GetFieldCount(SuccessfulTestResultMessage successfulTestResultMessage) =>
         (ushort)((successfulTestResultMessage.Uid is null ? 0 : 1) +

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -109,11 +109,18 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
 
     protected override TestResultMessages DeserializeCore(Stream stream)
     {
+        string? executionId = null;
+        string? instanceId = null;
         SuccessfulTestResultMessage[]? successfulTestResultMessages = [];
         FailedTestResultMessage[]? failedTestResultMessages = [];
 
-        (string? executionId, string? instanceId) = ReadExecutionScopedFields(stream, (fieldId, fieldSize) =>
+        ReadFields(stream, (fieldId, fieldSize) =>
         {
+            if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
+            {
+                return true;
+            }
+
             switch (fieldId)
             {
                 case TestResultMessagesFieldsId.SuccessfulTestMessageList:
@@ -294,17 +301,17 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
     }
 
     protected override void SerializeCore(TestResultMessages objectToSerialize, Stream stream)
-        => WriteExecutionScopedFields(
+    {
+        WriteExecutionScopedHeader(
             stream,
             objectToSerialize.ExecutionId,
             objectToSerialize.InstanceId,
             (ushort)((IsNullOrEmpty(objectToSerialize.SuccessfulTestMessages) ? 0 : 1) +
-                (IsNullOrEmpty(objectToSerialize.FailedTestMessages) ? 0 : 1)),
-            s =>
-            {
-                WriteSuccessfulTestMessagesPayload(s, objectToSerialize.SuccessfulTestMessages);
-                WriteFailedTestMessagesPayload(s, objectToSerialize.FailedTestMessages);
-            });
+                (IsNullOrEmpty(objectToSerialize.FailedTestMessages) ? 0 : 1)));
+
+        WriteSuccessfulTestMessagesPayload(stream, objectToSerialize.SuccessfulTestMessages);
+        WriteFailedTestMessagesPayload(stream, objectToSerialize.FailedTestMessages);
+    }
 
     private static void WriteSuccessfulTestMessagesPayload(Stream stream, SuccessfulTestResultMessage[]? successfulTestResultMessages)
         => WriteListPayload(stream, TestResultMessagesFieldsId.SuccessfulTestMessageList, successfulTestResultMessages, static (s, successfulTestResultMessage) =>


### PR DESCRIPTION
Fixes #9812.

## Summary

Four `dotnet test` IPC serializers — `DiscoveredTestMessagesSerializer`, `TestResultMessagesSerializer`, `TestInProgressMessagesSerializer`, and `FileArtifactMessagesSerializer` — shared an identical top-level `ExecutionId`/`InstanceId` envelope in their `DeserializeCore`/`SerializeCore` methods (the same `ExecutionId`/`InstanceId` switch cases + field-count/write scaffolding, ~18 lines per serializer). This PR extracts that shared scaffold.

## Changes

- Added two stateless static helpers to the shared `BaseSerializer` (`IPC/Serializers/BaseSerializer.cs`):
  - `ReadExecutionScopedFields(...)` — reads the leading `ExecutionId` (id 1) / `InstanceId` (id 2) string fields and delegates every other field id to a caller-supplied payload reader, returning the two envelope values.
  - `WriteExecutionScopedFields(...)` — writes the field-count prefix, the `ExecutionId`/`InstanceId` fields, then invokes a payload writer.
- Refactored the four serializers to use the helpers and dropped their now-redundant top-level `GetFieldCount(<Messages>)` methods (the per-message-item `GetFieldCount` overloads are unchanged).
- Updated the tracked `InternalAPI.Unshipped.txt` for the platform and the extension projects that embed these shared-source serializers.

The helpers are stateless (the serializers are registered as singletons), so no shared mutable state is introduced.

## Wire compatibility

The field ids (`ExecutionId=1`, `InstanceId=2`, message lists), their order and layout are unchanged — this is a pure code-dedup refactor. These files are also vendored into `dotnet/sdk`, so the round-trip contract is preserved.

## Verification

- `Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests` (standalone shared-source round-trip contract): **21/21 passed**.
- `Microsoft.Testing.Platform.UnitTests` `ProtocolTests` + `ProtocolEdgeCaseTests`: **33/33 passed**.
- Full solution/analyzer build succeeds (0 warnings, 0 errors).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>