### PR TITLE
Skip [AssemblyFixtureProvider] under Native AOT + add MSTEST0072 analyzer

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -35,6 +35,9 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="IsMSTestTestAdapterReferenced" />
+    <!-- Surfaced so analyzers can warn about features that are unsupported under Native AOT
+         (e.g. MSTEST0072 for [AssemblyFixtureProvider]). -->
+    <CompilerVisibleProperty Include="PublishAot" />
     <!-- Selects which MSTest source-generation strategy emits when a source generator is referenced:
          'ReflectionFree' (default) materializes attributes and emits delegate-based invokers so the
          adapter runs without runtime reflection (best for trimming/Native AOT); 'Rooting' only

--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -35,9 +35,11 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="IsMSTestTestAdapterReferenced" />
-    <!-- Surfaced so analyzers can warn about features that are unsupported under Native AOT
-         (e.g. MSTEST0072 for [AssemblyFixtureProvider]). -->
+    <!-- Surfaced so analyzers can warn about features that are unsupported under ahead-of-time
+         compilation (e.g. MSTEST0072 for [AssemblyFixtureProvider]): PublishAot (Native AOT) and
+         RunAOTCompilation (Blazor WebAssembly AOT). -->
     <CompilerVisibleProperty Include="PublishAot" />
+    <CompilerVisibleProperty Include="RunAOTCompilation" />
     <!-- Selects which MSTest source-generation strategy emits when a source generator is referenced:
          'ReflectionFree' (default) materializes attributes and emits delegate-based invokers so the
          adapter runs without runtime reflection (best for trimming/Native AOT); 'Rooting' only

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
@@ -24,27 +24,42 @@ internal sealed partial class TypeCache
         // the reflection path (so no IL2026/IL3050 is produced).
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
-            // The compile-time MSTEST0072 analyzer only covers Native AOT (build_property.PublishAot),
-            // but this guard also affects Mono iOS AOT and Blazor WebAssembly AOT. Emit a runtime warning
-            // so those consumers are not silently deprived of their fixtures.
-            //
-            // Scan the already-loaded assemblies (AppDomain.GetAssemblies) rather than walking the
-            // reference graph: reading each assembly's CustomAttributeData is metadata-only and stays
-            // AOT-safe, whereas Assembly.GetReferencedAssemblies + load-by-name is exactly the
-            // dynamic-code path this guard exists to avoid. This covers both the test assembly and any
-            // already-loaded provider library, so referenced providers are no longer silent here.
+            // The compile-time MSTEST0072 analyzer covers the referenced-provider case at build time
+            // (it can read referenced assemblies' metadata). At run time under AOT we cannot walk the
+            // reference graph (Assembly.GetReferencedAssemblies + load-by-name is the very dynamic-code
+            // path this guard avoids), so a referenced provider that has not been loaded yet is not
+            // detectable here. What we can reliably and AOT-safely surface is a marker on an
+            // already-loaded assembly — in particular the test assembly itself when it self-applies the
+            // attribute (a documented usage). Emit a best-effort warning for every loaded assembly that
+            // carries the marker so those cases are not silent.
             if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsWarningEnabled)
             {
                 foreach (Assembly loaded in AppDomain.CurrentDomain.GetAssemblies())
                 {
-                    if (loaded.IsDynamic || !HasAssemblyFixtureProviderMarker(loaded))
+                    if (loaded.IsDynamic)
                     {
                         continue;
                     }
 
-                    PlatformServiceProvider.Instance.AdapterTraceLogger.Warning(
-                        "TypeCache: [AssemblyFixtureProvider] is not supported when the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WebAssembly AOT). The AssemblyInitialize/AssemblyCleanup methods it exposes from assembly {0} will not run.",
-                        SafeGetAssemblyName(loaded));
+                    bool hasMarker;
+                    try
+                    {
+                        // Metadata-only probe. Isolate per-assembly failures (unresolvable custom-attribute
+                        // metadata on an unrelated assembly must not abort discovery), matching the normal
+                        // discovery path's handling.
+                        hasMarker = HasAssemblyFixtureProviderMarker(loaded);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+
+                    if (hasMarker)
+                    {
+                        PlatformServiceProvider.Instance.AdapterTraceLogger.Warning(
+                            "TypeCache: [AssemblyFixtureProvider] is not supported when the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WebAssembly AOT). The AssemblyInitialize/AssemblyCleanup methods it exposes from assembly {0} will not run.",
+                            SafeGetAssemblyName(loaded));
+                    }
                 }
             }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
@@ -16,6 +16,19 @@ internal sealed partial class TypeCache
 {
     private static void DiscoverFixturesFromProviders(Assembly currentAssembly, TestAssemblyInfo assemblyInfo, TypeCache @this)
     {
+#if NET && !WINDOWS_UWP
+        // [AssemblyFixtureProvider] discovery walks the runtime assembly reference graph
+        // (Assembly.GetReferencedAssemblies + assembly loading by name), which is not supported when
+        // the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WASM AOT).
+        // Skipping the feature there keeps behavior predictable and lets the trimmer statically remove
+        // the reflection path (so no IL2026/IL3050 is produced). The MSTEST0072 analyzer warns at build
+        // time that [AssemblyFixtureProvider] is unsupported for these consumers.
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return;
+        }
+#endif
+
         // Snapshot which slots were filled by the in-assembly pass. Local declarations are
         // authoritative — never let a provider overwrite or even consider those slots, so the
         // provider pass stays silent when the test assembly already declared a fixture method.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
@@ -21,10 +21,23 @@ internal sealed partial class TypeCache
         // (Assembly.GetReferencedAssemblies + assembly loading by name), which is not supported when
         // the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WASM AOT).
         // Skipping the feature there keeps behavior predictable and lets the trimmer statically remove
-        // the reflection path (so no IL2026/IL3050 is produced). The MSTEST0072 analyzer warns at build
-        // time that [AssemblyFixtureProvider] is unsupported for these consumers.
+        // the reflection path (so no IL2026/IL3050 is produced).
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
+            // The compile-time MSTEST0072 analyzer only covers Native AOT (build_property.PublishAot),
+            // but this guard also affects Mono iOS AOT and Blazor WebAssembly AOT. Emit a runtime warning
+            // so those consumers are not silently deprived of their fixtures. The check is metadata-only
+            // (no assembly loading), so it stays AOT-safe; providers on referenced libraries cannot be
+            // detected here without the very reference-graph walk we are avoiding, so those rely on the
+            // analyzer.
+            if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsWarningEnabled &&
+                HasAssemblyFixtureProviderMarker(currentAssembly))
+            {
+                PlatformServiceProvider.Instance.AdapterTraceLogger.Warning(
+                    "TypeCache: [AssemblyFixtureProvider] is not supported when the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WebAssembly AOT). The AssemblyInitialize/AssemblyCleanup methods it exposes from assembly {0} will not run.",
+                    SafeGetAssemblyName(currentAssembly));
+            }
+
             return;
         }
 #endif

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.ProviderDiscovery.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security;
@@ -26,16 +26,26 @@ internal sealed partial class TypeCache
         {
             // The compile-time MSTEST0072 analyzer only covers Native AOT (build_property.PublishAot),
             // but this guard also affects Mono iOS AOT and Blazor WebAssembly AOT. Emit a runtime warning
-            // so those consumers are not silently deprived of their fixtures. The check is metadata-only
-            // (no assembly loading), so it stays AOT-safe; providers on referenced libraries cannot be
-            // detected here without the very reference-graph walk we are avoiding, so those rely on the
-            // analyzer.
-            if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsWarningEnabled &&
-                HasAssemblyFixtureProviderMarker(currentAssembly))
+            // so those consumers are not silently deprived of their fixtures.
+            //
+            // Scan the already-loaded assemblies (AppDomain.GetAssemblies) rather than walking the
+            // reference graph: reading each assembly's CustomAttributeData is metadata-only and stays
+            // AOT-safe, whereas Assembly.GetReferencedAssemblies + load-by-name is exactly the
+            // dynamic-code path this guard exists to avoid. This covers both the test assembly and any
+            // already-loaded provider library, so referenced providers are no longer silent here.
+            if (PlatformServiceProvider.Instance.AdapterTraceLogger.IsWarningEnabled)
             {
-                PlatformServiceProvider.Instance.AdapterTraceLogger.Warning(
-                    "TypeCache: [AssemblyFixtureProvider] is not supported when the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WebAssembly AOT). The AssemblyInitialize/AssemblyCleanup methods it exposes from assembly {0} will not run.",
-                    SafeGetAssemblyName(currentAssembly));
+                foreach (Assembly loaded in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    if (loaded.IsDynamic || !HasAssemblyFixtureProviderMarker(loaded))
+                    {
+                        continue;
+                    }
+
+                    PlatformServiceProvider.Instance.AdapterTraceLogger.Warning(
+                        "TypeCache: [AssemblyFixtureProvider] is not supported when the runtime cannot generate dynamic code (Native AOT, Mono iOS AOT, Blazor WebAssembly AOT). The AssemblyInitialize/AssemblyCleanup methods it exposes from assembly {0} will not run.",
+                        SafeGetAssemblyName(loaded));
+                }
             }
 
             return;

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MSTEST0072 | Usage | Warning | AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0072)

