### PR TITLE
Unify template-resolve-and-sanitize pipeline in ArtifactNamingHelper

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.ReadFields(System.IO.Stream! stream, System.Func<ushort, int, bool>! tryReadField) -> void
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.TryReadExecutionScopedField(System.IO.Stream! stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId) -> bool
 static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteExecutionScopedHeader(System.IO.Stream! stream, string? executionId, string? instanceId, ushort payloadFieldCount) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
 Microsoft.Testing.Platform.Logging.FileLogger.FileLogger(Microsoft.Testing.Platform.Logging.FileLoggerOptions! options, Microsoft.Testing.Platform.Logging.LogLevel logLevel, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IConsole! console, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Helpers.IFileStreamFactory! fileStreamFactory, System.TimeSpan? flushTimeout = null) -> void
 Microsoft.Testing.Platform.Logging.FileLogger.IsFileHandleReleased.get -> bool

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingHelper.cs
@@ -71,4 +71,34 @@ internal static partial class ArtifactNamingHelper
             return ordinalReplacements.TryGetValue(fieldName, out string? value) ? value : match.Value;
         });
     }
+
+    /// <summary>
+    /// Resolves the standard placeholders in <paramref name="template"/> and sanitizes the leaf file name
+    /// portion of the result using <paramref name="sanitizeLeafFileName"/>. The directory portion (if any)
+    /// is preserved without sanitization so that absolute or relative paths containing path separators are
+    /// kept intact.
+    /// </summary>
+    /// <param name="template">The file name template that may contain <c>{pname}</c>, <c>{pid}</c>, <c>{time}</c>, etc. placeholders.</param>
+    /// <param name="processName">The process name (resolves <c>{pname}</c>).</param>
+    /// <param name="processId">The process ID (resolves <c>{pid}</c>).</param>
+    /// <param name="timestamp">The timestamp to use (resolves <c>{time}</c>).</param>
+    /// <param name="sanitizeLeafFileName">The sanitizer applied to the resolved leaf file name.</param>
+    /// <returns>The resolved and sanitized file name (or path, if the template contained a directory component).</returns>
+    /// <exception cref="ArgumentException">The resolved template does not produce a leaf file name (e.g. it ends with a directory separator).</exception>
+    public static string ResolveAndSanitize(string template, string processName, string processId, DateTimeOffset timestamp, Func<string, string> sanitizeLeafFileName)
+    {
+        Dictionary<string, string> replacements = GetStandardReplacements(processName, processId, timestamp);
+        string resolved = ResolveTemplate(template, replacements);
+
+        string directoryPart = Path.GetDirectoryName(resolved) ?? string.Empty;
+        string leafName = Path.GetFileName(resolved);
+        if (leafName.Length == 0)
+        {
+            throw new ArgumentException("The resolved template must produce a file name, not just a directory path.", nameof(template));
+        }
+
+        string sanitized = sanitizeLeafFileName(leafName);
+
+        return directoryPart.Length == 0 ? sanitized : Path.Combine(directoryPart, sanitized);
+    }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactNamingService.cs
@@ -22,18 +22,6 @@ internal sealed class ArtifactNamingService : IArtifactNamingService
     {
         string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
         string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
-        Dictionary<string, string> replacements = ArtifactNamingHelper.GetStandardReplacements(processName, processId, _clock.UtcNow);
-        string resolved = ArtifactNamingHelper.ResolveTemplate(template, replacements);
-
-        string directoryPart = Path.GetDirectoryName(resolved) ?? string.Empty;
-        string leafName = Path.GetFileName(resolved);
-        if (leafName.Length == 0)
-        {
-            throw new ArgumentException("The resolved template must produce a file name, not just a directory path.", nameof(template));
-        }
-
-        string sanitized = ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(leafName);
-
-        return directoryPart.Length == 0 ? sanitized : Path.Combine(directoryPart, sanitized);
+        return ArtifactNamingHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow, ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars);
     }
 }

--- a/src/Platform/SharedExtensionHelpers/ReportFileNameHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportFileNameHelper.cs
@@ -26,13 +26,5 @@ internal static class ReportFileNameHelper
     /// The resolved and sanitized file name (or path, if the template contained a directory component).
     /// </returns>
     public static string ResolveAndSanitize(string template, string processName, string processId, DateTimeOffset now)
-    {
-        Dictionary<string, string> replacements = ArtifactNamingHelper.GetStandardReplacements(processName, processId, now);
-        string resolved = ArtifactNamingHelper.ResolveTemplate(template, replacements);
-        string directoryPart = Path.GetDirectoryName(resolved) ?? string.Empty;
-        string sanitizedFileName = ReportFileNameSanitizer.ReplaceInvalidFileNameChars(Path.GetFileName(resolved));
-        return directoryPart.Length == 0
-            ? sanitizedFileName
-            : Path.Combine(directoryPart, sanitizedFileName);
-    }
+        => ArtifactNamingHelper.ResolveAndSanitize(template, processName, processId, now, ReportFileNameSanitizer.ReplaceInvalidFileNameChars);
 }


### PR DESCRIPTION
Fixes #9841.

## Problem

`ArtifactNamingService.ResolveFileName` (in `Microsoft.Testing.Platform`) and `ReportFileNameHelper.ResolveAndSanitize` (in `SharedExtensionHelpers`) implemented the same algorithm: resolve template placeholders via `ArtifactNamingHelper`, split the result into directory + leaf, sanitize the leaf, and reassemble the path. The only real differences were where the process name/id came from and which sanitizer was used.

## Change

Applied recommendation #2 from the issue (smaller, less invasive): extracted the shared pipeline into a single static overload `ArtifactNamingHelper.ResolveAndSanitize(template, processName, processId, timestamp, sanitizeLeafFileName)` that takes the leaf sanitizer as a `Func<string, string>` delegate.

- `ArtifactNamingService.ResolveFileName` now delegates, passing `ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars`.
- `ReportFileNameHelper.ResolveAndSanitize` now delegates, passing `ReportFileNameSanitizer.ReplaceInvalidFileNameChars`. Its public signature is unchanged (matches the shipped InternalAPI), so no shipped-API churn.
- The non-empty leaf-name guard that only `ArtifactNamingService` previously had is now applied on both paths.

The two sanitizers (`ArtifactFileNameSanitizer` / `ReportFileNameSanitizer`) are intentionally left as-is and passed in as delegates — consolidating them is tracked separately (the related issue referenced in #9841).

## Notes

- The new `ArtifactNamingHelper.ResolveAndSanitize` member is added to the `InternalAPI.Unshipped.txt` of every project that links the `ArtifactNamingHelper` source (RS0051).

## Testing

- `Microsoft.Testing.Platform.UnitTests` — ArtifactNaming* tests: 24/24 passed.
- `Microsoft.Testing.Extensions.UnitTests` — ReportFileName* tests: 12/12 passed.
- Report extensions (Trx/Html/JUnit/Ctrf/…) build clean with no RS0051 warnings.