### PR TITLE
Cache ParamArrayAttribute reflection in TestMethodInfo

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
@@ -15,11 +15,12 @@ internal partial class TestMethodInfo
         // array, so sharing the cached instance is safe.
         ParameterInfo[] parametersInfo = ParameterTypes;
 
-        // Use the lazily-computed, cached parameter metadata instead of re-scanning attributes on every
-        // call. For a data-driven test with N rows this avoids N redundant reflective attribute lookups.
-        EnsureParameterInfoComputed();
-        int requiredParameterCount = _requiredParameterCount;
-        bool hasParamsValue = _paramsParameterIndex >= 0;
+        // Use the shared, per-method cached parameter metadata instead of re-scanning attributes on every
+        // call. The metadata is a pure function of the method, so it is computed once per test method and
+        // reused across all data rows regardless of whether they share a TestMethodInfo instance.
+        ParameterMetadata metadata = GetParameterMetadata();
+        int requiredParameterCount = metadata.RequiredParameterCount;
+        bool hasParamsValue = metadata.HasParams;
         object? paramsValues = null;
 
         // If all the parameters are required, we have fewer arguments

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.ArgumentResolution.cs
@@ -14,26 +14,13 @@ internal partial class TestMethodInfo
         // (which allocates a fresh ParameterInfo[] on every call). ResolveArguments only reads the
         // array, so sharing the cached instance is safe.
         ParameterInfo[] parametersInfo = ParameterTypes;
-        int requiredParameterCount = 0;
-        bool hasParamsValue = false;
-        object? paramsValues = null;
-        foreach (ParameterInfo parameter in parametersInfo)
-        {
-            // If this is a params array parameter, create an instance to
-            // populate with any extra values provided. Don't increment
-            // required parameter count - params arguments are not actually required
-            if (parameter.GetCustomAttribute<ParamArrayAttribute>() != null)
-            {
-                hasParamsValue = true;
-                break;
-            }
 
-            // Count required parameters from method
-            if (!parameter.IsOptional)
-            {
-                requiredParameterCount++;
-            }
-        }
+        // Use the lazily-computed, cached parameter metadata instead of re-scanning attributes on every
+        // call. For a data-driven test with N rows this avoids N redundant reflective attribute lookups.
+        EnsureParameterInfoComputed();
+        int requiredParameterCount = _requiredParameterCount;
+        bool hasParamsValue = _paramsParameterIndex >= 0;
+        object? paramsValues = null;
 
         // If all the parameters are required, we have fewer arguments
         // supplied than required, or more arguments than the method takes

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -77,19 +77,21 @@ internal partial class TestMethodInfo : ITestMethod
     // re-run a reflective attribute scan for it. This is shared across TestMethodInfo instances, so even the
     // default execution path — where discovery unfolds data sources and each row constructs a fresh
     // TestMethodInfo — performs the scan only once per test method rather than once per row.
-    private static readonly ConcurrentDictionary<MethodInfo, ParameterMetadata> ParameterMetadataCache = new();
+    // The Lazy ensures the scan runs exactly once per method even when method-level parallelization lets
+    // several unfolded rows reach the miss path concurrently.
+    private static readonly ConcurrentDictionary<MethodInfo, Lazy<ParameterMetadata>> ParameterMetadataCache = new();
 
     private ParameterMetadata GetParameterMetadata()
     {
-        if (!ParameterMetadataCache.TryGetValue(MethodInfo, out ParameterMetadata metadata))
+        if (!ParameterMetadataCache.TryGetValue(MethodInfo, out Lazy<ParameterMetadata>? metadata))
         {
-            // Racing threads may compute this concurrently, but the result is a pure function of the method,
-            // so every writer stores the same value and last-write-wins is safe.
-            metadata = ParameterMetadata.Compute(ParameterTypes);
-            ParameterMetadataCache[MethodInfo] = metadata;
+            ParameterInfo[] parametersInfo = ParameterTypes;
+            metadata = ParameterMetadataCache.GetOrAdd(
+                MethodInfo,
+                _ => new Lazy<ParameterMetadata>(() => ParameterMetadata.Compute(parametersInfo), isThreadSafe: true));
         }
 
-        return metadata;
+        return metadata.Value;
     }
 
     private readonly record struct ParameterMetadata(int ParamsParameterIndex, int RequiredParameterCount)
