### PR TITLE
Update changelogs for MTP 2.3.2 / MSTest 4.3.2 release

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -16,7 +16,15 @@ See full log [of v4.3.2...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 ## <a name="2.3.2" />[2.3.2] - 2026-07-13
 
-Servicing release to keep Microsoft.Testing.Platform aligned with the MSTest 4.3.2 release. No functional platform changes.
+Servicing release to keep Microsoft.Testing.Platform aligned with the MSTest 4.3.2 release. No functional platform changes beyond the localization updates below.
+
+### Changed
+
+* Update localized resources for the Azure DevOps, GitHub Actions and Retry extensions and terminal output by @Evangelink in [#9847](https://github.com/microsoft/testfx/pull/9847)
+
+### Fixed
+
+* Fix localization placeholder in the GitHub Actions report resources by @Evangelink in [#9891](https://github.com/microsoft/testfx/pull/9891)
 
 ## <a name="2.3.1" />[2.3.1] - 2026-07-08
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## <a name="2.4.0" />[2.4.0] - UNRELEASED
 
-See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.0...v4.4.0)
+See full log [of v4.3.2...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.2...v4.4.0)
 
 ### Added
 

--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -14,6 +14,10 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Re-print errored assemblies in dotnet test end-of-run recap by @Evangelink in [#9545](https://github.com/microsoft/testfx/pull/9545)
 * Add server-initiated session cancellation to the dotnet test IPC protocol by @Evangelink in [#9549](https://github.com/microsoft/testfx/pull/9549)
 
+## <a name="2.3.2" />[2.3.2] - 2026-07-13
+
+Servicing release to keep Microsoft.Testing.Platform aligned with the MSTest 4.3.2 release. No functional platform changes.
+
 ## <a name="2.3.1" />[2.3.1] - 2026-07-08
 
 ### Fixed

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -20,6 +20,11 @@ See full log [of v4.3.0...v4.3.2](https://github.com/microsoft/testfx/compare/v4
 
 * Make `ReflectionFree` the default `MSTestSourceGenMode` for Native AOT / trimmed consumers by @Evangelink in [#9777](https://github.com/microsoft/testfx/pull/9777)
 * Point MSTest.Sdk back to the classic source generation + engine wiring (as shipped in 4.2.3) by @Evangelink in [#9825](https://github.com/microsoft/testfx/pull/9825)
+* Update localized MSTest analyzer diagnostic messages by @Evangelink in [#9860](https://github.com/microsoft/testfx/pull/9860)
+
+### Fixed
+
+* Fix localization placeholder in MSTest analyzer resources by @Evangelink in [#9891](https://github.com/microsoft/testfx/pull/9891)
 
 ## <a name="4.3.0" />[4.3.0] - 2026-07-08
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,15 @@ See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
 
+## <a name="4.3.2" />[4.3.2] - 2026-07-13
+
+See full log [of v4.3.0...v4.3.2](https://github.com/microsoft/testfx/compare/v4.3.0...v4.3.2)
+
+### Changed
+
+* Make `ReflectionFree` the default `MSTestSourceGenMode` for Native AOT / trimmed consumers by @Evangelink in [#9777](https://github.com/microsoft/testfx/pull/9777)
+* Point MSTest.Sdk back to the classic source generation + engine wiring (as shipped in 4.2.3) by @Evangelink in [#9825](https://github.com/microsoft/testfx/pull/9825)
+
 ## <a name="4.3.0" />[4.3.0] - 2026-07-08
 
 See full log [of v4.2.3...v4.3.0](https://github.com/microsoft/testfx/compare/v4.2.3...v4.3.0)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## <a name="4.4.0" />[4.4.0] - UNRELEASED
 
-See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.0...v4.4.0)
+See full log [of v4.3.2...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.2...v4.4.0)
 
 ### Fixed
 


### PR DESCRIPTION
## What

Adds the changelog sections for the upcoming servicing release (built from `rel/4.3`, versions 4.3.2 / 2.3.2).

### `docs/Changelog.md` — new `[4.3.2]` section (Changed)
- Make `ReflectionFree` the default `MSTestSourceGenMode` for Native AOT / trimmed consumers — [#9777](https://github.com/microsoft/testfx/pull/9777)
- Point MSTest.Sdk back to the classic source generation + engine wiring (as shipped in 4.2.3) — [#9825](https://github.com/microsoft/testfx/pull/9825)

### `docs/Changelog-Platform.md` — new `[2.3.2]` section
- Version-alignment note; no functional platform changes this release.

## How the content was derived

Diffed `v4.3.0..origin/rel/4.3` (7 commits). Only #9777 and #9825 are user-facing; the remaining commits are localization backports (not changelogged per repo convention), version bumps, and post-release bookkeeping. Both functional PRs touch MSTest only (`src/Adapter`, `src/Analyzers/Shared`, `src/Package/MSTest.Sdk`); none touch `src/Platform`, hence no MTP entries.

## Needs attention / manual review

- **Release date** is set to `2026-07-13`. Update if tagging happens on a different day.
- **MSTest 4.3.1 was never shipped** (no tag/release), so the jump 4.3.0 → 4.3.2 is intentional and there is no 4.3.1 section.
- #9825 was merged directly to `rel/4.3` (not `main`); the PR link still resolves.