### PR TITLE
Fix invalid placeholders in loc xlf breaking main

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -572,7 +572,7 @@ The type declaring these methods should also respect the following rules:
 – elle ne doit pas être générique
 – il doit prendre un paramètre de type « TestContext »
 – le type de retour doit être « void », « Task » ou « ValueTask ».
-{0}
+
 Le type déclarant ces méthodes doit également respecter les règles suivantes :
 - le type doit être une classe
 - la classe doit être « public » 

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -74,7 +74,7 @@
       </trans-unit>
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
-        <target state="translated">{0} все еще выполняется через {0} с</target>
+        <target state="translated">{0} все еще выполняется через {1} с</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">


### PR DESCRIPTION
## Problem

Main is broken with XliffTasks out-of-date errors:

```
error : 'xlf/Resources.fr.xlf' is out-of-date with 'Resources.resx'. [src/Analyzers/MSTest.Analyzers/MSTest.Analyzers.csproj]
error : 'Resources/xlf/GitHubActionsResources.ru.xlf' is out-of-date with 'Resources/GitHubActionsResources.resx'. [Microsoft.Testing.Extensions.GitHubActionsReport.csproj]
```

## Root cause

The OneLocBuild check-in (#9882) delivered translations whose `{}` format placeholders did not match the source string. XliffTasks validates placeholders and **rejects** mismatched targets, resetting them to English `state="new"`. On CI (which runs the check without updating), the checked-in `.xlf` therefore no longer matches what `UpdateXlf` produces → "out-of-date".

- **fr** `GlobalTestFixtureShouldBeValidDescription`: the translation injected a stray `{0}` where the source only has a blank line between the two paragraphs.
- **ru** `SlowTestStillRunning`: the source is `{0} still running after {1}s`, but the translation used `{0}` twice (the second one should be `{1}`, the elapsed seconds).

## Fix

Corrected the placeholders directly in both `.xlf` targets, keeping the translations intact:

- fr: removed the stray `{0}`, restoring the blank line to mirror the source.
- ru: changed the second `{0}` to `{1}`.

This is preferable to resetting the targets back to English (which would drop the translations and fail the localization acceptance tests) or skipping tests.

## Verification

Ran a dev build (`UpdateXlfOnBuild`) on both projects. `UpdateXlf` now leaves both targets as `state="translated"` (no reset), producing a clean `git diff` and 0 build errors — so both the CI xlf up-to-date check and the loc acceptance tests pass.