### PR TITLE
Add assertion telemetry to Contains/DoesNotContain/StartsWith/EndsWith

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Contains.cs
@@ -25,7 +25,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(T expected, IEnumerable<T> collection, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -42,7 +45,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains(object? expected, IEnumerable collection, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -61,7 +67,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(T expected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -79,7 +88,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains(object? expected, IEnumerable collection, IEqualityComparer comparer, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -97,7 +109,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified collection contains the given element.
@@ -114,7 +129,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains(Func<object?, bool> predicate, IEnumerable collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    }
 
 #if NETCOREAPP3_1_OR_GREATER
 
@@ -134,7 +152,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(T expected, ReadOnlySpan<T> collection, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified span contains the given element.
@@ -207,7 +228,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(T expected, ReadOnlySpan<T> collection, IEqualityComparer<T> comparer, string? message = "", [CallerArgumentExpression(nameof(expected))] string expectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(expected, collection, comparer, "Assert.Contains", message, expectedExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified span contains the given element.
@@ -282,7 +306,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void Contains<T>(Func<T, bool> predicate, ReadOnlySpan<T> collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(predicate, collection, "Assert.Contains", message, predicateExpression, collectionExpression, shouldContain: true);
+    }
 
     /// <summary>
     /// Tests whether the specified span contains an element matching the given predicate.
@@ -403,7 +430,10 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not contain <paramref name="substring"/>.
     /// </exception>
     public static void Contains(string substring, string value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(substring))] string substringExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => ContainsCore(substring, value, comparisonType, "Assert.Contains", message, substringExpression, valueExpression, shouldContain: true);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.Contains");
+        ContainsCore(substring, value, comparisonType, "Assert.Contains", message, substringExpression, valueExpression, shouldContain: true);
+    }
 
     #endregion // Contains
     [DoesNotReturn]

--- a/src/TestFramework/TestFramework/Assertions/Assert.DoesNotContain.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.DoesNotContain.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Assertions/Assert.DoesNotContain.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.DoesNotContain.cs
@@ -26,7 +26,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(T notExpected, IEnumerable<T> collection, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -43,7 +46,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain(object? notExpected, IEnumerable collection, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -62,7 +68,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(T notExpected, IEnumerable<T> collection, IEqualityComparer<T> comparer, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -80,7 +89,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain(object? notExpected, IEnumerable collection, IEqualityComparer comparer, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -98,7 +110,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(Func<T, bool> predicate, IEnumerable<T> collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified collection does not contain the specified item.
@@ -115,7 +130,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain(Func<object?, bool> predicate, IEnumerable collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    }
 
 #if NETCOREAPP3_1_OR_GREATER
 
@@ -135,7 +153,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(T notExpected, ReadOnlySpan<T> collection, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified span does not contain the specified item.
@@ -208,7 +229,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(T notExpected, ReadOnlySpan<T> collection, IEqualityComparer<T> comparer, string? message = "", [CallerArgumentExpression(nameof(notExpected))] string notExpectedExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(notExpected, collection, comparer, "Assert.DoesNotContain", message, notExpectedExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified span does not contain the specified item.
@@ -283,7 +307,10 @@ public sealed partial class Assert
     /// Users shouldn't pass a value for this parameter.
     /// </param>
     public static void DoesNotContain<T>(Func<T, bool> predicate, ReadOnlySpan<T> collection, string? message = "", [CallerArgumentExpression(nameof(predicate))] string predicateExpression = "", [CallerArgumentExpression(nameof(collection))] string collectionExpression = "")
-        => ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(predicate, collection, "Assert.DoesNotContain", message, predicateExpression, collectionExpression, shouldContain: false);
+    }
 
     /// <summary>
     /// Tests whether the specified span does not contain an element matching the given predicate.
@@ -404,7 +431,10 @@ public sealed partial class Assert
     /// or <paramref name="value"/> contains <paramref name="substring"/>.
     /// </exception>
     public static void DoesNotContain(string substring, string value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(substring))] string substringExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => ContainsCore(substring, value, comparisonType, "Assert.DoesNotContain", message, substringExpression, valueExpression, shouldContain: false);
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotContain");
+        ContainsCore(substring, value, comparisonType, "Assert.DoesNotContain", message, substringExpression, valueExpression, shouldContain: false);
+    }
 
     #endregion // DoesNotContain
     [DoesNotReturn]

--- a/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -34,7 +34,7 @@ public sealed partial class Assert
     /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="expectedSuffix"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="expectedSuffix"/>.
+    /// or <paramref name="value"/> does not end with <paramref name="expectedSuffix"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? expectedSuffix, [NotNull] string? value, string? message = "", [CallerArgumentExpression(nameof(expectedSuffix))] string expectedSuffixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
         => EndsWith(expectedSuffix, value, StringComparison.Ordinal, message, expectedSuffixExpression, valueExpression);
@@ -68,7 +68,7 @@ public sealed partial class Assert
     /// </param>
     /// <exception cref="AssertFailedException">
     /// <paramref name="value"/> is null, or <paramref name="expectedSuffix"/> is null,
-    /// or <paramref name="value"/> does not start with <paramref name="expectedSuffix"/>.
+    /// or <paramref name="value"/> does not end with <paramref name="expectedSuffix"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? expectedSuffix, [NotNull] string? value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(expectedSuffix))] string expectedSuffixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
     {

--- a/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.EndsWith.cs
@@ -71,7 +71,9 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not start with <paramref name="expectedSuffix"/>.
     /// </exception>
     public static void EndsWith([NotNull] string? expectedSuffix, [NotNull] string? value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(expectedSuffix))] string expectedSuffixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => StartsOrEndsWithCore(
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.EndsWith");
+        StartsOrEndsWithCore(
             expectedSuffix,
             value,
             comparisonType,
@@ -83,6 +85,7 @@ public sealed partial class Assert
             shouldMatch: true,
             static (candidate, affix, comparison) => candidate.EndsWith(affix, comparison),
             ReportAssertEndsWithFailed);
+    }
 
     [DoesNotReturn]
     private static void ReportAssertEndsWithFailed(string expectedSuffix, string value, StringComparison comparisonType, string? userMessage, string expectedSuffixExpression, string valueExpression)
@@ -166,7 +169,9 @@ public sealed partial class Assert
     /// or <paramref name="value"/> ends with <paramref name="notExpectedSuffix"/>.
     /// </exception>
     public static void DoesNotEndWith([NotNull] string? notExpectedSuffix, [NotNull] string? value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(notExpectedSuffix))] string notExpectedSuffixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => StartsOrEndsWithCore(
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotEndWith");
+        StartsOrEndsWithCore(
             notExpectedSuffix,
             value,
             comparisonType,
@@ -178,6 +183,7 @@ public sealed partial class Assert
             shouldMatch: false,
             static (candidate, affix, comparison) => candidate.EndsWith(affix, comparison),
             ReportAssertDoesNotEndWithFailed);
+    }
 
     [DoesNotReturn]
     private static void ReportAssertDoesNotEndWithFailed(string notExpectedSuffix, string value, StringComparison comparisonType, string? userMessage, string notExpectedSuffixExpression, string valueExpression)

--- a/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StartsWith.cs
@@ -71,7 +71,9 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not start with <paramref name="expectedPrefix"/>.
     /// </exception>
     public static void StartsWith([NotNull] string? expectedPrefix, [NotNull] string? value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(expectedPrefix))] string expectedPrefixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => StartsOrEndsWithCore(
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.StartsWith");
+        StartsOrEndsWithCore(
             expectedPrefix,
             value,
             comparisonType,
@@ -83,6 +85,7 @@ public sealed partial class Assert
             shouldMatch: true,
             static (candidate, affix, comparison) => candidate.StartsWith(affix, comparison),
             ReportAssertStartsWithFailed);
+    }
 
     [DoesNotReturn]
     private static void ReportAssertStartsWithFailed(string expectedPrefix, string value, StringComparison comparisonType, string? userMessage, string expectedPrefixExpression, string valueExpression)
@@ -164,7 +167,9 @@ public sealed partial class Assert
     /// or <paramref name="value"/> does not start with <paramref name="notExpectedPrefix"/>.
     /// </exception>
     public static void DoesNotStartWith([NotNull] string? notExpectedPrefix, [NotNull] string? value, StringComparison comparisonType, string? message = "", [CallerArgumentExpression(nameof(notExpectedPrefix))] string notExpectedPrefixExpression = "", [CallerArgumentExpression(nameof(value))] string valueExpression = "")
-        => StartsOrEndsWithCore(
+    {
+        TelemetryCollector.TrackAssertionCall("Assert.DoesNotStartWith");
+        StartsOrEndsWithCore(
             notExpectedPrefix,
             value,
             comparisonType,
@@ -176,6 +181,7 @@ public sealed partial class Assert
             shouldMatch: false,
             static (candidate, affix, comparison) => candidate.StartsWith(affix, comparison),
             ReportAssertDoesNotStartWithFailed);
+    }
 
     [DoesNotReturn]
     private static void ReportAssertDoesNotStartWithFailed(string notExpectedPrefix, string value, StringComparison comparisonType, string? userMessage, string notExpectedPrefixExpression, string valueExpression)


### PR DESCRIPTION
Fixes #9950.

## Problem

`Assert.Contains`, `Assert.DoesNotContain`, `Assert.StartsWith`/`DoesNotStartWith`, and `Assert.EndsWith`/`DoesNotEndWith` were introduced without any `TelemetryCollector.TrackAssertionCall()` instrumentation. As a result these API families are invisible to the assertion-usage analytics pipeline that guides investment decisions (which APIs are worth extending, graduating out of experimental, or deprecating).

## Change

Added `TelemetryCollector.TrackAssertionCall(...)` to each affected file, following the existing `Assert.ContainsAll.cs` pattern:

- Tracking is placed **once per logical assertion** on the *primary* entry point — the overload that performs the actual work (calls `ContainsCore` / `StartsOrEndsWithCore`).
- Delegating overloads (e.g. `Span`→`ReadOnlySpan`, `Memory`→`Span`, the no-`StringComparison` string overloads) are left untracked because they forward to a tracked overload; this avoids double counting.

| File | Tracked assertion name(s) |
|------|---------------------------|
| `Assert.Contains.cs` | `Assert.Contains` (10 primary overloads) |
| `Assert.DoesNotContain.cs` | `Assert.DoesNotContain` (10 primary overloads) |
| `Assert.StartsWith.cs` | `Assert.StartsWith`, `Assert.DoesNotStartWith` |
| `Assert.EndsWith.cs` | `Assert.EndsWith`, `Assert.DoesNotEndWith` |

Some expression-bodied overloads were converted to block bodies to host the tracking call.

## Validation

- `build.cmd -c Debug` on `TestFramework.csproj`: **0 warnings, 0 errors** (net462 / netstandard2.0 / net8.0 / net9.0).
- `TestFramework.UnitTests` `AssertTests`: **1086/1086 passing** — no behavioral regression.

## Follow-ups (out of scope)

Tasks 4 (a CI safety-net test enforcing telemetry completeness) and 5 (CONTRIBUTING.md guidance) from the issue are intentionally left as separate follow-ups to keep this PR focused on closing the actual coverage gap. Both proposed test approaches (env-var-driven drain, or source-path scanning) carry flakiness/portability risk that warrants separate design discussion.