### PR TITLE
Fix IDE0300 build errors by using collection expressions in tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsArtifactUploaderTests.cs
@@ -82,12 +82,11 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[]
-            {
+            [
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-hangdump",
                 "##vso[build.addbuildtag]has-test-failures",
-            },
+            ],
             GetCommandLines(),
             SequenceOrder.InAnyOrder);
         Assert.DoesNotContain(line => line.Contains("artifact.upload", StringComparison.Ordinal), GetCommandLines());
@@ -136,7 +135,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("inside.trx")}" },
+            [$"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("inside.trx")}"],
             GetCommandLines());
     }
 
@@ -160,12 +159,11 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[]
-            {
+            [
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-test-failures",
                 $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("test.trx")}",
-            },
+            ],
             GetCommandLines());
     }
 
@@ -189,7 +187,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("keep.trx")}" },
+            [$"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{InResults("keep.trx")}"],
             GetCommandLines());
     }
 
@@ -209,11 +207,10 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[]
-            {
+            [
                 "##vso[build.addbuildtag]has-crashdump",
                 "##vso[build.addbuildtag]has-hangdump",
-            },
+            ],
             GetCommandLines(),
             SequenceOrder.InAnyOrder);
     }
@@ -271,7 +268,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[] { "Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags." },
+            ["Azure DevOps artifact upload was requested, but TF_BUILD is not set to 'true'; skipping Azure DevOps artifact upload and build tags."],
             GetWarnings());
         Assert.IsEmpty(GetCommandLines());
     }
@@ -332,7 +329,7 @@ public sealed class AzureDevOpsArtifactUploaderTests
         await uploader.OnTestSessionFinishingAsync(new TestSessionContext()).ConfigureAwait(false);
 
         Assert.AreSequenceEqual(
-            new[] { $"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{escapedSpecialPath}" },
+            [$"##vso[artifact.upload containerfolder=Artifacts;artifactname=Artifacts]{escapedSpecialPath}"],
             GetCommandLines());
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CrashDumpTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.Diagnostics;
@@ -545,7 +545,7 @@ public sealed class CrashDumpTests
                 .OfType<FileArtifact>()
                 .Select(static a => a.FileInfo.FullName)
                 .ToArray();
-            Assert.AreSequenceEqual(new[] { testhostDump }, publishedDumps);
+            Assert.AreSequenceEqual([testhostDump], publishedDumps);
 
             // The "expected dump not found" warning must NOT be emitted: the testhost dump was
             // recognized via the regex even though `expectedDumpFile` (literal `%p` substitution)
@@ -596,7 +596,7 @@ public sealed class CrashDumpTests
                 .OfType<FileArtifact>()
                 .Select(static a => a.FileInfo.FullName)
                 .ToArray();
-            Assert.AreSequenceEqual(new[] { testhostDump }, publishedDumps);
+            Assert.AreSequenceEqual([testhostDump], publishedDumps);
             string captured = string.Join(" | ", outputDevice.Displayed);
             Assert.DoesNotContain("dump_555_backup_555.dmp", captured, "CannotFindExpectedCrashDumpFile must not be displayed when the testhost dump was recognized via the regex.");
         }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -617,7 +617,7 @@ public class CtrfReportEngineTests
 
         // `osPlatform` is one of the short identifiers, not the descriptive name.
         string osPlatform = env.GetProperty("osPlatform").GetString()!;
-        Assert.Contains(osPlatform, new[] { "win32", "linux", "darwin", "freebsd", "unknown" });
+        Assert.Contains(osPlatform, ["win32", "linux", "darwin", "freebsd", "unknown"]);
 
         // Descriptive OS string goes into `osVersion`.
         Assert.IsGreaterThan(0, env.GetProperty("osVersion").GetString()!.Length);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
@@ -58,7 +58,7 @@ public class TrxStreamingSerializerTests
         Assert.AreEqual(TrxStreamMessageKind.DebugOrTrace, round.Messages[2].Kind);
         Assert.IsNull(round.Messages[2].Message);
         Assert.IsNotNull(round.Categories);
-        Assert.AreSequenceEqual(new[] { "cat-a", "cat-b" }, round.Categories.ToArray());
+        Assert.AreSequenceEqual(["cat-a", "cat-b"], round.Categories.ToArray());
         Assert.IsNotNull(round.Metadata);
         Assert.AreEqual("k", round.Metadata[0].Key);
         Assert.AreEqual("v", round.Metadata[0].Value);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.CommandLine;
