### PR TITLE
perf: add Scenario3 (lifecycle overhead) to performance benchmark suite

### DIFF
--- a/test/Performance/MSTest.Performance.Runner/Program.cs
+++ b/test/Performance/MSTest.Performance.Runner/Program.cs
@@ -141,6 +141,36 @@ internal class EntryPoint
             .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
             .NextStep(() => new CleanupDisposable()));
 
+        // Scenario3: lifecycle overhead — same total execution count as Scenario1 (100 classes ×
+        // 100 methods = 10 000 executions), but every class has a [TestInitialize] and a
+        // [TestCleanup] method. Running Scenario1 and Scenario3 back-to-back on the same machine
+        // isolates the per-test cost of the MSTest lifecycle machinery.
+        pipelineRunner.AddPipeline("Default", "Scenario3_Lifecycle_PlainProcess", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
+        Pipeline
+            .FirstStep(() => new Scenario3(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.MethodLevel), parametersBag)
+            .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
+            .NextStep(() => new PlainProcess("Scenario3_Lifecycle_PlainProcess.zip"))
+            .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
+            .NextStep(() => new CleanupDisposable()));
+
+        // Class-level parallelism variant of the lifecycle scenario.
+        pipelineRunner.AddPipeline("Default", "Scenario3_Lifecycle_ClassLevel_PlainProcess", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
+        Pipeline
+            .FirstStep(() => new Scenario3(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.ClassLevel), parametersBag)
+            .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
+            .NextStep(() => new PlainProcess("Scenario3_Lifecycle_ClassLevel_PlainProcess.zip"))
+            .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
+            .NextStep(() => new CleanupDisposable()));
+
+        // dotnet-test path for the lifecycle scenario.
+        pipelineRunner.AddPipeline("Default", "Scenario3_Lifecycle_DotnetTest_PlainProcess", [OSPlatform.Windows, OSPlatform.Linux, OSPlatform.OSX], parametersBag =>
+        Pipeline
+            .FirstStep(() => new Scenario3(numberOfClass: 100, methodsPerClass: 100, tfm: "net9.0", executionScope: ExecutionScope.MethodLevel), parametersBag)
+            .NextStep(() => new DotnetMuxer(BuildConfiguration.Debug))
+            .NextStep(() => new DotnetTestProcess("Scenario3_Lifecycle_DotnetTest_PlainProcess.zip", BuildConfiguration.Debug))
+            .NextStep(() => new MoveFiles("*.zip", Path.Combine(Directory.GetCurrentDirectory(), "Results")))
+            .NextStep(() => new CleanupDisposable()));
+
         return pipelineRunner.Run(pipelineNameFilter);
     }
 }

