### PR TITLE
Fix MSTEST0063 to detect invalid constructors on derived TestClass attributes

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/TestClassConstructorShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestClassConstructorShouldBeValidAnalyzer.cs
@@ -60,7 +60,7 @@ public sealed class TestClassConstructorShouldBeValidAnalyzer : DiagnosticAnalyz
         if (namedTypeSymbol.TypeKind != TypeKind.Class
             || namedTypeSymbol.IsAbstract
             || namedTypeSymbol.IsStatic
-            || !namedTypeSymbol.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, testClassAttributeSymbol)))
+            || !namedTypeSymbol.IsTestClass(testClassAttributeSymbol))
         {
             return;
         }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassConstructorShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassConstructorShouldBeValidAnalyzerTests.cs
@@ -343,4 +343,98 @@ public sealed class TestClassConstructorShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenDerivedTestClassAttributeHasPrivateConstructor_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [STATestClass]
+            public class {|#0:MyTestClass|}
+            {
+                private MyTestClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(TestClassConstructorShouldBeValidAnalyzer.TestClassConstructorShouldBeValidRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenDerivedTestClassAttributeHasPublicParameterlessConstructor_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [STATestClass]
+            public class MyTestClass
+            {
+                public MyTestClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenCustomDerivedTestClassAttributeHasInternalConstructor_Diagnostic()
+    {
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [AttributeUsage(AttributeTargets.Class)]
+            public class MyTestClassAttribute : TestClassAttribute
+            {
+            }
+
+            [MyTestClass]
+            public class {|#0:MyTestClass|}
+            {
+                internal MyTestClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(TestClassConstructorShouldBeValidAnalyzer.TestClassConstructorShouldBeValidRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenCustomDerivedTestClassAttributeHasPublicConstructor_NoDiagnostic()
+    {
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [AttributeUsage(AttributeTargets.Class)]
+            public class MyTestClassAttribute : TestClassAttribute
+            {
+            }
+
+            [MyTestClass]
+            public class MyTestClass
+            {
+                public MyTestClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
Fixes #9836

## Problem

`TestClassConstructorShouldBeValidAnalyzer` (MSTEST0063) validates that `[TestClass]`-decorated classes have a public parameterless constructor or a public `TestContext`-parameter constructor.

The guard in `AnalyzeSymbol` used an **exact-match** check (`SymbolEqualityComparer.Default.Equals`) against `TestClassAttribute`, so classes decorated with **derived** test-class attributes — including the built-in `[STATestClass]` and any custom `class MyAttr : TestClassAttribute` — were **silently skipped**. Because MSTest discovers such classes at runtime via `Inherits()` logic, a private/internal constructor causes a runtime instantiation failure with no analyzer warning.

## Fix

Replace the exact-match guard with the shared `IsTestClass()` helper, which calls `Inherits()` and matches the runtime discovery behavior:

```csharp
// Before
!namedTypeSymbol.GetAttributes().Any(attr =>
    SymbolEqualityComparer.Default.Equals(attr.AttributeClass, testClassAttributeSymbol))

// After
!namedTypeSymbol.IsTestClass(testClassAttributeSymbol)
```

## Tests

Four new tests added to `TestClassConstructorShouldBeValidAnalyzerTests.cs`:

| Scenario | Expected |
|---|---|
| `[STATestClass]` + private constructor | Diagnostic |
| `[STATestClass]` + public parameterless constructor | NoDiagnostic |
| Custom derived TestClass attr + internal constructor | Diagnostic |
| Custom derived TestClass attr + public constructor | NoDiagnostic |

## Trade-offs

This is a **behavior change**: previously, classes with derived `[TestClass]` attributes and invalid constructors produced no warning; after this fix they do. This is the correct behavior — the fix brings the analyzer in line with MSTest's runtime class-discovery logic.

Build and `MSTest.Analyzers.UnitTests` (net472 + net8.0) pass locally.