### PR TITLE
Fix CA1416 build errors in FileLoggerTests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -461,6 +461,7 @@ public sealed class FileLoggerTests : IDisposable
         public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken)
             => _inner.Run(function, cancellationToken);
 
+        [UnsupportedOSPlatform("browser")]
         public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken)
             => _inner.RunLongRunning(action, name, cancellationToken);
 
@@ -486,6 +487,7 @@ public sealed class FileLoggerTests : IDisposable
         public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken)
             => _inner.Run(function, cancellationToken);
 
+        [UnsupportedOSPlatform("browser")]
         public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken)
             => _inner.RunLongRunning(action, name, cancellationToken);
 


### PR DESCRIPTION
Fixes the broken `main` build.

The `RecordingTask` and `NeverCompletingTask` test helpers in `FileLoggerTests.cs` implement `ITask.RunLongRunning`, which is annotated `[UnsupportedOSPlatform("browser")]` on the interface. Their overrides lacked the annotation, so calling `_inner.RunLongRunning` triggered CA1416 on `net8.0`/`net9.0`.

Added `[UnsupportedOSPlatform("browser")]` to both overrides (matching the only `SupportedPlatform` declared in the test project). Verified with a full Release build: 0 warnings, 0 errors across `net462`/`net8.0`/`net9.0`.
