### PR TITLE
Fix CI/CD workflow hygiene issues (#9835)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: '[main] '

--- a/.github/workflows/backport-base.yml
+++ b/.github/workflows/backport-base.yml
@@ -24,6 +24,7 @@ jobs:
   cleanup:
     if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner)) && github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: write
     steps:
@@ -64,6 +65,7 @@ jobs:
   run_backport:
     if: ${{ contains(format('{0},', inputs.repository_owners), format('{0},', github.repository_owner)) && github.event.issue.pull_request != '' && contains(github.event.comment.body, '/backport to') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,10 +12,19 @@ permissions:
   pull-requests: write
   actions: write
 
+# Avoid interrupting an in-flight backport: a cancelled `git am` mid-apply would
+# leave a half-created branch/PR. Serialize per source PR (comment triggers) and
+# per ref (schedule) without cancelling running work.
+concurrency:
+  group: backport-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   backport:
     if: ${{ contains(github.event.comment.body, '/backport to') || github.event_name == 'schedule' }}
-    uses: microsoft/testfx/.github/workflows/backport-base.yml@main
+    # Pin the reusable workflow to the exact commit that triggered this run so a
+    # mid-PR push to `main` cannot change backport behavior while runs are in flight.
+    uses: microsoft/testfx/.github/workflows/backport-base.yml@${{ github.sha }}
     with:
       pr_description_template: |
         Backport of #%source_pr_number% to %target_branch%

--- a/.github/workflows/check-vendored-files.yml
+++ b/.github/workflows/check-vendored-files.yml
@@ -37,6 +37,7 @@ jobs:
   validate:
     name: Validate manifest
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -50,6 +51,7 @@ jobs:
     needs: validate
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/copilot-curate-update.yml
+++ b/.github/workflows/copilot-curate-update.yml
@@ -30,6 +30,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,17 +9,24 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+concurrency:
+  group: copilot-setup-steps-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    # A full `./build.sh` (SDK restore + build) dominates this job; 30 minutes
+    # leaves headroom on a cold runner while still killing a genuinely hung build.
+    timeout-minutes: 30
 
     permissions:
       contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Build the repository
         run: ./build.sh

--- a/.github/workflows/dedup-analysis.yml
+++ b/.github/workflows/dedup-analysis.yml
@@ -35,6 +35,7 @@ permissions:
 jobs:
   scan-and-analyze:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   add_milestone:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.repository == 'microsoft/testfx' && (github.event.pull_request.user.login == 'dotnet-bot' || github.event.pull_request.user.login == 'dotnet-maestro[bot]') && (startsWith(github.event.pull_request.title, 'Localized file check-in') || startsWith(github.event.pull_request.title, '[main] Update dependencies from dotnet/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from microsoft/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from devdiv/')) }}
     steps:
     - name: Enable pull request auto-merge

--- a/.github/workflows/fv-docs-validation.yml
+++ b/.github/workflows/fv-docs-validation.yml
@@ -18,10 +18,15 @@ on:
       - "formal-verification/**"
   workflow_dispatch:
 
+concurrency:
+  group: fv-docs-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-fv-docs:
     name: Validate FV Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -11,9 +11,14 @@ on:
       - ".markdownlintignore"
       - ".github/workflows/markdownlint.yml"
 
+concurrency:
+  group: markdownlint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/skip-copilot-review-bot-prs.yml
+++ b/.github/workflows/skip-copilot-review-bot-prs.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   remove-copilot-reviewer:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ github.repository == 'microsoft/testfx' && (github.event.pull_request.user.login == 'dotnet-bot' || github.event.pull_request.user.login == 'dotnet-maestro[bot]') && (startsWith(github.event.pull_request.title, 'Localized file check-in') || startsWith(github.event.pull_request.title, '[main] Update dependencies from dotnet/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from microsoft/') || startsWith(github.event.pull_request.title, '[main] Update dependencies from devdiv/')) }}
     steps:
     - name: Remove Copilot as a requested reviewer

--- a/.github/workflows/update-bundled-playwright.yml
+++ b/.github/workflows/update-bundled-playwright.yml
@@ -34,6 +34,7 @@ jobs:
     name: Self-test script
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -48,6 +49,7 @@ jobs:
     name: Bump bundled Playwright
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # One in-flight update at a time so scheduled + manual runs don't race on the
     # shared update-bundled-playwright/autoupdate branch. Scoped to this job so
     # read-only PR self-tests are never gated behind the update lock.


### PR DESCRIPTION
Fixes #9835.

Addresses the CI/CD workflow hygiene findings from the repository quality report. Only hand-authored non-lock workflows were touched; auto-generated `*.lock.yml` files and the `gh-aw`-generated `agentic_commands.yml` / `agentics-maintenance.yml` were left alone.

## Changes

### High priority
- **`copilot-setup-steps.yml`**: `actions/checkout@v5` → `@v4` (v5 does not exist; the setup job would fail at checkout).
- **`backport.yml`**: pin the reusable workflow from the floating `backport-base.yml@main` to `backport-base.yml@${{ github.sha }}`, so a mid-PR push to `main` cannot change backport behavior for in-flight runs.

### `timeout-minutes` added
A hung step otherwise holds a runner for the 6-hour default.

| Workflow | Job(s) | Timeout |
|----------|--------|---------|
| `markdownlint.yml` | lint | 5 |
| `skip-copilot-review-bot-prs.yml` | remove-copilot-reviewer | 5 |
| `enable-auto-merge.yml` | add_milestone | 5 |
| `copilot-curate-update.yml` | update | 15 |
| `copilot-setup-steps.yml` | copilot-setup-steps | 30 (runs a full `./build.sh`) |
| `update-bundled-playwright.yml` | self-test, update | 15 |
| `fv-docs-validation.yml` | validate-fv-docs | 15 |
| `check-vendored-files.yml` | validate (15), check (30) | 15/30 |
| `dedup-analysis.yml` | scan-and-analyze | 30 |
| `backport-base.yml` | cleanup, run_backport | 30 |

> Note: `copilot-setup-steps.yml` was given 30 min instead of the report's suggested 15, because it runs a full repository build that can realistically exceed 15 min on a cold runner.

### `concurrency:` groups added
- `copilot-setup-steps.yml`, `markdownlint.yml`, `fv-docs-validation.yml` — `cancel-in-progress: true` (redundant PR/push runs are safe to cancel).
- `backport.yml` — `cancel-in-progress: false` (never interrupt an in-flight backport mid-`git am`), keyed per source PR / ref.

### Dependabot
- Added the `github-actions` package ecosystem to `.github/dependabot.yml` (weekly) to automate action pin updates.

All edited YAML files were validated for syntax.