--- a/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -82,13 +82,11 @@ public sealed class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer : D
         // Those attributes are declared outside this compilation (no source location), but the referencing
         // Native AOT test project is exactly where the runtime guard silently skips discovery, so report a
         // no-location diagnostic for each referenced assembly that carries the marker.
-        foreach (IAssemblySymbol referencedAssembly in context.Compilation.SourceModule.ReferencedAssemblySymbols)
+        foreach (IAssemblySymbol referencedAssembly in context.Compilation.SourceModule.ReferencedAssemblySymbols
+            .Where(referencedAssembly => referencedAssembly.GetAttributes()
+                .Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol))))
         {
-            if (referencedAssembly.GetAttributes()
-                .Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol)))
-            {
-                context.ReportNoLocationDiagnostic(Rule);
-            }
+            context.ReportNoLocationDiagnostic(Rule);
         }
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0072: <inheritdoc cref="Resources.AssemblyFixtureProviderNotSupportedWithNativeAotTitle"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.AssemblyFixtureProviderNotSupportedWithNativeAotTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.AssemblyFixtureProviderNotSupportedWithNativeAotDescription), Resources.ResourceManager, typeof(Resources));
+
+    /// <inheritdoc cref="Resources.AssemblyFixtureProviderNotSupportedWithNativeAotTitle" />
+    public static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.AssemblyFixtureProviderNotSupportedWithNativeAotRuleId,
+        Title,
+        MessageFormat,
+        Description,
+        Category.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+        = ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(AnalyzeCompilation);
+    }
+
+    private static void AnalyzeCompilation(CompilationAnalysisContext context)
+    {
+        // [AssemblyFixtureProvider] discovery walks the runtime assembly reference graph, which is only
+        // supported when the runtime can generate dynamic code. Under Native AOT the feature is skipped
+        // at runtime, so warn the user that the attribute has no effect there. Only report when the
+        // project opts into Native AOT.
+        if (!(context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue("build_property.PublishAot", out string? publishAot)
+            && bool.TryParse(publishAot, out bool publishAotValue)
+            && publishAotValue))
+        {
+            return;
+        }
+
+        INamedTypeSymbol? assemblyFixtureProviderAttributeSymbol = context.Compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingAssemblyFixtureProviderAttribute);
+        if (assemblyFixtureProviderAttributeSymbol is null)
+        {
+            return;
+        }
+
+        foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol)
+                && attribute.ApplicationSyntaxReference is not null)
+            {
+                context.ReportDiagnostic(attribute.ApplicationSyntaxReference.CreateDiagnostic(Rule, context.CancellationToken));
+            }
+        }
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
@@ -48,12 +48,12 @@ public sealed class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer : D
     private static void AnalyzeCompilation(CompilationAnalysisContext context)
     {
         // [AssemblyFixtureProvider] discovery walks the runtime assembly reference graph, which is only
-        // supported when the runtime can generate dynamic code. Under Native AOT the feature is skipped
-        // at runtime, so warn the user that the attribute has no effect there. Only report when the
-        // project opts into Native AOT.
-        if (!(context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue("build_property.PublishAot", out string? publishAot)
-            && bool.TryParse(publishAot, out bool publishAotValue)
-            && publishAotValue))
+        // supported when the runtime can generate dynamic code. Under ahead-of-time compilation the
+        // feature is skipped at run time, so warn the user that the attribute has no effect there.
+        // Report when the project opts into an AOT flavor detectable at build time: Native AOT
+        // (PublishAot) or Blazor WebAssembly AOT (RunAOTCompilation).
+        if (!(IsBuildPropertyTrue(context, "build_property.PublishAot")
+            || IsBuildPropertyTrue(context, "build_property.RunAOTCompilation")))
         {
             return;
         }
@@ -81,12 +81,17 @@ public sealed class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer : D
         // The documented/default usage places [AssemblyFixtureProvider] on a referenced fixture library.
         // Those attributes are declared outside this compilation (no source location), but the referencing
         // Native AOT test project is exactly where the runtime guard silently skips discovery, so report a
-        // no-location diagnostic for each referenced assembly that carries the marker.
-        foreach (IAssemblySymbol referencedAssembly in context.Compilation.SourceModule.ReferencedAssemblySymbols
-            .Where(referencedAssembly => referencedAssembly.GetAttributes()
+        // no-location diagnostic when any referenced assembly carries the marker.
+        if (context.Compilation.SourceModule.ReferencedAssemblySymbols
+            .Any(referencedAssembly => referencedAssembly.GetAttributes()
                 .Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol))))
         {
             context.ReportNoLocationDiagnostic(Rule);
         }
     }
