### PR TITLE
Fix MSTEST0037 incorrectly rewriting non-generic IDictionary.Contains

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -48,6 +48,7 @@ internal static class WellKnownTypeNames
     public const string System = "System";
     public const string SystemRuntimeInteropServicesRuntimeInformation = "System.Runtime.InteropServices.RuntimeInformation";
     public const string SystemCollectionsGenericIEnumerable1 = "System.Collections.Generic.IEnumerable`1";
+    public const string SystemCollectionsIDictionary = "System.Collections.IDictionary";
     public const string SystemDescriptionAttribute = "System.ComponentModel.DescriptionAttribute";
     public const string SystemFunc1 = "System.Func`1";
     public const string SystemIAsyncDisposable = "System.IAsyncDisposable";

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -46,7 +46,6 @@ internal static class WellKnownTypeNames
     public const string MicrosoftVisualStudioTestToolsUnitTestingWorkItemAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute";
 
     public const string System = "System";
-    public const string SystemRuntimeInteropServicesRuntimeInformation = "System.Runtime.InteropServices.RuntimeInformation";
     public const string SystemCollectionsGenericIEnumerable1 = "System.Collections.Generic.IEnumerable`1";
     public const string SystemCollectionsIDictionary = "System.Collections.IDictionary";
     public const string SystemDescriptionAttribute = "System.ComponentModel.DescriptionAttribute";
@@ -59,6 +58,7 @@ internal static class WellKnownTypeNames
     public const string SystemReflectionMethodInfo = "System.Reflection.MethodInfo";
     public const string SystemRuntimeCompilerServicesCallerFilePathAttribute = "System.Runtime.CompilerServices.CallerFilePathAttribute";
     public const string SystemRuntimeCompilerServicesCallerLineNumberAttribute = "System.Runtime.CompilerServices.CallerLineNumberAttribute";
+    public const string SystemRuntimeInteropServicesRuntimeInformation = "System.Runtime.InteropServices.RuntimeInformation";
     public const string SystemThreadingCancellationToken = "System.Threading.CancellationToken";
     public const string SystemThreadingCancellationTokenSource = "System.Threading.CancellationTokenSource";
     public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.Collection.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.Collection.cs
@@ -66,10 +66,9 @@ public sealed partial class UseProperAssertMethodsAnalyzer
             return false;
         }
 