--- a/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario3.cs
+++ b/test/Performance/MSTest.Performance.Runner/Scenarios/Scenario3.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.TestInfrastructure;
+
+namespace MSTest.Performance.Runner.Steps;
+
+/// <summary>
+/// Lifecycle-overhead scenario: each test class has a <c>[TestInitialize]</c> and a
+/// <c>[TestCleanup]</c> method (both minimal bodies, marked <c>NoInlining</c> so the JIT
+/// cannot collapse them). These hooks run for every test in every class, so the scenario
+/// isolates the per-test cost of the MSTest lifecycle machinery
+/// (TestInitialize/TestCleanup invocation dispatch, MethodInfo.Invoke, timeout-dictionary
+/// lookups, …).
+///
+/// Designed to pair with Scenario1 for direct overhead comparison — same total execution
+/// count (100 classes × 100 methods = 10 000 test executions), the only difference being
+/// the presence of the lifecycle hooks.
+/// </summary>
+internal class Scenario3 : IStep<NoInputOutput, SingleProject>
+{
+    private const string NuGetPackageExtensionName = ".nupkg";
+    private const string MSTestTestFrameworkPackageNamePrefix = "MSTest.TestFramework.";
+
+    private readonly int _numberOfClass;
+    private readonly int _methodsPerClass;
+    private readonly string _tfm;
+    private readonly ExecutionScope _executionScope;
+    private readonly int _workers;
+
+    public Scenario3(int numberOfClass, int methodsPerClass, string tfm, ExecutionScope executionScope, int workers = 0)
+    {
+        _numberOfClass = numberOfClass;
+        _methodsPerClass = methodsPerClass;
+        _tfm = tfm;
+        _executionScope = executionScope;
+        _workers = workers;
+    }
+
+    public string Description => "create Scenario3 (lifecycle overhead)";
+
+    public async Task<SingleProject> ExecuteAsync(NoInputOutput payload, IContext context)
+    {
+        Console.WriteLine($"Creating Scenario3 {_numberOfClass} classes, {_methodsPerClass} methods per class, ExecutionScope {_executionScope} with {_workers} workers");
+        var cpmPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "Directory.Packages.props"));
+        string microsoftNETTestSdkVersion = cpmPropFileDoc.Descendants("MicrosoftNETTestSdkVersion").Single().Value;
+        string msTestVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, MSTestTestFrameworkPackageNamePrefix);
+
+        StringBuilder stringBuilder = new();
+        for (int i = 0; i < _numberOfClass; i++)
+        {
+            stringBuilder.AppendLine(
+                CultureInfo.InvariantCulture,
+                $$"""
+
+                  [TestClass]
+                  public class UnitTest{{i}}
+                  {
+                      private int _state;
+
+                      [TestInitialize]
+                      [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+                      public void TestInitialize()
+                      {
+                          _state = 1;
+                      }
+
+                      [TestCleanup]
+                      [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+                      public void TestCleanup()
+                      {
+                          _state = 0;
+                      }
+                  """);
+            for (int k = 1; k < _methodsPerClass + 1; k++)
+            {
+                if (k % 2 == 0)
+                {
+                    stringBuilder.AppendLine(
+                        CultureInfo.InvariantCulture,
+                        $$"""
+
+                                  [TestMethod]
+                                  [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+                                  public System.Threading.Tasks.Task TestMethod{{k}}()
+                                  {
+                                      return System.Threading.Tasks.Task.CompletedTask;
+                                  }
+
+                          """);
+                }
+                else
+                {
+                    stringBuilder.AppendLine(
+                        CultureInfo.InvariantCulture,
+                        $$"""
+
+                                  [TestMethod]
+                                  [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+                                  public void TestMethod{{k}}()
+                                  {
+                                  }
+
+                          """);
+                }
+            }
+
+            stringBuilder.AppendLine("}");
+        }
+
+        TestAsset generator = await TestAsset.GenerateAssetAsync(
+            nameof(Scenario3),
+            CurrentMSTestSourceCode
+            .PatchCodeWithReplace("$TargetFramework$", $"<TargetFramework>{_tfm}</TargetFramework>")
+            .PatchCodeWithReplace("$MicrosoftNETTestSdkVersion$", microsoftNETTestSdkVersion)
+            .PatchCodeWithReplace("$MSTestVersion$", msTestVersion)
+            .PatchCodeWithReplace("$EnableMSTestRunner$", "<EnableMSTestRunner>true</EnableMSTestRunner>")
+            .PatchCodeWithReplace("$OutputType$", "<OutputType>Exe</OutputType>")
+            .PatchCodeWithReplace("$Extra$", string.Empty)
+            .PatchCodeWithReplace("$Tests$", stringBuilder.ToString())
+            .PatchCodeWithReplace("$ExecutionScope$", _executionScope.ToString())
+            .PatchCodeWithReplace("$Workers$", _workers.ToString(CultureInfo.InvariantCulture)),
+            addPublicFeeds: true);
+
+        context.AddDisposable(generator);
+        return new SingleProject([_tfm], generator, nameof(Scenario3));
+    }
+
+    private static string ExtractVersionFromPackage(string rootFolder, string packagePrefixName)
+    {
+        string[] matches = Directory.GetFiles(rootFolder, packagePrefixName + "*" + NuGetPackageExtensionName, SearchOption.TopDirectoryOnly);
+
+        if (matches.Length > 1)
+        {
+            // For some packages the find pattern will match multiple packages, for example:
+            // Microsoft.Testing.Platform.1.0.0.nupkg
+            // Microsoft.Testing.Platform.Extensions.1.0.0.nupkg
+            // Let's take shortest name which should be closest to the package we are looking for.
+            matches = [matches.OrderBy(x => x.Length).First()];
+        }
+
+        if (matches.Length != 1)
+        {
+            throw new InvalidOperationException($"Was expecting to find a single NuGet package named '{packagePrefixName}' in '{rootFolder}' but found {matches.Length}.");
+        }
+
+        string packageFullName = Path.GetFileName(matches[0]);
+        return packageFullName.Substring(packagePrefixName.Length, packageFullName.Length - packagePrefixName.Length - NuGetPackageExtensionName.Length);
+    }
+
+    protected const string CurrentMSTestSourceCode = """
+#file Scenario3.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PlatformTarget>x64</PlatformTarget>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    $TargetFramework$
+    $OutputType$
+    $EnableMSTestRunner$
+    $Extra$
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$MicrosoftNETTestSdkVersion$" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>
+
+#file UnitTest1.cs
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize(Workers = $Workers$, Scope = ExecutionScope.$ExecutionScope$)]
+
+$Tests$
+""";
+}


### PR DESCRIPTION
Fixes #9873

## Goal

The perf benchmark suite had two scenario types (Scenario1 = plain tests, Scenario2 = data-driven) but no scenario measuring the cost of MSTest's **test lifecycle hooks** (`[TestInitialize]` / `[TestCleanup]`), which run for every test in every class.

## Changes

Added **Scenario3**: 100 test classes × 100 methods = 10 000 executions (same total as Scenario1) where each class has:
- A `[TestInitialize]` method (sets a field — minimal body)
- A `[TestCleanup]` method (clears the field — minimal body)

Both lifecycle methods are `[MethodImpl(NoInlining)]` so the JIT cannot collapse them. The template is otherwise structurally identical to Scenario1, so Scenario1 vs Scenario3 wall-clock comparison on the same machine isolates the per-test lifecycle cost.

Three pipelines registered (mirroring Scenario2 coverage), all carrying the `*PlainProcess*` suffix so they are included in nightly runs:

| Pipeline name | Parallelism | Runner |
|---|---|---|
| `Scenario3_Lifecycle_PlainProcess` | MethodLevel | `PlainProcess` |
| `Scenario3_Lifecycle_ClassLevel_PlainProcess` | ClassLevel | `PlainProcess` |
| `Scenario3_Lifecycle_DotnetTest_PlainProcess` | MethodLevel | `DotnetTestProcess` |

No production code changes; no new dependencies.

## Reproducibility

```sh
# Requires: .\build.cmd -pack first
.dotnet/dotnet run --project test/Performance/MSTest.Performance.Runner \
  -- execute --pipelineNameFilter "*Scenario3*PlainProcess*"
```

## Test status

`.\build.cmd` on the perf runner project → **Build succeeded, 0 warnings, 0 errors**. No unit tests exist for the perf runner itself (it is a measurement harness).