### PR TITLE
Emit Azure DevOps logging commands at column 0 from the MSBuild test runner

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
@@ -29,12 +29,34 @@ public partial class InvokeTestingPlatformTask
     {
         if (!_captureOutput)
         {
-            Log.LogMessage(MessageImportance.High, singleLine);
+            // Azure DevOps logging commands (##[group], ##[endgroup], ##vso[...]) emitted by the
+            // Microsoft.Testing.Extensions.AzureDevOpsReport extension are only honored by the Azure Pipelines
+            // agent when they start at column 0. Routing them through Log.LogMessage lets the MSBuild console
+            // logger indent them (by at least two spaces), so the agent stops recognizing them: the log group no
+            // longer collapses and the raw '##[group]...' marker is rendered as garbled text. Write those command
+            // lines straight to stdout to preserve column 0; everything else keeps flowing through MSBuild logging.
+            if (IsAzureDevOpsLoggingCommand(singleLine))
+            {
+                Console.Out.WriteLine(singleLine);
+            }
+            else
+            {
+                Log.LogMessage(MessageImportance.High, singleLine);
+            }
         }
 
         // Collect the output to be written to the file.
         _output.AppendLine(singleLine);
     }
+
+    /// <summary>
+    /// Returns whether <paramref name="singleLine"/> is an Azure DevOps logging command that must reach the
+    /// pipeline log at column 0 to be processed by the agent (a format command such as <c>##[group]</c> /
+    /// <c>##[endgroup]</c>, or a <c>##vso[...]</c> command).
+    /// </summary>
+    internal static bool IsAzureDevOpsLoggingCommand(string singleLine)
+        => singleLine.StartsWith("##[", StringComparison.Ordinal)
+        || singleLine.StartsWith("##vso[", StringComparison.Ordinal);
 
     /// <inheritdoc />
     protected override void ProcessStarted()

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Testing.Platform.Helpers;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.MSBuild.UnitTests;
+
+[TestClass]
+public sealed class InvokeTestingPlatformTaskTests
+{
+    [TestMethod]
+    [DataRow("##[group]Tests: MyAssembly (net9.0)", true)]
+    [DataRow("##[endgroup]", true)]
+    [DataRow("##[section]Section", true)]
+    [DataRow("##vso[task.logissue type=error]boom", true)]
+    [DataRow("##vso[task.uploadsummary]/path/to/summary.md", true)]
+    [DataRow("Passed! - MyTest (1ms)", false)]
+    [DataRow("Running tests: MyAssembly.dll", false)]
+    [DataRow("  ##[group]indented is not a command", false)]
+    [DataRow("#[group]not-a-command", false)]
+    [DataRow("", false)]
+    public void IsAzureDevOpsLoggingCommand_ClassifiesLinesCorrectly(string line, bool expected)
+        => Assert.AreEqual(expected, InvokeTestingPlatformTask.IsAzureDevOpsLoggingCommand(line));
+
+    [TestMethod]
+    public void LogEventsFromTextOutput_AzureDevOpsCommands_AreWrittenToStdoutAtColumnZero_NotThroughMSBuildLog()
+    {
+        List<string> loggedMessages = [];
+        Mock<IBuildEngine> buildEngine = new();
+        buildEngine
+            .Setup(x => x.LogMessageEvent(It.IsAny<BuildMessageEventArgs>()))
+            .Callback<BuildMessageEventArgs>(e => loggedMessages.Add(e.Message ?? string.Empty));
+
+        TestableInvokeTestingPlatformTask task = new() { BuildEngine = buildEngine.Object };
+
+        TextWriter originalOut = Console.Out;
+        using StringWriter capturedStdout = new();
+        Console.SetOut(capturedStdout);
+        try
+        {
+            task.InvokeLogEventsFromTextOutput("##[group]Tests: MyAssembly (net9.0)");
+            task.InvokeLogEventsFromTextOutput("##[endgroup]");
+            task.InvokeLogEventsFromTextOutput("normal output line");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        string[] stdoutLines = capturedStdout.ToString().Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries);
+
+        // Azure DevOps commands are written verbatim to stdout at column 0 (exact element match => no indentation).
+        Assert.IsTrue(stdoutLines.Contains("##[group]Tests: MyAssembly (net9.0)"), capturedStdout.ToString());
+        Assert.IsTrue(stdoutLines.Contains("##[endgroup]"), capturedStdout.ToString());
+
+        // ...and are NOT routed through the MSBuild logger, which would indent them and break Azure DevOps parsing.
+        string joinedMessages = string.Join('\n', loggedMessages);
+        Assert.DoesNotContain("##[group]", joinedMessages);
+        Assert.DoesNotContain("##[endgroup]", joinedMessages);
+
+        // Regular output keeps flowing through the MSBuild logger and does not leak to stdout.
+        Assert.Contains("normal output line", loggedMessages);
+        Assert.DoesNotContain("normal output line", capturedStdout.ToString());
+    }
+
+    private sealed class TestableInvokeTestingPlatformTask : InvokeTestingPlatformTask
+    {
+        public TestableInvokeTestingPlatformTask()
+            : base(new StubFileSystem())
+        {
+        }
+
+        public void InvokeLogEventsFromTextOutput(string singleLine)
+            => LogEventsFromTextOutput(singleLine, MessageImportance.High);
+    }
+
+    private sealed class StubFileSystem : IFileSystem
+    {
+        public bool Exist(string path) => false;
+
+        public void CreateDirectory(string directory) => throw new NotSupportedException();
+
+        public Stream CreateNew(string path) => throw new NotSupportedException();
+
+        public void CopyFile(string source, string destination) => throw new NotSupportedException();
+
+        public void WriteAllText(string path, string? contents) => throw new NotSupportedException();
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -26,6 +26,7 @@ public sealed class InvokeTestingPlatformTaskTests
         => Assert.AreEqual(expected, InvokeTestingPlatformTask.IsAzureDevOpsLoggingCommand(line));
 
     [TestMethod]
+    [DoNotParallelize] // Mutates process-wide Console.Out; must not overlap with parallel tests capturing/using the console.
     public void LogEventsFromTextOutput_AzureDevOpsCommands_AreWrittenToStdoutAtColumnZero_NotThroughMSBuildLog()
     {
         List<string> loggedMessages = [];


### PR DESCRIPTION
## What

Fixes the broken Azure DevOps log-grouping feature when running tests through the MSBuild runner (`dotnet test` / `dotnet build -t:Test` with `TestingPlatformCaptureOutput=false`).

Symptoms reported (see e.g. [this build](https://dnceng.visualstudio.com/internal/_build/results?buildId=3021017&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=22fea640-1099-5f32-ec5d-316ad83f359a)):
1. Log group expand/collapse doesn't work.
2. Garbled markers such as `oup]Tests: Microsoft.Testing.Extensions.VSTestBridge.UnitTests (net8.0)`.

## Root cause

Both symptoms are the same bug — the `##[group]` command lines are **indented**, so the Azure Pipelines agent stops recognizing them.

1. Each test host (single assembly) correctly writes `##[group]Tests: …` at **column 0** to its own stdout (via `Microsoft.Testing.Extensions.AzureDevOpsReport`).
2. `InvokeTestingPlatformTask` (a `ToolTask`) captures that stdout and re-emits every line through `Log.LogMessage(High, …)` in `LogEventsFromTextOutput`.
3. MSBuild's console logger **indents task messages by 2 spaces**, so the raw pipeline log shows `  ##[group]Tests: …`.
4. Azure Pipelines only honors logging commands (`##[group]`, `##[endgroup]`, `##vso[...]`) when they start at column 0 (no trimming). Indented ⇒ no collapse, and the AzDO web UI renders the unrecognized marker as garbled text.

## Fix

In `InvokeTestingPlatformTask.LogEventsFromTextOutput`, route Azure DevOps command lines (starting with `##[` or `##vso[`) straight to `Console.Out` (column 0) instead of the indenting `Log.LogMessage`. All other output keeps flowing through MSBuild logging unchanged.

Each assembly's `##[group]` (session start) and `##[endgroup]` (session end) run through the same task instance on the same node, so markers stay matched.

## Tests

- `IsAzureDevOpsLoggingCommand` classifier data rows (commands vs. regular/indented output).
- A routing test asserting AzDO command lines are written to stdout verbatim at column 0 and are **not** routed through the (indenting) MSBuild logger, while regular output still goes through the logger.

All 20 unit tests in `Microsoft.Testing.Platform.MSBuild.UnitTests` pass; build is warning-free.

## Known limitation (follow-up)

Under multi-node `dotnet test` (`-m`), a task's `Console.Out` is only delivered from the in-proc node — worker-node console output is dropped by MSBuild. So after this change:
- Garbling is eliminated everywhere.
- Grouping collapses correctly for in-proc-node assemblies and for single-project / direct-terminal runs.
- Worker-node assemblies lose the markers (no garbling); their output is interleaved across assemblies anyway, which independently breaks grouping semantics.

Making grouping fully correct under parallel, interleaved `dotnet test` needs per-assembly output serialization/buffering; I'll follow up with an exploration/issue.