### PR TITLE
Backport additional finalized localization translations from main to rel/4.3

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -563,8 +563,8 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Aby byly metody s označením [GlobalTestInitialize] nebo [GlobalTestCleanup] platné, musí se řídit následujícím rozložením:
-– Nesmí být deklarované pro obecnou class.
+        <target state="translated">Aby byly metody s označením [GlobalTestInitialize] nebo [GlobalTestCleanup] platné, musí se řídit následujícím rozložením:
+– Nesmí být deklarované pro obecnou třídu (class).
 – Musí být „public“.
 – Musí být „static“.
 – Nesmí být „async void“.
@@ -574,11 +574,10 @@ The type declaring these methods should also respect the following rules:
 – Návratový typ musí být „void“, „Task“ nebo „ValueTask“.
 
 Typ deklarující tyto metody by měl také respektovat následující pravidla: 
-– Typ by měl být class.
-– class by měla být „public“.
-– class by neměla být „static“.
-– class by měla být označena atributem [TestClass] (nebo odvozeným atributem).
-– class by neměla být obecná.</target>
+– Typ by měl být třída (class).
+– Třída (class) by měla být „public“.
+– Třída (class) by měla být označena atributem [TestClass] (nebo odvozeným atributem).
+– Třída (class) by neměla být obecná.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -564,21 +564,21 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Methoden, die mit „[GlobalTestInitialize]“ oder „[GlobalTestCleanup]“ gekennzeichnet sind, sollten dem folgenden Layout folgen, um gültig zu sein:
+        <target state="translated">Methoden, die mit „[GlobalTestInitialize]“ oder „[GlobalTestCleanup]“ gekennzeichnet sind, sollten dem folgenden Layout folgen, um gültig zu sein:
 – kann nicht für eine generische class deklariert werden
 – muss „public“ sein
 – muss „static“ sein
 – darf nicht „async void“ sein
 – darf keine spezielle Methode sein (Finalizer, Operator...).
 – darf nicht „generic“ sein
+na zheyibo 
 – muss einen Parameter vom Typ „TestContext“ annehmen
 – der Rückgabetyp muss „void“, „Task“ oder „ValueTask“ sein
 
 Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachten:
-– Der Typ sollte eine class sein
+– Der Typ sollte eine class sein.
 – Die class sollte „public“ sein
-– Die class darf nicht „static“ sein
-– Die class muss mit „[TestClass]“ (oder einem abgeleiteten Attribut) markiert werden
+– Die class muss mit „[TestClass]“ (oder einem abgeleiteten Attribut) markiert werden.
 – die class darf nicht generisch sein.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -563,21 +563,20 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Los métodos marcados con '[GlobalTestInitialize]' o '[GlobalTestCleanup]' deben seguir el siguiente diseño para ser válidos:
+        <target state="translated">Los métodos marcados con "[GlobalTestInitialize]" o "[GlobalTestCleanup]" deben seguir el siguiente diseño para ser válidos:
 -no se puede declarar en una class genérica
-- debería ser 'public' 
-- debería estar 'static'
--no debe ser 'async void'
+- debería ser "public" 
+- debería estar "static"
+-no debe ser "async void"
 -no debe ser un método especial (finalizador, operador...).
 -no debe ser genérico
--debe tomar un parámetro de tipo 'TestContext'
-- El tipo de valor devuelto debe ser 'void', 'Task' o 'ValueTask'
+-debe tomar un parámetro de tipo "TestContext"
+- El tipo de valor devuelto debe ser "void", "Task" o "ValueTask"
 
 El tipo que declara estos métodos también debe respetar las reglas siguientes:
 -El tipo debe ser una class
--La class debe ser 'public'
--La class no debe ser 'static'
--La class debe marcarse con '[TestClass]' (o un atributo derivado)
+-La class debe ser "publico"
+-La class debe marcarse con "[TestClass]" (o un atributo derivado)
 -la class no debe ser genérica.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -563,21 +563,20 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
+        <target state="translated">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
 - elle ne peut pas être déclarée dans une classe générique
 – elle doit être « public »
