### PR TITLE
Fix CA1416 build failure in FileLoggerTests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -461,6 +461,7 @@ public sealed class FileLoggerTests : IDisposable
         public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken)
             => _inner.Run(function, cancellationToken);
 
+        [UnsupportedOSPlatform("browser")]
         public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken)
             => _inner.RunLongRunning(action, name, cancellationToken);
 
@@ -486,6 +487,7 @@ public sealed class FileLoggerTests : IDisposable
         public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken)
             => _inner.Run(function, cancellationToken);
 
+        [UnsupportedOSPlatform("browser")]
         public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken)
             => _inner.RunLongRunning(action, name, cancellationToken);
 


### PR DESCRIPTION
## Problem

The CI build fails on all legs (Linux/macOS/Windows, Debug/Release) — as seen on the darc dependency PR #9839, but the root cause is on `main`. The failing step is the main `Build` task, which errors with:

```
FileLoggerTests.cs(465,16): error CA1416: This call site is reachable on all platforms.
  'ITask.RunLongRunning(Func<Task>, string, CancellationToken)' is unsupported on: 'browser'.
FileLoggerTests.cs(490,16): error CA1416: ... (same)
```

(CA1416 is treated as an error, which is why the build fails and no test results are produced — the subsequent "Publish Test Results" / "Copy binlogs" failures are just downstream symptoms.)

## Root cause

The `ITask.RunLongRunning` interface member is annotated `[UnsupportedOSPlatform("browser")]`, and so is the `SystemTask` implementation. The two `ITask` test doubles in `FileLoggerTests` — `RecordingTask` and `NeverCompletingTask` — implement `RunLongRunning` **without** that annotation and delegate to a real `SystemTask`. Their call sites into `_inner.RunLongRunning(...)` are therefore "reachable on all platforms" while calling a browser-unsupported API, tripping CA1416 on `net8.0`/`net9.0`.

## Fix

Annotate both test-double `RunLongRunning` overrides with `[UnsupportedOSPlatform("browser")]` to match the interface member, matching the convention already used across this test project (e.g. `IPCTests`, `TestHostBuilderTests`). Only `browser` is used (not `wasi`) to avoid CA1418 on the Windows-only `net462` target where `wasi` is not a known platform name.

## Verification

Built `Microsoft.Testing.Platform.UnitTests` across all TFMs (`net8.0`, `net9.0`, `net462`) locally: **0 warnings, 0 errors**.