+
+    private static bool IsBuildPropertyTrue(CompilationAnalysisContext context, string propertyName)
+        => context.Options.AnalyzerConfigOptionsProvider.GlobalOptions.TryGetValue(propertyName, out string? value)
+            && bool.TryParse(value, out bool parsed)
+            && parsed;
 }

--- a/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.cs
@@ -64,12 +64,30 @@ public sealed class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer : D
             return;
         }
 
-        foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes())
+        // Attributes applied in the compilation being built have a source location we can point at.
+        foreach (AttributeData attribute in context.Compilation.Assembly.GetAttributes()
+            .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol)))
         {
-            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol)
-                && attribute.ApplicationSyntaxReference is not null)
+            if (attribute.ApplicationSyntaxReference is null)
+            {
+                context.ReportNoLocationDiagnostic(Rule);
+            }
+            else
             {
                 context.ReportDiagnostic(attribute.ApplicationSyntaxReference.CreateDiagnostic(Rule, context.CancellationToken));
+            }
+        }
+
+        // The documented/default usage places [AssemblyFixtureProvider] on a referenced fixture library.
+        // Those attributes are declared outside this compilation (no source location), but the referencing
+        // Native AOT test project is exactly where the runtime guard silently skips discovery, so report a
+        // no-location diagnostic for each referenced assembly that carries the marker.
+        foreach (IAssemblySymbol referencedAssembly in context.Compilation.SourceModule.ReferencedAssemblySymbols)
+        {
+            if (referencedAssembly.GetAttributes()
+                .Any(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, assemblyFixtureProviderAttributeSymbol)))
+            {
+                context.ReportNoLocationDiagnostic(Rule);
             }
         }
     }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -76,4 +76,5 @@ internal static class DiagnosticIds
     // public const string InheritedTestClassAttributeWithSourceGeneratorRuleId = "MSTEST0069"; - // Reserved. Owned by MSTest.SourceGeneration analyzer; don't reuse this ID.
     public const string MemberConditionShouldBeValidRuleId = "MSTEST0070";
     public const string RedundantTestMethodDisplayNameRuleId = "MSTEST0071";
