### PR TITLE
Promote infra APIs to public [Experimental("TPINTERNAL")] and drop the first IVT

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -53,6 +53,10 @@
 
     <!-- Experimental test API usages are allowed inside this solution -->
     <NoWarn>$(NoWarn);TPEXP</NoWarn>
+    <!-- Infrastructure APIs (marked [Experimental("TPINTERNAL")]) are public only so first-party
+         extensions can consume them across the assembly boundary. External consumers still hit the
+         diagnostic; inside this solution the usage is expected, so suppress it centrally. -->
+    <NoWarn>$(NoWarn);TPINTERNAL</NoWarn>
     <!-- netfx and netstandard don't have nullability info so the IDE0370 warning should be suppressed -->
     <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.0' OR $(TargetFramework.StartsWith('net4')) OR '$(TargetFramework)' == '$(UwpMinimum)'">$(NoWarn);IDE0370</NoWarn>
   </PropertyGroup>

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderBase.cs
@@ -1,15 +1,32 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Platform.CommandLine;
 
-internal abstract class CommandLineOptionsProviderBase : ICommandLineOptionsProvider
+/// <summary>
+/// <b>Infrastructure.</b> Base class that implements the boilerplate of
+/// <see cref="ICommandLineOptionsProvider"/> for first-party command-line option providers.
+/// </summary>
+/// <remarks>
+/// <b>This type is not intended to be used directly from application code.</b> It is public only so
+/// that first-party platform extensions can derive from it across the assembly boundary without an
+/// <c>InternalsVisibleTo</c> grant. Its shape is an implementation detail; do not depend on it from
+/// your own code.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("TPINTERNAL")]
+public abstract class CommandLineOptionsProviderBase : ICommandLineOptionsProvider
 {
     private readonly IReadOnlyCollection<CommandLineOption> _commandLineOptions;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandLineOptionsProviderBase"/> class.
+    /// </summary>
     protected CommandLineOptionsProviderBase(
         string uid,
         string version,
@@ -24,6 +41,9 @@ internal abstract class CommandLineOptionsProviderBase : ICommandLineOptionsProv
         _commandLineOptions = commandLineOptions ?? throw new ArgumentNullException(nameof(commandLineOptions));
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandLineOptionsProviderBase"/> class from an extension.
+    /// </summary>
     protected CommandLineOptionsProviderBase(
         IExtension extension,
         IReadOnlyCollection<CommandLineOption> commandLineOptions)
@@ -36,21 +56,29 @@ internal abstract class CommandLineOptionsProviderBase : ICommandLineOptionsProv
     {
     }
 
+    /// <inheritdoc />
     public string Uid { get; }
 
+    /// <inheritdoc />
     public string Version { get; }
 
+    /// <inheritdoc />
     public string DisplayName { get; }
 
+    /// <inheritdoc />
     public string Description { get; }
 
+    /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
+    /// <inheritdoc />
     public IReadOnlyCollection<CommandLineOption> GetCommandLineOptions() => _commandLineOptions;
 
+    /// <inheritdoc />
     public virtual Task<ValidationResult> ValidateOptionArgumentsAsync(CommandLineOption commandOption, string[] arguments)
         => ValidationResult.ValidTask;
 
+    /// <inheritdoc />
     public virtual Task<ValidationResult> ValidateCommandLineOptionsAsync(ICommandLineOptions commandLineOptions)
         => ValidationResult.ValidTask;
 
@@ -103,6 +131,10 @@ internal abstract class CommandLineOptionsProviderBase : ICommandLineOptionsProv
             : null;
     }
 
+    /// <summary>
+    /// Returns a valid result when <paramref name="value"/> is one of <paramref name="allowedValues"/>
+    /// (case-insensitive), otherwise an invalid result formatted with <paramref name="formatString"/>.
+    /// </summary>
     protected static Task<ValidationResult> ValidateAllowedValuesAsync(string value, string[] allowedValues, string formatString)
         => allowedValues.Contains(value, StringComparer.OrdinalIgnoreCase)
             ? ValidationResult.ValidTask

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IClock.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IClock.cs
@@ -1,9 +1,27 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace Microsoft.Testing.Platform.Helpers;
 
-internal interface IClock
+/// <summary>
+/// <b>Infrastructure.</b> Abstraction over the system clock used by Microsoft.Testing.Platform
+/// and its first-party extensions.
+/// </summary>
+/// <remarks>
+/// <b>This type is not intended to be used directly from application code.</b> It is public only so
+/// that first-party platform extensions can consume it across the assembly boundary without an
+/// <c>InternalsVisibleTo</c> grant (its instances are provided by the platform's service provider,
+/// so it cannot be source-embedded). Its shape is an implementation detail; do not depend on it
+/// from your own code.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("TPINTERNAL")]
+public interface IClock
 {
+    /// <summary>
+    /// Gets the current date and time in Coordinated Universal Time (UTC).
+    /// </summary>
     DateTimeOffset UtcNow { get; }
 }

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Shipped.txt
@@ -428,6 +428,15 @@ Microsoft.Testing.Platform.CommandLine.CommandLineManager.AddProvider(System.Fun
 Microsoft.Testing.Platform.CommandLine.CommandLineManager.BuildAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! parseResult, System.IServiceProvider! serviceProvider, Microsoft.Testing.Platform.Configurations.IConfiguration! configuration) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.CommandLine.CommandLineHandler!>!
 Microsoft.Testing.Platform.CommandLine.CommandLineManager.CommandLineManager(Microsoft.Testing.Platform.Helpers.IRuntimeFeature! runtimeFeature, Microsoft.Testing.Platform.Services.ITestApplicationModuleInfo! testApplicationModuleInfo) -> void
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(string! uid, string! version, string! displayName, string! description, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Description.get -> string!
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.DisplayName.get -> string!
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.GetCommandLineOptions() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>!
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Uid.get -> string!
+Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Version.get -> string!
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache.CommandLineOptionsProviderCache() -> void
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache.CommandLineOptionsProviderCache(Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider! commandLineOptionsProvider) -> void
@@ -646,6 +655,8 @@ Microsoft.Testing.Platform.Helpers.IAsyncMonitor.LockAsync(System.Threading.Canc
 Microsoft.Testing.Platform.Helpers.IAsyncMonitor.LockAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<System.IDisposable!>!
 Microsoft.Testing.Platform.Helpers.IAsyncMonitorFactory
 Microsoft.Testing.Platform.Helpers.IAsyncMonitorFactory.Create() -> Microsoft.Testing.Platform.Helpers.IAsyncMonitor!
+Microsoft.Testing.Platform.Helpers.IClock
+Microsoft.Testing.Platform.Helpers.IClock.UtcNow.get -> System.DateTimeOffset
 Microsoft.Testing.Platform.Helpers.IConsole
 Microsoft.Testing.Platform.Helpers.IConsole.BufferHeight.get -> int
 Microsoft.Testing.Platform.Helpers.IConsole.BufferWidth.get -> int
@@ -2914,6 +2925,9 @@ static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsOnValue(string! argument) -> bool
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsValidBooleanArgument(string! argument) -> bool
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsValidBooleanAutoArgument(string! argument) -> bool
+static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string! mainOptionName, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string![]! mainOptionNames, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateAllowedValuesAsync(string! value, string![]! allowedValues, string! formatString) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsValidator.ValidateAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! commandLineParseResult, System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider!>! systemCommandLineOptionsProviders, System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider!>! extensionCommandLineOptionsProviders, Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Configurations.JsonCommandLineOptionEntry!>? jsonCommandLineOptions = null) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 static Microsoft.Testing.Platform.CommandLine.CommandLineParser.Parse(string![]! args, Microsoft.Testing.Platform.Helpers.IEnvironment! environment) -> Microsoft.Testing.Platform.CommandLine.CommandLineParseResult!
 static Microsoft.Testing.Platform.CommandLine.PlatformCommandLineProvider.GetMinimumExpectedTests(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> int
@@ -3182,6 +3196,7 @@ static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetRequired
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetRuntimeFeature(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IRuntimeFeature!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetServiceInternal<TService>(this System.IServiceProvider! provider) -> TService?
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetServicesInternal<TService>(this System.IServiceProvider! provider) -> System.Collections.Generic.IEnumerable<TService>!
+static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetSystemClock(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IClock!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTask(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.ITask!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTelemetryCollector(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Telemetry.ITelemetryCollector!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTelemetryInformation(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Telemetry.ITelemetryInformation!
@@ -3246,6 +3261,8 @@ System.Numerics.Hashing.HashHelpers
 System.Runtime.CompilerServices.CompilerLoweringPreserveAttribute
 System.Runtime.CompilerServices.CompilerLoweringPreserveAttribute.CompilerLoweringPreserveAttribute() -> void
 System.Text.StringBuilderExtensions
+virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateCommandLineOptionsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
+virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateOptionArgumentsAsync(Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption! commandOption, string![]! arguments) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.Description.get -> string!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.DisplayName.get -> string!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Shipped.txt
@@ -428,15 +428,6 @@ Microsoft.Testing.Platform.CommandLine.CommandLineManager.AddProvider(System.Fun
 Microsoft.Testing.Platform.CommandLine.CommandLineManager.BuildAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! parseResult, System.IServiceProvider! serviceProvider, Microsoft.Testing.Platform.Configurations.IConfiguration! configuration) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.CommandLine.CommandLineHandler!>!
 Microsoft.Testing.Platform.CommandLine.CommandLineManager.CommandLineManager(Microsoft.Testing.Platform.Helpers.IRuntimeFeature! runtimeFeature, Microsoft.Testing.Platform.Services.ITestApplicationModuleInfo! testApplicationModuleInfo) -> void
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(string! uid, string! version, string! displayName, string! description, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Description.get -> string!
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.DisplayName.get -> string!
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.GetCommandLineOptions() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>!
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Uid.get -> string!
-Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Version.get -> string!
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache.CommandLineOptionsProviderCache() -> void
 Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderCache.CommandLineOptionsProviderCache(Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider! commandLineOptionsProvider) -> void
@@ -655,8 +646,6 @@ Microsoft.Testing.Platform.Helpers.IAsyncMonitor.LockAsync(System.Threading.Canc
 Microsoft.Testing.Platform.Helpers.IAsyncMonitor.LockAsync(System.TimeSpan timeout) -> System.Threading.Tasks.Task<System.IDisposable!>!
 Microsoft.Testing.Platform.Helpers.IAsyncMonitorFactory
 Microsoft.Testing.Platform.Helpers.IAsyncMonitorFactory.Create() -> Microsoft.Testing.Platform.Helpers.IAsyncMonitor!
-Microsoft.Testing.Platform.Helpers.IClock
-Microsoft.Testing.Platform.Helpers.IClock.UtcNow.get -> System.DateTimeOffset
 Microsoft.Testing.Platform.Helpers.IConsole
 Microsoft.Testing.Platform.Helpers.IConsole.BufferHeight.get -> int
 Microsoft.Testing.Platform.Helpers.IConsole.BufferWidth.get -> int
@@ -2925,9 +2914,6 @@ static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsOnValue(string! argument) -> bool
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsValidBooleanArgument(string! argument) -> bool
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionArgumentValidator.IsValidBooleanAutoArgument(string! argument) -> bool
-static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string! mainOptionName, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
-static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string![]! mainOptionNames, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
-static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateAllowedValuesAsync(string! value, string![]! allowedValues, string! formatString) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsValidator.ValidateAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! commandLineParseResult, System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider!>! systemCommandLineOptionsProviders, System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.CommandLine.ICommandLineOptionsProvider!>! extensionCommandLineOptionsProviders, Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Configurations.JsonCommandLineOptionEntry!>? jsonCommandLineOptions = null) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 static Microsoft.Testing.Platform.CommandLine.CommandLineParser.Parse(string![]! args, Microsoft.Testing.Platform.Helpers.IEnvironment! environment) -> Microsoft.Testing.Platform.CommandLine.CommandLineParseResult!
 static Microsoft.Testing.Platform.CommandLine.PlatformCommandLineProvider.GetMinimumExpectedTests(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> int
@@ -3196,7 +3182,6 @@ static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetRequired
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetRuntimeFeature(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IRuntimeFeature!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetServiceInternal<TService>(this System.IServiceProvider! provider) -> TService?
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetServicesInternal<TService>(this System.IServiceProvider! provider) -> System.Collections.Generic.IEnumerable<TService>!
-static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetSystemClock(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IClock!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTask(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.ITask!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTelemetryCollector(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Telemetry.ITelemetryCollector!
 static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetTelemetryInformation(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Telemetry.ITelemetryInformation!
@@ -3261,8 +3246,6 @@ System.Numerics.Hashing.HashHelpers
 System.Runtime.CompilerServices.CompilerLoweringPreserveAttribute
 System.Runtime.CompilerServices.CompilerLoweringPreserveAttribute.CompilerLoweringPreserveAttribute() -> void
 System.Text.StringBuilderExtensions
-virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateCommandLineOptionsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
-virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateOptionArgumentsAsync(Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption! commandOption, string![]! arguments) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.Description.get -> string!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.DisplayName.get -> string!
 virtual Microsoft.Testing.Platform.Configurations.ConfigurationSourceBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -69,3 +69,20 @@ Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporterOptions.Slo
 Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.RecordTestDuration(string! testNodeUid, string! displayName, System.TimeSpan? duration) -> void
 Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.GetSlowestTests(int count) -> System.Collections.Generic.IReadOnlyList<(string! DisplayName, System.TimeSpan Duration)>!
 static Microsoft.Testing.Platform.OutputDevice.TerminalOutputDevice.GetSlowestTestsCount(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> int
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(string! uid, string! version, string! displayName, string! description, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Description.get -> string!
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.DisplayName.get -> string!
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.GetCommandLineOptions() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>!
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Uid.get -> string!
+*REMOVED*Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Version.get -> string!
+*REMOVED*Microsoft.Testing.Platform.Helpers.IClock
+*REMOVED*Microsoft.Testing.Platform.Helpers.IClock.UtcNow.get -> System.DateTimeOffset
+*REMOVED*static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string! mainOptionName, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+*REMOVED*static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string![]! mainOptionNames, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+*REMOVED*static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateAllowedValuesAsync(string! value, string![]! allowedValues, string! formatString) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
+*REMOVED*static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetSystemClock(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IClock!
+*REMOVED*virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateCommandLineOptionsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
+*REMOVED*virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateOptionArgumentsAsync(Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption! commandOption, string![]! arguments) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!

--- a/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
+++ b/src/Platform/Microsoft.Testing.Platform/Microsoft.Testing.Platform.csproj
@@ -60,7 +60,6 @@ This package provides the core platform and the .NET implementation of the proto
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.Telemetry" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.TrxReport" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.UnitTests" Key="$(VsPublicKey)" />
-    <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VideoRecorder" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.Testing.Extensions.VSTestBridge.UnitTests" Key="$(VsPublicKey)" />
     <!--

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,21 @@
 #nullable enable
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.CommandLineOptionsProviderBase(string! uid, string! version, string! displayName, string! description, System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>! commandLineOptions) -> void
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Description.get -> string!
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.DisplayName.get -> string!
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.GetCommandLineOptions() -> System.Collections.Generic.IReadOnlyCollection<Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption!>!
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Uid.get -> string!
+[TPINTERNAL]Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.Version.get -> string!
+[TPINTERNAL]Microsoft.Testing.Platform.Helpers.IClock
+[TPINTERNAL]Microsoft.Testing.Platform.Helpers.IClock.UtcNow.get -> System.DateTimeOffset
+[TPINTERNAL]static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string! mainOptionName, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+[TPINTERNAL]static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.RequiresMainOption(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! options, string![]! subOptionNames, string![]! mainOptionNames, System.Func<string!>! errorMessageFactory) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>?
+[TPINTERNAL]static Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateAllowedValuesAsync(string! value, string![]! allowedValues, string! formatString) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
+[TPINTERNAL]static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetSystemClock(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Helpers.IClock!
+[TPINTERNAL]virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateCommandLineOptionsAsync(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
+[TPINTERNAL]virtual Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase.ValidateOptionArgumentsAsync(Microsoft.Testing.Platform.Extensions.CommandLine.CommandLineOption! commandOption, string![]! arguments) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 [TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities
 [TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool
 [TPEXP]Microsoft.Testing.Platform.Services.IClientInfo.Capabilities.get -> Microsoft.Testing.Platform.Services.IClientCapabilities!

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
@@ -143,7 +145,14 @@ public static class ServiceProviderExtensions
     internal static ITestSessionContext GetTestSessionContext(this IServiceProvider serviceProvider)
         => serviceProvider.GetRequiredServiceInternal<ITestSessionContext>();
 
-    internal static IClock GetSystemClock(this IServiceProvider serviceProvider)
+    /// <summary>
+    /// <b>Infrastructure.</b> Gets the platform system clock. Not intended for direct use by application code.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The platform <see cref="IClock"/>.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Experimental("TPINTERNAL")]
+    public static IClock GetSystemClock(this IServiceProvider serviceProvider)
         => serviceProvider.GetRequiredServiceInternal<IClock>();
 
     internal static ITask GetTask(this IServiceProvider serviceProvider)


### PR DESCRIPTION
Follow-up to #9937 (embedding of static helpers). This tackles the platform internals that **cannot** be embedded because their instances cross the assembly boundary, by exposing them as guarded public **infrastructure** APIs — and drops the first `InternalsVisibleTo` grant as a result.

## Why not `[Embedded]`?

`IClock` (like `IEnvironment`/`ITask`) is a **DI service instance** the platform resolves and hands to extensions. Source-embedding it produces two distinct CLR types, so assignment across the boundary fails — verified empirically: `CS0436` (type conflict) + `CS1503` (cannot convert `platform!IClock` to the embedded copy). These must go **public**.

## The "public but not for you" pattern

- `[EditorBrowsable(EditorBrowsableState.Never)]` — hidden from IntelliSense.
- `[Experimental("TPINTERNAL")]` — a **distinct** diagnostic id from the real-preview `TPEXP`. External consumers hit a hard opt-in gate; first-party code suppresses it **centrally** in `Directory.Build.props` (next to the existing `TPEXP` suppression), so no per-project churn.
- An "Infrastructure — not intended for direct use" XML-doc block carries the intent (the `[Experimental]` message text is fixed).

`[Experimental]` was chosen over `[Obsolete(..., DiagnosticId=…)]` because `DiagnosticId`/`UrlFormat` on `ObsoleteAttribute` are net5+-only and the platform also targets netstandard2.0/net462 (where `ObsoleteAttribute` is a sealed, un-polyfillable BCL type). `[Experimental]` is fully polyfilled across all TFMs, and the id/consumers won't change if we swap the attribute later.

## Changes

Promoted in place (namespace unchanged — a `.Internal` rename would be **binary-breaking** for already-shipped extension binaries under NuGet up-unification; widening `internal→public` in place is binary-safe), moved from `InternalAPI` → `PublicAPI` with the `[TPINTERNAL]` prefix:

- `Microsoft.Testing.Platform.Helpers.IClock`
- `ServiceProviderExtensions.GetSystemClock` (its accessor)
- `Microsoft.Testing.Platform.CommandLine.CommandLineOptionsProviderBase` (base class extensions derive from)

**Result:** `Microsoft.Testing.Extensions.VideoRecorder` no longer needs any platform internal, so its `InternalsVisibleTo` grant is **removed** — the first IVT dropped end-to-end.

## Validation

- Platform, VideoRecorder (now **IVT-free**), all other reporters (AzureDevOps/GitHubActions/Html/JUnit), Telemetry/CrashDump/HangDump/TrxReport, and Platform.UnitTests build **0 warnings / 0 errors**.
- The central `TPINTERNAL` suppression carries every first-party consumer without per-project changes; external consumers still hit the gate.

## Follow-up

Dropping the remaining reporters' IVTs needs the same treatment for `IEnvironment`, `ITask`, `IFileSystem` (+`IFileStream`), `ITestApplicationModuleInfo` (+`ExecutableInfo`), and `ITestApplicationProcessExitCode` — a mechanical next tranche now that the pattern and central plumbing are in place.