### PR TITLE
[rel/4.3] Restore InternalsVisibleTo for deprecated MSTest.Engine to fix MethodAccessException (#9769)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -63,10 +63,22 @@ This package provides the core platform and the .NET implementation of the proto
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VideoRecorder" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge.UnitTests" Key="$(VsPublicKey)" />
+    <!--
+      Microsoft.Testing.Framework / MSTest.Engine are the (now deprecated) source-generation engine assemblies.
+      They were renamed to Microsoft.Testing.Internal.Framework in https://github.com/microsoft/testfx/pull/2615,
+      which dropped these grants. But the previously shipped MSTest.Engine package (assembly name still
+      Microsoft.Testing.Framework, e.g. the 2.0.0-alpha builds referenced by MSTest.SourceGeneration) was compiled
+      against a platform where the grant existed, so its IL calls internals such as
+      Microsoft.Testing.Platform.Helpers.ArgumentGuard.Ensure. Loading that old engine against a newer platform
+      that no longer grants the friend relationship fails with System.MethodAccessException (see issue #9769).
+      Restoring the grant keeps that binary compatibility, mirroring the TestRequestExecutionTimeInfo workaround.
+    -->
+    <InternalsVisibleTo Include="Microsoft.Testing.Framework" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.Acceptance.IntegrationTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.AI" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Platform.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.TestInfrastructure" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="MSTest.Engine" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTest.TestAdapter" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="TestFramework.ForTestingMSTest" Key="$(VsPublicKey)" />
   </ItemGroup>


### PR DESCRIPTION
Backport of #9938 to `rel/4.3`.

## Problem

Native AOT / source-gen test projects fail at runtime with:

```
System.MethodAccessException: Attempt by method
'Microsoft.Testing.Framework.TestApplicationBuilderExtensions.AddTestFramework(...)'
to access method 'Microsoft.Testing.Platform.Helpers.ArgumentGuard.Ensure(Boolean, String, String)' failed.
```

Reported in #9769 (comment). Zero tests run, exit code 134.

## Root cause

MSTest.Sdk source-gen mode pulls in the (now deprecated) **MSTest.Engine** package, whose assembly name is still `Microsoft.Testing.Framework`. That assembly''s `TestApplicationBuilderExtensions.AddTestFramework` calls the **internal** `Microsoft.Testing.Platform.Helpers.ArgumentGuard.Ensure`.

The `InternalsVisibleTo` grants for `Microsoft.Testing.Framework` / `MSTest.Engine` were removed in #2615 when those projects were renamed to `Microsoft.Testing.Internal.Framework`. The already-shipped engine binary was compiled while the grant existed, so loading it against a newer `Microsoft.Testing.Platform` that no longer grants the friend relationship throws `MethodAccessException`.

## Fix

Restore the two `InternalsVisibleTo` grants (`Microsoft.Testing.Framework`, `MSTest.Engine`) in `Microsoft.Testing.Platform.csproj`, mirroring the existing `TestRequestExecutionTimeInfo` compatibility workaround (issue #8925).

Fixes #9769