+    public const string AssemblyFixtureProviderNotSupportedWithNativeAotRuleId = "MSTEST0072";
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace MSTest.Analyzers.Helpers;

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace MSTest.Analyzers.Helpers;

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -7,6 +7,7 @@ namespace MSTest.Analyzers.Helpers;
 internal static class WellKnownTypeNames
 {
     public const string MicrosoftVisualStudioTestToolsUnitTestingAssemblyCleanupAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyCleanupAttribute";
+    public const string MicrosoftVisualStudioTestToolsUnitTestingAssemblyFixtureProviderAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyFixtureProviderAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingAssemblyInitializeAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitializeAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingAssert = "Microsoft.VisualStudio.TestTools.UnitTesting.Assert";
     public const string MicrosoftVisualStudioTestToolsUnitTestingAssertFailedException = "Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException";

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -997,15 +997,15 @@ The type declaring these methods should also respect the following rules:
     <comment>{Locked="DisplayName"}</comment>
   </data>
   <data name="AssemblyFixtureProviderNotSupportedWithNativeAotTitle" xml:space="preserve">
-    <value>'[AssemblyFixtureProvider]' is not supported with Native AOT</value>
-    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</comment>
+    <value>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}</comment>
   </data>
   <data name="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat" xml:space="preserve">
-    <value>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</value>
-    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</comment>
+    <value>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</comment>
   </data>
   <data name="AssemblyFixtureProviderNotSupportedWithNativeAotDescription" xml:space="preserve">
