### PR TITLE
Regenerate out-of-date xlf to fix main pipeline

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -563,21 +563,21 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
-- elle ne peut pas être déclarée dans une classe générique
-– elle doit être « public »
-– cela devrait être « static ».
-– cela ne devrait pas être « async void ».
-– il ne doit pas s'agir d'une méthode spéciale (finaliseur, opérateur...).
-– elle ne doit pas être générique
-– il doit prendre un paramètre de type « TestContext »
-– le type de retour doit être « void », « Task » ou « ValueTask ».
-{0}
-Le type déclarant ces méthodes doit également respecter les règles suivantes :
-- le type doit être une classe
-- la classe doit être « public » 
--La classe doit être marquée avec « [TestClass] » (ou un attribut dérivé).
-- la classe ne doit pas être générique.</target>
+        <target state="new">Methods marked with '[GlobalTestInitialize]' or '[GlobalTestCleanup]' should follow the following layout to be valid:
+-it can't be declared on a generic class
+-it should be 'public'
+-it should be 'static'
+-it should not be 'async void'
+-it should not be a special method (finalizer, operator...).
+-it should not be generic
+-it should take one parameter of type 'TestContext'
+-return type should be 'void', 'Task' or 'ValueTask'
+
+The type declaring these methods should also respect the following rules:
+-The type should be a class
+-The class should be 'public'
+-The class should be marked with '[TestClass]' (or a derived attribute)
+-the class should not be generic.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -74,7 +74,7 @@
       </trans-unit>
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
-        <target state="translated">{0} все еще выполняется через {0} с</target>
+        <target state="new">{0} still running after {1}s</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">


### PR DESCRIPTION
## Problem

The `main` CI pipeline fails with `CheckXlf` errors:

```
error : 'xlf\Resources.fr.xlf' is out-of-date with 'Resources.resx'. Run `msbuild /t:UpdateXlf` ...
error : 'Resources\xlf\GitHubActionsResources.ru.xlf' is out-of-date with 'Resources\GitHubActionsResources.resx'. ...
```

## Root cause

OneLocBuild `f6ee69eef` (#9863) checked in machine translations with **mismatched format placeholders**:

- **Russian** `SlowTestStillRunning` — source is `{0} still running after {1}s`, but the translation used `{0}` twice and dropped `{1}`.
- **French** `GlobalTestFixtureShouldBeValidDescription` — the translation injected a `{0}` placeholder that does not exist in the source (a blank line in English).

XliffTasks validates placeholder consistency between `<source>` and `<target>`. It rejects those units and marks the xlf out-of-date. The `<source>` text itself matches the `.resx` byte-for-byte — only the translated `<target>` is inconsistent.

## Why local builds didn't catch it

Arcade sets `UpdateXlfOnBuild=true` for local (non-CI) builds, so `build.cmd` silently regenerates the xlf and succeeds — the fix is auto-applied and easy to miss. CI runs with `ContinuousIntegrationBuild=true` → `UpdateXlfOnBuild=false`, so `CheckXlf` fails instead of self-healing. Reproduced locally with `/p:ContinuousIntegrationBuild=true`.

## Fix

Regenerated both files via `UpdateXlf`, resetting the two affected units to `state="new"` (same resolution as #9862). Verified both projects build clean in CI mode (`ContinuousIntegrationBuild=true`). The next OneLocBuild will re-translate these units.

> Note: this is recurring — if OneLoc keeps producing translations that mangle `{0}`/`{1}` placeholders, the underlying localization issue is worth tracking separately.