### PR TITLE
Fix Retry attribute completeness gaps (#9917)

### DIFF
--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
@@ -12,10 +12,13 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// (the method-level value fully replaces the class-level value, regardless of whether it is larger or smaller).
 /// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
 /// <para>
-/// A retry is only performed when the test result outcome is <see cref="UnitTestOutcome.Failed"/> or
-/// <see cref="UnitTestOutcome.Timeout"/>. Any other outcome (including <see cref="UnitTestOutcome.Inconclusive"/>,
-/// for example when the test calls <c>Assert.Inconclusive()</c>) stops retrying and becomes the final
-/// result of the test.
+/// A retry is performed while at least one <see cref="TestResult"/> of the attempt has a
+/// <see cref="UnitTestOutcome.Failed"/> or <see cref="UnitTestOutcome.Timeout"/> outcome. Retrying stops as
+/// soon as an attempt produces no failed and no timed-out result. For a data-driven test (multiple results per
+/// attempt) this is an aggregate rule: an <see cref="UnitTestOutcome.Inconclusive"/> result (for example when
+/// the test calls <c>Assert.Inconclusive()</c>) only ends retrying when none of its sibling results in the same
+/// attempt failed or timed out; otherwise the attempt is still retried. The last attempt's results become the
+/// final outcome of the test.
 /// </para>
 /// <para>
 /// This attribute retries within a single test-host run. It is independent from the

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryAttribute.cs
@@ -11,6 +11,19 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// A <see cref="RetryAttribute"/> placed directly on a test method takes precedence over a class-level one
 /// (the method-level value fully replaces the class-level value, regardless of whether it is larger or smaller).
 /// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
+/// <para>
+/// A retry is only performed when the test result outcome is <see cref="UnitTestOutcome.Failed"/> or
+/// <see cref="UnitTestOutcome.Timeout"/>. Any other outcome (including <see cref="UnitTestOutcome.Inconclusive"/>,
+/// for example when the test calls <c>Assert.Inconclusive()</c>) stops retrying and becomes the final
+/// result of the test.
+/// </para>
+/// <para>
+/// This attribute retries within a single test-host run. It is independent from the
+/// <c>Microsoft.Testing.Extensions.Retry</c> <c>--retry-failed-tests</c> orchestrator, which re-invokes the whole
+/// test host. When both are enabled at the same time the attempt counts multiply (a test can run up to
+/// <c>(MaxRetryAttempts + 1) x (--retry-failed-tests + 1)</c> times), so avoid combining them unless that is
+/// intended.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public sealed class RetryAttribute : RetryBaseAttribute
@@ -26,7 +39,7 @@ public sealed class RetryAttribute : RetryBaseAttribute
         {
             throw new ArgumentOutOfRangeException(nameof(maxRetryAttempts));
         }
-#pragma warning disable CA1512 // Use ArgumentOutOfRangeException throw helper
+#pragma warning restore CA1512 // Use ArgumentOutOfRangeException throw helper
 
         MaxRetryAttempts = maxRetryAttempts;
     }

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
@@ -11,6 +11,12 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// When applied to a test class, the attribute is used as a default for every test method declared on the class.
 /// A retry attribute placed directly on a test method takes precedence over a class-level one.
 /// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
+/// <para>
+/// Retry is only triggered when a test result has an outcome of <see cref="UnitTestOutcome.Failed"/> or
+/// <see cref="UnitTestOutcome.Timeout"/>. Any other outcome (including <see cref="UnitTestOutcome.Inconclusive"/>,
+/// for example when the test calls <c>Assert.Inconclusive()</c>) is considered an acceptable result and
+/// stops retrying, so that outcome becomes the final result of the test.
+/// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
 public abstract class RetryBaseAttribute : Attribute