-– elle doit être « static »
-– elle ne doit pas être « async void »
-– il ne doit pas s’agir d’une méthode spéciale (finaliseur, opérateur...).
+– cela devrait être « static ».
+– cela ne devrait pas être « async void ».
+– il ne doit pas s'agir d'une méthode spéciale (finaliseur, opérateur...).
 – elle ne doit pas être générique
 – il doit prendre un paramètre de type « TestContext »
-- le type de retour doit être « void », « Task » ou « ValueTask »
-
+– le type de retour doit être « void », « Task » ou « ValueTask ».
+{0}
 Le type déclarant ces méthodes doit également respecter les règles suivantes :
 - le type doit être une classe
 - la classe doit être « public » 
-- la classe ne doit pas être « static »
-- la classe doit être marquée par « [TestClass] » (ou un attribut dérivé)
+-La classe doit être marquée avec « [TestClass] » (ou un attribut dérivé).
 - la classe ne doit pas être générique.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -563,21 +563,20 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">I metodi contrassegnati con ‘[GlobalTestInitialize]’ o ‘[GlobalTestCleanup]’ devono seguire il layout seguente per essere validi:
+        <target state="translated">I metodi contrassegnati con "[GlobalTestInitialize]" o "[GlobalTestCleanup]" devono seguire il layout seguente per essere validi:
 - Non può essere dichiarato in una classe generica
-- Deve essere 'public'
-- Deve essere 'static'
-- Non deve essere 'async void'
+- Deve essere "public"
+- Deve essere "static"
+- Non deve essere "async void"
 - Non deve essere un metodo speciale (finalizzatore, operatore...).
 - Non deve essere generico
-- Deve accettare un parametro di tipo 'TestContext'
-- Il tipo restituito deve essere 'void', 'Task' o 'ValueTask'
+- Deve accettare un parametro di tipo "TestContext"
+- Il tipo restituito deve essere "void", "Task" o "ValueTask"
 
 Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
 - Il tipo deve essere una classe
-- La classe deve essere 'public'
-- La classe non deve essere 'static'
-- La classe deve essere contrassegnata con '[TestClass]' (o un attributo derivato)
+- La classe deve essere "public"
+-La classe deve essere contrassegnata con "[TestClass]" (o un attributo derivato)
 - La classe non deve essere generica.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -563,7 +563,7 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">'[GlobalTestInitialize]' または '[GlobalTestCleanup]' でマークされたメソッドを有効にするには、次のレイアウトに従う必要があります:
+        <target state="translated">'[GlobalTestInitialize]' または '[GlobalTestCleanup]' でマークされたメソッドを有効にするには、次のレイアウトに従う必要があります:
 - ジェネリック class で宣言することはできません
 - 'public' である必要があります
 - 'static' である必要があります
@@ -576,7 +576,6 @@ The type declaring these methods should also respect the following rules:
 これらのメソッドを宣言する型も、次の規則に従う必要があります:
 - 型は class である必要があります
 -class は 'public' である必要があります
-- class を 'static' にすることはできません
 - class は '[TestClass]' (または派生属性) でマークする必要があります
 - class をジェネリックにすることはできません。</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -563,7 +563,7 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">'[GlobalTestInitialize]' 또는 '[GlobalTestCleanup]'으로 표시된 메서드는 다음 레이아웃을 따라야 유효합니다.
+        <target state="translated">'[GlobalTestInitialize]' 또는 '[GlobalTestCleanup]'으로 표시된 메서드는 다음 레이아웃을 따라야 유효합니다.
 - 제네릭 class에서 선언할 수 없습니다.
 - 'public'이어야 합니다. 
 - 'static'이어야 합니다.
@@ -574,10 +574,9 @@ The type declaring these methods should also respect the following rules:
 - 반환 형식은 'void', 'Task' 또는 'ValueTask'여야 합니다.
 
 이러한 메서드를 선언하는 형식은 다음 규칙도 준수해야 합니다.