@@ -105,7 +107,7 @@ internal partial class TestMethodInfo : ITestMethod
                 ParameterInfo parameter = parametersInfo[i];
 
                 // A params array parameter is not required and, when present, is always the last parameter.
-                // Use IsDefined rather than GetCustomAttribute to avoid materializing (and boxing) the attribute.
+                // Use IsDefined rather than GetCustomAttribute to avoid materializing the attribute instance.
                 if (parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false))
                 {
                     paramsParameterIndex = i;

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -85,12 +85,20 @@ internal partial class TestMethodInfo : ITestMethod
     // can assert that repeated and concurrent access for one MethodInfo collapses to a single computation.
     private static int s_parameterMetadataScanCount;
 
+    // Test-only callback invoked at the start of each parameter scan. Tests use it to hold a scan open long
+    // enough to make competing cache misses race deterministically. Never set outside tests.
+    private static Action? s_onParameterMetadataScanForTesting;
+
     internal static int ParameterMetadataScanCount => s_parameterMetadataScanCount;
+
+    internal static void SetParameterMetadataScanCallbackForTesting(Action? callback)
+        => s_onParameterMetadataScanForTesting = callback;
 
     internal static void ResetParameterMetadataCacheForTesting()
     {
         ParameterMetadataCache.Clear();
         Interlocked.Exchange(ref s_parameterMetadataScanCount, 0);
+        s_onParameterMetadataScanForTesting = null;
     }
 
     private ParameterMetadata GetParameterMetadata()
@@ -113,6 +121,7 @@ internal partial class TestMethodInfo : ITestMethod
         internal static ParameterMetadata Compute(ParameterInfo[] parametersInfo)
         {
             Interlocked.Increment(ref s_parameterMetadataScanCount);
+            s_onParameterMetadataScanForTesting?.Invoke();
             int requiredParameterCount = 0;
             int paramsParameterIndex = -1;
             for (int i = 0; i < parametersInfo.Length; i++)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -72,46 +72,54 @@ internal partial class TestMethodInfo : ITestMethod
     /// <inheritdoc />
     ParameterInfo[] ITestMethod.ParameterTypes => (ParameterInfo[])ParameterTypes.Clone();
 
-    // Cached parameter metadata used by ResolveArguments so it does not re-run a reflective attribute
-    // scan on every invocation. For a data-driven test with N rows this collapses N redundant scans into one.
-    // _paramsParameterIndex is the 0-based index of the params parameter (-1 if none); -2 is the
-    // "not computed yet" sentinel. _requiredParameterCount is the number of required (non-optional,
-    // non-params) parameters. Both are populated together by EnsureParameterInfoComputed().
-    private int _paramsParameterIndex = -2;
-    private int _requiredParameterCount;
+    // Immutable parameter metadata (params-parameter index and required-parameter count) is a pure function
+    // of the MethodInfo. It is cached at process scope keyed by MethodInfo so that ResolveArguments does not
+    // re-run a reflective attribute scan for it. This is shared across TestMethodInfo instances, so even the
+    // default execution path — where discovery unfolds data sources and each row constructs a fresh
+    // TestMethodInfo — performs the scan only once per test method rather than once per row.
+    private static readonly ConcurrentDictionary<MethodInfo, ParameterMetadata> ParameterMetadataCache = new();
 
-    private void EnsureParameterInfoComputed()
+    private ParameterMetadata GetParameterMetadata()
     {
-        if (_paramsParameterIndex != -2)
+        if (!ParameterMetadataCache.TryGetValue(MethodInfo, out ParameterMetadata metadata))
         {
-            return;
+            // Racing threads may compute this concurrently, but the result is a pure function of the method,
+            // so every writer stores the same value and last-write-wins is safe.
+            metadata = ParameterMetadata.Compute(ParameterTypes);
+            ParameterMetadataCache[MethodInfo] = metadata;
         }
 
-        ParameterInfo[] parametersInfo = ParameterTypes;
-        int requiredParameterCount = 0;
-        int paramsParameterIndex = -1;
-        for (int i = 0; i < parametersInfo.Length; i++)
+        return metadata;
+    }
+
+    private readonly record struct ParameterMetadata(int ParamsParameterIndex, int RequiredParameterCount)
+    {
+        internal bool HasParams => ParamsParameterIndex >= 0;
+
+        internal static ParameterMetadata Compute(ParameterInfo[] parametersInfo)
         {
-            ParameterInfo parameter = parametersInfo[i];
-
-            // A params array parameter is not required and, when present, is always the last parameter.
-            // Use IsDefined rather than GetCustomAttribute to avoid materializing (and boxing) the attribute.
-            if (parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false))
+            int requiredParameterCount = 0;
+            int paramsParameterIndex = -1;
+            for (int i = 0; i < parametersInfo.Length; i++)
             {
-                paramsParameterIndex = i;
-                break;
+                ParameterInfo parameter = parametersInfo[i];
+
+                // A params array parameter is not required and, when present, is always the last parameter.
+                // Use IsDefined rather than GetCustomAttribute to avoid materializing (and boxing) the attribute.
+                if (parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false))
+                {
+                    paramsParameterIndex = i;
+                    break;
+                }
+
+                if (!parameter.IsOptional)
+                {
+                    requiredParameterCount++;
+                }
             }
 
-            if (!parameter.IsOptional)
-            {
-                requiredParameterCount++;
-            }
+            return new ParameterMetadata(paramsParameterIndex, requiredParameterCount);
         }
-
-        // Write the required count before flipping the sentinel so that any reader observing a
-        // non-sentinel _paramsParameterIndex is guaranteed to also see the correct _requiredParameterCount.
-        _requiredParameterCount = requiredParameterCount;
-        _paramsParameterIndex = paramsParameterIndex;
     }
 
     /// <summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -72,6 +72,48 @@ internal partial class TestMethodInfo : ITestMethod
     /// <inheritdoc />
     ParameterInfo[] ITestMethod.ParameterTypes => (ParameterInfo[])ParameterTypes.Clone();
 
