### PR TITLE
docs: add missing 4.4.0 changelog entry for #9755

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 See full log [of v4.3.0...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.0...v4.4.0)
 
+### Changed
+
+* Make MSTest's Microsoft.Testing.Platform path native-only: `MSTest.TestAdapter` no longer depends on `Microsoft.Testing.Extensions.VSTestBridge` and now references `Microsoft.Testing.Extensions.TrxReport.Abstractions`, `Microsoft.Testing.Extensions.Telemetry`, and `Microsoft.TestPlatform.ObjectModel` directly by @Evangelink in [#9755](https://github.com/microsoft/testfx/pull/9755)
+
 ### Fixed
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)


### PR DESCRIPTION
## What

Adds the missing `[4.4.0]` changelog entry for **#9755** (*Drop MSTest's VSTest bridge dependency on the MTP path*, merged 2026-07-08).

`MSTest.TestAdapter` dropped its dependency on `Microsoft.Testing.Extensions.VSTestBridge` and now references `Microsoft.Testing.Extensions.TrxReport.Abstractions`, `Microsoft.Testing.Extensions.Telemetry`, and `Microsoft.TestPlatform.ObjectModel` directly. This is a user-visible dependency-graph change and belongs in the changelog.

## Why

The change was repeatedly flagged as missing from `docs/Changelog.md` by the adhoc-qa reports (#9612, #9842, #9872, #9876). The other items those reports carry over are either already resolved (the #9600 entries are now present) or low-urgency/alpha (AOTSG0001–0005) / tracked elsewhere (#8940 TODOs).

## Change

- Add a `### Changed` entry under `[4.4.0]` in `docs/Changelog.md`.