### PR TITLE
Embed more internal helpers to shrink cross-assembly API surface

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,9 @@
 #nullable enable
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
+Microsoft.Testing.Platform.Helpers.ArgumentGuard
+Microsoft.Testing.Platform.Helpers.PasteArguments
+static Microsoft.Testing.Platform.Helpers.ArgumentGuard.Ensure(bool condition, string! paramName, string! errorMessage) -> void
+static Microsoft.Testing.Platform.Helpers.PasteArguments.AppendArgument(System.Text.StringBuilder! stringBuilder, string! argument) -> void
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int
 static Microsoft.Testing.Platform.IPC.NamedPipeServer.EnsureDirectoryIsWritable(string! directory) -> void
 static Microsoft.Testing.Platform.IPC.NamedPipeServer.EnsurePathLengthWithinLimit(string! path) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
@@ -22,8 +22,10 @@
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" Link="Helpers\ApplicationStateGuard.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ArgumentGuard.cs" Link="Helpers\ArgumentGuard.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\EnvironmentVariableConstants.cs" Link="Helpers\EnvironmentVariableConstants.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\PasteArguments.cs" Link="Helpers\PasteArguments.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeoutHelper.cs" Link="Helpers\TimeoutHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeSpanParser.cs" Link="Helpers\TimeSpanParser.cs" />
   </ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
+Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
 Microsoft.Testing.Platform.Messages.SingleConsumerUnboundedChannel<T>.WaitToRead() -> bool
 Microsoft.Testing.Platform.RoslynDebug
+static Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper.IsMultiThreaded.get -> bool
 static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b) -> void
 static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b, string! message) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 #nullable enable
 Microsoft.Testing.Platform.Messages.SingleConsumerUnboundedChannel<T>.WaitToRead() -> bool
+Microsoft.Testing.Platform.RoslynDebug
+static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b) -> void
+static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b, string! message) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
@@ -9,6 +9,7 @@
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\CIEnvironmentDetector.cs" Link="Helpers\CIEnvironmentDetector.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynDebug.cs" Link="Helpers\RoslynDebug.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Messages\SingleConsumerUnboundedChannel.cs" Link="Helpers\SingleConsumerUnboundedChannel.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
@@ -10,6 +10,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\CIEnvironmentDetector.cs" Link="Helpers\CIEnvironmentDetector.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynDebug.cs" Link="Helpers\RoslynDebug.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RuntimeFeatureHelper.cs" Link="Helpers\RuntimeFeatureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Messages\SingleConsumerUnboundedChannel.cs" Link="Helpers\SingleConsumerUnboundedChannel.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
+Microsoft.Testing.Platform.Helpers.DisposeHelper
+static Microsoft.Testing.Platform.Helpers.DisposeHelper.DisposeAsync(object? obj) -> System.Threading.Tasks.Task!
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int
 static Microsoft.Testing.Platform.IPC.NamedPipeServer.EnsureDirectoryIsWritable(string! directory) -> void
 static Microsoft.Testing.Platform.IPC.NamedPipeServer.EnsurePathLengthWithinLimit(string! path) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Microsoft.Testing.Extensions.TrxReport.csproj
@@ -22,6 +22,7 @@
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" Link="Helpers\ApplicationStateGuard.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\DisposeHelper.cs" Link="Helpers\DisposeHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\EnvironmentVariableConstants.cs" Link="Helpers\EnvironmentVariableConstants.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeoutHelper.cs" Link="Helpers\TimeoutHelper.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
@@ -28,6 +28,7 @@ Microsoft.Testing.Extensions.RunSettingsProviderHelper
 Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.ContextAdapterBase.ContextAdapterBase(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.IRunSettings! runSettings, Microsoft.Testing.Platform.Requests.ITestExecutionFilter! filter, bool useFullyQualifiedNameAsUid) -> void
 Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.DiscoveryContextAdapter.DiscoveryContextAdapter(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.IRunSettings! runSettings, Microsoft.Testing.Platform.Requests.ITestExecutionFilter! filter, bool useFullyQualifiedNameAsUid) -> void
 Microsoft.Testing.Extensions.VSTestBridge.ObjectModel.RunContextAdapter.RunContextAdapter(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter.IRunSettings! runSettings, Microsoft.Testing.Platform.Requests.ITestExecutionFilter! filter, bool useFullyQualifiedNameAsUid) -> void
