### PR TITLE
Fix MSB3277 System.Collections.Immutable conflict in VstestConsoleWrapper tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,14 @@
          System.Memory to 4.0.5.0 (e.g. Visual Studio) and run the adapter without applying a binding
          redirect (the VSTest test host uses its own config) cannot otherwise load the 4.0.1.2 reference. -->
     <SystemMemoryVersion>4.6.3</SystemMemoryVersion>
+    <!-- Microsoft.Testing.Extensions.CodeCoverage (18.10.0-preview) depends on System.Collections.Immutable /
+         System.Reflection.Metadata 10.0.0, whereas the VSTest translation-layer packages
+         (Microsoft.TestPlatform.*) still pin 8.0.0. On .NETFramework this makes RAR pick the 8.0.0 assembly as
+         primary and report an unresolved MSB3277 conflict against the unified 10.0.0 reference. We pin both
+         packages to 10.0.0 so any project mixing those two dependency sets can reference the higher version
+         explicitly and let the older 8.0.0 reference unify up. -->
+    <SystemCollectionsImmutableVersion>10.0.0</SystemCollectionsImmutableVersion>
+    <SystemReflectionMetadataVersion>10.0.0</SystemReflectionMetadataVersion>
   </PropertyGroup>
   <PropertyGroup Label="Test dependencies">
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.3-beta1.24423.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
@@ -90,7 +98,9 @@
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
     <PackageVersion Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>

--- a/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests/MSTest.VstestConsoleWrapper.IntegrationTests.csproj
@@ -20,4 +20,13 @@
     </ProjectReference>
   </ItemGroup>
 
+  <!-- Microsoft.Testing.Extensions.CodeCoverage (18.10.0-preview) depends on System.Collections.Immutable /
+       System.Reflection.Metadata 10.0.0 while the VSTest translation-layer packages flowed in via
+       Automation.CLI still pin 8.0.0. Reference the 10.0.0 packages explicitly so RAR picks them as the
+       primary reference and unifies the older 8.0.0 reference up instead of failing with MSB3277. -->
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Reflection.Metadata" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Problem

`main` was failing to build `MSTest.VstestConsoleWrapper.IntegrationTests` (net462) with `MSB3277`:

```
error MSB3277: Found conflicts between different versions of "System.Collections.Immutable" that could not be resolved.
error MSB3277: There was a conflict between "System.Collections.Immutable, Version=8.0.0.0" and "System.Collections.Immutable, Version=10.0.0.0".
```

## Root cause

`Microsoft.Testing.Extensions.CodeCoverage` was bumped to `18.10.0-preview.26360.1`, which now depends on **System.Collections.Immutable / System.Reflection.Metadata 10.0.0**. The VSTest translation-layer packages (flowed in via the `Automation.CLI` project reference, pinned to `Microsoft.NET.Test.Sdk` 18.7.0) still pull **8.0.0**. On .NET Framework, RAR chose the 8.0.0 assembly as *primary* and could not reconcile it with the unified 10.0.0 reference, so the conflict was reported as an error.

## Fix

Following the repo's existing transitive-pin convention (e.g. `System.Memory`):

- `Directory.Packages.props`: added `SystemCollectionsImmutableVersion` / `SystemReflectionMetadataVersion` (`10.0.0`) properties plus `PackageVersion` entries, with an explanatory comment.
- `MSTest.VstestConsoleWrapper.IntegrationTests.csproj`: added explicit `PackageReference`s to both packages so `10.0.0` becomes the primary reference and the older `8.0.0` reference unifies up.

## Validation

`.\build.cmd -projects test\IntegrationTests\MSTest.VstestConsoleWrapper.IntegrationTests\MSTest.VstestConsoleWrapper.IntegrationTests.csproj -c Release` → **Build succeeded, 0 Warnings, 0 Errors**.