### PR TITLE
Fix invalid duplicate &lt;target&gt; elements in XLF files breaking the build

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -578,21 +578,6 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
 - la classe doit être « public » 
 -La classe doit être marquée avec « [TestClass] » (ou un attribut dérivé).
 - la classe ne doit pas être générique.</target>
-        <target state="new">Methods marked with '[GlobalTestInitialize]' or '[GlobalTestCleanup]' should follow the following layout to be valid:
--it can't be declared on a generic class
--it should be 'public'
--it should be 'static'
--it should not be 'async void'
--it should not be a special method (finalizer, operator...).
--it should not be generic
--it should take one parameter of type 'TestContext'
--return type should be 'void', 'Task' or 'ValueTask'
-
-The type declaring these methods should also respect the following rules:
--The type should be a class
--The class should be 'public'
--The class should be marked with '[TestClass]' (or a derived attribute)
--the class should not be generic.</target>
         <note>{Locked="[GlobalTestInitialize]"}{Locked="[GlobalTestCleanup]"}{Locked="[TestClass]"}{Locked="TestContext"}{Locked="ValueTask"}{Locked="Task"}{Locked="public"}{Locked="static"}{Locked="void"}{Locked="async void"}{Locked="async"}{Locked="class"}</note>
       </trans-unit>
       <trans-unit id="GlobalTestFixtureShouldBeValidMessageFormat">

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf
@@ -75,7 +75,6 @@
       <trans-unit id="SlowTestStillRunning">
         <source>{0} still running after {1}s</source>
         <target state="translated">{0} все еще выполняется через {1} с</target>
-        <target state="new">{0} still running after {1}s</target>
         <note>{0} is the fully qualified test name, {1} is the elapsed seconds.</note>
       </trans-unit>
       <trans-unit id="SlowTestThresholdOptionDescription">


### PR DESCRIPTION
## Problem

`main` is failing to build with XLIFF schema validation errors:

```
error : The element 'trans-unit' in namespace 'urn:oasis:names:tc:xliff:document:1.2' has invalid child element 'target' ...
```

## Root cause

Two `trans-unit` elements each contained a **duplicate second `<target>`** element. XLIFF 1.2 allows only a single `target` per `trans-unit` (followed by `note`/`context-group`/etc.), so the second one is a schema violation that fails the build.

## Fix

Removed the spurious duplicate `<target>` elements, keeping the translated ones:

- `src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf` — `GlobalTestFixtureShouldBeValidDescription`
- `src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Resources/xlf/GitHubActionsResources.ru.xlf` — `SlowTestStillRunning`

## Validation

Scanned all 338 `.xlf` files in the repo for duplicate/misordered/target-before-source issues — these two were the only offenders, and the scan is clean after the fix.