### PR TITLE
Update .xlf files to be in sync with .resx

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -563,21 +563,21 @@ The type declaring these methods should also respect the following rules:
 -The class should be 'public'
 -The class should be marked with '[TestClass]' (or a derived attribute)
 -the class should not be generic.</source>
-        <target state="translated">Les méthodes marquées par « [GlobalTestInitialize] » ou « [GlobalTestCleanup] » doivent respecter le schéma suivant pour être valides :
-- elle ne peut pas être déclarée dans une classe générique
-– elle doit être « public »
-– cela devrait être « static ».
-– cela ne devrait pas être « async void ».
-– il ne doit pas s'agir d'une méthode spéciale (finaliseur, opérateur...).
-– elle ne doit pas être générique
-– il doit prendre un paramètre de type « TestContext »
-– le type de retour doit être « void », « Task » ou « ValueTask ».
-{0}
-Le type déclarant ces méthodes doit également respecter les règles suivantes :
-- le type doit être une classe
-- la classe doit être « public » 
--La classe doit être marquée avec « [TestClass] » (ou un attribut dérivé).
-- la classe ne doit pas être générique.</target>
+        <target state="new">Methods marked with '[GlobalTestInitialize]' or '[GlobalTestCleanup]' should follow the following layout to be valid:
+-it can't be declared on a generic class
+-it should be 'public'
+-it should be 'static'
+-it should not be 'async void'
+-it should not be a special method (finalizer, operator...).
+-it should not be generic
+-it should take one parameter of type 'TestContext'
+-return type should be 'void', 'Task' or 'ValueTask'
+
+The type declaring these methods should also respect the following rules:
+-The type should be a class
+-The class should be 'public'
+-The class should be marked with '[TestClass]' (or a derived attribute)
+-the class should not be generic.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -74,7 +74,7 @@
       </trans-unit>
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
-        <target state="translated">{0} все еще выполняется через {0} с</target>
+        <target state="new">{0} still running after {1}s</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">


### PR DESCRIPTION
## Problem

The build is failing with `xlf is out-of-date with resx` errors:

```
error : 'xlf\Resources.fr.xlf' is out-of-date with 'Resources.resx'. Run `msbuild /t:UpdateXlf` ...
  [src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj]
error : 'Resources\xlf\GitHubActionsResources.ru.xlf' is out-of-date with 'Resources\GitHubActionsResources.resx'. Run `msbuild /t:UpdateXlf` ...
  [src\Platform\Microsoft.Testing.Extensions.GitHubActionsReport\Microsoft.Testing.Extensions.GitHubActionsReport.csproj]
```

## Root cause

The most recent localized check-in added translations for two units that XliffTasks rejects because their target placeholders don't match the source:

- **`SlowTestStillRunning` (ru)** — source is `{0} still running after {1}s`, but the translation was `{0} все еще выполняется через {0} с` (duplicated `{0}`, missing `{1}`).
- **`GlobalTestFixtureShouldBeValidClassLayout` (fr)** — same class of placeholder/format inconsistency.

Because of this, a clean `UpdateXlf`/`CheckXlf` run (which CI performs) considers the `.xlf` files out of date with the `.resx`, failing the build.

## Fix

Regenerated the two `.xlf` files via `UpdateXlf` (the repo-mandated procedure). This resets the two rejected units to `state="new"` so the build passes. They will be re-translated on the next OneLocBuild pass.

Change is scoped to exactly the two units named in the build errors — no reordering or other churn. Verified idempotent (a second clean regeneration produces no further changes).