### PR TITLE
Fix backport workflow failing on every push

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,9 +22,13 @@ concurrency:
 jobs:
   backport:
     if: ${{ contains(github.event.comment.body, '/backport to') || github.event_name == 'schedule' }}
-    # Pin the reusable workflow to the exact commit that triggered this run so a
-    # mid-PR push to `main` cannot change backport behavior while runs are in flight.
-    uses: microsoft/testfx/.github/workflows/backport-base.yml@${{ github.sha }}
+    # Reference the reusable workflow by local path so it always resolves to the
+    # same commit as this caller, pinning backport behavior to the triggering
+    # commit without an expression. An expression in `uses:` (e.g.
+    # `backport-base.yml@${{ github.sha }}`) is not a valid reusable-workflow
+    # reference and makes GitHub emit a failed "workflow file issue" run on every
+    # push, regardless of this workflow's declared triggers.
+    uses: ./.github/workflows/backport-base.yml
     with:
       pr_description_template: |
         Backport of #%source_pr_number% to %target_branch%


### PR DESCRIPTION
## Problem

Over the weekend the Actions tab filled with failures. The dominant, systemic one was **`.github/workflows/backport.yml` failing on every `push`** (24+ failures during Jul 11–12 and still ongoing on Jul 13). Each failed run had **0 jobs** and the message *"This run likely failed because of a workflow file issue"* — a phantom startup failure, even though `backport.yml` only declares `issue_comment` and `schedule` triggers.

## Root cause

Commit b7c497999 (*"Fix CI/CD workflow hygiene issues"*, Jul 11) changed the reusable-workflow reference to use an **expression**:

```yaml
uses: microsoft/testfx/.github/workflows/backport-base.yml@${{ github.sha }}
```

An expression in a reusable-workflow `uses:` ref is not a valid reference. When GitHub builds the workflow graph on **every push** (to any branch) it fails to resolve this reference and emits a failed "workflow file issue" run — regardless of the workflow's declared triggers, and before the job-level `if:` guard is ever evaluated.

## Fix

Reference the same-repo reusable workflow by **local path**:

```yaml
uses: ./.github/workflows/backport-base.yml
```

The `./` local reference is static/valid (no phantom per-push runs) and always resolves the callee from the **same commit as the caller** — which preserves the original pinning intent (backport behavior tied to the triggering commit) that the `@${{ github.sha }}` change was reaching for. On the real triggers (`issue_comment`/`schedule`), those events run from the default branch, so this matches prior behavior.

Verified the YAML parses and that no other workflow uses an expression in a `uses:` ref.

## Out of scope (noted, not fixed here)

- **Markdownlint (5×)** — legitimate MD040/MD012 errors in `samples/BrowserPlayground/README.md` on the in-flight PR branch `dev/amauryleve/psychic-tribble`; belongs to that PR.
- **Perf timing nightly (1×, Linux)** — a single scheduled perf-pipeline step failure (Windows passed); likely transient/environmental.