+    // Cached parameter metadata used by ResolveArguments so it does not re-run a reflective attribute
+    // scan on every invocation. For a data-driven test with N rows this collapses N redundant scans into one.
+    // _paramsParameterIndex is the 0-based index of the params parameter (-1 if none); -2 is the
+    // "not computed yet" sentinel. _requiredParameterCount is the number of required (non-optional,
+    // non-params) parameters. Both are populated together by EnsureParameterInfoComputed().
+    private int _paramsParameterIndex = -2;
+    private int _requiredParameterCount;
+
+    private void EnsureParameterInfoComputed()
+    {
+        if (_paramsParameterIndex != -2)
+        {
+            return;
+        }
+
+        ParameterInfo[] parametersInfo = ParameterTypes;
+        int requiredParameterCount = 0;
+        int paramsParameterIndex = -1;
+        for (int i = 0; i < parametersInfo.Length; i++)
+        {
+            ParameterInfo parameter = parametersInfo[i];
+
+            // A params array parameter is not required and, when present, is always the last parameter.
+            // Use IsDefined rather than GetCustomAttribute to avoid materializing (and boxing) the attribute.
+            if (parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false))
+            {
+                paramsParameterIndex = i;
+                break;
+            }
+
+            if (!parameter.IsOptional)
+            {
+                requiredParameterCount++;
+            }
+        }
+
+        // Write the required count before flipping the sentinel so that any reader observing a
+        // non-sentinel _paramsParameterIndex is guaranteed to also see the correct _requiredParameterCount.
+        _requiredParameterCount = requiredParameterCount;
+        _paramsParameterIndex = paramsParameterIndex;
+    }
+
     /// <summary>
     /// Gets the return type of the test method.
     /// </summary>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.cs