-    <value>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</value>
-    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</comment>
+    <value>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</comment>
   </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -996,4 +996,16 @@ The type declaring these methods should also respect the following rules:
     <value>Setting a 'DisplayName' on a test method to a value that is identical to the method name is redundant because the method name is already used as the display name by default. The redundant 'DisplayName' can be removed without changing how the test is reported.</value>
     <comment>{Locked="DisplayName"}</comment>
   </data>
+  <data name="AssemblyFixtureProviderNotSupportedWithNativeAotTitle" xml:space="preserve">
+    <value>'[AssemblyFixtureProvider]' is not supported with Native AOT</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</comment>
+  </data>
+  <data name="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat" xml:space="preserve">
+    <value>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</comment>
+  </data>
+  <data name="AssemblyFixtureProviderNotSupportedWithNativeAotDescription" xml:space="preserve">
+    <value>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</value>
+    <comment>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</comment>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -48,19 +48,19 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -47,6 +47,21 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="translated">Metody AssemblyCleanup musí mít platné rozložení</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -48,19 +48,19 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -47,6 +47,21 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="translated">AssemblyCleanup-Methoden müssen über ein gültiges Layout verfügen.</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -47,6 +47,21 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="translated">Los métodos AssemblyCleanup deben tener un diseño válido</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -48,19 +48,19 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -47,6 +47,21 @@ Le type doit être une classe
         <target state="translated">La méthode AssemblyCleanup doit avoir une disposition valide</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -48,19 +48,19 @@ Le type doit être une classe
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -47,6 +47,21 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="translated">Il metodo AssemblyCleanup deve avere un layout valido</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -48,19 +48,19 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -47,6 +47,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">AssemblyCleanup メソッドには有効なレイアウトが必要です</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -48,19 +48,19 @@ The type declaring these methods should also respect the following rules:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -47,6 +47,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">AssemblyCleanup 메서드에는 올바른 레이아웃이 있어야 합니다.</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -48,19 +48,19 @@ The type declaring these methods should also respect the following rules:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -47,6 +47,21 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="translated">Metody AssemblyCleanup powinny mieć prawidłowy układ</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -48,19 +48,19 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -47,6 +47,21 @@ O tipo declarando esses métodos também deve respeitar as seguintes regras:
         <target state="translated">Os métodos AssemblyCleanup devem ter um layout válido</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -48,19 +48,19 @@ O tipo declarando esses métodos também deve respeitar as seguintes regras:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -49,6 +49,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">Методы AssemblyCleanup должны использовать допустимый макет</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -50,19 +50,19 @@ The type declaring these methods should also respect the following rules:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -48,19 +48,19 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -47,6 +47,21 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="translated">AssemblyCleanup yöntemleri geçerli bir düzene sahip olmalıdır</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -47,6 +47,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">AssemblyCleanup 方法应具有有效的布局</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -48,19 +48,19 @@ The type declaring these methods should also respect the following rules:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -48,19 +48,19 @@ The type declaring these methods should also respect the following rules:
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
-        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
-        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT or Blazor WebAssembly AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
-        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation (such as Native AOT or Blazor WebAssembly AOT) and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}{Locked="Blazor WebAssembly AOT"}</note>
       </trans-unit>
       <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
-        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
-        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
-        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+        <source>'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with ahead-of-time compilation</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}</note>
       </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -47,6 +47,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">AssemblyCleanup 方法應該具有有效的配置</target>
         <note>{Locked="AssemblyCleanup"}</note>
       </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotDescription">
