### PR TITLE
Deduplicate file-name sanitization logic (ArtifactFileNameSanitizer vs ReportFileNameSanitizer)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs
@@ -5,10 +5,12 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Platform.Services;
 
-// Mirrors the extension-side Microsoft.Testing.Extensions.ReportFileNameSanitizer (linked source in
-// src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs). The extension copy has SHIPPED
-// InternalAPI entries in five extensions, so it cannot be moved without churn/risk. This core-internal
-// copy exists pending future consolidation of the two.
+// Canonical file-name sanitization used both by the platform's artifact naming (ArtifactNamingService)
+// and, via a thin delegating wrapper, by the extension-side Microsoft.Testing.Extensions.ReportFileNameSanitizer
+// (linked source in src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs). Keeping the logic here
+// avoids duplicating the sanitization rules: the extension copy is SHIPPED InternalAPI in five extensions, so
+// its type name must remain, but those extensions can reach this internal type through the InternalsVisibleTo
+// grant and simply forward to it.
 internal static partial class ArtifactFileNameSanitizer
 {
     private const char ReplacementChar = '_';

--- a/src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs
@@ -1,51 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions;
 
-internal static partial class ReportFileNameSanitizer
+// This type is SHIPPED InternalAPI across several report extensions (linked source), so it cannot be
+// removed or renamed without breaking those extensions. It delegates to the canonical implementation in
+// Microsoft.Testing.Platform (ArtifactFileNameSanitizer), which the report extensions can access through
+// the InternalsVisibleTo grant, so the sanitization rules live in a single place and cannot drift.
+internal static class ReportFileNameSanitizer
 {
-    private const char ReplacementChar = '_';
-    private static readonly Regex ReservedFileNamesRegex = BuildReservedFileNameRegex();
-
     internal static string ReplaceInvalidFileNameChars(string fileName)
-    {
-        char[] result = new char[fileName.Length];
-
-        for (int i = 0; i < fileName.Length; ++i)
-        {
-            result[i] = IsInvalidFileNameChar(fileName[i]) ? ReplacementChar : fileName[i];
-        }
-
-        string replaced = new string(result).TrimEnd();
-        ArgumentGuard.Ensure(replaced.Length > 0, nameof(fileName), $"File name {fileName} is empty after sanitizing invalid characters.");
-
-        if (IsReservedFileName(replaced))
-        {
-            replaced = ReplacementChar + replaced; // Cannot add to the end because it can have extensions.
-        }
-
-        return replaced;
-    }
-
-    private static bool IsInvalidFileNameChar(char c)
-        => c is < ' ' or '"' or '<' or '>' or '|' or ':' or '*' or '?' or '\\' or '/' or '@' or '(' or ')' or '^' or ' ';
-
-    private static bool IsReservedFileName(string fileName) =>
-        // CreateFile:
-        // The following reserved device names cannot be used as the name of a file:
-        // CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
-        // LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
-        // Also avoid these names followed by an extension, for example, NUL.tx7.
-        // Windows NT: CLOCK$ is also a reserved device name.
-        ReservedFileNamesRegex.IsMatch(fileName);
-
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$", RegexOptions.None, "en-150")]
-    private static partial Regex BuildReservedFileNameRegex();
-#else
-    private static Regex BuildReservedFileNameRegex() => new(@"(?i:^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]|CLOCK\$)(\..*)?)$");
-#endif
+        => ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(fileName);
 }


### PR DESCRIPTION
Fixes #9840.

## Problem

Two functionally identical file-name sanitization implementations existed:

- `src/Platform/Microsoft.Testing.Platform/Services/ArtifactFileNameSanitizer.cs` (core, `internal`, **unshipped** InternalAPI)
- `src/Platform/SharedExtensionHelpers/ReportFileNameSanitizer.cs` (linked into 5 report extensions, `Microsoft.Testing.Extensions.ReportFileNameSanitizer`, **shipped** InternalAPI)

Both duplicated ~45 lines: invalid-char replacement, trailing-whitespace trim, empty-result guard, and reserved Windows device-name prefixing. The core file even documented the duplication in a `// Mirrors ...` comment. Any rule change had to be applied to both copies or they'd silently diverge.

## Why not just move/link one file?

`Microsoft.Testing.Platform` grants `InternalsVisibleTo` to all 5 report extensions. Linking a single same-named type into core **and** each extension would produce a `CS0433` type-ambiguity build break (core's copy visible via `InternalsVisibleTo` + each extension's own linked copy). This is exactly why the duplication existed and why the shipped extension type couldn't simply be removed.

## Fix (issue's "linked source / single source of truth" strategy, adapted)

- The canonical sanitization logic now lives **only** in `ArtifactFileNameSanitizer` (core).
- The shipped `ReportFileNameSanitizer` becomes a thin wrapper that forwards to `ArtifactFileNameSanitizer.ReplaceInvalidFileNameChars(...)`. The extensions already have `InternalsVisibleTo` access to core internals, so they reach the canonical implementation directly.
- Updated the explanatory comments; removed the stale `// Mirrors ...` note.

The shipped `Microsoft.Testing.Extensions.ReportFileNameSanitizer.ReplaceInvalidFileNameChars` API surface is preserved unchanged, so **no InternalAPI churn** is required across the extensions.

## Verification

- All 5 report extensions (Trx, AzureDevOps, Html, JUnit, Ctrf), `Microsoft.Testing.Platform`, and `Microsoft.Testing.Extensions.UnitTests` build with 0 warnings / 0 errors.
- `Microsoft.Testing.Extensions.UnitTests` passes (`failed: 0`), including `ReportFileNameSanitizationConsistencyTests`, which asserts every report engine's linked sanitizer produces identical output.

Behavior is identical by construction — the wrapper calls the exact original logic, now single-sourced.