### PR TITLE
Add packaged-app identity/AUMID groundwork and Windows gating to PackagedApp extension

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -563,21 +563,21 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
-- elle ne peut pas être déclarée dans une classe générique
-– elle doit être « public »
-– cela devrait être « static ».
-– cela ne devrait pas être « async void ».
-– il ne doit pas s'agir d'une méthode spéciale (finaliseur, opérateur...).
-– elle ne doit pas être générique
-– il doit prendre un paramètre de type « TestContext »
-– le type de retour doit être « void », « Task » ou « ValueTask ».
-{0}
-Le type déclarant ces méthodes doit également respecter les règles suivantes :
-- le type doit être une classe
-- la classe doit être « public » 
--La classe doit être marquée avec « [TestClass] » (ou un attribut dérivé).
-- la classe ne doit pas être générique.</target>
+        <target state="new">Methods marked with '[GlobalTestInitialize]' or '[GlobalTestCleanup]' should follow the following layout to be valid:
+-it can't be declared on a generic class
+-it should be 'public'
+-it should be 'static'
+-it should not be 'async void'
+-it should not be a special method (finalizer, operator...).
+-it should not be generic
+-it should take one parameter of type 'TestContext'
+-return type should be 'void', 'Task' or 'ValueTask'
+
+The type declaring these methods should also respect the following rules:
+-The type should be a class
+-The class should be 'public'
+-The class should be marked with '[TestClass]' (or a derived attribute)
+-the class should not be generic.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -74,7 +74,7 @@
       </trans-unit>
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
-        <target state="translated">{0} все еще выполняется через {0} с</target>
+        <target state="new">{0} still running after {1}s</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxApplicationInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxApplicationInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.PackagedApp;

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxApplicationInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxApplicationInfo.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// A single application declared by a packaged Windows app's <c>AppxManifest.xml</c>
+/// (<c>Applications/Application</c>). A package can declare more than one, each with its own
+/// Application User Model ID, so the launcher resolves the one matching the requested executable
+/// rather than assuming a single application.
+/// </summary>
+internal sealed class AppxApplicationInfo
+{
+    internal AppxApplicationInfo(string id, string? executable, string appUserModelId)
+    {
+        Id = id;
+        Executable = executable;
+        AppUserModelId = appUserModelId;
+    }
+
+    /// <summary>Gets the application id (the manifest's <c>Application/@Id</c>).</summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the application's executable file name (the manifest's <c>Application/@Executable</c>),
+    /// or <see langword="null"/> when the manifest declares none. Used to disambiguate a package that
+    /// declares multiple applications by matching the executable the platform asked to launch.
+    /// </summary>
+    public string? Executable { get; }
+
+    /// <summary>
+    /// Gets the Application User Model ID (<c>{PackageFamilyName}!{Id}</c>) used to activate this
+    /// application.
+    /// </summary>
+    public string AppUserModelId { get; }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+using Microsoft.Testing.Extensions.PackagedApp.Resources;
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// The identity of a packaged Windows (UWP/WinUI) app, read from its <c>AppxManifest.xml</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A packaged app is launched by <em>Application User Model ID</em> (AUMID), never by
+/// <c>Process.Start</c>. The AUMID is <c>{PackageFamilyName}!{ApplicationId}</c>, and the package
+/// family name is <c>{PackageName}_{publisherId}</c> where <c>publisherId</c> is a 13-character hash
+/// of the manifest's <c>Publisher</c>. VSTest reads these values from VS-internal deployment
+/// components; this type computes them from the manifest using only public, cross-platform managed
+/// APIs so the extension does not depend on the Visual Studio install.
+/// </para>
+/// </remarks>
+internal sealed class AppxManifestInfo
+{
+    /// <summary>
+    /// The canonical file name of a packaged app's manifest inside its (loose or extracted) layout.
+    /// </summary>
+    internal const string AppxManifestFileName = "AppxManifest.xml";
+
+    // The alphabet Windows uses to encode the publisher hash (Douglas Crockford's base32: the digits
+    // and lowercase letters with i, l, o and u removed). Must not be reordered.
+    private const string PublisherHashAlphabet = "0123456789abcdefghjkmnpqrstvwxyz";
+
+    private AppxManifestInfo(string packageName, string publisher, string? applicationId)
+    {
+        PackageName = packageName;
+        Publisher = publisher;
+        ApplicationId = applicationId;
+        PackageFamilyName = $"{packageName}_{ComputePublisherId(publisher)}";
+        AppUserModelId = applicationId is null ? null : $"{PackageFamilyName}!{applicationId}";
+    }
+
+    /// <summary>Gets the package name (the manifest's <c>Identity/@Name</c>).</summary>
+    public string PackageName { get; }
+
+    /// <summary>Gets the publisher (the manifest's <c>Identity/@Publisher</c>).</summary>
+    public string Publisher { get; }
+
+    /// <summary>
+    /// Gets the id of the first application declared in the manifest (<c>Applications/Application/@Id</c>),
+    /// or <see langword="null"/> when the manifest declares no application.
+    /// </summary>
+    public string? ApplicationId { get; }
+
+    /// <summary>Gets the package family name (<c>{PackageName}_{publisherId}</c>).</summary>
+    public string PackageFamilyName { get; }
+
+    /// <summary>
+    /// Gets the Application User Model ID (<c>{PackageFamilyName}!{ApplicationId}</c>) used to activate
+    /// the app, or <see langword="null"/> when the manifest declares no application.
+    /// </summary>
+    public string? AppUserModelId { get; }
+
+    /// <summary>
+    /// Reads the manifest at the root of <paramref name="layoutDirectory"/> if the directory is a
+    /// packaged-app layout.
+    /// </summary>
+    /// <param name="layoutDirectory">The directory to probe for an <c>AppxManifest.xml</c>.</param>
+    /// <param name="info">The parsed manifest info when the directory is a packaged-app layout.</param>
+    /// <returns>
+    /// <see langword="true"/> when an <c>AppxManifest.xml</c> was found and parsed; otherwise
+    /// <see langword="false"/>.
+    /// </returns>
+    public static bool TryReadFromLayout(string layoutDirectory, [NotNullWhen(true)] out AppxManifestInfo? info)
+    {
+        string manifestPath = Path.Combine(layoutDirectory, AppxManifestFileName);
+        if (!File.Exists(manifestPath))
+        {
+            info = null;
+            return false;
+        }
+
+        info = ReadFromManifest(manifestPath);
+        return true;
+    }
+
+    /// <summary>Reads and parses the manifest at <paramref name="manifestPath"/>.</summary>
+    /// <param name="manifestPath">The path to an <c>AppxManifest.xml</c>.</param>
+    /// <returns>The parsed manifest info.</returns>
+    public static AppxManifestInfo ReadFromManifest(string manifestPath)
+    {
+        using FileStream stream = File.OpenRead(manifestPath);
+        return ReadFromManifest(stream);
+    }
+
+    /// <summary>Reads and parses a manifest from <paramref name="manifestStream"/>.</summary>
+    /// <param name="manifestStream">A stream over an <c>AppxManifest.xml</c>.</param>
+    /// <returns>The parsed manifest info.</returns>
+    public static AppxManifestInfo ReadFromManifest(Stream manifestStream)
+    {
+        var document = XDocument.Load(manifestStream);
+        XElement? root = document.Root;
+
+        // Match by local name so we are resilient to the manifest schema version (the foundation
+        // namespace URI changes across Windows 10 SDK revisions).
+        XElement? identity = root?.Elements().FirstOrDefault(static e => e.Name.LocalName == "Identity");
+        string? name = identity?.Attribute("Name")?.Value;
+        string? publisher = identity?.Attribute("Publisher")?.Value;
+
+        if (name is null || name.Length == 0 || publisher is null || publisher.Length == 0)
+        {
+            throw new InvalidOperationException(ExtensionResources.InvalidAppxManifestMissingIdentity);
+        }
+
+        string? applicationId = root?.Elements().FirstOrDefault(static e => e.Name.LocalName == "Applications")?
+            .Elements().FirstOrDefault(static e => e.Name.LocalName == "Application")?
+            .Attribute("Id")?.Value;
+
+        return new AppxManifestInfo(name, publisher, applicationId);
+    }
+
+    /// <summary>
+    /// Computes the 13-character publisher id (the suffix of the package family name) for
+    /// <paramref name="publisher"/>, using the public Windows algorithm: base32-encode the first 8
+    /// bytes of the SHA-256 hash of the UTF-16LE publisher string.
+    /// </summary>
+    /// <param name="publisher">The manifest's <c>Identity/@Publisher</c> value.</param>
+    /// <returns>The 13-character publisher id.</returns>
+    internal static string ComputePublisherId(string publisher)
+    {
+        byte[] hash = SHA256.HashData(Encoding.Unicode.GetBytes(publisher));
+
+        // Take the first 8 bytes (64 bits) and encode them big-endian as 13 base32 characters. 64 bits
+        // is not a multiple of 5, so the final character carries the 4 leftover bits padded with a 0.
+        var builder = new StringBuilder(13);
+        int buffer = 0;
+        int bitsInBuffer = 0;
+        for (int i = 0; i < 8; i++)
+        {
+            buffer = (buffer << 8) | hash[i];
+            bitsInBuffer += 8;
+            while (bitsInBuffer >= 5)
+            {
+                bitsInBuffer -= 5;
+                builder.Append(PublisherHashAlphabet[(buffer >> bitsInBuffer) & 0x1F]);
+                buffer &= (1 << bitsInBuffer) - 1;
+            }
+        }
+
+        if (bitsInBuffer > 0)
+        {
+            builder.Append(PublisherHashAlphabet[(buffer << (5 - bitsInBuffer)) & 0x1F]);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security.Cryptography;

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -73,6 +73,34 @@ internal sealed class AppxManifestInfo
         return File.Exists(manifestPath) ? manifestPath : null;
     }
 
+    /// <summary>
+    /// Searches <paramref name="startDirectory"/> and each of its ancestors for an
+    /// <c>AppxManifest.xml</c> and returns the path to the nearest one. A packaged app's manifest
+    /// lives at the package layout root, but an <c>Application/@Executable</c> can point into a
+    /// subdirectory (for example <c>bin\host.exe</c>), so the executable's own directory is not
+    /// necessarily the root. Walking up locates the manifest in that valid layout too, so the launcher
+    /// does not miss a packaged layout and fall through to <c>Process.Start</c>. Like
+    /// <see cref="GetManifestPath(string)"/> this is a cheap existence probe that never parses.
+    /// </summary>
+    /// <param name="startDirectory">The directory to start searching from (typically the executable's directory).</param>
+    /// <returns>
+    /// The full path to the nearest <c>AppxManifest.xml</c> at or above <paramref name="startDirectory"/>;
+    /// otherwise <see langword="null"/>.
+    /// </returns>
+    public static string? FindManifestPath(string startDirectory)
+    {
+        for (DirectoryInfo? directory = new(startDirectory); directory is not null; directory = directory.Parent)
+        {
+            string? manifestPath = GetManifestPath(directory.FullName);
+            if (manifestPath is not null)
+            {
+                return manifestPath;
+            }
+        }
+
+        return null;
+    }
+
     /// <summary>Reads and parses the manifest at <paramref name="manifestPath"/>.</summary>
     /// <param name="manifestPath">The path to an <c>AppxManifest.xml</c>.</param>
     /// <returns>The parsed manifest info.</returns>
@@ -154,7 +182,7 @@ internal sealed class AppxManifestInfo
 
         AppxApplicationInfo[] matches = [.. Applications.Where(application =>
             application.Executable is not null
-            && string.Equals(application.Executable, executableFileName, StringComparison.OrdinalIgnoreCase))];
+            && string.Equals(GetExecutableFileName(application.Executable), executableFileName, StringComparison.OrdinalIgnoreCase))];
 
         return matches.Length == 1
             ? matches[0]
@@ -164,6 +192,16 @@ internal sealed class AppxManifestInfo
                     ExtensionResources.AmbiguousAppxManifestApplication,
                     executableFileName,
                     string.Join(", ", Applications.Select(static application => application.AppUserModelId))));
