### PR TITLE
Bump VSTest version from 18.7.0 to 18.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,7 @@
     <!-- UWP and WinUI dependencies -->
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.14</MicrosoftNETCoreUniversalWindowsPlatformVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
-    <MicrosoftNETTestSdkVersion>18.7.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>18.8.0</MicrosoftNETTestSdkVersion>
     <!-- MicrosoftPlaywrightVersion is consumed by the build and baked into the shipped MSTest.Sdk
          template. It MUST be kept in sync with the literal Microsoft.Playwright.MSTest.v4
          PackageVersion declared near the bottom of this file (the one Dependabot updates). The

--- a/samples/public/Directory.Build.props
+++ b/samples/public/Directory.Build.props
@@ -25,7 +25,7 @@
       (it ships as a 1.0.0-alpha.* build), which is why it has its own property here.
     -->
     <MicrosoftTestingExtensionsPackagedAppVersion>1.0.0-alpha.26363.8</MicrosoftTestingExtensionsPackagedAppVersion>
-    <VSTestVersion>18.7.0</VSTestVersion>
+    <VSTestVersion>18.8.0</VSTestVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);SA0001;EnableGenerateDocumentationFile</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Bumps the VSTest / `Microsoft.NET.Test.Sdk` version from 18.7.0 to 18.8.0.

Changes:
- `Directory.Packages.props`: `MicrosoftNETTestSdkVersion` → 18.8.0
- `samples/public/Directory.Build.props`: `VSTestVersion` → 18.8.0