### PR TITLE
Revert WinUI sample PackagedApp reference until packaged-app launch is supported

### DIFF
--- a/samples/public/Directory.Build.props
+++ b/samples/public/Directory.Build.props
@@ -19,12 +19,6 @@
     <MSTestEngineVersion>$(MSTestAOTVersion)</MSTestEngineVersion>
     <PlaywrightVersion>1.61.0</PlaywrightVersion>
     <TestingPlatformVersion>2.3.2</TestingPlatformVersion>
-    <!--
-      Microsoft.Testing.Extensions.PackagedApp is the experimental extension that deploys and launches
-      a packaged Windows (UWP/WinUI) test host. It versions independently from the 2.x testing platform
-      (it ships as a 1.0.0-alpha.* build), which is why it has its own property here.
-    -->
-    <MicrosoftTestingExtensionsPackagedAppVersion>1.0.0-alpha.26363.8</MicrosoftTestingExtensionsPackagedAppVersion>
     <VSTestVersion>18.7.0</VSTestVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);SA0001;EnableGenerateDocumentationFile</NoWarn>

--- a/samples/public/mstest-runner/MSTestRunnerWinUI/MSTestRunnerWinUI/MSTestRunnerWinUI.csproj
+++ b/samples/public/mstest-runner/MSTestRunnerWinUI/MSTestRunnerWinUI/MSTestRunnerWinUI.csproj
@@ -53,13 +53,6 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.7175" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.251106002" />
     <PackageReference Include="MSTest" Version="$(MSTestVersion)" />
-    <!--
-      Deploy and launch the packaged WinUI test host through Microsoft.Testing.Platform's ITestHostLauncher
-      extension point. Referencing the package is enough: its MSBuild props register the launcher through the
-      SelfRegisteredExtensions that this app already calls in UnitTestApp.OnLaunched (do NOT also call
-      AddPackagedAppDeployment() explicitly, as only one test host launcher may be registered). MTP-only.
-    -->
-    <PackageReference Include="Microsoft.Testing.Extensions.PackagedApp" Version="$(MicrosoftTestingExtensionsPackagedAppVersion)" Condition=" '$(EnableMSTestRunner)' == 'true' " />
   </ItemGroup>
 
   <!--

--- a/samples/public/mstest-runner/MSTestRunnerWinUI/MSTestRunnerWinUI/UnitTestApp.xaml.cs
+++ b/samples/public/mstest-runner/MSTestRunnerWinUI/MSTestRunnerWinUI/UnitTestApp.xaml.cs
@@ -61,11 +61,6 @@ public partial class UnitTestApp : Application
                 .Where(arg => !arg.Contains("EnableMSTestRunner"))
                 .ToArray();
             ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(cliArgs);
-
-            // Registers all MSBuild-contributed extensions, including the Microsoft.Testing.Extensions.PackagedApp
-            // launcher (from the PackageReference in the csproj). That launcher deploys this packaged WinUI test
-            // host into an isolated directory and launches it from there through the platform's ITestHostLauncher
-            // extension point.
             builder.AddSelfRegisteredExtensions(cliArgs);
             using ITestApplication app = await builder.BuildAsync();
             await app.RunAsync();


### PR DESCRIPTION
## Summary

This surgically reverts the three sample changes introduced by #9908 ("Wire WinUI MTP sample to Microsoft.Testing.Extensions.PackagedApp"), restoring the `MSTestRunnerWinUI` sample to its previous, working in-process state.

## Why

The WinUI sample (`samples/public/mstest-runner/MSTestRunnerWinUI`) is a **packaged (MSIX) app** (`EnableMsixTooling=true`, `Package.appxmanifest`, `ProjectCapability Include="Msix"`). Referencing `Microsoft.Testing.Extensions.PackagedApp` auto-registers its `ITestHostLauncher`, which forces the platform's controller / deploy-and-launch path (registering any launcher sets `requireProcessRestart=true`).

However, the current `PackagedAppTestHostLauncher` only performs a `CopyDirectory` + `Process.Start` of the **loose layout copy** — it **cannot launch a packaged/MSIX app**. Proper `PackageManager` registration + AUMID activation is still a pending follow-up (#2784). As a result, #9908 made the sample **build successfully but fail at launch**, so it no longer demonstrates the intended runtime flow.

This reverts the reference until packaged-app (AUMID) activation lands, at which point the sample can be re-wired.

## Changes

1. `MSTestRunnerWinUI.csproj` — removed the `Microsoft.Testing.Extensions.PackagedApp` `PackageReference` and its explanatory comment. Other references (MSTest, WindowsAppSDK, etc.) are untouched.
2. `samples/public/Directory.Build.props` — removed the `MicrosoftTestingExtensionsPackagedAppVersion` property and its comment. `TestingPlatformVersion` (2.3.2) is unchanged.
3. `UnitTestApp.xaml.cs` — removed the comment block above `builder.AddSelfRegisteredExtensions(cliArgs);`, restoring the original adjacency of the two builder calls.

## Verification

- Built with the repo SDK: `dotnet build samples\public\mstest-runner\MSTestRunnerWinUI\MSTestRunnerWinUI.slnx -c Release -p:Platform=x64 -p:TreatWarningsAsErrors=true` → **0 Warning(s), 0 Error(s)**.
- Confirmed the generated `obj/.../SelfRegisteredExtensions.cs` no longer contains `Microsoft.Testing.Extensions.PackagedApp`.

## References

- Reverts sample changes from #9908
- Blocked-on follow-up: #2784 (packaged-app / AUMID activation)