-- 형식은 class여야 합니다.
--class는 'public'이어야 합니다.
-- class는 'static'이 되어서는 안 됩니다.
-- class는 '[TestClass]'(또는 파생 특성)로 표시되어야 합니다.
+-형식은 class여야 합니다.
+- class는 'public'이어야 합니다.
+-class는 '[TestClass]'(또는 파생 특성)로 표시되어야 합니다.
 - class는 제네릭이 아니어야 합니다.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -563,7 +563,7 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Metody oznaczone znakiem „[GlobalTestInitialize]” lub „[GlobalTestCleanup]” powinny być zgodne z następującym układem, aby były prawidłowe:
+        <target state="translated">Metody oznaczone znakiem „[GlobalTestInitialize]” lub „[GlobalTestCleanup]” powinny być zgodne z następującym układem, aby były prawidłowe:
 — nie może być zadeklarowana w class ogólnej
 — powinna być typu „public”
 — powinna mieć wartość „static”
@@ -574,10 +574,9 @@ The type declaring these methods should also respect the following rules:
 — zwracany typ powinien mieć wartość „void”, „Task” lub „ValueTask”
 
 Typ deklarujący te metody powinien również przestrzegać następujących reguł:
-— typ powinien być class
+— Typ powinien być class
 — class powinna być „publiczna”
-— class nie powinna mieć wartości „static”
-— class powinna być oznaczona „[TestClass]” (lub atrybutem pochodnym)
+— class powinna być oznaczona znakiem „[TestClass]” (lub atrybutem pochodnym)
 — class nie powinna być ogólna.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -563,21 +563,20 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Os métodos marcados com "[GlobalTestInitialize]" ou "[GlobalTestCleanup]" devem seguir o seguinte layout para serem válidos:
+        <target state="translated">Os métodos marcados com ‘[GlobalTestInitialize]’ ou ‘[GlobalTestCleanup]’ devem seguir o seguinte layout para serem válidos:
 -não podem ser declarados em uma classe genérica
--devem ser "public"
--devem ser "static"
--não devem ser "async void"
+-devem ser ‘public’
+-devem ser ‘static’
+-não devem ser ‘async void’
 -não devem ser um método especial (finalizador, operador...).
 -não devem ser genéricos
--devem usar um parâmetro do tipo “TestContext”
--o tipo de retorno deve ser “void”, “Task” ou “ValueTask”
+-devem usar um parâmetro do tipo ‘TestContext’
+-o tipo de retorno deve ser ‘void’, ‘Task’ ou ‘ValueTask’
 
 O tipo que declara esses métodos também deve respeitar as seguintes regras:
 -O tipo deve ser uma classe
--A classe deve ser "public"
--A classe não deve ser “static”
--A classe deve ser marcada com “[TestClass]” (ou um atributo derivado)
+-A classe deve ser ‘public’
+-A classe deve ser marcada com ‘[TestClass]’ (ou um atributo derivado)
 -a classe não deve ser genérica.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -569,22 +569,21 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">Чтобы метод, помеченный "[GlobalTestInitialize]" или "[GlobalTestCleanup]", был допустимым, он должен соответствовать следующей структуре:
-– не может быть объявлен для универсального class ("generic")
+        <target state="translated">Чтобы метод, помеченный "[GlobalTestInitialize]" или "[GlobalTestCleanup]", был допустимым, он должен соответствовать следующей структуре:
+– не может быть объявлен для универсального class
 – должен быть общедоступным ("public")
 – должен быть статическим ("static")
 – не должен быть асинхронным и не возвращающим значения ("async void")
 – не должен быть специальным (метод завершения, оператор…).
-– не должен быть общим ("generic")
+– не должен быть универсальным ("generic")
 – должен принимать один параметр типа "TestContext"
 – должен иметь тип возвращаемого значения "void", "Task" или "ValueTask"
 
 Тип, объявляющий такие методы, также должен соответствовать следующим правилам:
 – должен быть class
 – class должен быть общедоступным ("public")
-– class должен быть статическим ("static")
-– class должен быть помечен как "[TestClass]" (или производный атрибут)
-– class должен быть универсальным ("generic").</target>
+– class должен быть помечен как "[TestClass]" (или производный атрибут);
+– class не должен быть универсальным.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -563,7 +563,7 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">‘[GlobalTestInitialize]’ veya ‘[GlobalTestCleanup]’ ile işaretlenmiş yöntemlerin geçerli olabilmesi için şu düzeni izlemesi gerekir:
+        <target state="translated">'[GlobalTestInitialize]' veya '[GlobalTestCleanup]' ile işaretlenmiş yöntemlerin geçerli olabilmesi için şu düzeni izlemesi gerekir:
 -genel bir class tanımlanamaz
 -'public' olmalıdır
 -'static' olmalıdır
