### PR TITLE
Skip MSTest adapter telemetry on wasi-wasm to avoid SHA256 PlatformNotSupportedException

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/MSTestEngine.cs
+++ b/src/Adapter/MSTest.TestAdapter/MSTestEngine.cs
@@ -182,6 +182,17 @@ internal sealed class MSTestEngine
     private static void EnsureTelemetryInitialized()
     {
 #if !WINDOWS_UWP && !WIN_UI
+#if NETCOREAPP
+        // Telemetry anonymizes custom test-attribute type names with SHA256, which is not supported
+        // on wasi-wasm (https://github.com/dotnet/runtime/issues/99126). Skip telemetry collection
+        // there so discovery does not throw a PlatformNotSupportedException; the platform side
+        // already skips its own SHA256-based telemetry on wasi for the same reason.
+        if (OperatingSystem.IsWasi())
+        {
+            return;
+        }
+#endif
+
         // Initialize telemetry collection if not already set (e.g. first call in the session).
         if (!MSTestTelemetryDataCollector.IsTelemetryOptedOut())
         {

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WasmExecutionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WasmExecutionTests.cs
@@ -100,10 +100,19 @@ public sealed class WasmExecutionTests : AcceptanceTestBase<NopAssetFixture>
 #file UnitTest1.cs
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+// A derived TestMethod attribute forces the MSTest adapter's telemetry to anonymize the custom
+// attribute's type name with SHA256. SHA256 is unsupported on wasi-wasm
+// (https://github.com/dotnet/runtime/issues/99126), so with telemetry enabled (the default here)
+// this used to throw a PlatformNotSupportedException during discovery. Keeping it in the asset
+// guards the wasi telemetry skip.
+public sealed class CustomTestMethodAttribute : TestMethodAttribute
+{
+}
+
 [TestClass]
 public sealed class UnitTest1
 {
-    [TestMethod]
+    [CustomTestMethod]
     public void PassingTest()
         => Assert.AreEqual(4, 2 + 2);
 


### PR DESCRIPTION
## What

Closes the last un-guarded `SHA256` path on `wasi-wasm`, related to #5366.

The MSTest adapter's telemetry anonymizes custom test-attribute type names with `SHA256` (`MSTestTelemetryDataCollector.AnonymizeString` → `SHA256.HashData`). `SHA256` is unsupported on `wasi-wasm` (dotnet/runtime#99126). With telemetry enabled (the default), **discovering a custom/derived `[TestMethod]` or `[TestClass]` attribute** hit that path and threw `PlatformNotSupportedException` during discovery.

The two platform-side SHA256 telemetry paths (`ExtensionInformationCollector`, `TestHostBuilder.AddApplicationTelemetryMetadata`) were already guarded for wasi; this was the remaining one in the adapter.

## Change

- **`MSTestEngine.EnsureTelemetryInitialized`**: skip telemetry initialization on `wasi-wasm` (`#if NETCOREAPP` + `OperatingSystem.IsWasi()`), so the collector — and therefore the SHA256 anonymization — is never created there. No-op on net462/UWP/WinUI. `browser-wasm` is untouched (SHA256 works there). The telemetry send paths already tolerate a null collector, so nothing else was needed.
- **`WasmExecutionTests`**: extended the wasi acceptance asset with a `CustomTestMethodAttribute : TestMethodAttribute` (telemetry stays on by default) so it exercises the exact path that used to throw. The test already asserts no `PlatformNotSupportedException` appears and that tests run (`succeeded: 2 / failed: 1`).

## Validation

- `MSTest.TestAdapter` builds across all TFMs, 0 warnings / 0 errors.
- `MSTest.Acceptance.IntegrationTests` builds, 0 warnings / 0 errors.

## Notes

This is a targeted fix for one telemetry-only failure mode. The broader wasm scenario (test execution on wasi-wasm / browser-wasm via the generated MTP entry point) is already implemented and covered by `WasmExecutionTests` / `BrowserWasmExecutionTests`.