### PR TITLE
Backport localization placeholder fixes from main to rel/4.3

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -572,7 +572,7 @@ The type declaring these methods should also respect the following rules:
 – elle ne doit pas être générique
 – il doit prendre un paramètre de type « TestContext »
 – le type de retour doit être « void », « Task » ou « ValueTask ».
-{0}
+
 Le type déclarant ces méthodes doit également respecter les règles suivantes :
 - le type doit être une classe
 - la classe doit être « public » 

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -74,7 +74,7 @@
       </trans-unit>
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
-        <target state="translated">{0} все еще выполняется через {0} с</target>
+        <target state="translated">{0} все еще выполняется через {1} с</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">


### PR DESCRIPTION
Backports two localization **placeholder** fixes from `main` (originally #9888) to `rel/4.3`. Both target strings already exist in `rel/4.3`, so these are safe, user-facing corrections.

| Resource / lang | trans-unit | Bug in rel/4.3 | Fix |
|---|---|---|---|
| `GitHubActionsResources.ru.xlf` | `SlowTestStillRunning` | `{0} … через {0} с` — `{0}` used twice, so elapsed seconds (`{1}`) never render | `{0} … через {1} с` |
| `MSTest.Analyzers/Resources.fr.xlf` | `GlobalTestFixtureShouldBeValidDescription` | stray `{0}` line (absent from the English source) rendered literally | stray line removed |

The two edited trans-units are now identical to `main`. Other localization deltas between `main` and `rel/4.3` were intentionally excluded (new-feature strings not present in 4.3, and the `FileLogger` message where `main` is temporarily un-translated after a source change).