### PR TITLE
test: add edge-case tests for TestClassShouldBeValidAnalyzer static-class guard

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassShouldBeValidAnalyzerTests.cs
@@ -586,7 +586,7 @@ public sealed class TestClassShouldBeValidAnalyzerTests
             public static class MyStaticClass
             {
                 [GlobalTestInitialize]
-                public static void GlobalInit()
+                public static void GlobalInit(TestContext testContext)
                 {
                 }
             }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestClassShouldBeValidAnalyzerTests.cs
@@ -545,4 +545,53 @@ public sealed class TestClassShouldBeValidAnalyzerTests
                 .WithArguments("MyTestClass"),
             fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenStaticTestClassContainsDerivedTestMethodAttribute_Diagnostic()
+    {
+        // The static-class guard uses Inherits() for TestMethodAttribute subclasses,
+        // so [DataTestMethod] (which inherits from [TestMethod]) triggers the diagnostic
+        // because static classes cannot be test classes.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public static class {|#0:MyStaticClass|}
+            {
+                [DataTestMethod]
+                [DataRow(1)]
+                public static void MyTestMethod(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestClassShouldBeValidAnalyzer.TestClassShouldBeValidRule)
+                .WithLocation(0)
+                .WithArguments("MyStaticClass"));
+    }
+
+    [TestMethod]
+    public async Task WhenStaticTestClassContainsGlobalTestInitialize_NoDiagnostic()
+    {
+        // The static-class guard only checks TestInitialize, TestCleanup, ClassInitialize,
+        // ClassCleanup, and TestMethod-derived attributes. GlobalTestInitialize is NOT in
+        // that list, so a static [TestClass] containing only [GlobalTestInitialize] is valid.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public static class MyStaticClass
+            {
+                [GlobalTestInitialize]
+                public static void GlobalInit()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
## Goal

Fixes #9951.

The `TestClassShouldBeValidAnalyzer` (MSTEST0002) static-class validation branch had two untested paths. This PR adds two focused tests to `TestClassShouldBeValidAnalyzerTests`.

## Changes

- **`WhenStaticTestClassContainsDerivedTestMethodAttribute_Diagnostic`** — a static `[TestClass]` with `[DataTestMethod]` (a `TestMethodAttribute` subclass) fires MSTEST0002, exercising the `attribute.AttributeClass.Inherits(testMethodAttributeSymbol)` branch of the static-class guard.
- **`WhenStaticTestClassContainsGlobalTestInitialize_NoDiagnostic`** — a static `[TestClass]` with only `[GlobalTestInitialize]` does NOT fire, confirming the analyzer intentionally omits that attribute from the static-class check (it only checks `TestInitialize`, `TestCleanup`, `ClassInitialize`, `ClassCleanup`, and `TestMethod`-derived attributes).

## Verification

Built and ran `MSTest.Analyzers.UnitTests` on `net472` and `net8.0` — all tests pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>