### PR TITLE
Fix MSTEST0037: use Assert.IsEmpty instead of Assert.HasCount(0, ...)

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -440,7 +440,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await StartPublisherAsync(publisher);
         await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(node), CancellationToken.None);
 
-        Assert.HasCount(0, client.UploadTestResultAttachmentCalls);
+        Assert.IsEmpty(client.UploadTestResultAttachmentCalls);
     }
 
     [TestMethod]
@@ -496,7 +496,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.AreEqual(1, publishCalls);
-        Assert.HasCount(0, client.UploadTestResultAttachmentCalls);
+        Assert.IsEmpty(client.UploadTestResultAttachmentCalls);
         Assert.Contains(AzureDevOpsResources.AzureDevOpsLivePublishingResultIdParseFailedWarning, string.Join(Environment.NewLine, logger.Logs));
     }
 
@@ -634,7 +634,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), new SessionFileArtifact(sessionUid, new FileInfo(logPath), "log"), CancellationToken.None);
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
-        Assert.HasCount(0, client.UploadTestRunAttachmentCalls);
+        Assert.IsEmpty(client.UploadTestRunAttachmentCalls);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolSerializerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolSerializerTests.cs
@@ -155,7 +155,7 @@ public sealed class DotnetTestProtocolSerializerTests
 
         DiscoveredTestMessage second = actual.DiscoveredMessages[1];
         Assert.AreEqual("Uid2", second.Uid);
-        Assert.HasCount(0, second.Traits);
+        Assert.IsEmpty(second.Traits);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -340,7 +340,7 @@ public sealed class ProtocolTests
         Assert.AreEqual(message.ExecutionId, actual.ExecutionId);
         Assert.AreEqual(message.InstanceId, actual.InstanceId);
         Assert.IsNotNull(actual.InProgressMessages);
-        Assert.HasCount(0, actual.InProgressMessages);
+        Assert.IsEmpty(actual.InProgressMessages);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -225,7 +225,7 @@ public sealed class AsynchronousMessageBusTests
 
         await proxy.PublishAsync(consumer, new BlockingData());
 
-        Assert.HasCount(0, consumer.ConsumedData);
+        Assert.IsEmpty(consumer.ConsumedData);
 
         await asynchronousMessageBus.DisableAsync();
     }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestHostOrchestratorManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestHostOrchestratorManagerTests.cs
@@ -80,7 +80,7 @@ public sealed class TestHostOrchestratorManagerTests
 
         PublicApi.TestHostOrchestratorConfiguration config = await manager.BuildAsync(_serviceProvider);
 
-        Assert.HasCount(0, config.TestHostOrchestrators);
+        Assert.IsEmpty(config.TestHostOrchestrators);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes the MSTEST0037 build errors surfaced by the updated `MSTest.Analyzers` dependency (see #9810). The analyzer now flags `Assert.HasCount(0, collection)` and recommends `Assert.IsEmpty(collection)`.

## Changes

Replaced `Assert.HasCount(0, x)` with `Assert.IsEmpty(x)` at 7 call sites:

- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestHostOrchestratorManagerTests.cs`
- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs`
- `test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs`
- `test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolSerializerTests.cs`
- `test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs` (3 occurrences)

Intentionally left untouched: `HasCount` usages in `MSTest.Analyzers.UnitTests` (analyzer test inputs/expectations) and `TestFramework.UnitTests` (tests exercising the `HasCount` API itself).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>