### PR TITLE
Let unpackaged WinUI test apps exit under Microsoft.Testing.Platform

### DIFF
--- a/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
@@ -173,6 +173,14 @@ public class UITestMethodAttribute : TestMethodAttribute
         var uiThread = new Thread(treadStart)
         {
             Name = "UI Thread for Tests",
+
+            // Application.Start pumps a message loop that only returns when the app exits, which the
+            // WinUITestTarget model never triggers. As a foreground thread it would keep the process
+            // alive after the run - harmless under a test host that force-kills the process, but a
+            // hang when the test app IS the process (e.g. an unpackaged WinUI app under
+            // Microsoft.Testing.Platform). Making it a background thread lets the process exit once
+            // the run completes; the thread stays alive as long as the run awaits results on it.
+            IsBackground = true,
         };
         uiThread.Start();
         tsc.Task.Wait();

--- a/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
@@ -174,12 +174,10 @@ public class UITestMethodAttribute : TestMethodAttribute
         {
             Name = "UI Thread for Tests",
 
-            // Application.Start pumps a message loop that only returns when the app exits, which the
-            // WinUITestTarget model never triggers. As a foreground thread it would keep the process
-            // alive after the run - harmless under a test host that force-kills the process, but a
-            // hang when the test app IS the process (e.g. an unpackaged WinUI app under
-            // Microsoft.Testing.Platform). Making it a background thread lets the process exit once
-            // the run completes; the thread stays alive as long as the run awaits results on it.
+            // Application.Start pumps a message loop that never returns in the WinUITestTarget
+            // model, so a foreground thread would keep the process alive after the run and hang when
+            // the test app is itself the process (unpackaged WinUI under Microsoft.Testing.Platform).
+            // A background thread lets the process exit once the run completes. See issue #2784.
             IsBackground = true,
         };
         uiThread.Start();


### PR DESCRIPTION
## What / why

Part of the MTP side of #2784 (testing **unpackaged** WinUI apps). VSTest is explicitly out of scope here.

While building an end-to-end PoC of an unpackaged WinUI app (`WindowsPackageType=None`) running under Microsoft.Testing.Platform (`EnableMSTestRunner=true`), I found that the `WinUITestTarget` model **hangs the process forever after a passing run**.

Root cause: `UITestMethodAttribute.InitializeApplication` starts the WinUI UI thread via `Application.Start`, whose message loop only returns when the app exits — something this model never triggers. The thread was created as a **foreground** thread, so it keeps the process alive after the run. That's harmless under a test host that force-kills the process, but a hang when the test app *is* the process (unpackaged WinUI on MTP).

## Change

Mark the UI thread `IsBackground = true`. The process now exits once the run completes; the thread still stays alive as long as the run awaits results on it (the main flow blocks on the test's `TaskCompletionSource`, so tests can't be cut short).

```diff
 var uiThread = new Thread(treadStart)
 {
     Name = "UI Thread for Tests",
+    IsBackground = true,
 };
```

## Verification (PoC)

Unpackaged WinUI app + MTP, with a plain `[TestMethod]` and a `[UITestMethod]` that instantiates a WinUI `Grid` on the UI thread (only works if the WinAppSDK runtime is actually bootstrapped in the unpackaged process):

- **Before:** `Passed! total: 2, succeeded: 2`, then the process **hangs** indefinitely.
- **After:** same `Passed!` summary, then **clean exit, code 0** (~2s).

Notes from the PoC (context, not part of this PR):
- The user-side requirement to make WinUI unpackaged is `<WindowsPackageType>None</WindowsPackageType>`, which triggers the WinAppSDK auto-initializer that bootstraps the runtime. With that set, MTP already launches and runs the app.
- The bootstrapper also needs a fully-installed unpackaged runtime (framework **+ DDLM/Main** package); a version with only the framework installed FailFasts at startup. This is a machine/runtime prerequisite, not something MSTest controls.

## Follow-ups (not in this PR)
- Add an unpackaged WinUI sample under `samples/public`.
- Add an acceptance test mirroring `WinUITests.cs` that exercises `[UITestMethod]` on the unpackaged path (kept out here to avoid CI flakiness from WinUI UI + PRI tooling requirements).

Refs #2784