+    }
+
+    // The manifest's Application/@Executable is package-root-relative and may include a subdirectory
+    // (for example "bin\host.exe"), always with Windows separators. Reduce it to the bare file name so
+    // it can be matched against the executable file name the platform asked to launch, independently of
+    // the OS running the parser.
+    private static string GetExecutableFileName(string executable)
+    {
+        int lastSeparator = executable.LastIndexOfAny(['\\', '/']);
+        return lastSeparator < 0 ? executable : executable[(lastSeparator + 1)..];
     }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -31,13 +31,12 @@ internal sealed class AppxManifestInfo
     // and lowercase letters with i, l, o and u removed). Must not be reordered.
     private const string PublisherHashAlphabet = "0123456789abcdefghjkmnpqrstvwxyz";
 
-    private AppxManifestInfo(string packageName, string publisher, string? applicationId)
+    private AppxManifestInfo(string packageName, string publisher, IReadOnlyList<AppxApplicationInfo> applications)
     {
         PackageName = packageName;
         Publisher = publisher;
-        ApplicationId = applicationId;
         PackageFamilyName = $"{packageName}_{ComputePublisherId(publisher)}";
-        AppUserModelId = applicationId is null ? null : $"{PackageFamilyName}!{applicationId}";
+        Applications = applications;
     }
 
     /// <summary>Gets the package name (the manifest's <c>Identity/@Name</c>).</summary>
@@ -46,20 +45,16 @@ internal sealed class AppxManifestInfo
     /// <summary>Gets the publisher (the manifest's <c>Identity/@Publisher</c>).</summary>
     public string Publisher { get; }
 
-    /// <summary>
-    /// Gets the id of the first application declared in the manifest (<c>Applications/Application/@Id</c>),
-    /// or <see langword="null"/> when the manifest declares no application.
-    /// </summary>
-    public string? ApplicationId { get; }
-
     /// <summary>Gets the package family name (<c>{PackageName}_{publisherId}</c>).</summary>
     public string PackageFamilyName { get; }
 
     /// <summary>
-    /// Gets the Application User Model ID (<c>{PackageFamilyName}!{ApplicationId}</c>) used to activate
-    /// the app, or <see langword="null"/> when the manifest declares no application.
+    /// Gets the applications declared by the manifest (<c>Applications/Application</c>), in manifest
+    /// order. A package can declare several applications, so callers must select the one they want
+    /// (see <see cref="ResolveApplication(string?)"/>) rather than assuming a single entry. The list
+    /// is empty when the manifest declares no application.
     /// </summary>
-    public string? AppUserModelId { get; }
+    public IReadOnlyList<AppxApplicationInfo> Applications { get; }
 
     /// <summary>
     /// Returns the path to the <c>AppxManifest.xml</c> at the root of <paramref name="layoutDirectory"/>
@@ -106,11 +101,69 @@ internal sealed class AppxManifestInfo
             throw new InvalidOperationException(ExtensionResources.InvalidAppxManifestMissingIdentity);
         }
 
-        string? applicationId = root?.Elements().FirstOrDefault(static e => e.Name.LocalName == "Applications")?
-            .Elements().FirstOrDefault(static e => e.Name.LocalName == "Application")?
-            .Attribute("Id")?.Value;
+        string packageFamilyName = $"{name}_{ComputePublisherId(publisher)}";
 
-        return new AppxManifestInfo(name, publisher, applicationId);
+        // A package may declare several applications, each with its own id (and AUMID). Capture them
+        // all so the launcher can resolve the one matching the executable it was asked to launch,
+        // instead of guessing with the first entry.
+        List<AppxApplicationInfo> applications = root?.Elements().FirstOrDefault(static e => e.Name.LocalName == "Applications")?
+            .Elements().Where(static e => e.Name.LocalName == "Application")
+            .Select(application =>
+            {
+                string? applicationId = application.Attribute("Id")?.Value;
+                string? executable = application.Attribute("Executable")?.Value;
+                return applicationId is null || applicationId.Length == 0
+                    ? null
+                    : new AppxApplicationInfo(applicationId, executable, $"{packageFamilyName}!{applicationId}");
+            })
+            .Where(static application => application is not null)
+            .Select(static application => application!)
+            .ToList()
+            ?? [];
+
+        return new AppxManifestInfo(name, publisher, applications);
+    }
+
+    /// <summary>
+    /// Resolves the application whose test host the platform asked to launch. Most packages declare a
+    /// single application, which is returned directly. When a package declares several, the entry is
+    /// disambiguated by matching <paramref name="executableFileName"/> against each
+    /// <c>Application/@Executable</c>; an ambiguous request (no match, or several matches) is rejected
+    /// rather than silently defaulting to the first application, which would identify the wrong app.
+    /// </summary>
+    /// <param name="executableFileName">
+    /// The file name (not full path) of the executable the platform asked to launch, used to pick the
+    /// matching application when the manifest declares more than one.
+    /// </param>
+    /// <returns>
+    /// The matching application, or <see langword="null"/> when the manifest declares no application.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The manifest declares multiple applications and <paramref name="executableFileName"/> does not
+    /// match exactly one of them.
+    /// </exception>
+    public AppxApplicationInfo? ResolveApplication(string? executableFileName)
+    {
+        switch (Applications.Count)
+        {
+            case 0:
+                return null;
+            case 1:
+                return Applications[0];
+        }
+
+        AppxApplicationInfo[] matches = [.. Applications.Where(application =>
+            application.Executable is not null
+            && string.Equals(application.Executable, executableFileName, StringComparison.OrdinalIgnoreCase))];
+
+        return matches.Length == 1
+            ? matches[0]
+            : throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ExtensionResources.AmbiguousAppxManifestApplication,
+                    executableFileName,
+                    string.Join(", ", Applications.Select(static application => application.AppUserModelId))));
     }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -62,26 +62,20 @@ internal sealed class AppxManifestInfo
     public string? AppUserModelId { get; }
 
     /// <summary>
-    /// Reads the manifest at the root of <paramref name="layoutDirectory"/> if the directory is a
-    /// packaged-app layout.
+    /// Returns the path to the <c>AppxManifest.xml</c> at the root of <paramref name="layoutDirectory"/>
+    /// when the directory is a packaged-app layout. This is a cheap, non-throwing probe: it only tests
+    /// for the file's existence and never parses it. Callers that need the parsed identity pass the
+    /// returned path to <see cref="ReadFromManifest(string)"/>.
     /// </summary>
     /// <param name="layoutDirectory">The directory to probe for an <c>AppxManifest.xml</c>.</param>
-    /// <param name="info">The parsed manifest info when the directory is a packaged-app layout.</param>
     /// <returns>
-    /// <see langword="true"/> when an <c>AppxManifest.xml</c> was found and parsed; otherwise
-    /// <see langword="false"/>.
+    /// The full path to the manifest when the directory is a packaged-app layout; otherwise
+    /// <see langword="null"/>.
     /// </returns>
-    public static bool TryReadFromLayout(string layoutDirectory, [NotNullWhen(true)] out AppxManifestInfo? info)
+    public static string? GetManifestPath(string layoutDirectory)
     {
         string manifestPath = Path.Combine(layoutDirectory, AppxManifestFileName);
-        if (!File.Exists(manifestPath))
-        {
-            info = null;
-            return false;
-        }
-
-        info = ReadFromManifest(manifestPath);
-        return true;
+        return File.Exists(manifestPath) ? manifestPath : null;
     }
 
     /// <summary>Reads and parses the manifest at <paramref name="manifestPath"/>.</summary>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.Publisher.get -> strin
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ResolveApplication(string? executableFileName) -> Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo?
 const Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppxManifestFileName = "AppxManifest.xml" -> string!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ComputePublisherId(string! publisher) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.FindManifestPath(string! startDirectory) -> string?
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.GetManifestPath(string! layoutDirectory) -> string?
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(System.IO.Stream! manifestStream) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(string! manifestPath) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -7,6 +7,6 @@ Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.PackageName.get -> str
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.Publisher.get -> string!
 const Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppxManifestFileName = "AppxManifest.xml" -> string!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ComputePublisherId(string! publisher) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.GetManifestPath(string! layoutDirectory) -> string?
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(System.IO.Stream! manifestStream) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(string! manifestPath) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
-static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.TryReadFromLayout(string! layoutDirectory, out Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo? info) -> bool

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,10 +1,15 @@
 #nullable enable
+Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo
+Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.AppUserModelId.get -> string!
+Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.AppxApplicationInfo(string! id, string? executable, string! appUserModelId) -> void
+Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.Executable.get -> string?
+Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.Id.get -> string!
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo
-Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppUserModelId.get -> string?
-Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ApplicationId.get -> string?
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.Applications.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo!>!
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.PackageFamilyName.get -> string!
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.PackageName.get -> string!
 Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.Publisher.get -> string!
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ResolveApplication(string? executableFileName) -> Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo?
 const Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppxManifestFileName = "AppxManifest.xml" -> string!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ComputePublisherId(string! publisher) -> string!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.GetManifestPath(string! layoutDirectory) -> string?

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppUserModelId.get -> string?
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ApplicationId.get -> string?
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.PackageFamilyName.get -> string!
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.PackageName.get -> string!
+Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.Publisher.get -> string!
+const Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.AppxManifestFileName = "AppxManifest.xml" -> string!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ComputePublisherId(string! publisher) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(System.IO.Stream! manifestStream) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(string! manifestPath) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
+static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.TryReadFromLayout(string! layoutDirectory, out Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo? info) -> bool

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -20,7 +20,7 @@
     <PackageDescription>
       <![CDATA[This package provides extensions to Microsoft Testing Platform intended to extend base functionalities.
 
-This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows (UWP/WinUI) test host from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).]]>
+This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows (UWP/WinUI) test host from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).]]>
     </PackageDescription>
   </PropertyGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -55,4 +55,8 @@ This package extends Microsoft Testing Platform to deploy and launch a packaged 
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -20,7 +20,7 @@
     <PackageDescription>
       <![CDATA[This package provides extensions to Microsoft Testing Platform intended to extend base functionalities.
 
-This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows (UWP/WinUI) test host from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).]]>
+This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).]]>
     </PackageDescription>
   </PropertyGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -20,7 +20,7 @@
     <PackageDescription>
       <![CDATA[This package provides extensions to Microsoft Testing Platform intended to extend base functionalities.
 
-This package extends Microsoft Testing Platform to deploy and launch a packaged Windows (UWP/WinUI) test host through a custom mechanism instead of starting it in place.]]>
+This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows (UWP/WinUI) test host from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).]]>
     </PackageDescription>
   </PropertyGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
@@ -3,12 +3,12 @@
 > [!IMPORTANT]
 > This package is experimental and consumes the experimental `ITestHostLauncher` extension point of [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform). The API may change or be removed in a future update.
 
-`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys a non-packaged (loose-layout) Windows test host (UWP or packaged WinUI project output) into an isolated directory and launches it from there, instead of starting the test host in place.
+`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) into an isolated directory and launches it from there, instead of starting the test host in place.
 
-It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. UWP and packaged WinUI ship as MSIX and share the same launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for both:
+It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. Packaged Windows apps — UWP and packaged WinUI — require package identity and ship as MSIX; they share a single launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for them:
 
-- **Deploy + launch loose layout** (implemented): a non-packaged (loose-layout) app is deployed to a deployment directory and the produced executable is launched from there.
-- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#9933](https://github.com/microsoft/testfx/issues/9933). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
+- **Deploy + launch loose layout** (implemented): a non-packaged (loose-layout) app — one without an `AppxManifest.xml`, such as unpackaged WinUI — is deployed to a deployment directory and the produced executable is launched from there.
+- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout — UWP or packaged WinUI — is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#9933](https://github.com/microsoft/testfx/issues/9933). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
 
 Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.PackagedApp` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
@@ -22,7 +22,7 @@ dotnet add package Microsoft.Testing.Extensions.PackagedApp
 
 This package extends Microsoft.Testing.Platform with:
 
-- **Deployment + launch**: stages the non-packaged (loose-layout) Windows (UWP/WinUI) test host payload into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts are not launched yet (see [#9933](https://github.com/microsoft/testfx/issues/9933)).
+- **Deployment + launch**: stages a non-packaged (loose-layout) Windows test host payload (for example, unpackaged WinUI) into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts — UWP and packaged WinUI — are not launched yet (see [#9933](https://github.com/microsoft/testfx/issues/9933)).
 - **Mechanism-agnostic monitoring**: returns an `ITestHostHandle` that exposes only the lifecycle the platform needs and no local process id.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
@@ -3,12 +3,12 @@
 > [!IMPORTANT]
 > This package is experimental and consumes the experimental `ITestHostLauncher` extension point of [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform). The API may change or be removed in a future update.
 
-`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys a packaged Windows test host (UWP or packaged WinUI) into an isolated directory and launches it from there, instead of starting the test host in place.
+`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys a non-packaged (loose-layout) Windows test host (UWP or packaged WinUI project output) into an isolated directory and launches it from there, instead of starting the test host in place.
 
-It is the consumer of the platform's `ITestHostLauncher` extension point for packaged Windows apps. UWP and packaged WinUI ship as MSIX and share the same launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for both:
+It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. UWP and packaged WinUI ship as MSIX and share the same launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for both:
 
-- **Deploy + launch** (implemented): the app's loose layout is deployed to a deployment directory and the produced executable is launched from there.
-- **Packaged AUMID activation** (planned): the loose layout is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#2784](https://github.com/microsoft/testfx/issues/2784).
+- **Deploy + launch loose layout** (implemented): a non-packaged (loose-layout) app is deployed to a deployment directory and the produced executable is launched from there.
+- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#2784](https://github.com/microsoft/testfx/issues/2784). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
 
 Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.PackagedApp` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
@@ -22,7 +22,7 @@ dotnet add package Microsoft.Testing.Extensions.PackagedApp
 
 This package extends Microsoft.Testing.Platform with:
 
