### PR TITLE
Replace Regex.Split+LINQ Take with string.Split+for in MSBuild StackTraceHelper

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
@@ -20,16 +20,17 @@ internal static class StackTraceHelper
             return false;
         }
 
-        string[] stackFrames = Regex.Split(errorStackTrace, Environment.NewLine);
+        string[] stackFrames = errorStackTrace.Split([Environment.NewLine], StringSplitOptions.None);
         if (stackFrames.Length == 0)
         {
             return false;
         }
 
         // Take 20 frames at max, so we don't search 1000 items in a long stack trace.
-        foreach (string? stackFrame in stackFrames.Take(20))
+        int limit = Math.Min(stackFrames.Length, 20);
+        for (int i = 0; i < limit; i++)
         {
-            if (TryGetStackFrameLocation(stackFrame, out lineNumber, out file, out place))
+            if (TryGetStackFrameLocation(stackFrames[i], out lineNumber, out file, out place))
             {
                 return true;
             }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Testing.Platform.MSBuild;
 
 internal static class StackTraceHelper
 {
+    private static readonly string[] NewLineSeparator = [Environment.NewLine];
+
     private static Regex? s_regex;
 
     internal static bool TryFindLocationFromStackFrame(string? errorStackTrace, [NotNullWhen(true)] out string? file, out int lineNumber, out string? place)
@@ -20,7 +22,7 @@ internal static class StackTraceHelper
             return false;
         }
 
-        string[] stackFrames = errorStackTrace.Split([Environment.NewLine], StringSplitOptions.None);
+        string[] stackFrames = errorStackTrace.Split(NewLineSeparator, StringSplitOptions.None);
         if (stackFrames.Length == 0)
         {
             return false;


### PR DESCRIPTION
Fixes #9834

## What

`StackTraceHelper.TryFindLocationFromStackFrame` runs for **every failed test** in MSBuild diagnostic output (via `FailedTestHelper`), so in CI pipelines with many failures it's a hot path. This removes two avoidable per-call overheads:

1. **`Regex.Split(errorStackTrace, Environment.NewLine)`** → `errorStackTrace.Split([Environment.NewLine], StringSplitOptions.None)`. Splitting on a plain literal string no longer goes through the regex engine.
2. **`stackFrames.Take(20)`** → a bounded `for` loop, eliminating the per-call `TakeIterator<string>` LINQ allocation.

Behavior is identical: same delimiter, same 20-frame cap, same early return on first match.

## Note vs. the original automated patch

The automated proposal in #9834 used the single-string `string.Split(Environment.NewLine)` overload, which **does not exist on `netstandard2.0`/.NET Framework** — that's why the workflow couldn't validate the build. This PR uses the `Split(string[], StringSplitOptions)` overload, which compiles on all target frameworks the project ships (`net8.0`, `net9.0`, `netstandard2.0`).

## Validation

- `Microsoft.Testing.Platform.MSBuild` builds cleanly on all TFMs (0 warnings, 0 errors).
- `Microsoft.Testing.Platform.MSBuild.UnitTests` — all 9 tests pass (including the StackTraceHelper location-found and location-missing cases).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>