@@ -110,7 +110,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("hangdump-timeout", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        Assert.AreSequenceEqual(new[] { "5m" }, arguments);
+        Assert.AreSequenceEqual(["5m"], arguments);
     }
 
     [TestMethod]
@@ -124,7 +124,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("filter-uid", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        Assert.AreSequenceEqual(new[] { "a", "b", "c" }, arguments);
+        Assert.AreSequenceEqual(["a", "b", "c"], arguments);
     }
 
     [TestMethod]
@@ -140,7 +140,7 @@ public sealed class CommandLineConfigurationExtensionsTests
 
         Assert.IsTrue(configuration.TryGetCommandLineOptionArguments("foo", out string[]? arguments));
         Assert.IsNotNull(arguments);
-        Assert.AreSequenceEqual(new[] { "indexed" }, arguments);
+        Assert.AreSequenceEqual(["indexed"], arguments);
     }
 
     [TestMethod]
@@ -175,14 +175,14 @@ public sealed class CommandLineConfigurationExtensionsTests
         Assert.IsTrue(options.IsOptionSet("filter-uid"));
 
         Assert.IsTrue(options.TryGetOptionArgumentList("hangdump-timeout", out string[]? timeoutArgs));
-        Assert.AreSequenceEqual(new[] { "10m" }, timeoutArgs);
+        Assert.AreSequenceEqual(["10m"], timeoutArgs);
 
         Assert.IsTrue(options.TryGetOptionArgumentList("hangdump", out string[]? hangdumpArgs));
         Assert.IsNotNull(hangdumpArgs);
         Assert.IsEmpty(hangdumpArgs);
 
         Assert.IsTrue(options.TryGetOptionArgumentList("filter-uid", out string[]? filterArgs));
-        Assert.AreSequenceEqual(new[] { "a", "b" }, filterArgs);
+        Assert.AreSequenceEqual(["a", "b"], filterArgs);
     }
 
     private static IConfiguration BuildConfiguration(IReadOnlyList<KeyValuePair<string, string?>> entries)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/JsonCommandLineOptionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.CommandLine;