-- **Deployment + launch**: stages the packaged Windows (UWP/WinUI) test host payload into an isolated directory and launches the deployed copy.
+- **Deployment + launch**: stages the non-packaged (loose-layout) Windows (UWP/WinUI) test host payload into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts are not launched yet (see [#2784](https://github.com/microsoft/testfx/issues/2784)).
 - **Mechanism-agnostic monitoring**: returns an `ITestHostHandle` that exposes only the lifecycle the platform needs and no local process id.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
@@ -8,7 +8,7 @@
 It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. UWP and packaged WinUI ship as MSIX and share the same launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for both:
 
 - **Deploy + launch loose layout** (implemented): a non-packaged (loose-layout) app is deployed to a deployment directory and the produced executable is launched from there.
-- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#2784](https://github.com/microsoft/testfx/issues/2784). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
+- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#9933](https://github.com/microsoft/testfx/issues/9933). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
 
 Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.PackagedApp` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
@@ -22,7 +22,7 @@ dotnet add package Microsoft.Testing.Extensions.PackagedApp
 
 This package extends Microsoft.Testing.Platform with:
 
-- **Deployment + launch**: stages the non-packaged (loose-layout) Windows (UWP/WinUI) test host payload into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts are not launched yet (see [#2784](https://github.com/microsoft/testfx/issues/2784)).
+- **Deployment + launch**: stages the non-packaged (loose-layout) Windows (UWP/WinUI) test host payload into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts are not launched yet (see [#9933](https://github.com/microsoft/testfx/issues/9933)).
 - **Mechanism-agnostic monitoring**: returns an `ITestHostHandle` that exposes only the lifecycle the platform needs and no local process id.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
@@ -7,17 +7,17 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions;
 
 /// <summary>
-/// Provides extension methods for adding Windows (UWP/WinUI) test host deployment support
-/// to the test application builder.
+/// Provides extension methods for adding non-packaged (loose-layout) Windows test host deployment
+/// support (for example, unpackaged WinUI) to the test application builder.
 /// </summary>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class PackagedAppExtensions
 {
     /// <summary>
-    /// Registers a test host launcher that deploys a non-packaged (loose-layout) Windows (UWP/WinUI)
-    /// test host into an isolated directory and launches it from there. Genuinely packaged (MSIX)
-    /// layouts are not launched yet and are rejected with an actionable error (see
-    /// https://github.com/microsoft/testfx/issues/9933).
+    /// Registers a test host launcher that deploys a non-packaged (loose-layout) Windows test host
+    /// (for example, unpackaged WinUI) into an isolated directory and launches it from there.
+    /// Genuinely packaged (MSIX) layouts — UWP or packaged WinUI — are not launched yet and are
+    /// rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddPackagedAppDeployment(this ITestApplicationBuilder builder)

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.PackagedApp;
@@ -7,15 +7,17 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions;
 
 /// <summary>
-/// Provides extension methods for adding packaged Windows (UWP/WinUI) test host deployment support
+/// Provides extension methods for adding Windows (UWP/WinUI) test host deployment support
 /// to the test application builder.
 /// </summary>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class PackagedAppExtensions
 {
     /// <summary>
-    /// Registers a test host launcher that deploys the packaged Windows (UWP/WinUI) test host into
-    /// an isolated directory and launches it from there.
+    /// Registers a test host launcher that deploys a non-packaged (loose-layout) Windows (UWP/WinUI)
+    /// test host into an isolated directory and launches it from there. Genuinely packaged (MSIX)
+    /// layouts are not launched yet and are rejected with an actionable error (see
+    /// https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddPackagedAppDeployment(this ITestApplicationBuilder builder)

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
@@ -6,9 +6,9 @@ using Microsoft.Testing.Platform.Extensions.TestHostControllers;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// An <see cref="ITestHostHandle"/> over a deployed non-packaged (loose-layout) Windows (UWP/WinUI)
-/// test host process that deliberately exposes no identifier, modelling a launch where no local,
-/// queryable PID is available.
+/// An <see cref="ITestHostHandle"/> over a deployed non-packaged (loose-layout) Windows test host
+/// process (for example, unpackaged WinUI) that deliberately exposes no identifier, modelling a
+/// launch where no local, queryable PID is available.
 /// </summary>
 internal sealed class PackagedAppTestHostHandle : ITestHostHandle
 {

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostHandle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions.TestHostControllers;
@@ -6,9 +6,9 @@ using Microsoft.Testing.Platform.Extensions.TestHostControllers;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// An <see cref="ITestHostHandle"/> over a deployed packaged Windows (UWP/WinUI) test host process
-/// that deliberately exposes no identifier, modelling a launch where no local, queryable PID is
-/// available.
+/// An <see cref="ITestHostHandle"/> over a deployed non-packaged (loose-layout) Windows (UWP/WinUI)
+/// test host process that deliberately exposes no identifier, modelling a launch where no local,
+/// queryable PID is available.
 /// </summary>
 internal sealed class PackagedAppTestHostHandle : ITestHostHandle
 {

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -21,10 +21,15 @@ namespace Microsoft.Testing.Extensions.PackagedApp;
 /// WinUI); see https://github.com/microsoft/testfx/issues/2784.
 /// </para>
 /// <para>
-/// This reference implementation performs the deploy-and-launch step (stage the loose layout, then
-/// launch the produced executable from the deployment directory). The packaged AUMID-activation
-/// branch — registering the layout with <c>PackageManager.RegisterPackageByUriAsync</c> and calling
-/// <c>IApplicationActivationManager.ActivateApplication</c> — is a clearly-marked follow-up.
+/// This reference implementation performs the deploy-and-launch step for a <em>non-packaged</em>
+/// (loose-layout) test host (stage the layout, then launch the produced executable from the
+/// deployment directory). A genuinely packaged layout — detected by the presence of an
+/// <c>AppxManifest.xml</c> — cannot be started with <c>Process.Start</c>; its AUMID-activation branch
+/// (registering the layout with <c>PackageManager.RegisterPackageByUriAsync</c> and calling
+/// <c>IApplicationActivationManager.ActivateApplication</c>) is a clearly-marked follow-up
+/// (https://github.com/microsoft/testfx/issues/2784), so for now such a layout is rejected with an
+/// actionable error rather than silently failing at launch. The AUMID that activation will use is
+/// already computed from the manifest by <see cref="AppxManifestInfo"/>.
 /// </para>
 /// <para>
 /// In all cases the platform owns argument/environment preparation, the controller-to-host IPC pipe,
@@ -42,7 +47,10 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
 
     public string Description => ExtensionResources.PackagedAppExtensionDescription;
 
-    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+    // Packaged Windows apps (UWP/WinUI) are a Windows-only concept. On other operating systems the
+    // launcher stays disabled so it is never registered, which keeps the platform on its default
+    // in-process/Process.Start path instead of forcing the controller (deploy-and-launch) host.
+    public Task<bool> IsEnabledAsync() => Task.FromResult(OperatingSystem.IsWindows());
 
     public Task<ITestHostHandle> LaunchTestHostAsync(TestHostLaunchContext context, CancellationToken cancellationToken)
     {
@@ -52,15 +60,28 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         string sourceDirectory = Path.GetDirectoryName(context.FileName)
             ?? throw new InvalidOperationException($"Unable to determine the source directory of '{context.FileName}'.");
 
-        // 1. Deploy the app's loose layout into an isolated directory. For packaged UWP/WinUI this is
-        //    also where the layout would be registered via PackageManager.RegisterPackageByUriAsync.
+        // A genuinely packaged (MSIX) app cannot be started with Process.Start: it must be registered
+        // with the PackageManager and activated by AUMID. That path is not implemented yet (see issue
+        // #2784), so fail fast with an actionable message — including the AUMID activation would use —
+        // instead of starting an executable that cannot host the run.
+        if (AppxManifestInfo.TryReadFromLayout(sourceDirectory, out AppxManifestInfo? manifestInfo))
+        {
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    ExtensionResources.PackagedAppLaunchNotSupported,
+                    manifestInfo.AppUserModelId ?? manifestInfo.PackageFamilyName,
+                    Path.Combine(sourceDirectory, AppxManifestInfo.AppxManifestFileName)));
+        }
+
+        // The layout is not packaged (no AppxManifest.xml). Deploy the loose layout into an isolated
+        // directory and launch the produced executable from there.
+        // 1. Copy the app's loose layout into an isolated directory.
         string deploymentDirectory = Path.Combine(Path.GetTempPath(), "MTPPackagedAppDeployment", Guid.NewGuid().ToString("N"));
         CopyDirectory(sourceDirectory, deploymentDirectory, cancellationToken);
 
         // 2. Launch the deployed test host, forwarding the platform-prepared arguments and
         //    environment (which include the controller IPC pipe name the host connects back on).
-        //    Packaged UWP/WinUI would instead AUMID-activate here via IApplicationActivationManager
-        //    and wrap the activated process id.
         string deployedFileName = Path.Combine(deploymentDirectory, Path.GetFileName(context.FileName));
         var startInfo = new ProcessStartInfo(deployedFileName)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -63,8 +63,10 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         // A genuinely packaged (MSIX) app cannot be started with Process.Start: it must be registered
         // with the PackageManager and activated by AUMID. That path is not implemented yet (see issue
         // #9933), so fail fast with an actionable message — including the AUMID activation would use —
-        // instead of starting an executable that cannot host the run.
-        string? manifestPath = AppxManifestInfo.GetManifestPath(sourceDirectory);
+        // instead of starting an executable that cannot host the run. The manifest lives at the package
+        // layout root, which may be an ancestor of the executable's directory (Application/@Executable
+        // can point into a subdirectory), so search upward rather than only the executable's directory.
+        string? manifestPath = AppxManifestInfo.FindManifestPath(sourceDirectory);
         if (manifestPath is not null)
         {
             var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -7,9 +7,10 @@ using Microsoft.Testing.Platform.Extensions.TestHostControllers;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// An <see cref="ITestHostLauncher"/> for packaged Windows test applications (UWP and packaged
-/// WinUI): it deploys the test host's loose layout into an isolated directory and launches it from
-/// there, instead of starting the test host in place.
+/// An <see cref="ITestHostLauncher"/> for Windows test applications: it deploys a non-packaged
+/// (loose-layout) test host (for example, unpackaged WinUI) into an isolated directory and launches
+/// it from there, instead of starting the test host in place. Genuinely packaged (MSIX) layouts —
+/// UWP or packaged WinUI — are rejected for now (see the remarks).
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -68,11 +68,16 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         if (manifestPath is not null)
         {
             var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
+
+            // Resolve the application matching the executable the platform asked to launch so the
+            // reported identity is the one activation would actually use (a package can declare several
+            // applications). Fall back to the package family name when the manifest declares none.
+            AppxApplicationInfo? application = manifestInfo.ResolveApplication(Path.GetFileName(context.FileName));
             throw new InvalidOperationException(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     ExtensionResources.PackagedAppLaunchNotSupported,
-                    manifestInfo.AppUserModelId ?? manifestInfo.PackageFamilyName,
+                    application?.AppUserModelId ?? manifestInfo.PackageFamilyName,
                     manifestPath));
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -64,14 +64,16 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         // with the PackageManager and activated by AUMID. That path is not implemented yet (see issue
         // #2784), so fail fast with an actionable message — including the AUMID activation would use —
         // instead of starting an executable that cannot host the run.
-        if (AppxManifestInfo.TryReadFromLayout(sourceDirectory, out AppxManifestInfo? manifestInfo))
+        string? manifestPath = AppxManifestInfo.GetManifestPath(sourceDirectory);
+        if (manifestPath is not null)
         {
+            var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
             throw new InvalidOperationException(
                 string.Format(
                     CultureInfo.InvariantCulture,
                     ExtensionResources.PackagedAppLaunchNotSupported,
                     manifestInfo.AppUserModelId ?? manifestInfo.PackageFamilyName,
-                    Path.Combine(sourceDirectory, AppxManifestInfo.AppxManifestFileName)));
+                    manifestPath));
         }
 
         // The layout is not packaged (no AppxManifest.xml). Deploy the loose layout into an isolated

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.PackagedApp.Resources;
@@ -18,7 +18,7 @@ namespace Microsoft.Testing.Extensions.PackagedApp;
 /// launch mechanism: the loose layout is registered with the <c>PackageManager</c> and the app is
 /// activated by Application User Model ID (AUMID) via <c>IApplicationActivationManager</c>. That
 /// mechanism is the reason VSTest's <c>UwpTestHostRuntimeProvider</c> exists (it serves both UWP and
-/// WinUI); see https://github.com/microsoft/testfx/issues/2784.
+/// WinUI); see https://github.com/microsoft/testfx/issues/9933.
 /// </para>
 /// <para>
 /// This reference implementation performs the deploy-and-launch step for a <em>non-packaged</em>
@@ -27,7 +27,7 @@ namespace Microsoft.Testing.Extensions.PackagedApp;
 /// <c>AppxManifest.xml</c> — cannot be started with <c>Process.Start</c>; its AUMID-activation branch
 /// (registering the layout with <c>PackageManager.RegisterPackageByUriAsync</c> and calling
 /// <c>IApplicationActivationManager.ActivateApplication</c>) is a clearly-marked follow-up
-/// (https://github.com/microsoft/testfx/issues/2784), so for now such a layout is rejected with an
+/// (https://github.com/microsoft/testfx/issues/9933), so for now such a layout is rejected with an
 /// actionable error rather than silently failing at launch. The AUMID that activation will use is
 /// already computed from the manifest by <see cref="AppxManifestInfo"/>.
 /// </para>
@@ -62,7 +62,7 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
 
         // A genuinely packaged (MSIX) app cannot be started with Process.Start: it must be registered
         // with the PackageManager and activated by AUMID. That path is not implemented yet (see issue
-        // #2784), so fail fast with an actionable message — including the AUMID activation would use —
+        // #9933), so fail fast with an actionable message — including the AUMID activation would use —
         // instead of starting an executable that cannot host the run.
         string? manifestPath = AppxManifestInfo.GetManifestPath(sourceDirectory);
         if (manifestPath is not null)

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PackagedAppExtensionDescription" xml:space="preserve">
-    <value>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</value>
+    <value>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</value>
   </data>
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -123,4 +123,10 @@
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>
   </data>
+  <data name="InvalidAppxManifestMissingIdentity" xml:space="preserve">
+    <value>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</value>
+  </data>
+  <data name="PackagedAppLaunchNotSupported" xml:space="preserve">
+    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</value>
+  </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PackagedAppExtensionDescription" xml:space="preserve">
-    <value>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</value>
+    <value>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</value>
   </data>
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>
@@ -130,6 +130,6 @@
     <value>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</value>
   </data>
   <data name="PackagedAppLaunchNotSupported" xml:space="preserve">
-    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</value>
+    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</value>
   </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -118,10 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PackagedAppExtensionDescription" xml:space="preserve">
-    <value>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</value>
+    <value>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</value>
   </data>
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>
+  </data>
+  <data name="AmbiguousAppxManifestApplication" xml:space="preserve">
+    <value>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</value>
   </data>
   <data name="InvalidAppxManifestMissingIdentity" xml:space="preserve">
     <value>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Nasadí zabaleného hostitele testů Windows (UWP/WinUI) do izolovaného adresáře a spustí ho odtamtud.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Spouštěč hostitele testu zabalené aplikace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Nasadí zabaleného hostitele testů Windows (UWP/WinUI) do izolovaného adresáře a spustí ho odtamtud.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Nasadí zabaleného hostitele testů Windows (UWP/WinUI) do izolovaného adresáře a spustí ho odtamtud.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Nasadí zabaleného hostitele testů Windows (UWP/WinUI) do izolovaného adresáře a spustí ho odtamtud.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Nasadí zabaleného hostitele testů Windows (UWP/WinUI) do izolovaného adresáře a spustí ho odtamtud.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Stellt einen verpackten Windows-Testhost (UWP/WinUI) in einem isolierten Verzeichnis bereit und startet ihn von dort aus.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Testhoststarter für App-Pakete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Stellt einen verpackten Windows-Testhost (UWP/WinUI) in einem isolierten Verzeichnis bereit und startet ihn von dort aus.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Stellt einen verpackten Windows-Testhost (UWP/WinUI) in einem isolierten Verzeichnis bereit und startet ihn von dort aus.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Stellt einen verpackten Windows-Testhost (UWP/WinUI) in einem isolierten Verzeichnis bereit und startet ihn von dort aus.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Stellt einen verpackten Windows-Testhost (UWP/WinUI) in einem isolierten Verzeichnis bereit und startet ihn von dort aus.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Implementa un host de prueba de Windows empaquetado (UWP/WinUI) en un directorio aislado y lo inicia desde allí.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Implementa un host de prueba de Windows empaquetado (UWP/WinUI) en un directorio aislado y lo inicia desde allí.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Implementa un host de prueba de Windows empaquetado (UWP/WinUI) en un directorio aislado y lo inicia desde allí.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Iniciador de host de prueba de aplicaciones empaquetadas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Implementa un host de prueba de Windows empaquetado (UWP/WinUI) en un directorio aislado y lo inicia desde allí.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Implementa un host de prueba de Windows empaquetado (UWP/WinUI) en un directorio aislado y lo inicia desde allí.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Déploie un hôte de test Windows packagé (UWP/WinUI) dans un répertoire isolé et le lance à partir de cet emplacement.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Déploie un hôte de test Windows packagé (UWP/WinUI) dans un répertoire isolé et le lance à partir de cet emplacement.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Déploie un hôte de test Windows packagé (UWP/WinUI) dans un répertoire isolé et le lance à partir de cet emplacement.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Lanceur d’hôte de test d’applications packagées</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Déploie un hôte de test Windows packagé (UWP/WinUI) dans un répertoire isolé et le lance à partir de cet emplacement.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Déploie un hôte de test Windows packagé (UWP/WinUI) dans un répertoire isolé et le lance à partir de cet emplacement.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Distribuisce un host di test Windows (UWP/WinUI) in pacchetto in una directory isolata e lo avvia da qui.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Distribuisce un host di test Windows (UWP/WinUI) in pacchetto in una directory isolata e lo avvia da qui.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Launcher host di test app in pacchetto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Distribuisce un host di test Windows (UWP/WinUI) in pacchetto in una directory isolata e lo avvia da qui.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Distribuisce un host di test Windows (UWP/WinUI) in pacchetto in una directory isolata e lo avvia da qui.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Distribuisce un host di test Windows (UWP/WinUI) in pacchetto in una directory isolata e lo avvia da qui.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">パッケージ化された Windows (UWP/WinUI) テスト ホストを分離されたディレクトリに展開し、そこから起動します。</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">パッケージ化された Windows (UWP/WinUI) テスト ホストを分離されたディレクトリに展開し、そこから起動します。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">パッケージ化された Windows (UWP/WinUI) テスト ホストを分離されたディレクトリに展開し、そこから起動します。</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">パッケージ化された Windows (UWP/WinUI) テスト ホストを分離されたディレクトリに展開し、そこから起動します。</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">パッケージ化された Windows (UWP/WinUI) テスト ホストを分離されたディレクトリに展開し、そこから起動します。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">パッケージ アプリ テスト ホスト ランチャー</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">패키지된 Windows(UWP/WinUI) 테스트 호스트를 격리된 디렉터리에 배포하고 해당 디렉터리에서 시작합니다.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">패키지된 Windows(UWP/WinUI) 테스트 호스트를 격리된 디렉터리에 배포하고 해당 디렉터리에서 시작합니다.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">패키지된 Windows(UWP/WinUI) 테스트 호스트를 격리된 디렉터리에 배포하고 해당 디렉터리에서 시작합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">패키지된 Windows(UWP/WinUI) 테스트 호스트를 격리된 디렉터리에 배포하고 해당 디렉터리에서 시작합니다.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">패키지된 Windows(UWP/WinUI) 테스트 호스트를 격리된 디렉터리에 배포하고 해당 디렉터리에서 시작합니다.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">패키지된 앱 테스트 호스트 실행기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Wdraża pakietowego hosta testowego Windows (UWP/WinUI) w odizolowanym katalogu i uruchamia go z tego miejsca.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Wdraża pakietowego hosta testowego Windows (UWP/WinUI) w odizolowanym katalogu i uruchamia go z tego miejsca.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Wdraża pakietowego hosta testowego Windows (UWP/WinUI) w odizolowanym katalogu i uruchamia go z tego miejsca.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Wdraża pakietowego hosta testowego Windows (UWP/WinUI) w odizolowanym katalogu i uruchamia go z tego miejsca.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Wdraża pakietowego hosta testowego Windows (UWP/WinUI) w odizolowanym katalogu i uruchamia go z tego miejsca.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Uruchamianie pakietowego hosta testowego aplikacji</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Implanta um host de teste do Windows (UWP/WinUI) empacotado em um diretório isolado e o inicia a partir desse diretório.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Implanta um host de teste do Windows (UWP/WinUI) empacotado em um diretório isolado e o inicia a partir desse diretório.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Implanta um host de teste do Windows (UWP/WinUI) empacotado em um diretório isolado e o inicia a partir desse diretório.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Implanta um host de teste do Windows (UWP/WinUI) empacotado em um diretório isolado e o inicia a partir desse diretório.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Inicializador do host de teste do aplicativo empacotado</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Implanta um host de teste do Windows (UWP/WinUI) empacotado em um diretório isolado e o inicia a partir desse diretório.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Развертывает упакованный узел тестирования Windows (UWP/WinUI) в изолированном каталоге и запускает его оттуда.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Развертывает упакованный узел тестирования Windows (UWP/WinUI) в изолированном каталоге и запускает его оттуда.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Развертывает упакованный узел тестирования Windows (UWP/WinUI) в изолированном каталоге и запускает его оттуда.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Средство запуска узла тестирования упакованных приложений</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Развертывает упакованный узел тестирования Windows (UWP/WinUI) в изолированном каталоге и запускает его оттуда.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Развертывает упакованный узел тестирования Windows (UWP/WinUI) в изолированном каталоге и запускает его оттуда.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">Paketlenmiş bir Windows (UWP/WinUI) test konağını yalıtılmış bir dizine dağıtır ve oradan başlatır.</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">Paketlenmiş uygulama test konağı başlatıcısı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">Paketlenmiş bir Windows (UWP/WinUI) test konağını yalıtılmış bir dizine dağıtır ve oradan başlatır.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">Paketlenmiş bir Windows (UWP/WinUI) test konağını yalıtılmış bir dizine dağıtır ve oradan başlatır.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Paketlenmiş bir Windows (UWP/WinUI) test konağını yalıtılmış bir dizine dağıtır ve oradan başlatır.</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">Paketlenmiş bir Windows (UWP/WinUI) test konağını yalıtılmış bir dizine dağıtır ve oradan başlatır.</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">将打包的 Windows (UWP/WinUI)测试主机部署到隔离目录，并从该目录启动它。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">打包应用测试主机启动器</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">将打包的 Windows (UWP/WinUI)测试主机部署到隔离目录，并从该目录启动它。</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">将打包的 Windows (UWP/WinUI)测试主机部署到隔离目录，并从该目录启动它。</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">将打包的 Windows (UWP/WinUI)测试主机部署到隔离目录，并从该目录启动它。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">将打包的 Windows (UWP/WinUI)测试主机部署到隔离目录，并从该目录启动它。</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">將封裝的 Windows (UWP/WinUI) 測試主機部署到隔離目錄，並從該目錄啟動。</target>
         <note />
       </trans-unit>
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="InvalidAppxManifestMissingIdentity">
+        <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
+        <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
         <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
         <target state="translated">將封裝的 Windows (UWP/WinUI) 測試主機部署到隔離目錄，並從該目錄啟動。</target>
@@ -10,6 +15,11 @@
       <trans-unit id="PackagedAppExtensionDisplayName">
         <source>Packaged app test host launcher</source>
         <target state="translated">封裝應用程式測試主機啟動器</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppLaunchNotSupported">
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/2784). Only non-packaged (loose-layout) test hosts can be launched today.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -13,7 +13,7 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
         <target state="needs-review-translation">將封裝的 Windows (UWP/WinUI) 測試主機部署到隔離目錄，並從該目錄啟動。</target>
         <note />
       </trans-unit>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="AmbiguousAppxManifestApplication">
+        <source>The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</source>
+        <target state="new">The packaged app manifest declares multiple applications and none uniquely matches the executable '{0}'. Candidate Application User Model IDs: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidAppxManifestMissingIdentity">
         <source>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</source>
         <target state="new">The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a packaged Windows (UWP/WinUI) test host to an isolated directory and launches it from there.</source>
-        <target state="translated">將封裝的 Windows (UWP/WinUI) 測試主機部署到隔離目錄，並從該目錄啟動。</target>
+        <source>Deploys a non-packaged (loose-layout) Windows (UWP/WinUI) test host to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/2784).</source>
+        <target state="needs-review-translation">將封裝的 Windows (UWP/WinUI) 測試主機部署到隔離目錄，並從該目錄啟動。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Builder;
@@ -6,12 +6,13 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add packaged Windows (UWP/WinUI) test host deployment support.
+/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add non-packaged (loose-layout) Windows (UWP/WinUI) test host deployment support.
 /// </summary>
 public static class TestingPlatformBuilderHook
 {
     /// <summary>
-    /// Adds packaged Windows (UWP/WinUI) test host deployment support to the Testing Platform Builder.
+    /// Adds non-packaged (loose-layout) Windows (UWP/WinUI) test host deployment support to the Testing Platform Builder.
+    /// Genuinely packaged (MSIX) layouts are not launched yet and are rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
     /// <param name="_">The command line arguments.</param>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
@@ -6,13 +6,13 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add non-packaged (loose-layout) Windows (UWP/WinUI) test host deployment support.
+/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add non-packaged (loose-layout) Windows test host deployment support (for example, unpackaged WinUI).
 /// </summary>
 public static class TestingPlatformBuilderHook
 {
     /// <summary>
-    /// Adds non-packaged (loose-layout) Windows (UWP/WinUI) test host deployment support to the Testing Platform Builder.
-    /// Genuinely packaged (MSIX) layouts are not launched yet and are rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
+    /// Adds non-packaged (loose-layout) Windows test host deployment support (for example, unpackaged WinUI) to the Testing Platform Builder.
+    /// Genuinely packaged (MSIX) layouts — UWP or packaged WinUI — are not launched yet and are rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
     /// <param name="_">The command line arguments.</param>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedAppLaunchNotSupportedTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedAppLaunchNotSupportedTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -12,7 +12,7 @@ public sealed class PackagedAppLaunchNotSupportedTests : AcceptanceTestBase<Pack
     // Application Id="App". The package family name suffix is the deterministic publisher hash of
     // "CN=Contoso", so the AUMID the launcher reports is stable and can be asserted verbatim.
     private const string ExpectedAppUserModelId = "Contoso.MyTestApp_h91ms92gdsmmt!App";
-    private const string TrackingIssueUrl = "https://github.com/microsoft/testfx/issues/2784";
+    private const string TrackingIssueUrl = "https://github.com/microsoft/testfx/issues/9933";
 
     // The sentinel exit code the asset returns after catching the launcher's InvalidOperationException.
     private const int LaunchNotSupportedExitCode = 3;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedAppLaunchNotSupportedTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedAppLaunchNotSupportedTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class PackagedAppLaunchNotSupportedTests : AcceptanceTestBase<PackagedAppLaunchNotSupportedTests.TestAssetFixture>
+{
+    private const string AssetName = "PackagedAppLaunchNotSupportedTest";
+
+    // The asset's AppxManifest.xml declares Name="Contoso.MyTestApp" Publisher="CN=Contoso" and an
+    // Application Id="App". The package family name suffix is the deterministic publisher hash of
+    // "CN=Contoso", so the AUMID the launcher reports is stable and can be asserted verbatim.
+    private const string ExpectedAppUserModelId = "Contoso.MyTestApp_h91ms92gdsmmt!App";
+    private const string TrackingIssueUrl = "https://github.com/microsoft/testfx/issues/2784";
+
+    // The sentinel exit code the asset returns after catching the launcher's InvalidOperationException.
+    private const int LaunchNotSupportedExitCode = 3;
+
+    [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    [OSCondition(ConditionMode.Include, OperatingSystems.Windows, IgnoreMessage = "The launcher is only enabled on Windows; on other operating systems it stays disabled and never inspects the layout.")]
+    public async Task LaunchTestHost_WithPackagedLayout_FailsFastWithActionableMessage(string currentTfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        // The layout contains an AppxManifest.xml, so the launcher must refuse to Process.Start it and
+        // instead throw. The asset catches that exception and surfaces it, so the run fails
+        // deterministically rather than launching a host that cannot host the run.
+        testHostResult.AssertExitCodeIs(LaunchNotSupportedExitCode);
+
+        // The message must stay actionable: it names the exact packaged app (via its AUMID) that could
+        // not be launched and points at the tracking issue for the missing activation support.
+        testHostResult.AssertOutputContains(ExpectedAppUserModelId);
+        testHostResult.AssertOutputContains(TrackingIssueUrl);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string Sources = """
+#file PackagedAppLaunchNotSupportedTest.csproj
+
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>true</UseAppHost>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <!-- AddPackagedAppDeployment is an experimental (TPEXP) API and the PackagedApp package is an
+         experimental package with a downgraded (alpha) version (NETSDK1201). -->
+    <NoWarn>$(NoWarn);TPEXP;NETSDK1201</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+    <PackageReference Include="Microsoft.Testing.Extensions.PackagedApp" Version="$MicrosoftTestingExtensionsPackagedAppVersion$" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Bake a packaged-app manifest next to the built test host so the launcher classifies the layout
+         as packaged (MSIX) and refuses to Process.Start it. -->
+    <Content Include="AppxManifest.xml" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>
+
+#file AppxManifest.xml
+
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+  <Applications>
+    <Application Id="App" />
+  </Applications>
+</Package>
+
+#file Program.cs
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Testing.Extensions;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Services;
+
+public class Startup
+{
+    public static async Task<int> Main(string[] args)
+    {
+        var testApplicationBuilder = await TestApplication.CreateBuilderAsync(args);
+        testApplicationBuilder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_,__) => new DummyTestFramework());
+        testApplicationBuilder.AddPackagedAppDeployment();
+        using ITestApplication app = await testApplicationBuilder.BuildAsync();
+
+        // The controller process launches the (deployed) test host through the PackagedApp launcher.
+        // Because an AppxManifest.xml sits next to this app, the launcher throws instead of doing a
+        // plain Process.Start. Catch it and surface it deterministically so the acceptance test can
+        // assert on both the exit code and the actionable message.
+        try
+        {
+            return await app.RunAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.ToString());
+            return 3;
+        }
+    }
+}
+
+public class DummyTestFramework : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestFramework);
+
+    public string Version => "2.0.0";
+
+    public string DisplayName => nameof(DummyTestFramework);
+
+    public string Description => nameof(DummyTestFramework);
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, new TestNode()
+        {
+            Uid = "Test1",
+            DisplayName = "Test1",
+            Properties = new PropertyBag(new PassedTestNodeStateProperty()),
+        }));
+
+        context.Complete();
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+                Sources
+                .PatchTargetFrameworks(TargetFrameworks.Net)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsPackagedAppVersion$", MicrosoftTestingExtensionsPackagedAppVersion));
+    }
+
+    public TestContext TestContext { get; set; }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
@@ -129,14 +129,13 @@ public sealed class AppxManifestInfoTests
     }
 
     [TestMethod]
-    public void TryReadFromLayout_WithoutManifest_ReturnsFalse()
+    public void GetManifestPath_WithoutManifest_ReturnsNull()
     {
         string directory = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
         {
-            Assert.IsFalse(AppxManifestInfo.TryReadFromLayout(directory, out AppxManifestInfo? info));
-            Assert.IsNull(info);
+            Assert.IsNull(AppxManifestInfo.GetManifestPath(directory));
         }
         finally
         {
@@ -145,19 +144,19 @@ public sealed class AppxManifestInfoTests
     }
 
     [TestMethod]
-    public void TryReadFromLayout_WithManifest_ReturnsParsedInfo()
+    public void GetManifestPath_WithManifest_ReturnsPathWithoutParsing()
     {
         string directory = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
         try
         {
-            File.WriteAllText(
-                Path.Combine(directory, AppxManifestInfo.AppxManifestFileName),
-                BuildManifestXml("Contoso.MyTestApp", MicrosoftStorePublisher, "App"));
+            string manifestPath = Path.Combine(directory, AppxManifestInfo.AppxManifestFileName);
 
-            Assert.IsTrue(AppxManifestInfo.TryReadFromLayout(directory, out AppxManifestInfo? info));
-            Assert.IsNotNull(info);
-            Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", info.AppUserModelId);
+            // Intentionally not a valid manifest: GetManifestPath must be a pure existence probe that
+            // never parses, so an unparsable file must still be reported.
+            File.WriteAllText(manifestPath, "not xml");
+
+            Assert.AreEqual(manifestPath, AppxManifestInfo.GetManifestPath(directory));
         }
         finally
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.
+#if !NETFRAMEWORK
+
+using Microsoft.Testing.Extensions.PackagedApp;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class AppxManifestInfoTests
+{
+    // The publisher of Microsoft Store apps, whose well-known publisher id is "8wekyb3d8bbwe".
+    private const string MicrosoftStorePublisher = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+    private const string MicrosoftStorePublisherId = "8wekyb3d8bbwe";
+
+    [TestMethod]
+    public void ComputePublisherId_ForMicrosoftStorePublisher_MatchesWellKnownHash()
+        => Assert.AreEqual(MicrosoftStorePublisherId, AppxManifestInfo.ComputePublisherId(MicrosoftStorePublisher));
+
+    [TestMethod]
+    public void ComputePublisherId_IsThirteenCharacters()
+        => Assert.HasCount(13, AppxManifestInfo.ComputePublisherId("CN=Contoso"));
+
+    [TestMethod]
+    public void ComputePublisherId_IsStableForSameInput()
+        => Assert.AreEqual(
+            AppxManifestInfo.ComputePublisherId("CN=Contoso"),
+            AppxManifestInfo.ComputePublisherId("CN=Contoso"));
+
+    [TestMethod]
+    public void ComputePublisherId_IsCaseSensitive()
+        => Assert.AreNotEqual(
+            AppxManifestInfo.ComputePublisherId("CN=Contoso"),
+            AppxManifestInfo.ComputePublisherId("CN=contoso"));
+
+    [TestMethod]
+    public void ReadFromManifest_ComputesPackageFamilyNameAndAppUserModelId()
+    {
+        AppxManifestInfo info = ReadManifest(
+            name: "Contoso.MyTestApp",
+            publisher: MicrosoftStorePublisher,
+            applicationId: "App");
+
+        Assert.AreEqual("Contoso.MyTestApp", info.PackageName);
+        Assert.AreEqual(MicrosoftStorePublisher, info.Publisher);
+        Assert.AreEqual("App", info.ApplicationId);
+        Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", info.PackageFamilyName);
+        Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", info.AppUserModelId);
+    }
+
+    [TestMethod]
+    public void ReadFromManifest_WithoutApplication_LeavesAppUserModelIdNull()
+    {
+        AppxManifestInfo info = ReadManifest(
+            name: "Contoso.MyTestApp",
+            publisher: MicrosoftStorePublisher,
+            applicationId: null);
+
+        Assert.IsNull(info.ApplicationId);
+        Assert.IsNull(info.AppUserModelId);
+        Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", info.PackageFamilyName);
+    }
+
+    [TestMethod]
+    public void ReadFromManifest_IgnoresSchemaNamespaceVersion()
+    {
+        // A different foundation-namespace revision must still parse (we match by local name).
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/2020">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="App" />
+              </Applications>
+            </Package>
+            """;
+
+        AppxManifestInfo info = ReadManifest(ManifestXml);
+
+        Assert.AreEqual("Contoso.MyTestApp", info.PackageName);
+        Assert.AreEqual("App", info.ApplicationId);
+    }
+
+    [TestMethod]
+    public void ReadFromManifest_UsesFirstApplicationId()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="First" />
+                <Application Id="Second" />
+              </Applications>
+            </Package>
+            """;
+
+        Assert.AreEqual("First", ReadManifest(ManifestXml).ApplicationId);
+    }
+
+    [TestMethod]
+    public void ReadFromManifest_WithoutIdentity_Throws()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Applications>
+                <Application Id="App" />
+              </Applications>
+            </Package>
+            """;
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => ReadManifest(ManifestXml));
+    }
+
+    [TestMethod]
+    public void ReadFromManifest_WithoutPublisher_Throws()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Version="1.0.0.0" />
+            </Package>
+            """;
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => ReadManifest(ManifestXml));
+    }
+
+    [TestMethod]
+    public void TryReadFromLayout_WithoutManifest_ReturnsFalse()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            Assert.IsFalse(AppxManifestInfo.TryReadFromLayout(directory, out AppxManifestInfo? info));
+            Assert.IsNull(info);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void TryReadFromLayout_WithManifest_ReturnsParsedInfo()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(directory, AppxManifestInfo.AppxManifestFileName),
+                BuildManifestXml("Contoso.MyTestApp", MicrosoftStorePublisher, "App"));
+
+            Assert.IsTrue(AppxManifestInfo.TryReadFromLayout(directory, out AppxManifestInfo? info));
+            Assert.IsNotNull(info);
+            Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", info.AppUserModelId);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static AppxManifestInfo ReadManifest(string name, string publisher, string? applicationId)
+        => ReadManifest(BuildManifestXml(name, publisher, applicationId));
+
+    private static AppxManifestInfo ReadManifest(string manifestXml)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(manifestXml));
+        return AppxManifestInfo.ReadFromManifest(stream);
+    }
+
+    private static string BuildManifestXml(string name, string publisher, string? applicationId)
+    {
+        string applications = applicationId is null
+            ? string.Empty
+            : $"""
+                 <Applications>
+                   <Application Id="{applicationId}" />
+                 </Applications>
+               """;
+
+        return $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="{name}" Publisher="{publisher}" Version="1.0.0.0" />
+            {applications}
+            </Package>
+            """;
+    }
+}
+
+#endif

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
@@ -45,21 +45,23 @@ public sealed class AppxManifestInfoTests
 
         Assert.AreEqual("Contoso.MyTestApp", info.PackageName);
         Assert.AreEqual(MicrosoftStorePublisher, info.Publisher);
-        Assert.AreEqual("App", info.ApplicationId);
         Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", info.PackageFamilyName);
-        Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", info.AppUserModelId);
+
+        AppxApplicationInfo application = Assert.ContainsSingle(info.Applications);
+        Assert.AreEqual("App", application.Id);
+        Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", application.AppUserModelId);
     }
 
     [TestMethod]
-    public void ReadFromManifest_WithoutApplication_LeavesAppUserModelIdNull()
+    public void ReadFromManifest_WithoutApplication_LeavesApplicationsEmpty()
     {
         AppxManifestInfo info = ReadManifest(
             name: "Contoso.MyTestApp",
             publisher: MicrosoftStorePublisher,
             applicationId: null);
 
-        Assert.IsNull(info.ApplicationId);
-        Assert.IsNull(info.AppUserModelId);
+        Assert.IsEmpty(info.Applications);
+        Assert.IsNull(info.ResolveApplication("MyTestApp.exe"));
         Assert.AreEqual($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", info.PackageFamilyName);
     }
 
@@ -80,24 +82,82 @@ public sealed class AppxManifestInfoTests
         AppxManifestInfo info = ReadManifest(ManifestXml);
 
         Assert.AreEqual("Contoso.MyTestApp", info.PackageName);
-        Assert.AreEqual("App", info.ApplicationId);
+        Assert.AreEqual("App", Assert.ContainsSingle(info.Applications).Id);
     }
 
     [TestMethod]
-    public void ReadFromManifest_UsesFirstApplicationId()
+    public void ReadFromManifest_ParsesAllApplicationsInManifestOrder()
     {
         const string ManifestXml = """
             <?xml version="1.0" encoding="utf-8"?>
             <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
               <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
               <Applications>
-                <Application Id="First" />
-                <Application Id="Second" />
+                <Application Id="First" Executable="First.exe" />
+                <Application Id="Second" Executable="Second.exe" />
               </Applications>
             </Package>
             """;
 
-        Assert.AreEqual("First", ReadManifest(ManifestXml).ApplicationId);
+        AppxManifestInfo info = ReadManifest(ManifestXml);
+
+        Assert.HasCount(2, info.Applications);
+        Assert.AreEqual("First", info.Applications[0].Id);
+        Assert.AreEqual("First.exe", info.Applications[0].Executable);
+        Assert.AreEqual("Second", info.Applications[1].Id);
+        Assert.AreEqual("Second.exe", info.Applications[1].Executable);
+    }
+
+    [TestMethod]
+    public void ResolveApplication_WithSingleApplication_ReturnsItRegardlessOfExecutable()
+    {
+        AppxManifestInfo info = ReadManifest(
+            name: "Contoso.MyTestApp",
+            publisher: MicrosoftStorePublisher,
+            applicationId: "App");
+
+        // A single application is unambiguous, so it is returned even when the executable does not match.
+        Assert.AreEqual("App", info.ResolveApplication("does-not-matter.exe")?.Id);
+    }
+
+    [TestMethod]
+    public void ResolveApplication_WithMultipleApplications_SelectsTheOneMatchingTheExecutable()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="First" Executable="First.exe" />
+                <Application Id="Second" Executable="Second.exe" />
+              </Applications>
+            </Package>
+            """;
+
+        AppxManifestInfo info = ReadManifest(ManifestXml);
+
+        // The executable disambiguates: the second application is selected rather than defaulting to the first.
+        Assert.AreEqual("Second", info.ResolveApplication("Second.exe")?.Id);
+    }
+
+    [TestMethod]
+    public void ResolveApplication_WithMultipleApplicationsAndNoMatch_Throws()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="First" Executable="First.exe" />
+                <Application Id="Second" Executable="Second.exe" />
+              </Applications>
+            </Package>
+            """;
+
+        AppxManifestInfo info = ReadManifest(ManifestXml);
+
+        // An ambiguous request must be rejected instead of silently defaulting to the first application.
+        Assert.ThrowsExactly<InvalidOperationException>(() => info.ResolveApplication("Unknown.exe"));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppxManifestInfoTests.cs
@@ -224,6 +224,66 @@ public sealed class AppxManifestInfoTests
         }
     }
 
+    [TestMethod]
+    public void FindManifestPath_WhenManifestIsInAnAncestorDirectory_ReturnsTheNearestManifest()
+    {
+        // Model a valid MSIX layout where the manifest sits at the package root but the executable
+        // lives in a subdirectory (Application/@Executable = "bin\host.exe").
+        string root = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"));
+        string executableDirectory = Path.Combine(root, "bin");
+        Directory.CreateDirectory(executableDirectory);
+        try
+        {
+            string manifestPath = Path.Combine(root, AppxManifestInfo.AppxManifestFileName);
+            File.WriteAllText(manifestPath, "not xml");
+
+            // GetManifestPath only probes the executable's own directory and must miss the ancestor
+            // manifest, whereas FindManifestPath walks up and locates it.
+            Assert.IsNull(AppxManifestInfo.GetManifestPath(executableDirectory));
+            Assert.AreEqual(manifestPath, AppxManifestInfo.FindManifestPath(executableDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void FindManifestPath_WithoutAnyManifest_ReturnsNull()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "AppxManifestInfoTests", Guid.NewGuid().ToString("N"), "bin");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            Assert.IsNull(AppxManifestInfo.FindManifestPath(directory));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ResolveApplication_MatchesExecutableDeclaredWithASubdirectoryPath()
+    {
+        // A valid MSIX manifest can declare Executable with a package-relative subdirectory path; the
+        // platform still asks to launch the bare executable file name, so resolution must match on it.
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Contoso" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="First" Executable="bin\First.exe" />
+                <Application Id="Second" Executable="bin\Second.exe" />
+              </Applications>
+            </Package>
+            """;
+
+        AppxManifestInfo info = ReadManifest(ManifestXml);
+
+        Assert.AreEqual("Second", info.ResolveApplication("Second.exe")?.Id);
+    }
+
     private static AppxManifestInfo ReadManifest(string name, string publisher, string? applicationId)
         => ReadManifest(BuildManifestXml(name, publisher, applicationId));
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Microsoft.Testing.Extensions.UnitTests.csproj
@@ -55,6 +55,9 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.AzureFoundry\Microsoft.Testing.Extensions.AzureFoundry.csproj">
       <SetTargetFramework Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETCoreApp'">TargetFramework=netstandard2.0</SetTargetFramework>
     </ProjectReference>
+    <!-- The PackagedApp extension only targets .NET (net8.0/net9.0), so it is referenced only for those TFMs. -->
+    <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Extensions.PackagedApp\Microsoft.Testing.Extensions.PackagedApp.csproj"
+                      Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
@@ -46,7 +46,33 @@ public sealed class PackagedAppTestHostLauncherTests
         Assert.Contains($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", exception.Message);
     }
 
-    private static async Task<InvalidOperationException> LaunchInLayoutContainingManifestAsync(string? applicationId)
+    [TestMethod]
+    public async Task LaunchTestHostAsync_WithMultipleApplications_ReportsTheOneMatchingTheExecutable()
+    {
+        const string ManifestXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="Contoso.MyTestApp" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="1.0.0.0" />
+              <Applications>
+                <Application Id="First" Executable="First.exe" />
+                <Application Id="Second" Executable="MyTestApp.exe" />
+              </Applications>
+            </Package>
+            """;
+
+        InvalidOperationException exception = await LaunchInLayoutContainingManifestAsync(ManifestXml, testHostFileName: "MyTestApp.exe");
+
+        // The reported identity must be the app whose Executable matches the requested test host, not
+        // simply the first application declared in the manifest.
+        Assert.Contains($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!Second", exception.Message);
+    }
+
+    private static Task<InvalidOperationException> LaunchInLayoutContainingManifestAsync(string? applicationId)
+        => LaunchInLayoutContainingManifestAsync(
+            BuildManifestXml("Contoso.MyTestApp", MicrosoftStorePublisher, applicationId),
+            testHostFileName: "MyTestApp.exe");
+
+    private static async Task<InvalidOperationException> LaunchInLayoutContainingManifestAsync(string manifestXml, string testHostFileName)
     {
         string directory = Path.Combine(Path.GetTempPath(), "PackagedAppTestHostLauncherTests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(directory);
@@ -54,12 +80,12 @@ public sealed class PackagedAppTestHostLauncherTests
         {
             File.WriteAllText(
                 Path.Combine(directory, AppxManifestInfo.AppxManifestFileName),
-                BuildManifestXml("Contoso.MyTestApp", MicrosoftStorePublisher, applicationId));
+                manifestXml);
 
             var launcher = new PackagedAppTestHostLauncher();
 
             // The executable does not need to exist: the packaged-layout check happens before any launch.
-            string fakeTestHost = Path.Combine(directory, "MyTestApp.exe");
+            string fakeTestHost = Path.Combine(directory, testHostFileName);
 #pragma warning disable TPEXP // TestHostLaunchContext is experimental.
             var context = new TestHostLaunchContext(fakeTestHost, [], new Dictionary<string, string?>(), workingDirectory: null);
             return await Assert.ThrowsExactlyAsync<InvalidOperationException>(

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.
+#if !NETFRAMEWORK
+
+using Microsoft.Testing.Extensions.PackagedApp;
+using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class PackagedAppTestHostLauncherTests
+{
+    private const string MicrosoftStorePublisher = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+    private const string MicrosoftStorePublisherId = "8wekyb3d8bbwe";
+
+    [TestMethod]
+    public async Task IsEnabledAsync_IsEnabledOnlyOnWindows()
+    {
+        var launcher = new PackagedAppTestHostLauncher();
+
+        // Packaged Windows apps are Windows-only. On other operating systems the launcher must report
+        // itself disabled so it is never registered and the platform is not forced onto the controller
+        // (deploy-and-launch) host. This assertion runs on both Windows and non-Windows CI legs.
+        Assert.AreEqual(OperatingSystem.IsWindows(), await launcher.IsEnabledAsync());
+    }
+
+    [TestMethod]
+    public async Task LaunchTestHostAsync_WithPackagedLayout_ThrowsWithApplicationUserModelId()
+    {
+        InvalidOperationException exception = await LaunchInLayoutContainingManifestAsync(applicationId: "App");
+
+        // The error must stay actionable: it carries the AUMID activation would use, so a reader knows
+        // exactly which packaged app could not be launched.
+        Assert.Contains($"Contoso.MyTestApp_{MicrosoftStorePublisherId}!App", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task LaunchTestHostAsync_WithPackagedLayoutWithoutApplication_ThrowsWithPackageFamilyName()
+    {
+        InvalidOperationException exception = await LaunchInLayoutContainingManifestAsync(applicationId: null);
+
+        // With no Application declared there is no AUMID, so the message falls back to the package
+        // family name rather than an empty identity.
+        Assert.Contains($"Contoso.MyTestApp_{MicrosoftStorePublisherId}", exception.Message);
+    }
+
+    private static async Task<InvalidOperationException> LaunchInLayoutContainingManifestAsync(string? applicationId)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "PackagedAppTestHostLauncherTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(directory, AppxManifestInfo.AppxManifestFileName),
+                BuildManifestXml("Contoso.MyTestApp", MicrosoftStorePublisher, applicationId));
+
+            var launcher = new PackagedAppTestHostLauncher();
+
+            // The executable does not need to exist: the packaged-layout check happens before any launch.
+            string fakeTestHost = Path.Combine(directory, "MyTestApp.exe");
+#pragma warning disable TPEXP // TestHostLaunchContext is experimental.
+            var context = new TestHostLaunchContext(fakeTestHost, [], new Dictionary<string, string?>(), workingDirectory: null);
+            return await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                () => launcher.LaunchTestHostAsync(context, CancellationToken.None));
+#pragma warning restore TPEXP
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string BuildManifestXml(string name, string publisher, string? applicationId)
+    {
+        string applications = applicationId is null
+            ? string.Empty
+            : $"""
+                 <Applications>
+                   <Application Id="{applicationId}" />
+                 </Applications>
+               """;
+
+        return $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+              <Identity Name="{name}" Publisher="{publisher}" Version="1.0.0.0" />
+            {applications}
+            </Package>
+            """;
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Follow-up to the discussion under #9908 about `Microsoft.Testing.Extensions.PackagedApp`. Today the launcher's only real launch path is `CopyDirectory` + `Process.Start`, which **cannot** launch a packaged (MSIX) WinUI/UWP app. VSTest gets loose-layout **registration** and **AUMID activation** from Visual-Studio-internal deployment components (`IVsAppContainerProjectDeploy2`, `IDeploymentServicesProvider.GetAppLauncher()`, MEF-composed from the VS install) that are not redistributable, so a standalone MTP extension cannot depend on them.

This PR lands the parts of that flow that need **no VS-internal API**, plus makes the extension honest about what it can do today. It does **not** add any public API surface: `AppxManifestInfo`/`AppxApplicationInfo` are internal helpers (tracked in `InternalAPI.Unshipped.txt`).

## Changes

- **`AppxManifestInfo`** (new, internal): parses `AppxManifest.xml` and computes the **PackageFamilyName** and, per declared `<Application>`, the **Application User Model ID** (`{PackageFamilyName}!{AppId}`) using the public Windows publisher-hash algorithm — SHA-256 of the UTF-16LE `Publisher`, first 8 bytes, Crockford base32. Pure managed and cross-platform; it is the managed, VS-independent equivalent of VS's internal `deploymentFile.AppUserModelId`. A package may declare several applications, so `ResolveApplication(executableFileName)` selects the one whose `Executable` matches the requested test host and rejects ambiguous requests instead of defaulting to the first entry.
- **Windows gating**: `IsEnabledAsync()` now returns `OperatingSystem.IsWindows()`. On non-Windows the launcher is never registered, so the platform keeps its default in-process path instead of being forced onto the controller/deploy path by a no-op launcher.
- **Fail fast on packaged layouts**: `LaunchTestHostAsync` detects a packaged layout (an `AppxManifest.xml` at the executable's directory or a parent package root) and throws an actionable error — including the AUMID of the application matching the requested executable and a pointer to #9933 — instead of silently `Process.Start`ing an executable that can't host the run. Non-packaged (loose-layout) hosts keep the existing behavior unchanged.
- **Honest descriptions**: the extension display description, the NuGet `PackageDescription`, `PACKAGE.md`, and the public XML docs now describe the supported path as launching a **non-packaged (loose-layout)** Windows host (for example, unpackaged WinUI), and describe genuinely packaged (MSIX) apps — UWP or packaged WinUI — as the rejected/planned path pending #9933. (UWP always requires package identity and an `AppxManifest.xml`, so it is inherently packaged and is not part of the supported path today.)

## Still a follow-up (not in this PR — #9933)

Actual `PackageManager.RegisterPackageByUriAsync` registration, `IApplicationActivationManager` AUMID activation, and the AppContainer connect-back transport (the platform passes the controller IPC pipe name via an environment variable, which an activated packaged process does not inherit) remain to be done. (#2784 tracks the distinct *unpackaged* WinUI scenario and is not the tracker for this work.)

## Verification

- `Microsoft.Testing.Extensions.PackagedApp` builds with **0 warnings / 0 errors** (incl. `-p:TreatWarningsAsErrors=true`); internal API and xlf updated.
- `AppxManifestInfoTests` and `PackagedAppTestHostLauncherTests` (including multi-application resolution and subdirectory-executable package-root detection) discovered and passing.