@@ -34,6 +40,9 @@ public abstract class RetryBaseAttribute : Attribute
         foreach (TestResult result in results)
         {
             UnitTestOutcome outcome = result.Outcome;
+
+            // Only Failed and Timeout outcomes are considered retriable. Every other outcome
+            // (including Inconclusive) is treated as an acceptable result that stops the retry loop.
             if (outcome is UnitTestOutcome.Failed or UnitTestOutcome.Timeout)
             {
                 return false;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
@@ -12,10 +12,12 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// A retry attribute placed directly on a test method takes precedence over a class-level one.
 /// The attribute is not inherited: applying it to a base test class does not apply it to derived test classes.
 /// <para>
-/// Retry is only triggered when a test result has an outcome of <see cref="UnitTestOutcome.Failed"/> or
-/// <see cref="UnitTestOutcome.Timeout"/>. Any other outcome (including <see cref="UnitTestOutcome.Inconclusive"/>,
-/// for example when the test calls <c>Assert.Inconclusive()</c>) is considered an acceptable result and
-/// stops retrying, so that outcome becomes the final result of the test.
+/// The runner only invokes <see cref="ExecuteAsync"/> after the initial (non-retry) run produced an
+/// unacceptable result, i.e. at least one of the produced <see cref="TestResult"/> entries had a
+/// <see cref="UnitTestOutcome.Failed"/> or <see cref="UnitTestOutcome.Timeout"/> outcome. It does not itself
+/// re-run the test on subsequent attempts: once <see cref="ExecuteAsync"/> is entered, the derived
+/// implementation owns the retry loop and decides when to stop. Derived types may use
+/// <c>IsAcceptableResultForRetry</c> (as <see cref="RetryAttribute"/> does) or implement any other policy.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
@@ -41,8 +43,9 @@ public abstract class RetryBaseAttribute : Attribute
         {
             UnitTestOutcome outcome = result.Outcome;
 
-            // Only Failed and Timeout outcomes are considered retriable. Every other outcome
-            // (including Inconclusive) is treated as an acceptable result that stops the retry loop.
+            // The attempt is retried when any single result is Failed or Timeout. Any other outcome (including
+            // Inconclusive) is acceptable on its own, so an attempt is treated as acceptable (retry stops) only
+            // when none of its results is Failed or Timeout.
             if (outcome is UnitTestOutcome.Failed or UnitTestOutcome.Timeout)
             {
                 return false;

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
@@ -12,6 +12,12 @@ public sealed class RetryResult
     private readonly List<TestResult[]> _testResults = [];
 
     /// <summary>
+    /// Gets the test results of all retry attempts, in the order they were added.
+    /// Each element corresponds to a single attempt and holds the test results produced by that attempt.
+    /// </summary>
+    public IReadOnlyList<TestResult[]> AllResults => _testResults;
+
+    /// <summary>
     /// Adds a set of test results to the retry result.
     /// </summary>
     /// <param name="testResults">The test results for the current attempt.</param>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.ObjectModel;
+
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>
@@ -10,12 +12,14 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public sealed class RetryResult
 {
     private readonly List<TestResult[]> _testResults = [];
+    private ReadOnlyCollection<TestResult[]>? _testResultsView;
 
     /// <summary>
     /// Gets the test results of all retry attempts, in the order they were added.
     /// Each element corresponds to a single attempt and holds the test results produced by that attempt.
     /// </summary>
-    public IReadOnlyList<TestResult[]> AllResults => _testResults;
+    public IReadOnlyList<TestResult[]> AllResults
+        => _testResultsView ??= new ReadOnlyCollection<TestResult[]>(_testResults);
 
     /// <summary>
     /// Adds a set of test results to the retry result.

--- a/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+[MSTESTEXP]Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult.AllResults.get -> System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]!>!
 Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceResolver
 static Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceResolver.RegisterDataProvider(System.Type! declaringType, string! sourceName, Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceType sourceType, System.Func<object?[]!, object?>! dataProvider) -> void
 static Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceResolver.RegisterDisplayNameProvider(System.Type! declaringType, string! methodName, System.Func<System.Reflection.MethodInfo!, object?[]?, string?>! displayNameProvider) -> void

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/RetryAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/RetryAttributeTests.cs
@@ -172,4 +172,29 @@ public class RetryAttributeTests : TestContainer
 
         callCount.Should().Be(1);
     }
+
+    public async Task ExecuteAsync_WhenMultipleAttempts_AllResultsContainsEveryAttemptInOrder()
+    {
+        var attribute = new RetryAttribute(maxRetryAttempts: 3);
+        int callCount = 0;
+
+        TestResult[] firstRunResults = [new TestResult { Outcome = UnitTestOutcome.Failed }];
+        var context = new RetryContext(
+            () =>
+            {
+                callCount++;
+                UnitTestOutcome outcome = callCount < 3 ? UnitTestOutcome.Failed : UnitTestOutcome.Passed;
+                return Task.FromResult(new[] { new TestResult { Outcome = outcome } });
+            },
+            firstRunResults);
+
+        RetryResult result = await attribute.ExecuteAsync(context);
+
+        result.AllResults.Should().HaveCount(3);
+        result.AllResults.Select(r => r.Single().Outcome).Should().Equal(
+            UnitTestOutcome.Failed,
+            UnitTestOutcome.Failed,
+            UnitTestOutcome.Passed);
+        result.AllResults[result.AllResults.Count - 1].Should().BeSameAs(result.TryGetLast());
+    }
 }


### PR DESCRIPTION
Addresses the actionable tasks from #9917 on the MSTest `[Retry]` / `RetryBaseAttribute` subsystem.

## Changes

- **Task 1 (High) — pragma bug:** In `RetryAttribute`, the second `#pragma warning disable CA1512` was a copy-paste mistake and is now `#pragma warning restore CA1512`, so the suppression is properly closed instead of leaking to the rest of the file.
- **Task 3 (Medium) — attempt history:** Added a public `IReadOnlyList<TestResult[]> AllResults` accessor to `RetryResult` (with the matching `PublicAPI.Unshipped.txt` entry) so tooling/loggers can inspect every retry attempt, not just the last outcome.
- **Task 4 (Medium, Option B) — dual-retry docs:** Documented in `RetryAttribute` remarks that combining `[Retry]` with the MTP `--retry-failed-tests` orchestrator multiplies the attempt count.
- **Task 5 (Low) — Inconclusive behavior:** Documented on `RetryAttribute` and `RetryBaseAttribute` (and a clarifying code comment on `IsAcceptableResultForRetry`) that only `Failed`/`Timeout` outcomes trigger a retry, while `Inconclusive` (and any other outcome) stops retrying and becomes the final result.

## Intentionally skipped

- **Task 2 — `RetryContext.AttemptNumber`:** Architecturally not applicable. The retry loop lives *inside* the attribute's `ExecuteAsync` (which already has its own counter), and `RetryContext` is a readonly struct created once by the runner and passed by value — there is no place to increment a per-attempt value. The report's "pass the loop counter from the runner" suggestion is based on a misreading; the runner has no loop.
- **Task 4 Option A (new `MSTEST0044` analyzer):** Introducing a new public diagnostic + resources is a design decision best left to the team, so this PR takes the low-risk Option B (docs) only.

## Verification

- `TestFramework.csproj` and `TestFramework.UnitTests.csproj` build clean (0 warnings / 0 errors).
- All 14 `RetryAttributeTests` pass, including a new `ExecuteAsync_WhenMultipleAttempts_AllResultsContainsEveryAttemptInOrder` test covering `AllResults`.