@@ -575,8 +575,7 @@ The type declaring these methods should also respect the following rules:
 
 Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
 -Tür bir class olmalıdır
--class ‘public’ olmalıdır
--class 'static' olmamalıdır
+-class 'public' olmalıdır
 -class '[TestClass]' (veya türetilmiş bir öznitelik) ile işaretlenmelidir
 -class genel olmamalıdır.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -563,7 +563,7 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">标记有 "[GlobalTestInitialize]" 或 "[GlobalTestCleanup]" 的方法应遵循以下布局才会有效:
+        <target state="translated">标记有 "[GlobalTestInitialize]" 或 "[GlobalTestCleanup]" 的方法应遵循以下布局才会有效:
 - 不能在泛型 class 上声明它
 - 它应为 "public"
 - 它应为 "static"
@@ -574,10 +574,9 @@ The type declaring these methods should also respect the following rules:
 - 返回类型应为 "void"、"Task" 或 "ValueTask"
 
 声明这些方法的类型还应遵循以下规则:
-- 类型应为 class
+- 类型应为class 
 - class 应该为 "public"
-- class 不应为 "static"
-- 应使用 "[TestClass]"（或派生属性）标记 class
+- 应使用 "[TestClass]" (或派生属性)标记 class
 - class 不应是泛型的。</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -563,20 +563,19 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="needs-review-translation">標示為 '[GlobalTestInitialize]' 或 '[GlobalTestCleanup]' 的方法應該遵循下列配置才能有效：
--其不能在泛型 class 上宣告
+        <target state="translated">標示為 '[GlobalTestInitialize]' 或 '[GlobalTestCleanup]' 的方法應該遵循下列配置才能有效：
+-其不能在泛型類別上宣告
 -其應為 'public'
 -其應為 'static'
 -其不應為 'async void'
 -其不應為特殊方法 (完成項、運算子...)。
 -其不應為泛型
--其應該接受類型為 'TestContext' 的一個參數
--傳回類型應為 'void'、'Task' 或 'ValueTask'
+-其應該接受 class 為 'TestContext' 的一個參數
+-傳回 class 應為 'void'、'Task' 或 'ValueTask'
 
-宣告這些方法的類型還應遵循以下規則:
--類型應為 class
+宣告這些方法的 class 還應遵循以下規則:
+-class 應為類別
 -class 應為 'public'
--class 不應為 'static'
 -class 應標示為 '[TestClass]' (或衍生屬性)
 -class 不應為泛型。</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>


### PR DESCRIPTION
Follow-up to #9847. Backports **13 additional finalized localization translations** from `main` to `rel/4.3` — one per language for the `MSTest.Analyzers` `Resources` file.

## Context
After #9847 merged, a new OneLocBuild finalized several analyzer *description* strings on `main`. On `rel/4.3` these entries were still `needs-review-translation`. This PR promotes them to the finalized `translated` version from `main`.

This round also corrects a subtle line-ending issue in the original backport tooling: multi-line `<source>` strings are now compared with normalized newlines, so multi-line entries that genuinely match are no longer skipped, while inserted targets keep the file's original CRLF endings.

## Guarantees (verified programmatically)
- **No new entries** — only existing trans-units are touched.
- **Source-matched** — every backported unit's English `<source>` is identical to `main` (ignoring newline style only).
- **Only open entries filled** — transitions are strictly `needs-review-translation` -> `translated`; already-`translated` rel entries are untouched.
- Target/state now match `main` exactly; UTF-8 BOM and CRLF preserved; all 13 files remain well-formed XML.

## Scope
13 targets across 13 files (all `needs-review-translation` -> `translated`). No further backportable entries remain (the other still-untranslated strings are either untranslated on `main` too, or have a different English source on `rel/4.3`).