@@ -51,7 +51,7 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(entries);
         Assert.AreEqual("timeout", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        Assert.AreSequenceEqual(new[] { "30s" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["30s"], entry.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -87,7 +87,7 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(entries);
         Assert.AreEqual("filter-uid", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        Assert.AreSequenceEqual(new[] { "a", "b", "c" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["a", "b", "c"], entry.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -163,7 +163,7 @@ public sealed class JsonCommandLineOptionsTests
         Assert.HasCount(4, entries);
 
         JsonCommandLineOptionEntry timeout = entries.Single(e => e.OptionName == "timeout");
-        Assert.AreSequenceEqual(new[] { "30s" }, timeout.Arguments.ToArray());
+        Assert.AreSequenceEqual(["30s"], timeout.Arguments.ToArray());
         Assert.IsFalse(timeout.IsDisabled);
 
         JsonCommandLineOptionEntry noBanner = entries.Single(e => e.OptionName == "no-banner");
@@ -174,7 +174,7 @@ public sealed class JsonCommandLineOptionsTests
         Assert.IsTrue(hangdump.IsDisabled);
 
         JsonCommandLineOptionEntry filterUid = entries.Single(e => e.OptionName == "filter-uid");
-        Assert.AreSequenceEqual(new[] { "a", "b" }, filterUid.Arguments.ToArray());
+        Assert.AreSequenceEqual(["a", "b"], filterUid.Arguments.ToArray());
     }
 
     // ---------------------------------------------------------------------
@@ -636,11 +636,11 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
         Assert.AreEqual("timeout", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        Assert.AreSequenceEqual(new[] { "true" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["true"], entry.Arguments.ToArray());
 
         Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
         Assert.IsTrue(isSet);
-        Assert.AreSequenceEqual(new[] { "true" }, arguments);
+        Assert.AreSequenceEqual(["true"], arguments);
     }
 
     [TestMethod]
@@ -658,11 +658,11 @@ public sealed class JsonCommandLineOptionsTests
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
         Assert.AreEqual("timeout", entry.OptionName);
         Assert.IsFalse(entry.IsDisabled);
-        Assert.AreSequenceEqual(new[] { "false" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["false"], entry.Arguments.ToArray());
 
         Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
         Assert.IsTrue(isSet);
-        Assert.AreSequenceEqual(new[] { "false" }, arguments);
+        Assert.AreSequenceEqual(["false"], arguments);
     }
 
     [TestMethod]
@@ -679,11 +679,11 @@ public sealed class JsonCommandLineOptionsTests
 
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
         Assert.AreEqual("timeout", entry.OptionName);
-        Assert.AreSequenceEqual(new[] { "30s" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["30s"], entry.Arguments.ToArray());
 
         Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("timeout", out bool isSet, out string[] arguments));
         Assert.IsTrue(isSet);
-        Assert.AreSequenceEqual(new[] { "30s" }, arguments);
+        Assert.AreSequenceEqual(["30s"], arguments);
     }
 
     [TestMethod]
@@ -755,11 +755,11 @@ public sealed class JsonCommandLineOptionsTests
             new CommandLineOption("filter-uid", "desc", ArgumentArity.OneOrMore, isHidden: false)));
 
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
-        Assert.AreSequenceEqual(new[] { "a", "b" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["a", "b"], entry.Arguments.ToArray());
 
         Assert.IsTrue(aggregated.TryGetCommandLineOptionFromProviders("filter-uid", out bool isSet, out string[] arguments));
         Assert.IsTrue(isSet);
-        Assert.AreSequenceEqual(new[] { "a", "b" }, arguments);
+        Assert.AreSequenceEqual(["a", "b"], arguments);
     }
 
     [TestMethod]
@@ -774,7 +774,7 @@ public sealed class JsonCommandLineOptionsTests
             new CommandLineOption("timeout", "desc", ArgumentArity.ExactlyOne, isHidden: false)));
 
         JsonCommandLineOptionEntry entry = Assert.ContainsSingle(aggregated.EnumerateJsonCommandLineOptions());
-        Assert.AreSequenceEqual(new[] { "true" }, entry.Arguments.ToArray());
+        Assert.AreSequenceEqual(["true"], entry.Arguments.ToArray());
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CurrentTestApplicationModuleInfoTests.cs
@@ -21,7 +21,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["--filter", "MyTest"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -35,7 +35,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -60,7 +60,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "exec", "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["exec", "myapp.dll", "--filter", "MyTest"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -74,7 +74,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "exec", "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["exec", "myapp.dll", "--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -86,7 +86,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "exec", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["exec", "--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "myapp.dll", "--filter", "MyTest" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["myapp.dll", "--filter", "MyTest"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -112,7 +112,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "myapp.dll", "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["myapp.dll", "--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -124,7 +124,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     [TestMethod]
@@ -142,7 +142,7 @@ public sealed class CurrentTestApplicationModuleInfoTests
 
         ExecutableInfo executable = info.GetCurrentExecutableInfo();
 
-        Assert.AreSequenceEqual(new[] { "--retry-failed-tests", "1" }, executable.Arguments.ToArray());
+        Assert.AreSequenceEqual(["--retry-failed-tests", "1"], executable.Arguments.ToArray());
     }
 
     private static Mock<IEnvironment> CreateDotnetMuxerEnvironment(string[] commandLineArgs)


### PR DESCRIPTION
## Problem

Main is failing to build (e.g. [build 3021928](https://dev.azure.com/dnceng/internal/_build/results?buildId=3021928)) with **153 IDE0300 errors** ("Collection initialization can be simplified").

A recent SDK/analyzer bump raised the built-in Roslyn analyzer's default severity for **IDE0300** to `warning`, and CI treats warnings as errors. The repo's `.editorconfig` already declares `dotnet_style_prefer_collection_expression = true`, so the intended style is collection expressions — the older `new[] { ... }` usages in a few recently-added unit test files were now flagged.

## Fix

Converted the flagged `new[] { ... }` array creations to collection expressions `[ ... ]` (exactly what the analyzer suggests) across the affected unit test files:

- `Microsoft.Testing.Platform.UnitTests` — `JsonCommandLineOptionsTests`, `CommandLineConfigurationExtensionsTests`, `CurrentTestApplicationModuleInfoTests`
- `Microsoft.Testing.Extensions.UnitTests` — `AzureDevOpsArtifactUploaderTests`, `CrashDumpTests`, `CtrfReportEngineTests`, `TrxStreamingSerializerTests`

The interpolated-string cases (`$"...{InResults("x.trx")}..."`) and multi-line initializers were handled carefully.

## Verification

Both affected projects rebuild across all target frameworks with **0 warnings, 0 errors**.