+        <source>'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</source>
+        <target state="new">'[AssemblyFixtureProvider]' discovery relies on walking the runtime assembly reference graph, which is not supported when the runtime cannot generate dynamic code (for example under Native AOT). The attribute is ignored in such builds, so the provided assembly initialize and cleanup methods will not run. Declare the '[AssemblyInitialize]' and '[AssemblyCleanup]' methods directly in the test assembly instead.</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="[AssemblyInitialize]"}{Locked="[AssemblyCleanup]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotMessageFormat">
+        <source>'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported when publishing with Native AOT and will be ignored at run time</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
+      <trans-unit id="AssemblyFixtureProviderNotSupportedWithNativeAotTitle">
+        <source>'[AssemblyFixtureProvider]' is not supported with Native AOT</source>
+        <target state="new">'[AssemblyFixtureProvider]' is not supported with Native AOT</target>
+        <note>{Locked="[AssemblyFixtureProvider]"}{Locked="Native AOT"}</note>
+      </trans-unit>
       <trans-unit id="AssemblyInitializeShouldBeValidDescription">
         <source>Methods marked with '[AssemblyInitialize]' should follow the following layout to be valid:
 -it can't be declared on a generic class

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderNativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AssemblyFixtureProviderNativeAotTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class AssemblyFixtureProviderNativeAotTests : AcceptanceTestBase<AssemblyFixtureProviderNativeAotTests.TestAssetFixture>
+{
+    [TestMethod]
+    public async Task AssemblyFixtureProvider_WhenDynamicCodeUnsupported_IsSkipped()
+    {
+        // PublishAot=true sets the RuntimeFeature.IsDynamicCodeSupported feature switch to false even
+        // for a managed build (see PublishAotNonNativeTests), so this exercises the runtime guard that
+        // skips [AssemblyFixtureProvider] discovery without needing an actual native compile.
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.TestProjectName, TargetFrameworks.NetCurrent);
+
+        // Pass --settings my.runsettings so CaptureTraceOutput=false forwards Console.WriteLine
+        // output to stdout (otherwise MSTest captures it and the assertions below cannot see it).
+        TestHostResult testHostResult = await testHost.ExecuteAsync("--settings my.runsettings", cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
+
+        // The test still runs...
+        testHostResult.AssertOutputContains("MyTests.TestMethod ran");
+
+        // ...but the assembly-init / assembly-cleanup declared in the referenced provider library are
+        // NOT executed, because provider discovery is skipped when dynamic code is unsupported.
+        testHostResult.AssertOutputDoesNotContain("ProviderLibrary.SharedFixtures.AssemblyInit ran");
+        testHostResult.AssertOutputDoesNotContain("ProviderLibrary.SharedFixtures.AssemblyCleanup ran");
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        public const string AssetName = "AssemblyFixtureProviderNativeAotAcceptance";
+        public const string TestProjectName = "AssemblyFixtureProviderNativeAot.Tests";
+        public const string LibraryProjectName = "ProviderLibrary";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            SourceCode
+                .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file AssemblyFixtureProviderNativeAot.Tests.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFramework>$TargetFramework$</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <!-- Sets RuntimeFeature.IsDynamicCodeSupported to false without an actual native compile. -->
+    <PublishAot>true</PublishAot>
+    <!-- [AssemblyFixtureProvider] is intentionally unsupported here; suppress MSTEST0072 so the
+         managed build used by this test is not failed by the analyzer warning it emits. -->
+    <NoWarn>$(NoWarn);MSTEST0072</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="ProviderLibrary/ProviderLibrary.csproj" />
+    <Compile Remove="ProviderLibrary/**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+#file my.runsettings
+<RunSettings>
+  <MSTest>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+  </MSTest>
+</RunSettings>
+
+#file MyTests.cs
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ProviderLibrary;
+
+namespace MyTests;
+
+[TestClass]
+public class MyTests
+{
+    [TestMethod]
+    public void TestMethod()
+    {
+        // Reference a type from the provider library so it is pulled in as a runtime dependency.
+        Assert.AreEqual("ok", SharedFixtures.Ping());
+        Console.WriteLine("MyTests.TestMethod ran");
+    }
+}
+
+#file ProviderLibrary/ProviderLibrary.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$TargetFramework$</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+</Project>
+
+#file ProviderLibrary/SharedFixtures.cs
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: AssemblyFixtureProvider(typeof(ProviderLibrary.SharedFixtures))]
+
+namespace ProviderLibrary;
+
+public static class SharedFixtures
+{
+    public static string Ping() => "ok";
+
+    [AssemblyInitialize]
+    public static void AssemblyInit(TestContext context)
+        => Console.WriteLine("ProviderLibrary.SharedFixtures.AssemblyInit ran");
+
+    [AssemblyCleanup]
+    public static void AssemblyCleanup()
+        => Console.WriteLine("ProviderLibrary.SharedFixtures.AssemblyCleanup ran");
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; }
+}

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Testing;
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests
+{
+    private static async Task VerifyAsync(string code, bool publishAot, params DiagnosticResult[] expected)
+    {
+        var test = new VerifyCS.Test
+        {
+            TestCode = code,
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add((
+            "/.globalconfig",
+            $"""
+            is_global = true
+
+            build_property.PublishAot = {(publishAot ? "true" : "false")}
+            """));
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenPublishAotAndAttributeIsUsed_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: [|AssemblyFixtureProvider(typeof(GlobalFixtures))|]]
+
+            public static class GlobalFixtures
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+            """;
+
+        await VerifyAsync(code, publishAot: true);
+    }
+
+    [TestMethod]
+    public async Task WhenPublishAotAndAttributeUsedMultipleTimes_DiagnosticOnEach()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: [|AssemblyFixtureProvider(typeof(FixturesOne))|]]
+            [assembly: [|AssemblyFixtureProvider(typeof(FixturesTwo))|]]
+
+            public static class FixturesOne
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+
+            public static class FixturesTwo
+            {
+                [AssemblyCleanup]
+                public static void Cleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyAsync(code, publishAot: true);
+    }
+
+    [TestMethod]
+    public async Task WhenNotPublishAot_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: AssemblyFixtureProvider(typeof(GlobalFixtures))]
+
+            public static class GlobalFixtures
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+            """;
+
+        await VerifyAsync(code, publishAot: false);
+    }
+
+    [TestMethod]
+    public async Task WhenPublishAotAndAttributeNotUsed_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTests
+            {
+                [TestMethod]
+                public void MyTest()
+                {
+                }
+            }
+            """;
+
+        await VerifyAsync(code, publishAot: true);
+    }
+}

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
@@ -14,22 +14,46 @@ namespace MSTest.Analyzers.Test;
 public class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests
 {
     private static async Task VerifyAsync(string code, bool publishAot, params DiagnosticResult[] expected)
+        => await VerifyWithPropertiesAsync(code, expected, ("build_property.PublishAot", publishAot ? "true" : "false"));
+
+    private static async Task VerifyWithPropertiesAsync(string code, DiagnosticResult[] expected, params (string Key, string Value)[] properties)
     {
         var test = new VerifyCS.Test
         {
             TestCode = code,
         };
 
+        string propertyLines = string.Join(Environment.NewLine, properties.Select(p => $"{p.Key} = {p.Value}"));
         test.TestState.AnalyzerConfigFiles.Add((
             "/.globalconfig",
             $"""
             is_global = true
 
-            build_property.PublishAot = {(publishAot ? "true" : "false")}
+            {propertyLines}
             """));
 
         test.ExpectedDiagnostics.AddRange(expected);
         await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenRunAOTCompilationAndAttributeIsUsed_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: [|AssemblyFixtureProvider(typeof(GlobalFixtures))|]]
+
+            public static class GlobalFixtures
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+            """;
+
+        await VerifyWithPropertiesAsync(code, [], ("build_property.RunAOTCompilation", "true"));
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
@@ -78,6 +79,115 @@ public class AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzerTests
             """;
 
         await VerifyAsync(code, publishAot: true);
+    }
+
+    [TestMethod]
+    public async Task WhenPublishAotAndAttributeOnReferencedAssembly_Diagnostic()
+    {
+        string providerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: AssemblyFixtureProvider(typeof(GlobalFixtures))]
+
+            public static class GlobalFixtures
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+            """;
+
+        string consumerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTests
+            {
+                [TestMethod]
+                public void MyTest()
+                {
+                }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = consumerCode,
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add((
+            "/.globalconfig",
+            """
+            is_global = true
+
+            build_property.PublishAot = true
+            """));
+
+        var providerProject = new ProjectState("FixtureLib", LanguageNames.CSharp, "/FixtureLib/", "cs");
+        providerProject.Sources.Add(("Provider.cs", providerCode));
+        providerProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute).Assembly.Location));
+        providerProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext).Assembly.Location));
+        test.TestState.AdditionalProjects.Add("FixtureLib", providerProject);
+        test.TestState.AdditionalProjectReferences.Add("FixtureLib");
+
+        // The attribute lives in a referenced assembly, so the diagnostic has no source location.
+        test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic(AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer.Rule).WithNoLocation());
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenNotPublishAot_AttributeOnReferencedAssembly_NoDiagnostic()
+    {
+        string providerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: AssemblyFixtureProvider(typeof(GlobalFixtures))]
+
+            public static class GlobalFixtures
+            {
+                [AssemblyInitialize]
+                public static void Init(TestContext context)
+                {
+                }
+            }
+            """;
+
+        string consumerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTests
+            {
+                [TestMethod]
+                public void MyTest()
+                {
+                }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = consumerCode,
+        };
+
+        test.TestState.AnalyzerConfigFiles.Add((
+            "/.globalconfig",
+            """
+            is_global = true
+
+            build_property.PublishAot = false
+            """));
+
+        var providerProject = new ProjectState("FixtureLib", LanguageNames.CSharp, "/FixtureLib/", "cs");
+        providerProject.Sources.Add(("Provider.cs", providerCode));
+        providerProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.ParallelizeAttribute).Assembly.Location));
+        providerProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Microsoft.VisualStudio.TestTools.UnitTesting.TestContext).Assembly.Location));
+        test.TestState.AdditionalProjects.Add("FixtureLib", providerProject);
+        test.TestState.AdditionalProjectReferences.Add("FixtureLib");
+
+        await test.RunAsync();
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

`[AssemblyFixtureProvider]` cross-assembly discovery walks the **runtime assembly reference graph** (`Assembly.GetReferencedAssemblies()` + load-by-name via `AssemblyLoadContext`). That is fundamentally a reflection/runtime-loading mechanism and cannot be made reflection-free by the source generator. Under Native AOT it also surfaced an `IL2026` — the last MSTest-owned trim/AOT warning a consumer hit when publishing a Native AOT test app with `MSTestSourceGenMode=ReflectionFree` and warnings-as-errors.

Rather than paper over it with a suppression, this PR makes the behavior explicit: **skip the feature when dynamic code is unsupported, and surface it both at build time (analyzer) and at run time (trace warning).**

## Changes

**1. Skip discovery when dynamic code is unsupported** (`TypeCache.ProviderDiscovery.cs`)
Guard `DiscoverFixturesFromProviders` on `RuntimeFeature.IsDynamicCodeSupported`. Because ILC constant-folds that switch to `false` under AOT, the guarded reflection path is statically removed — so the `IL2026` disappears with **no suppression needed** (same pattern already used in `DataSerializationHelper`).

**2. Best-effort runtime warning**
When discovery is skipped, emit a trace warning so consumers are not silently deprived of their fixtures. It scans the **already-loaded** assemblies (`AppDomain.GetAssemblies`, metadata-only via `CustomAttributeData`, with per-assembly failure isolation) — it deliberately does **not** walk the reference graph, so it stays AOT-safe. Consequently it can only see markers on assemblies that happen to be loaded (e.g. a self-applied marker on the test assembly); an *unloaded* referenced provider is not detectable at run time AOT-safely. Referenced providers are instead covered at build time by the analyzer. The warning is emitted through MTP's diagnostic logger (`--diagnostic` output).

**3. New analyzer MSTEST0072** — `AssemblyFixtureProviderNotSupportedWithNativeAotAnalyzer`
Warns at build time when the project opts into an AOT flavor detectable at build time — `PublishAot` (Native AOT) **or** `RunAOTCompilation` (Blazor WebAssembly AOT) — and `[AssemblyFixtureProvider]` is in play. It inspects **both** the compilation's own assembly attributes (reported at the attribute location) **and referenced assemblies' attributes** (reported as a no-location diagnostic), so the documented default usage — the attribute placed on a referenced fixture library consumed by an AOT test project — is covered. `PublishAot` and `RunAOTCompilation` are exposed to analyzers via new `CompilerVisibleProperty` entries in `MSTest.TestAdapter.targets`. Includes resources (+ regenerated xlf for all 13 locales), `AnalyzerReleases.Unshipped.md` entry, and unit tests (including the referenced-assembly and `RunAOTCompilation` scenarios).

**4. Acceptance test** — `AssemblyFixtureProviderNativeAotTests` verifies that under `PublishAot=true` (which sets `IsDynamicCodeSupported=false` for a managed build) the referenced provider's `AssemblyInitialize`/`AssemblyCleanup` are skipped while the test still passes.

## Notes

- **Analyzer coverage.** MSTEST0072 detects `[AssemblyFixtureProvider]` whether it is declared in the compilation being built or on a **referenced** library, and it triggers on both build-time-detectable AOT flavors (`PublishAot`, `RunAOTCompilation`). The only case it cannot cover is a runtime that disables dynamic code **without** either build property being set (e.g. Mono iOS AOT), where there is no build-time signal to key off; the best-effort runtime trace warning is the fallback there, limited to already-loaded assemblies as described in change #2.
- Supersedes the earlier suppression-based commit on this branch.

## Validation

- `dotnet build` of the adapter (net8.0) and `MSTest.Analyzers` → 0 errors (release-tracking analyzer satisfied).
- New analyzer unit tests (7, incl. referenced-assembly and `RunAOTCompilation` cases) pass on net8.0.
- Downstream: with discovery skipped under AOT, the reflection-free Native AOT publish reaches native codegen with no MSTest-owned IL20xx/IL30xx warnings.