-        foreach (ISymbol member in iDictionaryTypeSymbol.GetMembers("Contains"))
+        foreach (IMethodSymbol dictionaryContains in iDictionaryTypeSymbol.GetMembers("Contains").OfType<IMethodSymbol>())
         {
-            if (member is IMethodSymbol dictionaryContains &&
-                containingType.FindImplementationForInterfaceMember(dictionaryContains) is IMethodSymbol implementation &&
+            if (containingType.FindImplementationForInterfaceMember(dictionaryContains) is IMethodSymbol implementation &&
                 SymbolEqualityComparer.Default.Equals(implementation.OriginalDefinition, containsMethod.OriginalDefinition))
             {
                 return true;

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.Collection.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.Collection.cs
@@ -38,6 +38,48 @@ public sealed partial class UseProperAssertMethodsAnalyzer
             IsBCLSymbol(type, objectTypeSymbol);
 
     /// <summary>
+    /// Returns <see langword="true"/> when the invoked <c>Contains</c> method is the non-generic
+    /// <see cref="System.Collections.IDictionary.Contains(object)"/> (or an implementation of it).
+    /// That method checks for a matching <em>key</em>, whereas <c>Assert.Contains</c> enumerates the
+    /// dictionary (yielding <see cref="System.Collections.DictionaryEntry"/> items), so the two are not
+    /// equivalent and the code fix would silently change behavior.
+    /// </summary>
+    private static bool IsNonGenericDictionaryContains(IMethodSymbol containsMethod, INamedTypeSymbol? iDictionaryTypeSymbol)
+    {
+        if (iDictionaryTypeSymbol is null)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol containingType = containsMethod.ContainingType;
+
+        // Direct call through the interface, e.g. 'IDictionary dict; dict.Contains(key)'.
+        if (SymbolEqualityComparer.Default.Equals(containingType.OriginalDefinition, iDictionaryTypeSymbol))
+        {
+            return true;
+        }
+
+        // Call through a concrete type that implements IDictionary (e.g. Hashtable), where the invoked
+        // 'Contains' is the implementation of 'IDictionary.Contains'.
+        if (!containingType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, iDictionaryTypeSymbol)))
+        {
+            return false;
+        }
+
+        foreach (ISymbol member in iDictionaryTypeSymbol.GetMembers("Contains"))
+        {
+            if (member is IMethodSymbol dictionaryContains &&
+                containingType.FindImplementationForInterfaceMember(dictionaryContains) is IMethodSymbol implementation &&
+                SymbolEqualityComparer.Default.Equals(implementation.OriginalDefinition, containsMethod.OriginalDefinition))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns <see langword="true"/> when <paramref name="type"/> is one of <see cref="System.Span{T}"/>,
     /// <see cref="System.ReadOnlySpan{T}"/>, <see cref="System.Memory{T}"/> or <see cref="System.ReadOnlyMemory{T}"/>.
     /// These types expose <c>Length</c> and have <c>Assert.HasCount</c> overloads, but cannot satisfy
@@ -69,6 +111,7 @@ public sealed partial class UseProperAssertMethodsAnalyzer
         IOperation operation,
         INamedTypeSymbol objectTypeSymbol,
         INamedTypeSymbol? enumerableTypeSymbol,
+        INamedTypeSymbol? iDictionaryTypeSymbol,
         out SyntaxNode? collectionExpression,
         out SyntaxNode? itemExpression,
         out SyntaxNode? comparerExpression)
@@ -88,6 +131,17 @@ public sealed partial class UseProperAssertMethodsAnalyzer
                 {
                     ITypeSymbol? enumerableElementType = invocation.TargetMethod.ContainingType.OriginalDefinition.AllInterfaces.FirstOrDefault(
                         i => i.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)?.TypeArguments[0];
+
+                    if (enumerableElementType is null && IsNonGenericDictionaryContains(invocation.TargetMethod, iDictionaryTypeSymbol))
+                    {
+                        // Non-generic 'System.Collections.IDictionary.Contains(object key)' checks for a matching *key*,
+                        // whereas 'Assert.Contains' enumerates the dictionary (yielding 'DictionaryEntry' items).
+                        // These have different semantics, so suggesting 'Assert.Contains' here would change behavior.
+                        collectionExpression = null;
+                        itemExpression = null;
+                        comparerExpression = null;
+                        return CollectionCheckStatus.Unknown;
+                    }
 
                     if (enumerableElementType is null || enumerableElementType.Equals(containsParameterType, SymbolEqualityComparer.Default))
                     {

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.IsTrueIsFalse.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.IsTrueIsFalse.cs
@@ -16,7 +16,7 @@ namespace MSTest.Analyzers;
 
 public sealed partial class UseProperAssertMethodsAnalyzer
 {
-    private static void AnalyzeIsTrueOrIsFalseInvocation(OperationAnalysisContext context, IOperation conditionArgument, bool isTrueInvocation, INamedTypeSymbol objectTypeSymbol, INamedTypeSymbol? enumerableTypeSymbol, INamedTypeSymbol? iComparableOfTSymbol)
+    private static void AnalyzeIsTrueOrIsFalseInvocation(OperationAnalysisContext context, IOperation conditionArgument, bool isTrueInvocation, INamedTypeSymbol objectTypeSymbol, INamedTypeSymbol? enumerableTypeSymbol, INamedTypeSymbol? iComparableOfTSymbol, INamedTypeSymbol? iDictionaryTypeSymbol)
     {
         RoslynDebug.Assert(context.Operation is IInvocationOperation, "Expected IInvocationOperation.");
 
@@ -107,7 +107,7 @@ public sealed partial class UseProperAssertMethodsAnalyzer
         }
 
         // Check for collection method patterns: myCollection.Contains(...)
-        CollectionCheckStatus collectionMethodStatus = RecognizeCollectionMethodCheck(conditionArgument, objectTypeSymbol, enumerableTypeSymbol, out SyntaxNode? collectionExpr, out SyntaxNode? itemExpr, out SyntaxNode? comparerExpr);
+        CollectionCheckStatus collectionMethodStatus = RecognizeCollectionMethodCheck(conditionArgument, objectTypeSymbol, enumerableTypeSymbol, iDictionaryTypeSymbol, out SyntaxNode? collectionExpr, out SyntaxNode? itemExpr, out SyntaxNode? comparerExpr);
         if (collectionMethodStatus != CollectionCheckStatus.Unknown)
         {
             if (collectionMethodStatus == CollectionCheckStatus.Contains)

--- a/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseProperAssertMethodsAnalyzer.cs
@@ -267,12 +267,13 @@ public sealed partial class UseProperAssertMethodsAnalyzer : DiagnosticAnalyzer
             INamedTypeSymbol objectTypeSymbol = context.Compilation.GetSpecialType(SpecialType.System_Object);
             context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemLinqEnumerable, out INamedTypeSymbol? enumerableTypeSymbol);
             INamedTypeSymbol? iComparableOfTSymbol = context.Compilation.GetTypeByMetadataName("System.IComparable`1");
+            context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsIDictionary, out INamedTypeSymbol? iDictionaryTypeSymbol);
 
-            context.RegisterOperationAction(context => AnalyzeInvocationOperation(context, assertTypeSymbol, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol), OperationKind.Invocation);
+            context.RegisterOperationAction(context => AnalyzeInvocationOperation(context, assertTypeSymbol, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol, iDictionaryTypeSymbol), OperationKind.Invocation);
         });
     }
 
-    private static void AnalyzeInvocationOperation(OperationAnalysisContext context, INamedTypeSymbol assertTypeSymbol, INamedTypeSymbol objectTypeSymbol, INamedTypeSymbol? enumerableTypeSymbol, INamedTypeSymbol? iComparableOfTSymbol)
+    private static void AnalyzeInvocationOperation(OperationAnalysisContext context, INamedTypeSymbol assertTypeSymbol, INamedTypeSymbol objectTypeSymbol, INamedTypeSymbol? enumerableTypeSymbol, INamedTypeSymbol? iComparableOfTSymbol, INamedTypeSymbol? iDictionaryTypeSymbol)
     {
         var operation = (IInvocationOperation)context.Operation;
         IMethodSymbol targetMethod = operation.TargetMethod;
@@ -289,11 +290,11 @@ public sealed partial class UseProperAssertMethodsAnalyzer : DiagnosticAnalyzer
         switch (targetMethod.Name)
         {
             case "IsTrue":
-                AnalyzeIsTrueOrIsFalseInvocation(context, firstArgument, isTrueInvocation: true, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol);
+                AnalyzeIsTrueOrIsFalseInvocation(context, firstArgument, isTrueInvocation: true, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol, iDictionaryTypeSymbol);
                 break;
 
             case "IsFalse":
-                AnalyzeIsTrueOrIsFalseInvocation(context, firstArgument, isTrueInvocation: false, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol);
+                AnalyzeIsTrueOrIsFalseInvocation(context, firstArgument, isTrueInvocation: false, objectTypeSymbol, enumerableTypeSymbol, iComparableOfTSymbol, iDictionaryTypeSymbol);
                 break;
 
             case "AreEqual":

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseProperAssertMethodsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseProperAssertMethodsAnalyzerTests.cs
@@ -1395,6 +1395,38 @@ public sealed class UseProperAssertMethodsAnalyzerTests
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
 
+    [TestMethod]
+    public async Task WhenAssertIsTrueOrIsFalseWithNonGenericIDictionaryContains_NoDiagnostic()
+    {
+        // 'System.Collections.IDictionary.Contains(object)' checks for a matching *key*, whereas
+        // 'Assert.Contains' enumerates the dictionary (yielding 'DictionaryEntry' items). These have
+        // different semantics, so the analyzer must not suggest 'Assert.Contains' here.
+        // See https://github.com/microsoft/testfx/issues/9966.
+        string code = """
+            using System.Collections;
+            using System.Collections.Generic;
+
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTests
+            {
+                [TestMethod]
+                public void Contains()
+                {
+                    IDictionary dict = new Dictionary<string, string>() { { "a", "b" } };
+                    Assert.IsTrue(dict.Contains("a"));
+                    Assert.IsFalse(dict.Contains("a"));
+
+                    Hashtable hashtable = new Hashtable();
+                    Assert.IsTrue(hashtable.Contains("a"));
+                    Assert.IsFalse(hashtable.Contains("a"));
+                }
+            }
+            """;
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
     #region New test cases for string methods
 
     [TestMethod]


### PR DESCRIPTION
Fixes #9966.

## Problem

MSTEST0037 (`UseProperAssertMethods`) fired on `Assert.IsTrue(dict.Contains("a"))` where `dict` is typed as the non-generic `System.Collections.IDictionary`, and the code fix rewrote it to `Assert.Contains("a", dict)` — which **changes behavior and makes the test fail**.

`IDictionary.Contains(object key)` checks for a matching **key**, whereas `Assert.Contains(item, collection)` **enumerates** the collection. Enumerating a dictionary yields `DictionaryEntry`/`KeyValuePair` items, not keys, so the two are not equivalent.

## Root cause

The collection-`Contains` recognizer reported a diagnostic for any non-generic `IEnumerable` collection (where the generic `IEnumerable<T>` element type resolved to `null`). Non-generic dictionaries fell into that branch.

## Fix

Before reporting in the non-generic branch, the analyzer now detects whether the invoked `Contains` is `System.Collections.IDictionary.Contains` — either called directly through the interface, or as the implementation on a concrete type such as `Hashtable` — and skips the suggestion. Generic `Dictionary<K,V>` / `ICollection<KeyValuePair<K,V>>.Contains` is unaffected because its element type matches the parameter type.

## Changes

- `WellKnownTypeNames.cs` — add `System.Collections.IDictionary` well-known name.
- `UseProperAssertMethodsAnalyzer.cs` — resolve and thread the `IDictionary` symbol through.
- `UseProperAssertMethodsAnalyzer.IsTrueIsFalse.cs` — pass the symbol to the recognizer.
- `UseProperAssertMethodsAnalyzer.Collection.cs` — new `IsNonGenericDictionaryContains` helper + guard.
- Added test `WhenAssertIsTrueOrIsFalseWithNonGenericIDictionaryContains_NoDiagnostic` covering both `IDictionary` and `Hashtable`.

## Verification

Analyzer builds clean. All 132 `UseProperAssertMethodsAnalyzerTests` pass on net8.0; the subset passes on net472.