### PR TITLE
Add release notes link to NuGet packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,5 +12,9 @@
   <!-- Pack config -->
   <PropertyGroup>
     <CommonPackageTags>Microsoft test testing unittest unittesting unit-testing tdd</CommonPackageTags>
+
+    <!-- Populates the "Release Notes" tab on nuget.org. Defaults to the MSTest changelog;
+         Microsoft.Testing.Platform packages override this in src/Platform/Directory.Build.props. -->
+    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog.md.</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
   <PropertyGroup>
     <CommonPackageTags>Microsoft test testing unittest unittesting unit-testing tdd</CommonPackageTags>
 
-    <!-- Populates the "Release Notes" tab on nuget.org. Defaults to the MSTest changelog;
-         Microsoft.Testing.Platform packages override this in src/Platform/Directory.Build.props. -->
-    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog.md.</PackageReleaseNotes>
+    <!-- Populates the "Release Notes" tab on nuget.org. Defaults to the MSTest changelog entry for this
+         version; Microsoft.Testing.Platform packages override this in src/Platform/Directory.Build.props. -->
+    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog.md#$(VersionPrefix).</PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/Platform/Directory.Build.props
+++ b/src/Platform/Directory.Build.props
@@ -16,8 +16,10 @@
 
   <!-- Pack config -->
   <PropertyGroup>
-    <!-- Platform and extensions have their own changelog, distinct from MSTest's. -->
-    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog-Platform.md.</PackageReleaseNotes>
+    <!-- Platform and extensions have their own changelog, distinct from MSTest's. The anchor uses the
+         platform version so extension packages (which have their own VersionPrefix) still land on the
+         right changelog entry. -->
+    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog-Platform.md#$(TestingPlatformVersionPrefix).</PackageReleaseNotes>
   </PropertyGroup>
 
   <!-- Build config -->

--- a/src/Platform/Directory.Build.props
+++ b/src/Platform/Directory.Build.props
@@ -14,6 +14,12 @@
     <TestingPlatformNextMajorVersion Condition=" '$(TestingPlatformNextMajorVersion)' == '' ">$([MSBuild]::Add($(TestingPlatformVersionPrefix.Split('.')[0]), 1)).0.0</TestingPlatformNextMajorVersion>
   </PropertyGroup>
 
+  <!-- Pack config -->
+  <PropertyGroup>
+    <!-- Platform and extensions have their own changelog, distinct from MSTest's. -->
+    <PackageReleaseNotes>See the release notes at https://github.com/microsoft/testfx/blob/main/docs/Changelog-Platform.md.</PackageReleaseNotes>
+  </PropertyGroup>
+
   <!-- Build config -->
   <PropertyGroup>
     <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsTrimmable>


### PR DESCRIPTION
## What

Populates the **Release Notes** tab on nuget.org for our packages by setting the `PackageReleaseNotes` MSBuild property (previously unset, so no tab was rendered — e.g. like [Azure.Identity](https://www.nuget.org/packages/Azure.Identity#releasenotes-body-tab)).

The link deep-links to the version-specific changelog entry, split per product:

- **MSTest** packages (`src/Directory.Build.props`) → `docs/Changelog.md#<VersionPrefix>` (e.g. `#4.4.0`)
- **Microsoft.Testing.Platform** + extensions (`src/Platform/Directory.Build.props`) → `docs/Changelog-Platform.md#<TestingPlatformVersionPrefix>` (e.g. `#2.4.0`)

Since `src/Platform/Directory.Build.props` imports the parent and then overrides the property, MTP packages get the platform changelog while everything else inherits the MSTest one. The anchor uses `TestingPlatformVersionPrefix` (not each package's own `VersionPrefix`), so extension packages that carry their own version (e.g. CtrfReport `1.0.0`) still land on the correct platform entry (`#2.4.0`). Using `VersionPrefix`/`TestingPlatformVersionPrefix` rather than `Version` keeps the anchor clean (no `-dev`/`-preview` suffix that wouldn't exist in the changelog). nuget.org auto-links the URL on the rendered tab.

## Verification

Ran `.\build.cmd -pack -c Release` and confirmed the correct `<releaseNotes>` lands in each nuspec:

- `MSTest.TestAdapter` / `MSTest.TestFramework` → `.../Changelog.md#4.4.0`
- `Microsoft.Testing.Platform` → `.../Changelog-Platform.md#2.4.0`
- `Microsoft.Testing.Extensions.CtrfReport` (own version 1.0.0) → `.../Changelog-Platform.md#2.4.0`

Fixes #9926