### PR TITLE
Fix Invoke_TestTarget_With_Incompatible_Arch on Windows x64 CI

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -213,7 +213,19 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
 
             if (OperatingSystem.IsWindows())
             {
-                result.AssertOutputContains("The specified executable is not a valid application for this OS platform.");
+                // Launching an incompatible-architecture apphost can surface with different native
+                // error text depending on the exact Windows build/runtime path:
+                //   1) CreateProcess fails with ERROR_BAD_EXE_FORMAT / ERROR_EXE_MACHINE_TYPE_MISMATCH
+                //      and .NET wraps it with the friendly "not a valid application for this OS platform".
+                //   2) CreateProcess fails but GetLastError() reports 0, so the raw Win32Exception message
+                //      is "The operation completed successfully." (HResult 0x80004005).
+                // Both prove we attempted to launch the incompatible-arch apphost and failed. The MSB6003 +
+                // "An error occurred trying to start process" assertions above already establish that.
+                bool hasInvalidApplication = result.StandardOutput.Contains("The specified executable is not a valid application for this OS platform.", StringComparison.Ordinal);
+                bool hasOperationCompleted = result.StandardOutput.Contains("The operation completed successfully.", StringComparison.Ordinal);
+                Assert.IsTrue(
+                    hasInvalidApplication || hasOperationCompleted,
+                    $"Expected output to contain either \"The specified executable is not a valid application for this OS platform.\" or \"The operation completed successfully.\". Actual output: {result.StandardOutput}");
             }
             else if (OperatingSystem.IsMacOS())
             {


### PR DESCRIPTION
## Problem

The `microsoft-testfx` official build on `main` is red ([build 3022040](https://dnceng.visualstudio.com/internal/_build/results?buildId=3022040&view=results)).

The Windows acceptance-test leg failed on `Invoke_TestTarget_With_Incompatible_Arch` (`MSBuildTests.Test.cs:216`). The test builds a test project for an incompatible architecture (arm64 on an x64 runner) and asserts the launch fails with the exact .NET message:

> The specified executable is not a valid application for this OS platform.

On this CI machine, launching the incompatible-arch apphost failed differently: `CreateProcess` failed but `GetLastError()` returned `0`, so .NET threw a raw `Win32Exception` (HResult `0x80004005`) whose message is:

> The operation completed successfully.

```
error MSB6003: The specified task executable "MSBuild Tests.exe" could not be run.
System.ComponentModel.Win32Exception (0x80004005): An error occurred trying to
start process '...\MSBuild Tests.exe' ... The operation completed successfully.
```

Because the exact native message isn't deterministic across Windows builds/runtime paths, the assertion was fragile. The test failing caused the Windows job to be cancelled (surfacing as a worker timeout).

## Fix

Relax the Windows assertion to accept **either** launch-failure message. The `MSB6003` + `"An error occurred trying to start process"` assertions above already prove the incompatible-arch apphost launch was reached, which is the actual intent of the test.

## Note on the other failure

The same build also shows `OneLocBuild` failing with `Octokit.AuthorizationException: Bad credentials`. That is an expired/invalid GitHub PAT pipeline secret consumed by the arcade `onelocbuild.yml` template — an infrastructure/token issue outside this repo's source, not addressed here.