+Microsoft.Testing.Platform.RoslynDebug
 override Microsoft.Testing.Extensions.VSTestBridge.CommandLine.RunSettingsCommandLineOptionsProvider.EnvironmentVariablesNotSupportedOnBrowserError.get -> string!
 override Microsoft.Testing.Extensions.VSTestBridge.Configurations.RunSettingsConfigurationProvider.DisplayName.get -> string!
 override Microsoft.Testing.Extensions.VSTestBridge.Configurations.RunSettingsConfigurationProvider.Uid.get -> string!
@@ -39,3 +40,5 @@ static Microsoft.Testing.Extensions.RunSettingsProviderHelper.CanReadFile(Micros
 static Microsoft.Testing.Extensions.RunSettingsProviderHelper.FindInvalidTestParameter(string![]! arguments) -> string?
 static Microsoft.Testing.Extensions.RunSettingsProviderHelper.HasEnvironmentVariables(System.Xml.Linq.XDocument! runSettings) -> bool
 static Microsoft.Testing.Extensions.RunSettingsProviderHelper.TryLoadRunSettingsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Helpers.IEnvironment! environment, string! runSettingsOptionName) -> System.Threading.Tasks.Task<System.Xml.Linq.XDocument?>!
+static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b) -> void
+static Microsoft.Testing.Platform.RoslynDebug.Assert(bool b, string! message) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Microsoft.Testing.Extensions.VSTestBridge.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Microsoft.Testing.Extensions.VSTestBridge.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <!-- Embedded helpers from Microsoft.Testing.Platform -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynDebug.cs" Link="Helpers\RoslynDebug.cs" />
     <!-- Dependency-free logic shared with the MSTest adapter's native MTP providers (see issue #9762). -->
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsProviderHelper.cs" Link="Helpers\RunSettingsProviderHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsCommandLineOptionsProviderBase.cs" Link="Helpers\RunSettingsCommandLineOptionsProviderBase.cs" />

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ArgumentGuard.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ArgumentGuard.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.Helpers;
 
