### PR TITLE
Add explicit type tests for AvoidOutParameterOnAssertIsInstanceOfTypeFixer

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutParameterOnAssertIsInstanceOfTypeFixerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutParameterOnAssertIsInstanceOfTypeFixerTests.cs
@@ -273,6 +273,98 @@ public sealed class AvoidOutParameterOnAssertIsInstanceOfTypeFixerTests
     }
 
     [TestMethod]
+    public async Task FixIsInstanceOfTypeWithExplicitType_ShouldProduceTypedVariableDeclaration()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                    object value = "test";
+                    /*trivia1*/Assert.IsInstanceOfType<string>(value, out {|CS1615:string result|})/*trivia2*/;/*trivia3*/
+                }
+
+                [TestMethod]
+                public void TestMethod2()
+                {
+                    object value = "test";
+
+
+                    Assert.IsInstanceOfType<string>(value, out {|CS1615:string result|});
+
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                    object value = "test";
+                    /*trivia1*/string result = Assert.IsInstanceOfType<string>(value)/*trivia2*/;/*trivia3*/
+                }
+
+                [TestMethod]
+                public void TestMethod2()
+                {
+                    object value = "test";
+
+
+                    string result = Assert.IsInstanceOfType<string>(value);
+
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task FixIsInstanceOfTypeWithExplicitTypeAndMessage_ShouldProduceTypedVariableDeclaration()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    object value = "test";
+                    Assert.IsInstanceOfType<string>(value, out {|CS1615:string result|}, "message");
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    object value = "test";
+                    string result = Assert.IsInstanceOfType<string>(value, "message");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
     public async Task FixIsInstanceOfTypeWithMultiLineStatements_PreservesIndentation()
     {
         string code = """


### PR DESCRIPTION
Fixes #9874

## Summary

`AvoidOutParameterOnAssertIsInstanceOfTypeFixer.FixIsInstanceOfTypeCallAsync` has two distinct code paths:

1. When the type is non-null (explicit type declaration like `out string result`) → creates a `VariableDeclarationSyntax`.
2. When the type is null (existing variable like `out result`) → creates an `AssignmentExpression`.

The `out var result` case was covered, but the **explicit type** case (e.g., `out string result` → `string result = ...`) was not tested.

## Changes

Added two tests to `AvoidOutParameterOnAssertIsInstanceOfTypeFixerTests.cs`:

- `FixIsInstanceOfTypeWithExplicitType_ShouldProduceTypedVariableDeclaration` — `out string result` → `string result = Assert.IsInstanceOfType<string>(value)` (with/without trivia, single and multi-instance).
- `FixIsInstanceOfTypeWithExplicitTypeAndMessage_ShouldProduceTypedVariableDeclaration` — same with a message argument.

## Verification

- Build succeeded (0 warnings, 0 errors).
- All 8 tests in the class pass (6 existing + 2 new) on net8.0.