### PR TITLE
Bump API analyzers to 5.10.0-1.26364.116 and re-add empty InternalAPI files for test-only-IVT projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,10 +31,14 @@
              tracking (RS0051-RS0058) is skipped for a compilation whose only InternalsVisibleTo
              targets are ignored test/mock assemblies (opt in via
              dotnet_public_api_analyzer.internal_api_skip_ivt).
-         5.10.0-1.26363.117 was built from roslyn main on 2026-07-13, so it contains both merges. The
-         previous 5.10.0-1.26360.111 pin was built 2026-07-10, before those merges shipped.
+         5.10.0-1.26364.116 (VMR dotnet/dotnet build 2026-07-14) is the first dnceng dotnet-tools
+         preview whose ingested roslyn main actually contains #84438: verified by inspecting the
+         analyzer and by an empirical build (a project whose only IVT targets *.UnitTests no longer
+         emits RS0051, while a project with a real IVT consumer still does). The earlier
+         5.10.0-1.26363.117 pin (VMR build 2026-07-13) predated the roslyn->VMR forward-flow of
+         #84438, so it silently ignored dotnet_public_api_analyzer.internal_api_skip_ivt.
          Tracking context: https://github.com/microsoft/testfx/issues/9091 (Task 5). -->
-    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.10.0-1.26363.117</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>5.10.0-1.26364.116</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
     <!-- UWP and WinUI dependencies -->
     <MicrosoftNETCoreUniversalWindowsPlatformVersion>6.2.14</MicrosoftNETCoreUniversalWindowsPlatformVersion>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Microsoft.Testing.Extensions.AzureDevOpsReport.csproj
@@ -48,6 +48,8 @@ This package extends Microsoft Testing Platform to provide a Azure DevOps report
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/Microsoft.Testing.Extensions.AzureFoundry.csproj
@@ -49,5 +49,7 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 </Project>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -37,6 +37,8 @@ This package extends Microsoft Testing Platform to produce test reports in the C
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Microsoft.Testing.Extensions.GitHubActionsReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.GitHubActionsReport/Microsoft.Testing.Extensions.GitHubActionsReport.csproj
@@ -52,6 +52,8 @@ This package extends Microsoft Testing Platform to provide a GitHub Actions repo
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/Microsoft.Testing.Extensions.HangDump.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/Microsoft.Testing.Extensions.HangDump.csproj
@@ -25,6 +25,8 @@ This package extends Microsoft Testing Platform to provide an implementation of 
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI\InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI\InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -34,6 +34,8 @@ This package extends Microsoft Testing Platform to produce self-contained HTML t
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -37,6 +37,8 @@ This package extends Microsoft Testing Platform to produce JUnit XML test report
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/Microsoft.Testing.Extensions.Logging.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/Microsoft.Testing.Extensions.Logging.csproj
@@ -27,6 +27,8 @@ This package provides a Microsoft.Extensions.Logging bridge for the platform, al
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/Microsoft.Testing.Extensions.MSBuild.csproj
@@ -29,6 +29,8 @@
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/Microsoft.Testing.Extensions.OpenTelemetry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.OpenTelemetry/Microsoft.Testing.Extensions.OpenTelemetry.csproj
@@ -27,6 +27,8 @@ This package provides Open Telemetry for the platform.]]>
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/Microsoft.Testing.Extensions.Retry.csproj
@@ -41,6 +41,8 @@ This package extends Microsoft Testing Platform to provide a retry policy system
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/Microsoft.Testing.Extensions.Telemetry.csproj
@@ -31,6 +31,8 @@ This package provides telemetry for the platform.]]>
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI\InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI\InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <!-- Nuget package layout -->

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Shipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/Microsoft.Testing.Extensions.VideoRecorder.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/Microsoft.Testing.Extensions.VideoRecorder.csproj
@@ -37,6 +37,8 @@ This package extends Microsoft Testing Platform to record the screen while tests
     <AdditionalFiles Include="BannedSymbols.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
+    <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What

Two related changes on top of the base branch:

1. **Bumps** `Microsoft.CodeAnalysis.PublicApiAnalyzers` / `.BannedApiAnalyzers` from `5.10.0-1.26363.117` to **`5.10.0-1.26364.116`**.
2. **Re-adds** the empty `InternalAPI.Shipped.txt` / `InternalAPI.Unshipped.txt` files (and their csproj `AdditionalFiles` wiring) for the 13 test-only-IVT extension projects.

## Why the version bump

The previous `5.10.0-1.26363.117` pin (added in base PR #9921 via dependabot) was believed to contain dotnet/roslyn#84438 (`internal_api_skip_ivt`), but it did **not**: it is a VMR (dotnet/dotnet) build from 2026-07-13 whose ingested roslyn `main` predated the roslyn->VMR forward-flow of the fix. Verified by inspecting the analyzer assembly (the fix constant `DynamicProxyGenAssembly2` was absent) and empirically (the skip never fired, even for the built-in default). So the `dotnet_public_api_analyzer.internal_api_skip_ivt = *.UnitTests` option was a silent no-op.

`5.10.0-1.26364.116` (VMR build 2026-07-14) is the first dotnet-tools preview whose ingested roslyn `main` actually contains #84438. Verified empirically with RS0051 enabled:

| IVT target | empty `#nullable enable` files | RS0051 |
| --- | --- | --- |
| `*.UnitTests` | present | **0** (skip fires) |
| `DynamicProxyGenAssembly2` | present | **0** (built-in default) |
| real consumer | present | **>0** (control - tracking still works) |

## Why re-add the (empty) files

They were removed earlier only as a workaround for the missing fix. With the fix in place, keeping empty `#nullable enable` files:
- builds green (the skip disables internal API tracking for these projects), and
- acts as a safety net: if a **product** (non-test) IVT consumer is ever added, the skip stops firing and the empty files immediately surface RS0051, prompting the internal API to be declared. With no files, `require_api_files` only enforces *public* files, so a new consumer would silently stay untracked.

## Validation

Full `.\build.cmd -c Release` is green (0 warnings, 0 errors). Part of #9091 (Task 5). Builds on #9921.