+[Embedded]
 internal static class ArgumentGuard
 {
     public static void Ensure([DoesNotReturnIf(false)] bool condition, string paramName, string errorMessage)

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/DisposeHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/DisposeHelper.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.Testing.Platform.Extensions;
 
 namespace Microsoft.Testing.Platform.Helpers;
 
+[Embedded]
 internal static class DisposeHelper
 {
     public static async Task DisposeAsync(object? obj)

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/PasteArguments.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.Helpers;
 
 // https://github.com/dotnet/runtime/blob/019c8d72effbdb4f69564695f1df7c4417ec060d/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
+[Embedded]
 internal static partial class PasteArguments
 {
-    // WARNING: Don't change the signature of this internal method. It's exposed via IVT to other assemblies.
-    // Renaming it is a BREAKING CHANGE.
+    // This helper is embedded and source-linked into consuming assemblies (see [Embedded]).
+    // It is no longer exposed via IVT metadata, so renaming it is only a source-level change
+    // for the consumers that source-link it, not a binary breaking change.
     internal static void AppendArgument(StringBuilder stringBuilder, string argument)
     {
         if (stringBuilder.Length != 0)

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/RoslynDebug.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 // Copied from https://github.com/dotnet/sdk/blob/main/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Utilities/Compiler/Debug.cs
 // (previously sourced from dotnet/roslyn-analyzers before that repo was archived).
 namespace Microsoft.Testing.Platform;
 
+[Embedded]
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "This is the replacement type for Debug")]
 [ExcludeFromCodeCoverage]
 internal static class RoslynDebug

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/RuntimeFeatureHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/RuntimeFeatureHelper.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+
 namespace Microsoft.Testing.Platform.Helpers;
 
 /// <summary>
 /// Runtime feature detection that the platform uses to adapt its behavior to the host.
 /// </summary>
+[Embedded]
 internal static class RuntimeFeatureHelper
 {
     /// <summary>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" Link="Helpers\ApplicationStateGuard.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\EnvironmentVariableConstants.cs" Link="Helpers\EnvironmentVariableConstants.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\PasteArguments.cs" Link="Helpers\PasteArguments.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeoutHelper.cs" Link="Helpers\TimeoutHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeSpanParser.cs" Link="Helpers\TimeSpanParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />


### PR DESCRIPTION
## Summary

Spike to shrink the cross-assembly surface the platform exposes via `InternalsVisibleTo`, using two complementary techniques depending on whether a type's **instances cross the assembly boundary**:

- **Static/value helpers** (no instance crosses the boundary) → `[Embedded]` + source-link.
- **DI service abstractions / base classes** (instances or subclassing cross the boundary) → `public` + `[EditorBrowsable(Never)]` + `[Experimental("TPINTERNAL")]` infrastructure APIs.

## 1. Embedded helpers (source-linked, hidden from metadata)

| Helper | Source-linked into |
| --- | --- |
| `RoslynDebug` | Telemetry, VSTestBridge |
| `ArgumentGuard` | Retry |
| `PasteArguments` | Retry, Platform.UnitTests |
| `DisposeHelper` | TrxReport |
| `RuntimeFeatureHelper` | Telemetry |

Each consumer gets the matching `InternalAPI.Unshipped.txt` entries. `PasteArguments`'s stale "IVT/breaking-change" comment was updated.

## 2. Infrastructure APIs (public but not for consumers)

The identity issue: `IClock` (and `IEnvironment`/`ITask`) are DI **instances** the platform hands to extensions, so `[Embedded]`+source-link fails (proven: CS0436 type-conflict + CS1503). These must go **public**. To signal "public only for technical cross-assembly reasons, not for you":

- `[EditorBrowsable(EditorBrowsableState.Never)]` — hidden from IntelliSense.
- `[Experimental("TPINTERNAL")]` — a **distinct** diagnostic id from the real-preview `TPEXP`; external consumers hit a hard opt-in gate, while first-party code suppresses it **centrally** in `Directory.Build.props` (next to the existing `TPEXP` suppression). Swappable to `[Obsolete(..., DiagnosticId=…)]` later without touching the id or consumers (note: `DiagnosticId`/`UrlFormat` are net5+-only, and the platform also targets netstandard2.0/net462, which is why `[Experimental]` — fully polyfilled — is the pragmatic start).
- An "Infrastructure — not intended for direct use" XML-doc block carries the real intent (the `[Experimental]` message is fixed).

Promoted in place (namespace unchanged — a `.Internal` rename would be **binary-breaking** for already-shipped extension binaries under NuGet up-unification; widening `internal→public` in place is binary-safe):

- `IClock`, `ServiceProviderExtensions.GetSystemClock`, `CommandLineOptionsProviderBase` (moved from `InternalAPI` → `PublicAPI` with the `[TPINTERNAL]` prefix).

**Result:** with these public, `Microsoft.Testing.Extensions.VideoRecorder` no longer needs any platform internal → its `InternalsVisibleTo` grant is **removed** (first IVT dropped end-to-end).

## Validation

- Platform, VideoRecorder (now **IVT-free**), all other reporters (AzureDevOps/GitHubActions/Html/JUnit), Telemetry/CrashDump/HangDump/TrxReport/Retry/VSTestBridge, and Platform.UnitTests all build **0 warnings / 0 errors**.
- The central `TPINTERNAL` suppression means all first-party consumers keep building without per-project changes; external consumers still hit the gate.
- Moved source is byte-identical; `internal→public` is in-place (no namespace rename).

## Notes / follow-ups

- Analyzer caveat: the `PublicApiAnalyzers` build this repo consumes still tracks `[Embedded]` types in `InternalAPI*.txt` (dotnet/roslyn#84437 not yet in a consumable package), so embedded helpers are intentionally kept in the txt files for now.
- Dropping the **other** reporters' IVTs additionally needs `IEnvironment`, `ITask`, `IFileSystem` (+`IFileStream`), `ITestApplicationModuleInfo` (+`ExecutableInfo`), `ITestApplicationProcessExitCode` promoted the same way — a follow-up tranche.