@@ -81,6 +81,18 @@ internal partial class TestMethodInfo : ITestMethod
     // several unfolded rows reach the miss path concurrently.
     private static readonly ConcurrentDictionary<MethodInfo, Lazy<ParameterMetadata>> ParameterMetadataCache = new();
 
+    // Test-only instrumentation counting how many times the reflective parameter scan actually ran, so tests
+    // can assert that repeated and concurrent access for one MethodInfo collapses to a single computation.
+    private static int s_parameterMetadataScanCount;
+
+    internal static int ParameterMetadataScanCount => s_parameterMetadataScanCount;
+
+    internal static void ResetParameterMetadataCacheForTesting()
+    {
+        ParameterMetadataCache.Clear();
+        Interlocked.Exchange(ref s_parameterMetadataScanCount, 0);
+    }
+
     private ParameterMetadata GetParameterMetadata()
     {
         if (!ParameterMetadataCache.TryGetValue(MethodInfo, out Lazy<ParameterMetadata>? metadata))
@@ -100,6 +112,7 @@ internal partial class TestMethodInfo : ITestMethod
 
         internal static ParameterMetadata Compute(ParameterInfo[] parametersInfo)
         {
+            Interlocked.Increment(ref s_parameterMetadataScanCount);
             int requiredParameterCount = 0;
             int paramsParameterIndex = -1;
             for (int i = 0; i < parametersInfo.Length; i++)

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.get -> System.Guid?
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.set -> void
+static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ParameterMetadataScanCount.get -> int
+static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ResetParameterMetadataCacheForTesting() -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.RuntimeContext.IsMultiThreaded.get -> bool

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -3,4 +3,5 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestEleme
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.set -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ParameterMetadataScanCount.get -> int
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ResetParameterMetadataCacheForTesting() -> void
+static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.SetParameterMetadataScanCallbackForTesting(System.Action? callback) -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.RuntimeContext.IsMultiThreaded.get -> bool

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -1777,7 +1777,69 @@ public class TestMethodInfoTests : TestContainer
         ((string[])expectedArguments[1]).SequenceEqual((string[])resolvedArguments[1]!).Should().BeTrue();
     }
 
-    // Regression tests for https://github.com/microsoft/testfx/issues/7846
+    // Regression test for https://github.com/microsoft/testfx/issues/9949
+    // The params/required parameter metadata is a pure function of the MethodInfo and is cached at process
+    // scope keyed by MethodInfo. Discovery unfolds data sources by default, so each row constructs a fresh
+    // TestMethodInfo for the same MethodInfo; the reflective scan must still run only once across them.
+    public void ResolveArguments_ComputesParameterMetadataOncePerMethodAcrossInstances()
+    {
+        TestMethodInfo.ResetParameterMetadataCacheForTesting();
+        MethodInfo paramsArgumentMethod = typeof(DummyTestClass).GetMethod("DummyParamsArgumentMethod")!;
+
+        for (int i = 0; i < 5; i++)
+        {
+            var method = new TestMethodInfo(paramsArgumentMethod, _testClassInfo)
+            {
+                TimeoutInfo = TimeoutInfo.FromTimeout(3600 * 1000),
+                Executor = _testMethodAttribute,
+            };
+
+            object?[] resolvedArguments = method.ResolveArguments([i, "str1", "str2"]);
+            resolvedArguments.Length.Should().Be(2);
+            resolvedArguments[1].Should().BeOfType<string[]>();
+        }
+
+        TestMethodInfo.ParameterMetadataScanCount.Should().Be(1);
+    }
+
+    // Regression test for https://github.com/microsoft/testfx/issues/9949
+    // Under method-level parallelization several rows for the same MethodInfo can reach the cache-miss path
+    // concurrently. The Lazy execution-and-publication cache must still collapse them to a single scan.
+    public async Task ResolveArguments_ComputesParameterMetadataOnceUnderConcurrentFirstAccess()
+    {
+        TestMethodInfo.ResetParameterMetadataCacheForTesting();
+        MethodInfo paramsArgumentMethod = typeof(DummyTestClass).GetMethod("DummyParamsArgumentMethod")!;
+
+        const int concurrency = 32;
+        using var startGate = new ManualResetEventSlim(false);
+        var tasks = new Task<object?[]>[concurrency];
+        for (int i = 0; i < concurrency; i++)
+        {
+            tasks[i] = Task.Run(() =>
+            {
+                var method = new TestMethodInfo(paramsArgumentMethod, _testClassInfo)
+                {
+                    TimeoutInfo = TimeoutInfo.FromTimeout(3600 * 1000),
+                    Executor = _testMethodAttribute,
+                };
+
+                // Release all threads at once to maximize the chance of a concurrent first access.
+                startGate.Wait();
+                return method.ResolveArguments([1, "str1", "str2"]);
+            });
+        }
+
+        startGate.Set();
+        object?[][] results = await Task.WhenAll(tasks);
+
+        TestMethodInfo.ParameterMetadataScanCount.Should().Be(1);
+        foreach (object?[] resolvedArguments in results)
+        {
+            resolvedArguments.Length.Should().Be(2);
+            resolvedArguments[1].Should().BeOfType<string[]>();
+        }
+    }
+
     // Verify that log output buffers are cleared between invocations to prevent
     // exponential memory growth with DynamicData tests.
     // NOTE: The TestClassInfo (class init/cleanup) and UnitTestRunner (assembly init/cleanup)

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -1805,38 +1805,69 @@ public class TestMethodInfoTests : TestContainer
     // Regression test for https://github.com/microsoft/testfx/issues/9949
     // Under method-level parallelization several rows for the same MethodInfo can reach the cache-miss path
     // concurrently. The Lazy execution-and-publication cache must still collapse them to a single scan.
+    // The test is made deterministic by (1) confirming every worker is parked before releasing them together
+    // and (2) holding the first scan open (via a callback) so competing workers provably reach the still-empty
+    // cache while it runs — a direct compute-then-store cache would record more than one scan here.
     public async Task ResolveArguments_ComputesParameterMetadataOnceUnderConcurrentFirstAccess()
     {
         TestMethodInfo.ResetParameterMetadataCacheForTesting();
         MethodInfo paramsArgumentMethod = typeof(DummyTestClass).GetMethod("DummyParamsArgumentMethod")!;
 
-        const int concurrency = 32;
+        const int concurrency = 8;
         using var startGate = new ManualResetEventSlim(false);
-        var tasks = new Task<object?[]>[concurrency];
-        for (int i = 0; i < concurrency; i++)
+        using var scanStarted = new ManualResetEventSlim(false);
+        using var releaseScan = new ManualResetEventSlim(false);
+        int parkedWorkers = 0;
+
+        // Hold the first scan open until the test releases it, so any competing misses accumulate meanwhile.
+        TestMethodInfo.SetParameterMetadataScanCallbackForTesting(() =>
         {
-            tasks[i] = Task.Run(() =>
+            scanStarted.Set();
+            releaseScan.Wait();
+        });
+
+        try
+        {
+            var tasks = new Task<object?[]>[concurrency];
+            for (int i = 0; i < concurrency; i++)
             {
-                var method = new TestMethodInfo(paramsArgumentMethod, _testClassInfo)
+                tasks[i] = Task.Run(() =>
                 {
-                    TimeoutInfo = TimeoutInfo.FromTimeout(3600 * 1000),
-                    Executor = _testMethodAttribute,
-                };
+                    var method = new TestMethodInfo(paramsArgumentMethod, _testClassInfo)
+                    {
+                        TimeoutInfo = TimeoutInfo.FromTimeout(3600 * 1000),
+                        Executor = _testMethodAttribute,
+                    };
 
-                // Release all threads at once to maximize the chance of a concurrent first access.
-                startGate.Wait();
-                return method.ResolveArguments([1, "str1", "str2"]);
-            });
+                    Interlocked.Increment(ref parkedWorkers);
+                    startGate.Wait();
+                    return method.ResolveArguments([1, "str1", "str2"]);
+                });
+            }
+
+            // Release the workers only once all of them are provably waiting at the gate.
+            SpinWait.SpinUntil(() => Volatile.Read(ref parkedWorkers) == concurrency);
+            startGate.Set();
+
+            // Wait until one scan is in progress, then give the other workers time to hit the cache-miss
+            // path before letting the scan finish and publish its result.
+            scanStarted.Wait();
+            Thread.Sleep(100);
+            releaseScan.Set();
+
+            object?[][] results = await Task.WhenAll(tasks);
+
+            TestMethodInfo.ParameterMetadataScanCount.Should().Be(1);
+            foreach (object?[] resolvedArguments in results)
+            {
+                resolvedArguments.Length.Should().Be(2);
+                resolvedArguments[1].Should().BeOfType<string[]>();
+            }
         }
