### PR TITLE
[test-improver] Add edge case tests for MSTEST0031 (DoNotUseSystemDescriptionAttribute) — derived TestMethod attributes

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseSystemDescriptionAttributeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotUseSystemDescriptionAttributeAnalyzerTests.cs
@@ -226,4 +226,84 @@ public sealed class DoNotUseSystemDescriptionAttributeAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenSTATestMethodHasSystemDescriptionAttribute_Diagnostic()
+    {
+        // STATestMethodAttribute inherits from TestMethodAttribute, so the Inherits() check should
+        // catch it and report the same diagnostic as for [TestMethod].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [STATestMethod]
+                [System.ComponentModel.Description("Description")]
+                public void [|MyTestMethod|]()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [STATestMethod]
+                [Description("Description")]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenCustomDerivedTestMethodAttributeHasSystemDescriptionAttribute_Diagnostic()
+    {
+        // A user-defined attribute that derives from TestMethodAttribute is matched by the
+        // Inherits() check, so it should report the same diagnostic as for [TestMethod].
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public sealed class MyTestMethodAttribute : TestMethodAttribute
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                [System.ComponentModel.Description("Description")]
+                public void [|MyTestMethod|]()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public sealed class MyTestMethodAttribute : TestMethodAttribute
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                [Description("Description")]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #9870.

`DoNotUseSystemDescriptionAttributeAnalyzer` (MSTEST0031) uses `Inherits()` — not exact-match — to identify the test-method attribute, so it fires for **any** attribute deriving from `TestMethodAttribute`. `[DataTestMethod]` was already covered, but `[STATestMethod]` and custom derived attributes were not.

## Changes

Added two tests to `DoNotUseSystemDescriptionAttributeAnalyzerTests`:

| Test | Scenario | Expected |
|---|---|---|
| `WhenSTATestMethodHasSystemDescriptionAttribute_Diagnostic` | Built-in `[STATestMethod]` (derives from `TestMethodAttribute`) with `[System.ComponentModel.Description]` | Diagnostic + fixer replaces with MSTest `[Description]` |
| `WhenCustomDerivedTestMethodAttributeHasSystemDescriptionAttribute_Diagnostic` | User-defined `sealed class MyTestMethodAttribute : TestMethodAttribute` with `[System.ComponentModel.Description]` | Diagnostic + fixer replaces with MSTest `[Description]` |

## Test status

`MSTest.Analyzers.UnitTests` builds and passes on both `net472` and `net8.0` (9 tests in the suite: 7 pre-existing + 2 new).