-
-        startGate.Set();
-        object?[][] results = await Task.WhenAll(tasks);
-
-        TestMethodInfo.ParameterMetadataScanCount.Should().Be(1);
-        foreach (object?[] resolvedArguments in results)
+        finally
         {
-            resolvedArguments.Length.Should().Be(2);
-            resolvedArguments[1].Should().BeOfType<string[]>();
+            releaseScan.Set();
+            TestMethodInfo.SetParameterMetadataScanCallbackForTesting(null);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #9949.

For data-driven test methods (`[DataRow]`, `[DynamicData]`, …), `ResolveArguments()` in `TestMethodInfo` performed a per-invocation reflection scan to detect the `params` parameter and count the required parameters — calling `parameter.GetCustomAttribute<ParamArrayAttribute>()` and `parameter.IsOptional` on **every** call. Because discovery unfolds data sources by default, each data row constructs a fresh `TestMethodInfo` for the same `MethodInfo`, so this reflective work was repeated once per row.

## Changes

- Introduced a `ParameterMetadata` `readonly record struct` holding the `params`-parameter index (`-1` if absent) and the required (non-optional, non-`params`) parameter count.
- The metadata is a pure function of the `MethodInfo`, so it is cached at **process scope** in a `static ConcurrentDictionary<MethodInfo, Lazy<ParameterMetadata>>`. The cache is shared across `TestMethodInfo` instances, so the reflective scan runs **once per test method** regardless of how many rows/instances there are — including the default unfolded execution path.
- The value is a `Lazy<ParameterMetadata>` (`isThreadSafe: true`), using execution-and-publication so that even under method-level parallelization, where several rows can hit the cache-miss path concurrently, the scan executes exactly once.
- The scan uses `IsDefined(typeof(ParamArrayAttribute), inherit: false)` instead of `GetCustomAttribute<ParamArrayAttribute>()`, avoiding materialization of an attribute instance.
- `ResolveArguments()` now reads the cached `ParameterMetadata` instead of re-scanning on every call.

## Impact

| Scenario | Before | After |
|---|---|---|
| 1 000-row data-driven test (default unfolded) | ~1 000 reflective scans (one per row's fresh `TestMethodInfo`) | 1 scan per test method |
| Non-data-driven test | 1 reflective scan | 1 scan (`IsDefined`, no attribute instance) |

This turns the O(N) reflective attribute lookups into O(1) per test method. Behavior is unchanged.

## Testing

- Added two regression tests in `TestMethodInfoTests` (backed by internal `ParameterMetadataScanCount` / `ResetParameterMetadataCacheForTesting` test hooks) that assert the scan runs exactly once:
  - across multiple `TestMethodInfo` instances for one `MethodInfo` (the default unfolded path);
  - under concurrent first access (method-level parallelization).
- Builds clean across all target frameworks; `MSTestAdapter.PlatformServices.UnitTests` (covering `ResolveArguments` across required/optional/`params`/over- and under-supplied argument paths) pass on net462, net48, net8.0, net9.0, and net8.0-windows.