### PR TITLE
Implement packaged (MSIX) registration and AUMID activation in Microsoft.Testing.Extensions.PackagedApp (#9933)

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/ActivatedAppTestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/ActivatedAppTestHostHandle.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if PACKAGEDAPP_WINRT
+
+using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// An <see cref="ITestHostHandle"/> over a packaged (MSIX) test host that was activated by Application
+/// User Model ID. Unlike the loose-layout handle, a real, queryable process id is available — it is
+/// returned by <c>IApplicationActivationManager::ActivateApplication</c> — so the handle monitors and
+/// terminates the actual activated process and surfaces its id as the identifier.
+/// </summary>
+internal sealed class ActivatedAppTestHostHandle : ITestHostHandle
+{
+    private readonly Process _process;
+
+    public ActivatedAppTestHostHandle(uint processId)
+        => _process = Process.GetProcessById((int)processId);
+
+    public string? Identifier => _process.Id.ToString(CultureInfo.InvariantCulture);
+
+    public int ExitCode => _process.ExitCode;
+
+    public bool HasExited => _process.HasExited;
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken) => _process.WaitForExitAsync(cancellationToken);
+
+    public void Terminate()
+    {
+        try
+        {
+            _process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // The process has already exited.
+        }
+    }
+
+    public void Dispose() => _process.Dispose();
+}
+
+#endif

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/ActivatedAppTestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/ActivatedAppTestHostHandle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if PACKAGEDAPP_WINRT
@@ -16,9 +16,13 @@ namespace Microsoft.Testing.Extensions.PackagedApp;
 internal sealed class ActivatedAppTestHostHandle : ITestHostHandle
 {
     private readonly Process _process;
+    private readonly string? _handshakePath;
 
-    public ActivatedAppTestHostHandle(uint processId)
-        => _process = Process.GetProcessById((int)processId);
+    public ActivatedAppTestHostHandle(uint processId, string? handshakePath)
+    {
+        _process = Process.GetProcessById((int)processId);
+        _handshakePath = handshakePath;
+    }
 
     public string? Identifier => _process.Id.ToString(CultureInfo.InvariantCulture);
 
@@ -40,7 +44,18 @@ internal sealed class ActivatedAppTestHostHandle : ITestHostHandle
         }
     }
 
-    public void Dispose() => _process.Dispose();
+    public void Dispose()
+    {
+        _process.Dispose();
+
+        // The activated host normally consumes and deletes the connect-back hand-off itself, but if it
+        // exited before reading it (for example a crash on startup) the file would otherwise be left
+        // behind with the pipe name/correlation data. Remove it here as a best-effort backstop.
+        if (_handshakePath is not null)
+        {
+            PackagedAppConnectBackHandshake.TryDelete(_handshakePath);
+        }
+    }
 }
 
 #endif

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Testing.Platform.Helpers.PasteArguments
+static Microsoft.Testing.Platform.Helpers.PasteArguments.AppendArgument(System.Text.StringBuilder! stringBuilder, string! argument) -> void
 Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo
 Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.AppUserModelId.get -> string!
 Microsoft.Testing.Extensions.PackagedApp.AppxApplicationInfo.AppxApplicationInfo(string! id, string? executable, string! appUserModelId) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -21,6 +21,7 @@ static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifes
 Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake
 Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackReader
 static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.GetHandshakeDirectory(string! packageFamilyName) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.GetHandshakeFileName(string! testHostControllerPid) -> string!
 static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.GetHandshakeFilePath(string! packageFamilyName, string! testHostControllerPid) -> string!
 static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.ReadAndDelete(string! filePath) -> System.Collections.Generic.IReadOnlyDictionary<string!, string?>?
 static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.TryDelete(string! filePath) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/InternalAPI.Unshipped.txt
@@ -16,3 +16,12 @@ static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.FindManifestPat
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.GetManifestPath(string! layoutDirectory) -> string?
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(System.IO.Stream! manifestStream) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
 static Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo.ReadFromManifest(string! manifestPath) -> Microsoft.Testing.Extensions.PackagedApp.AppxManifestInfo!
+Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake
+Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackReader
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.GetHandshakeDirectory(string! packageFamilyName) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.GetHandshakeFilePath(string! packageFamilyName, string! testHostControllerPid) -> string!
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.ReadAndDelete(string! filePath) -> System.Collections.Generic.IReadOnlyDictionary<string!, string?>?
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.TryDelete(string! filePath) -> void
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(System.Collections.Generic.IReadOnlyList<string!>! arguments) -> string?
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackHandshake.Write(string! filePath, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string!, string?>>! entries) -> void
+static Microsoft.Testing.Extensions.PackagedApp.PackagedAppConnectBackReader.TryApplyConnectBackEnvironment(System.Collections.Generic.IReadOnlyList<string!>! commandLineArguments) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/Windows/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/Windows/InternalAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+#nullable enable
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.ActivatedAppTestHostHandle(uint processId) -> void
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.Dispose() -> void
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.ExitCode.get -> int
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.HasExited.get -> bool
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.Identifier.get -> string?
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.Terminate() -> void
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.WaitForExitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.PackagedApp.Interop.ApplicationActivationManager
+static Microsoft.Testing.Extensions.PackagedApp.Interop.ApplicationActivationManager.ActivateApplication(string! appUserModelId, string? arguments) -> uint
+Microsoft.Testing.Extensions.PackagedApp.PackageDeployer
+static Microsoft.Testing.Extensions.PackagedApp.PackageDeployer.RegisterAndActivateAsync(string! manifestPath, string! appUserModelId, string? activationArguments, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<uint>!

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/Windows/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/InternalAPI/Windows/InternalAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 #nullable enable
 Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle
-Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.ActivatedAppTestHostHandle(uint processId) -> void
+Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.ActivatedAppTestHostHandle(uint processId, string? handshakePath) -> void
 Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.Dispose() -> void
 Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.ExitCode.get -> int
 Microsoft.Testing.Extensions.PackagedApp.ActivatedAppTestHostHandle.HasExited.get -> bool

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Interop/ApplicationActivationManager.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Interop/ApplicationActivationManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if PACKAGEDAPP_WINRT

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Interop/ApplicationActivationManager.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Interop/ApplicationActivationManager.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if PACKAGEDAPP_WINRT
+
+namespace Microsoft.Testing.Extensions.PackagedApp.Interop;
+
+/// <summary>
+/// Minimal, redistributable COM interop for the public
+/// <c>IApplicationActivationManager::ActivateApplication</c> API (declared in <c>shobjidl_core.h</c>,
+/// available since Windows 8). It activates a packaged app by Application User Model ID (AUMID) and
+/// returns the created process id, which is exactly the primitive VSTest gets from a
+/// Visual-Studio-internal deployment component — here obtained through a public OS API instead.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static class ApplicationActivationManager
+{
+    /// <summary>
+    /// Activates the packaged app identified by <paramref name="appUserModelId"/> for the generic
+    /// launch contract, delivering <paramref name="arguments"/> to it as command-line arguments (a
+    /// packaged full-trust desktop app receives the activation arguments as <c>argv</c>).
+    /// </summary>
+    /// <param name="appUserModelId">The AUMID (<c>{PackageFamilyName}!{ApplicationId}</c>).</param>
+    /// <param name="arguments">The command line to deliver to the activated app, or <see langword="null"/>.</param>
+    /// <returns>The process id of the activated app instance.</returns>
+    public static uint ActivateApplication(string appUserModelId, string? arguments)
+    {
+        var manager = (IApplicationActivationManager)new ApplicationActivationManagerClass();
+        manager.ActivateApplication(appUserModelId, arguments, ActivateOptions.None, out uint processId);
+        return processId;
+    }
+
+    [Flags]
+    private enum ActivateOptions
+    {
+        None = 0x00000000,
+    }
+
+    // CLSID_ApplicationActivationManager.
+    [ComImport]
+    [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    private class ApplicationActivationManagerClass
+    {
+    }
+
+    // IApplicationActivationManager. The methods must appear in vtable order (ActivateApplication,
+    // ActivateForFile, ActivateForProtocol); the latter two are declared only to keep the layout
+    // correct and take their IShellItemArray argument as an opaque pointer since they are never called.
+    [ComImport]
+    [Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IApplicationActivationManager
+    {
+        void ActivateApplication(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string? arguments,
+            [In] ActivateOptions options,
+            [Out] out uint processId);
+
+        void ActivateForFile(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [In] IntPtr itemArray,
+            [In, MarshalAs(UnmanagedType.LPWStr)] string verb,
+            [Out] out uint processId);
+
+        void ActivateForProtocol(
+            [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [In] IntPtr itemArray,
+            [Out] out uint processId);
+    }
+}
+
+#endif

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -30,7 +30,7 @@
     <PackageDescription>
       <![CDATA[This package provides extensions to Microsoft Testing Platform intended to extend base functionalities.
 
-This package extends Microsoft Testing Platform to deploy and launch Windows test hosts. It deploys and launches a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) from an isolated directory instead of starting it in place, and — in its Windows build (net*-windows) — registers a packaged (MSIX) app layout with the PackageManager and activates it by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933).]]>
+This package extends Microsoft Testing Platform to deploy and launch Windows test hosts. It deploys and launches a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) from an isolated directory instead of starting it in place, and — in its Windows build (net*-windows) — registers a packaged, full-trust MSIX desktop app layout with the PackageManager and activates it by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933). True UWP/AppContainer hosts are not supported.]]>
     </PackageDescription>
   </PropertyGroup>
 
@@ -46,6 +46,9 @@ This package extends Microsoft Testing Platform to deploy and launch Windows tes
 
   <ItemGroup>
     <Compile Include="$(RepoRoot)src/Polyfills/**/*.cs" Link="Polyfills\%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Reuse the platform's Windows command-line quoting so the activation-argument round-trip cannot
+         diverge from the rest of the product (same helper the Retry extension source-links). -->
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\PasteArguments.cs" Link="Helpers\PasteArguments.cs" />
   </ItemGroup>
 
   <!-- NuGet package layout -->

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -9,6 +9,9 @@
          deployment and fail fast for a packaged layout. NuGet serves the Windows asset to a consumer
          that targets a matching Windows TFM and the plain asset to everyone else. -->
     <TargetFrameworks>$(SupportedNetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
+    <!-- Allow the Windows TFMs to build (restore the Windows targeting packs) on non-Windows CI legs;
+         the produced Windows assets are just compiled there, not run. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <GenerateBuildInfo>true</GenerateBuildInfo>
     <BuildInfoTemplateFile>$(RepoRoot)src\Platform\SharedExtensionHelpers\BuildInfo.cs.template</BuildInfoTemplateFile>
     <!-- This extension consumes the experimental ITestHostLauncher extension point. -->

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Microsoft.Testing.Extensions.PackagedApp.csproj
@@ -3,8 +3,12 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Testing.Extensions.PackagedApp</RootNamespace>
     <!-- The packaged-app launcher uses modern Process APIs (ArgumentList, WaitForExitAsync,
-         Kill(entireProcessTree)) and targets runtime hosts, so it ships only for .NET. -->
-    <TargetFrameworks>$(SupportedNetFrameworks)</TargetFrameworks>
+         Kill(entireProcessTree)) and targets runtime hosts, so it ships only for .NET. The
+         net*-windows10.0.19041.0 flavors additionally light up the packaged (MSIX) register-and-
+         activate path via the PackageManager WinRT projection; the plain flavors keep the loose-layout
+         deployment and fail fast for a packaged layout. NuGet serves the Windows asset to a consumer
+         that targets a matching Windows TFM and the plain asset to everyone else. -->
+    <TargetFrameworks>$(SupportedNetFrameworks);net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0</TargetFrameworks>
     <GenerateBuildInfo>true</GenerateBuildInfo>
     <BuildInfoTemplateFile>$(RepoRoot)src\Platform\SharedExtensionHelpers\BuildInfo.cs.template</BuildInfoTemplateFile>
     <!-- This extension consumes the experimental ITestHostLauncher extension point. -->
@@ -15,12 +19,18 @@
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
+  <!-- The register-and-activate path (PackageManager + IApplicationActivationManager) only compiles for
+       the Windows TFMs where the WinRT projection is available. -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
+    <DefineConstants>$(DefineConstants);PACKAGEDAPP_WINRT</DefineConstants>
+  </PropertyGroup>
+
   <!-- NuGet properties -->
   <PropertyGroup>
     <PackageDescription>
       <![CDATA[This package provides extensions to Microsoft Testing Platform intended to extend base functionalities.
 
-This package extends Microsoft Testing Platform to deploy and launch a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) from an isolated directory instead of starting it in place. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout with the PackageManager and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).]]>
+This package extends Microsoft Testing Platform to deploy and launch Windows test hosts. It deploys and launches a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) from an isolated directory instead of starting it in place, and — in its Windows build (net*-windows) — registers a packaged (MSIX) app layout with the PackageManager and activates it by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933).]]>
     </PackageDescription>
   </PropertyGroup>
 
@@ -30,6 +40,8 @@ This package extends Microsoft Testing Platform to deploy and launch a non-packa
     <AdditionalFiles Include="PublicAPI/PublicAPI.Unshipped.txt" />
     <AdditionalFiles Include="InternalAPI/InternalAPI.Shipped.txt" />
     <AdditionalFiles Include="InternalAPI/InternalAPI.Unshipped.txt" />
+    <!-- Internal API surface that only exists in the Windows build (register-and-activate path). -->
+    <AdditionalFiles Include="InternalAPI/Windows/InternalAPI.Unshipped.txt" Condition="$(TargetFramework.Contains('-windows'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
@@ -3,12 +3,12 @@
 > [!IMPORTANT]
 > This package is experimental and consumes the experimental `ITestHostLauncher` extension point of [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform). The API may change or be removed in a future update.
 
-`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) into an isolated directory and launches it from there, instead of starting the test host in place.
+`Microsoft.Testing.Extensions.PackagedApp` is an extension for [Microsoft.Testing.Platform](https://www.nuget.org/packages/Microsoft.Testing.Platform) that deploys and launches Windows test hosts: a non-packaged (loose-layout) host (for example, unpackaged WinUI) is deployed into an isolated directory and launched from there, and — in its Windows build (`net*-windows`) — a packaged, full-trust MSIX desktop host is registered with the OS and activated by Application User Model ID (AUMID).
 
-It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. Packaged Windows apps — UWP and packaged WinUI — require package identity and ship as MSIX; they share a single launch mechanism, which is why VSTest exposes a single `UwpTestHostRuntimeProvider` for them:
+It is the consumer of the platform's `ITestHostLauncher` extension point for Windows test hosts. Packaged Windows apps require package identity and ship as MSIX; VSTest exposes a single `UwpTestHostRuntimeProvider` for the equivalent scenario, built on Visual-Studio-internal deployment components, whereas this extension uses only public, redistributable Windows APIs:
 
-- **Deploy + launch loose layout** (implemented): a non-packaged (loose-layout) app — one without an `AppxManifest.xml`, such as unpackaged WinUI — is deployed to a deployment directory and the produced executable is launched from there.
-- **Packaged AUMID activation** (planned): a genuinely packaged (MSIX) layout — UWP or packaged WinUI — is registered with the `PackageManager` and the app is activated by Application User Model ID (AUMID) via `IApplicationActivationManager` — the scenario behind [#9933](https://github.com/microsoft/testfx/issues/9933). Until then, a packaged layout is rejected with an actionable error rather than silently failing at launch.
+- **Deploy + launch loose layout**: a non-packaged (loose-layout) app — one without an `AppxManifest.xml`, such as unpackaged WinUI — is deployed to a deployment directory and the produced executable is launched from there.
+- **Packaged AUMID activation** (Windows build): a packaged (MSIX) layout is registered in place with the `PackageManager` and the app is activated by AUMID via `IApplicationActivationManager` — the scenario tracked by [#9933](https://github.com/microsoft/testfx/issues/9933). This connect-back transport targets **full-trust packaged (MSIX) desktop hosts**; true UWP/AppContainer hosts are not supported, and registering an unsigned build-output layout requires Developer Mode (or sideloading). The plain `net8.0`/`net9.0` build rejects a packaged layout with an actionable error pointing at the Windows TFM.
 
 Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Extensions.PackagedApp` code in the [microsoft/testfx](https://github.com/microsoft/testfx) GitHub repository.
 
@@ -22,8 +22,8 @@ dotnet add package Microsoft.Testing.Extensions.PackagedApp
 
 This package extends Microsoft.Testing.Platform with:
 
-- **Deployment + launch**: stages a non-packaged (loose-layout) Windows test host payload (for example, unpackaged WinUI) into an isolated directory and launches the deployed copy. Genuinely packaged (MSIX) hosts — UWP and packaged WinUI — are not launched yet (see [#9933](https://github.com/microsoft/testfx/issues/9933)).
-- **Mechanism-agnostic monitoring**: returns an `ITestHostHandle` that exposes only the lifecycle the platform needs and no local process id.
+- **Deployment + launch**: stages a non-packaged (loose-layout) Windows test host payload (for example, unpackaged WinUI) into an isolated directory and launches the deployed copy; the Windows build additionally registers and activates a packaged, full-trust MSIX desktop host by AUMID (see [#9933](https://github.com/microsoft/testfx/issues/9933)).
+- **Mechanism-agnostic monitoring**: returns an `ITestHostHandle` that exposes only the lifecycle the platform needs (surfacing the activated process id for the packaged path, and none for the deployed loose-layout path).
 
 ## Documentation
 

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackageDeployer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackageDeployer.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if PACKAGEDAPP_WINRT
+
+using Microsoft.Testing.Extensions.PackagedApp.Interop;
+using Microsoft.Testing.Extensions.PackagedApp.Resources;
+
+using Windows.Management.Deployment;
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// Registers a packaged (MSIX) loose layout with the OS and activates it by Application User Model ID,
+/// using only public, redistributable Windows APIs — the <see cref="PackageManager"/> WinRT class for
+/// registration and <see cref="ApplicationActivationManager"/> for activation. This is the equivalent
+/// of the Visual-Studio-internal deployment components VSTest relies on, implemented without them.
+/// </summary>
+[SupportedOSPlatform("windows10.0.19041.0")]
+internal static class PackageDeployer
+{
+    /// <summary>
+    /// Registers the loose layout described by <paramref name="manifestPath"/> in place (no copy) and
+    /// then activates <paramref name="appUserModelId"/>, forwarding <paramref name="activationArguments"/>
+    /// as the activated app's command line.
+    /// </summary>
+    /// <param name="manifestPath">The full path to the layout's <c>AppxManifest.xml</c>.</param>
+    /// <param name="appUserModelId">The AUMID to activate once registered.</param>
+    /// <param name="activationArguments">The command line to deliver to the activated app.</param>
+    /// <param name="cancellationToken">A token to observe while registering.</param>
+    /// <returns>The process id of the activated app instance.</returns>
+    public static async Task<uint> RegisterAndActivateAsync(
+        string manifestPath,
+        string appUserModelId,
+        string? activationArguments,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var packageManager = new PackageManager();
+
+        // DeveloperMode registers the unsigned build-output layout in place. It requires Developer Mode
+        // (or sideloading) to be enabled on the machine, exactly like 'Add-AppxPackage -Register'.
+        var options = new RegisterPackageOptions
+        {
+            DeveloperMode = true,
+        };
+
+        DeploymentResult result = await packageManager
+            .RegisterPackageByUriAsync(new Uri(manifestPath), options)
+            .AsTask(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (result.ExtendedErrorCode is not null)
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.CurrentCulture, ExtensionResources.PackagedAppRegistrationFailed, manifestPath, result.ErrorText),
+                result.ExtendedErrorCode);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ApplicationActivationManager.ActivateApplication(appUserModelId, activationArguments);
+    }
+}
+
+#endif

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackageDeployer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackageDeployer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if PACKAGEDAPP_WINRT
@@ -46,12 +46,32 @@ internal static class PackageDeployer
             DeveloperMode = true,
         };
 
-        DeploymentResult result = await packageManager
-            .RegisterPackageByUriAsync(new Uri(manifestPath), options)
-            .AsTask(cancellationToken)
-            .ConfigureAwait(false);
+        DeploymentResult result;
+        try
+        {
+            result = await packageManager
+                .RegisterPackageByUriAsync(new Uri(manifestPath), options)
+                .AsTask(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancellation is expected; let it propagate unwrapped.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The WinRT operation can fault (rather than completing with a DeploymentResult), for example
+            // when Developer Mode is disabled or the layout is invalid. Surface it with the actionable
+            // registration message instead of a raw COM/WinRT exception.
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.CurrentCulture, ExtensionResources.PackagedAppRegistrationFailed, manifestPath, ex.Message),
+                ex);
+        }
 
-        if (result.ExtendedErrorCode is not null)
+        // Registration reports success through IsRegistered; ExtendedErrorCode can also carry a non-fatal
+        // (informational) HRESULT, so IsRegistered is the authoritative signal.
+        if (!result.IsRegistered)
         {
             throw new InvalidOperationException(
                 string.Format(CultureInfo.CurrentCulture, ExtensionResources.PackagedAppRegistrationFailed, manifestPath, result.ErrorText),

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// The out-of-band hand-off that lets a packaged (MSIX) test host receive the controller-to-host
+/// connect-back environment variables that a plain <c>Process.Start</c> would have inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The platform tells a spawned test host how to connect back to its controller through environment
+/// variables (the IPC pipe name, correlation id, parent PID, …). A packaged app activated by
+/// Application User Model ID is created by the Windows activation/PLM infrastructure, not by the
+/// controller, so it does <em>not</em> inherit that environment block. To bridge the gap the launcher
+/// (which runs in the controller and therefore has the fully-prepared environment) writes those
+/// variables to a small file inside the package's own writable data folder
+/// (<c>%LOCALAPPDATA%\Packages\{PackageFamilyName}\LocalState</c>, a path both sides derive from the
+/// package family name), and the activated host reads them back in-process — before the platform's
+/// own environment-variable-based connect-back runs — through
+/// <see cref="TestingPlatformBuilderHook"/>.
+/// </para>
+/// <para>
+/// The file is named with the test host controller PID (the value the platform passes on the command
+/// line as <c>--internal-testhostcontroller-pid</c>) so that concurrent runs of the same package do
+/// not collide, and it is deleted by the host as soon as it has been consumed.
+/// </para>
+/// </remarks>
+internal static class PackagedAppConnectBackHandshake
+{
+    // The platform's command-line option that carries the test host controller PID. Both the launcher
+    // (naming the file) and the activated host (locating it) agree on this value. Kept as a literal
+    // because PlatformCommandLineProvider.TestHostControllerPIDOptionKey is internal to the platform
+    // assembly; the two ship and version together in this repo.
+    private const string TestHostControllerPidOptionKey = "internal-testhostcontroller-pid";
+
+    // Marker prefixes distinguishing a null value from a (possibly empty) string value on each line,
+    // so an empty string round-trips as an empty string rather than as null.
+    private const char NullValueMarker = 'N';
+    private const char StringValueMarker = 'V';
+
+    /// <summary>
+    /// Returns the directory inside the package's writable local application data where the handshake
+    /// file is exchanged (<c>%LOCALAPPDATA%\Packages\{packageFamilyName}\LocalState</c>).
+    /// </summary>
+    public static string GetHandshakeDirectory(string packageFamilyName)
+        => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Packages",
+            packageFamilyName,
+            "LocalState");
+
+    /// <summary>
+    /// Returns the full path of the handshake file for a given package family name and test host
+    /// controller PID.
+    /// </summary>
+    public static string GetHandshakeFilePath(string packageFamilyName, string testHostControllerPid)
+        => Path.Combine(
+            GetHandshakeDirectory(packageFamilyName),
+            $"mtp-testhostcontroller-{testHostControllerPid}.handshake");
+
+    /// <summary>
+    /// Extracts the value of the <c>--internal-testhostcontroller-pid</c> option from a command line,
+    /// or <see langword="null"/> when it is absent (which means the current process is not an activated
+    /// test host waiting on a controller connect-back).
+    /// </summary>
+    public static string? TryGetTestHostControllerPid(IReadOnlyList<string> arguments)
+    {
+        for (int i = 0; i < arguments.Count - 1; i++)
+        {
+            if (string.Equals(arguments[i], $"--{TestHostControllerPidOptionKey}", StringComparison.Ordinal))
+            {
+                return arguments[i + 1];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Writes the connect-back environment variables to <paramref name="filePath"/>, creating the
+    /// containing directory when needed. Overwrites any pre-existing file (for example a leftover from
+    /// a crashed run) so the activated host always reads the current run's values.
+    /// </summary>
+    public static void Write(string filePath, IEnumerable<KeyValuePair<string, string?>> entries)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
+
+        var builder = new StringBuilder();
+        foreach (KeyValuePair<string, string?> entry in entries)
+        {
+            builder.Append(entry.Key).Append('=');
+            if (entry.Value is null)
+            {
+                builder.Append(NullValueMarker);
+            }
+            else
+            {
+                builder.Append(StringValueMarker).Append(Convert.ToBase64String(Encoding.UTF8.GetBytes(entry.Value)));
+            }
+
+            builder.Append('\n');
+        }
+
+        File.WriteAllText(filePath, builder.ToString(), Encoding.UTF8);
+    }
+
+    /// <summary>
+    /// Best-effort deletion of the handshake file, used to clean up when no host was activated to
+    /// consume it. A failure to remove the (user-scoped, transient) file must not fail the run.
+    /// </summary>
+    public static void TryDelete(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Debug.WriteLine($"Best-effort delete of connect-back handshake file '{filePath}' failed: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Reads the connect-back environment variables from <paramref name="filePath"/> and deletes the
+    /// file, or returns <see langword="null"/> when the file does not exist. Deletion is best-effort:
+    /// a failure to remove the (user-scoped, transient) file must not fail the run.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string?>? ReadAndDelete(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return null;
+        }
+
+        string[] lines = File.ReadAllLines(filePath, Encoding.UTF8);
+
+        try
+        {
+            File.Delete(filePath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Debug.WriteLine($"Best-effort delete of connect-back handshake file '{filePath}' failed: {ex}");
+        }
+
+        var result = new Dictionary<string, string?>(StringComparer.Ordinal);
+        foreach (string line in lines)
+        {
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            int separator = line.IndexOf('=');
+            if (separator <= 0 || separator == line.Length - 1)
+            {
+                continue;
+            }
+
+            string key = line[..separator];
+            char marker = line[separator + 1];
+            string encoded = line[(separator + 2)..];
+            result[key] = marker switch
+            {
+                NullValueMarker => null,
+                StringValueMarker => Encoding.UTF8.GetString(Convert.FromBase64String(encoded)),
+                _ => null,
+            };
+        }
+
+        return result;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.PackagedApp;

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
@@ -41,7 +41,11 @@ internal static class PackagedAppConnectBackHandshake
 
     /// <summary>
     /// Returns the directory inside the package's writable local application data where the handshake
-    /// file is exchanged (<c>%LOCALAPPDATA%\Packages\{packageFamilyName}\LocalState</c>).
+    /// file is exchanged (<c>%LOCALAPPDATA%\Packages\{packageFamilyName}\LocalState</c>). This is used by
+    /// the launcher, which runs in the (unpackaged) controller where <see cref="Environment.SpecialFolder.LocalApplicationData"/>
+    /// is the real, unredirected local app data. The activated packaged host must instead resolve its own
+    /// package LocalState through the package-aware <c>ApplicationData.Current.LocalFolder</c>, because in
+    /// a packaged process local app data is redirected away from this path.
     /// </summary>
     public static string GetHandshakeDirectory(string packageFamilyName)
         => Path.Combine(
@@ -51,13 +55,21 @@ internal static class PackagedAppConnectBackHandshake
             "LocalState");
 
     /// <summary>
+    /// Returns the file name (without directory) of the handshake file for a given test host controller
+    /// PID. The directory differs between the two sides (see <see cref="GetHandshakeFilePath"/> and the
+    /// activated host, which resolves its own package LocalState), but the file name is shared.
+    /// </summary>
+    public static string GetHandshakeFileName(string testHostControllerPid)
+        => $"mtp-testhostcontroller-{testHostControllerPid}.handshake";
+
+    /// <summary>
     /// Returns the full path of the handshake file for a given package family name and test host
     /// controller PID.
     /// </summary>
     public static string GetHandshakeFilePath(string packageFamilyName, string testHostControllerPid)
         => Path.Combine(
             GetHandshakeDirectory(packageFamilyName),
-            $"mtp-testhostcontroller-{testHostControllerPid}.handshake");
+            GetHandshakeFileName(testHostControllerPid));
 
     /// <summary>
     /// Extracts the value of the <c>--internal-testhostcontroller-pid</c> option from a command line,

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackHandshake.cs
@@ -176,12 +176,22 @@ internal static class PackagedAppConnectBackHandshake
             string key = line[..separator];
             char marker = line[separator + 1];
             string encoded = line[(separator + 2)..];
-            result[key] = marker switch
+
+            if (marker == NullValueMarker)
             {
-                NullValueMarker => null,
-                StringValueMarker => Encoding.UTF8.GetString(Convert.FromBase64String(encoded)),
-                _ => null,
-            };
+                result[key] = null;
+            }
+            else if (marker == StringValueMarker)
+            {
+                try
+                {
+                    result[key] = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+                }
+                catch (FormatException)
+                {
+                    // Ignore malformed entries.
+                }
+            }
         }
 
         return result;

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
@@ -50,7 +50,16 @@ internal static class PackagedAppConnectBackReader
             return;
         }
 
-        string handshakePath = PackagedAppConnectBackHandshake.GetHandshakeFilePath(packageFamilyName, testHostControllerPid);
+        // Resolve the handshake path from the package's own LocalState. In a packaged process the
+        // package-aware ApplicationData.Current.LocalFolder is the correct, unredirected
+        // %LOCALAPPDATA%\Packages\{PFN}\LocalState the (unpackaged) launcher wrote to;
+        // Environment.SpecialFolder.LocalApplicationData is redirected here and would not find the file.
+        string fileName = PackagedAppConnectBackHandshake.GetHandshakeFileName(testHostControllerPid);
+        string? localStateDirectory = TryGetPackageLocalStateDirectory();
+        string handshakePath = localStateDirectory is not null
+            ? Path.Combine(localStateDirectory, fileName)
+            : PackagedAppConnectBackHandshake.GetHandshakeFilePath(packageFamilyName, testHostControllerPid);
+
         IReadOnlyDictionary<string, string?>? environment = PackagedAppConnectBackHandshake.ReadAndDelete(handshakePath);
         if (environment is null)
         {
@@ -66,4 +75,24 @@ internal static class PackagedAppConnectBackReader
             Environment.SetEnvironmentVariable(entry.Key, entry.Value);
         }
     }
+
+    // Returns the current package's LocalState directory (the package-aware, unredirected path), or null
+    // when the process has no package identity. Only the Windows build can resolve this through the WinRT
+    // ApplicationData projection; other builds fall back to the family-name-derived path.
+#if PACKAGEDAPP_WINRT
+    private static string? TryGetPackageLocalStateDirectory()
+    {
+        try
+        {
+            return Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.Runtime.InteropServices.COMException)
+        {
+            // No package identity (not expected for an activated packaged host).
+            return null;
+        }
+    }
+#else
+    private static string? TryGetPackageLocalStateDirectory() => null;
+#endif
 }

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.PackagedApp;
@@ -59,10 +59,10 @@ internal static class PackagedAppConnectBackReader
 
         foreach (KeyValuePair<string, string?> entry in environment)
         {
-            // Apply authoritatively: this is the exact environment the platform prepared for the host,
-            // reproducing what a normal Process.Start child would have inherited from the controller. That
-            // includes variables an ITestHostEnvironmentVariableProvider modified or removed (a null value
-            // deletes the variable), which a "set only when missing" strategy would silently drop.
+            // Apply authoritatively the controller-to-host connect-back variables the launcher handed
+            // off (a null value deletes the variable). These are the variables an AUMID-activated host
+            // needs to reach its controller and would not otherwise inherit across the activation
+            // boundary.
             Environment.SetEnvironmentVariable(entry.Key, entry.Value);
         }
     }

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.PackagedApp;
+
+/// <summary>
+/// The activated-host side of the connect-back hand-off. When the current process is a packaged (MSIX)
+/// test host that was activated by Application User Model ID — and therefore did not inherit the
+/// controller-to-host connect-back environment variables — this reads them back from the package's
+/// LocalState (where <see cref="PackagedAppTestHostLauncher"/> wrote them) and applies them to the
+/// process environment, so the platform's normal environment-variable-based connect-back then works
+/// unchanged.
+/// </summary>
+internal static class PackagedAppConnectBackReader
+{
+    /// <summary>
+    /// Applies the handed-off connect-back environment variables when the current process is an
+    /// activated packaged test host. It is a no-op for the controller, for non-packaged layouts, and
+    /// when there is no handshake file to consume. Must run before the platform reads the connect-back
+    /// environment (that is, before the test application is built).
+    /// </summary>
+    /// <param name="commandLineArguments">The current process command line.</param>
+    public static void TryApplyConnectBackEnvironment(IReadOnlyList<string> commandLineArguments)
+    {
+        // Only the spawned test host leg carries the test host controller PID option; the controller
+        // process does not, so it never consumes a handshake.
+        string? testHostControllerPid = PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(commandLineArguments);
+        if (testHostControllerPid is null)
+        {
+            return;
+        }
+
+        // We only act when running from a packaged (MSIX) layout, detected by an AppxManifest.xml at or
+        // above the app's install directory (the same manifest the launcher registered).
+        string? manifestPath = AppxManifestInfo.FindManifestPath(AppContext.BaseDirectory);
+        if (manifestPath is null)
+        {
+            return;
+        }
+
+        string packageFamilyName;
+        try
+        {
+            packageFamilyName = AppxManifestInfo.ReadFromManifest(manifestPath).PackageFamilyName;
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            // A malformed or unreadable manifest is not fatal here: without the package family name we
+            // cannot locate the handshake, so leave the platform to surface the missing connect-back.
+            return;
+        }
+
+        string handshakePath = PackagedAppConnectBackHandshake.GetHandshakeFilePath(packageFamilyName, testHostControllerPid);
+        IReadOnlyDictionary<string, string?>? environment = PackagedAppConnectBackHandshake.ReadAndDelete(handshakePath);
+        if (environment is null)
+        {
+            return;
+        }
+
+        foreach (KeyValuePair<string, string?> entry in environment)
+        {
+            // Apply authoritatively: this is the exact environment the platform prepared for the host,
+            // reproducing what a normal Process.Start child would have inherited from the controller. That
+            // includes variables an ITestHostEnvironmentVariableProvider modified or removed (a null value
+            // deletes the variable), which a "set only when missing" strategy would silently drop.
+            Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppConnectBackReader.cs
@@ -43,7 +43,7 @@ internal static class PackagedAppConnectBackReader
         {
             packageFamilyName = AppxManifestInfo.ReadFromManifest(manifestPath).PackageFamilyName;
         }
-        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or System.Xml.XmlException)
         {
             // A malformed or unreadable manifest is not fatal here: without the package family name we
             // cannot locate the handshake, so leave the platform to surface the missing connect-back.

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Testing.Extensions;
 
 /// <summary>
 /// Provides extension methods for adding Windows test host deployment support (non-packaged
-/// loose layouts such as unpackaged WinUI, and packaged MSIX apps) to the test application builder.
+/// loose layouts such as unpackaged WinUI, and packaged, full-trust MSIX desktop apps) to the test
+/// application builder.
 /// </summary>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class PackagedAppExtensions
@@ -16,10 +17,10 @@ public static class PackagedAppExtensions
     /// <summary>
     /// Registers a test host launcher for Windows test applications. Non-packaged (loose-layout) hosts
     /// (for example, unpackaged WinUI) are deployed into an isolated directory and launched from there.
-    /// Packaged (MSIX) hosts — UWP or packaged WinUI — are registered with the OS and activated by
-    /// Application User Model ID in the Windows build of this extension (see
+    /// Packaged, full-trust MSIX desktop hosts are registered with the OS and activated by Application
+    /// User Model ID in the Windows build of this extension (see
     /// https://github.com/microsoft/testfx/issues/9933); the plain build rejects a packaged layout with
-    /// an actionable error.
+    /// an actionable error. True UWP/AppContainer hosts are not supported by this connect-back transport.
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddPackagedAppDeployment(this ITestApplicationBuilder builder)
@@ -28,9 +29,11 @@ public static class PackagedAppExtensions
 
         // When this process is a packaged (MSIX) test host activated by AUMID it did not inherit the
         // controller-to-host connect-back environment variables; restore them from the launcher's
-        // hand-off before the platform builds the test application and reads that environment. This runs
-        // for both the MSBuild-registered hook and direct callers of this method. It is a no-op for the
-        // controller, for non-packaged layouts, and when there is no handshake to consume.
+        // hand-off before the platform reads that environment when it builds the test application. This
+        // runs for both the MSBuild-registered hook and direct callers of this method. It is a no-op for
+        // the controller, for non-packaged layouts, and when there is no handshake to consume. Note that
+        // environment consumed strictly earlier during CreateBuilderAsync (culture, config discovery) is
+        // not reproduced for the packaged path; only the platform connect-back variables are.
         PackagedAppConnectBackReader.TryApplyConnectBackEnvironment(Environment.GetCommandLineArgs());
 
         builder.TestHostControllers.AddTestHostLauncher(_ => new PackagedAppTestHostLauncher());

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppExtensions.cs
@@ -7,22 +7,32 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions;
 
 /// <summary>
-/// Provides extension methods for adding non-packaged (loose-layout) Windows test host deployment
-/// support (for example, unpackaged WinUI) to the test application builder.
+/// Provides extension methods for adding Windows test host deployment support (non-packaged
+/// loose layouts such as unpackaged WinUI, and packaged MSIX apps) to the test application builder.
 /// </summary>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class PackagedAppExtensions
 {
     /// <summary>
-    /// Registers a test host launcher that deploys a non-packaged (loose-layout) Windows test host
-    /// (for example, unpackaged WinUI) into an isolated directory and launches it from there.
-    /// Genuinely packaged (MSIX) layouts — UWP or packaged WinUI — are not launched yet and are
-    /// rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
+    /// Registers a test host launcher for Windows test applications. Non-packaged (loose-layout) hosts
+    /// (for example, unpackaged WinUI) are deployed into an isolated directory and launched from there.
+    /// Packaged (MSIX) hosts — UWP or packaged WinUI — are registered with the OS and activated by
+    /// Application User Model ID in the Windows build of this extension (see
+    /// https://github.com/microsoft/testfx/issues/9933); the plain build rejects a packaged layout with
+    /// an actionable error.
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddPackagedAppDeployment(this ITestApplicationBuilder builder)
     {
         _ = builder ?? throw new System.ArgumentNullException(nameof(builder));
+
+        // When this process is a packaged (MSIX) test host activated by AUMID it did not inherit the
+        // controller-to-host connect-back environment variables; restore them from the launcher's
+        // hand-off before the platform builds the test application and reads that environment. This runs
+        // for both the MSBuild-registered hook and direct callers of this method. It is a no-op for the
+        // controller, for non-packaged layouts, and when there is no handshake to consume.
+        PackagedAppConnectBackReader.TryApplyConnectBackEnvironment(Environment.GetCommandLineArgs());
+
         builder.TestHostControllers.AddTestHostLauncher(_ => new PackagedAppTestHostLauncher());
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -90,10 +90,11 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
 
 #if PACKAGEDAPP_WINRT
     // The prefix of the environment variables the platform uses for the controller-to-host connect-back
-    // (pipe name, correlation id, parent PID, start time, …). Only these are handed off to the activated
-    // packaged host: they are exactly what the host needs to reach its controller, they contain no
-    // user-provided secrets, and they are read after this extension's builder hook runs.
-    private const string ConnectBackEnvironmentVariablePrefix = "TESTINGPLATFORM_";
+    // (pipe name, correlation id, parent PID, start time, skip-extension flag). Only these are handed off
+    // to the activated packaged host: they are exactly what the host needs to reach its controller, they
+    // contain no user-provided data (unlike broader TESTINGPLATFORM_* variables such as inline
+    // runsettings, which can carry secrets), and they are read after this extension's builder hook runs.
+    private const string ConnectBackEnvironmentVariablePrefix = "TESTINGPLATFORM_TESTHOSTCONTROLLER_";
 
     private static async Task<ITestHostHandle> LaunchPackagedAsync(TestHostLaunchContext context, string manifestPath, CancellationToken cancellationToken)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -1,17 +1,20 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.PackagedApp.Resources;
 using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+#if PACKAGEDAPP_WINRT
+using Microsoft.Testing.Platform.Helpers;
+#endif
 
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
 /// An <see cref="ITestHostLauncher"/> for Windows test applications. It handles two layouts:
 /// a non-packaged (loose-layout) host — for example unpackaged WinUI — which is deployed into an
-/// isolated directory and launched from there; and a genuinely packaged (MSIX) host — UWP or packaged
-/// WinUI — which cannot be started with <c>Process.Start</c> and is instead registered with the OS and
-/// activated by Application User Model ID (AUMID).
+/// isolated directory and launched from there; and a packaged, full-trust MSIX desktop host, which
+/// cannot be started with <c>Process.Start</c> and is instead registered with the OS and activated by
+/// Application User Model ID (AUMID).
 /// </summary>
 /// <remarks>
 /// <para>
@@ -31,12 +34,15 @@ namespace Microsoft.Testing.Extensions.PackagedApp;
 /// receives as <c>argv</c>.
 /// </para>
 /// <para>
-/// The full register-and-activate path ships only in the Windows build of this extension
-/// (<c>net*-windows10.0.19041.0</c>), where the <c>PackageManager</c> WinRT projection is available.
-/// The plain <c>net8.0</c>/<c>net9.0</c> build still deploys and launches non-packaged loose layouts,
-/// but rejects a packaged layout with an actionable error so a consumer that resolves that build is
-/// told to target a Windows TFM. Registering an unsigned build-output layout additionally requires
-/// Developer Mode (or sideloading) to be enabled on the machine.
+/// This connect-back transport therefore targets <em>full-trust</em> packaged (MSIX) desktop hosts. A
+/// true UWP/AppContainer host is not supported: activation arguments are not delivered as <c>argv</c>
+/// there, and the controller pipe is not granted the package SID. The full register-and-activate path
+/// ships only in the Windows build of this extension (<c>net*-windows10.0.19041.0</c>), where the
+/// <c>PackageManager</c> WinRT projection is available. The plain <c>net8.0</c>/<c>net9.0</c> build
+/// still deploys and launches non-packaged loose layouts, but rejects a packaged layout with an
+/// actionable error so a consumer that resolves that build is told to target a Windows TFM. Registering
+/// an unsigned build-output layout additionally requires Developer Mode (or sideloading) to be enabled
+/// on the machine.
 /// </para>
 /// <para>
 /// In all cases the platform owns argument/environment preparation, the controller-to-host IPC pipe,
@@ -83,6 +89,12 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
     }
 
 #if PACKAGEDAPP_WINRT
+    // The prefix of the environment variables the platform uses for the controller-to-host connect-back
+    // (pipe name, correlation id, parent PID, start time, …). Only these are handed off to the activated
+    // packaged host: they are exactly what the host needs to reach its controller, they contain no
+    // user-provided secrets, and they are read after this extension's builder hook runs.
+    private const string ConnectBackEnvironmentVariablePrefix = "TESTINGPLATFORM_";
+
     private static async Task<ITestHostHandle> LaunchPackagedAsync(TestHostLaunchContext context, string manifestPath, CancellationToken cancellationToken)
     {
         var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
@@ -98,38 +110,48 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
                     manifestInfo.PackageFamilyName,
                     manifestPath));
 
-        // Hand off the environment the platform prepared for the test host through the package's
-        // LocalState, keyed by the test host controller PID so concurrent runs of the same package do
-        // not collide. An AUMID-activated process is created by the Windows activation infrastructure and
-        // does not inherit the controller's process environment (which a plain Process.Start child would),
-        // so the full prepared environment — not just the connect-back additions — must be reproduced.
-        // The activated host applies it in-process before the platform's environment-variable-based
-        // connect-back runs (see PackagedAppConnectBackReader).
+        // Hand off the controller-to-host connect-back environment variables through the package's
+        // LocalState, keyed by the test host controller PID so concurrent runs of the same package do not
+        // collide. An AUMID-activated process is created by the Windows activation infrastructure and does
+        // not inherit the controller's environment, so these variables must be reproduced out-of-band. The
+        // hand-off is deliberately limited to the platform connect-back variables (not the full prepared
+        // environment): they carry no user secrets, and environment consumed before this extension's
+        // builder hook runs cannot be reproduced from here anyway. The activated host applies them
+        // in-process before the platform's environment-variable-based connect-back runs (see
+        // PackagedAppConnectBackReader).
         string? testHostControllerPid = PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(context.Arguments);
         string? handshakePath = null;
         if (testHostControllerPid is not null)
         {
             handshakePath = PackagedAppConnectBackHandshake.GetHandshakeFilePath(manifestInfo.PackageFamilyName, testHostControllerPid);
-            PackagedAppConnectBackHandshake.Write(handshakePath, context.EnvironmentVariables);
+            PackagedAppConnectBackHandshake.Write(handshakePath, GetConnectBackEnvironment(context));
         }
 
         // Register the loose layout in place and activate it, forwarding the platform-prepared command
         // line (which a packaged full-trust desktop app receives as argv). Activation returns the real
         // process id, so the handle can monitor and terminate the actual activated process.
-        string activationArguments = BuildCommandLine(context.Arguments);
+        var commandLineBuilder = new StringBuilder();
+        foreach (string argument in context.Arguments)
+        {
+            PasteArguments.AppendArgument(commandLineBuilder, argument);
+        }
+
         try
         {
             uint processId = await PackageDeployer
-                .RegisterAndActivateAsync(manifestPath, application.AppUserModelId, activationArguments, cancellationToken)
+                .RegisterAndActivateAsync(manifestPath, application.AppUserModelId, commandLineBuilder.ToString(), cancellationToken)
                 .ConfigureAwait(false);
 
-            return new ActivatedAppTestHostHandle(processId);
+            // The handle owns deleting the hand-off from now on: the activated host normally consumes and
+            // deletes it, but if that host exits before reading it the handle still removes it on dispose,
+            // so connect-back data is never left behind.
+            return new ActivatedAppTestHostHandle(processId, handshakePath);
         }
         catch
         {
             // No host was activated to consume the hand-off, so remove it now; leaving it behind would
             // let a later run — or a process that reuses this controller PID — pick up stale connect-back
-            // data. On success the activated host owns deleting the file once it has read it.
+            // data.
             if (handshakePath is not null)
             {
                 PackagedAppConnectBackHandshake.TryDelete(handshakePath);
@@ -139,92 +161,18 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         }
     }
 
-    // Reconstructs a single command line from the platform-prepared arguments using the Windows
-    // CommandLineToArgvW quoting rules, so the activated app parses back exactly the same argv.
-    private static string BuildCommandLine(IReadOnlyList<string> arguments)
+    // Selects the controller-to-host connect-back variables (see ConnectBackEnvironmentVariablePrefix)
+    // from the platform-prepared environment. These are the variables an AUMID-activated host needs to
+    // reach its controller and that it would not otherwise inherit.
+    private static IEnumerable<KeyValuePair<string, string?>> GetConnectBackEnvironment(TestHostLaunchContext context)
     {
-        var builder = new StringBuilder();
-        foreach (string argument in arguments)
+        foreach (KeyValuePair<string, string?> environmentVariable in context.EnvironmentVariables)
         {
-            AppendArgument(builder, argument);
-        }
-
-        return builder.ToString();
-    }
-
-    // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
-    private static void AppendArgument(StringBuilder builder, string argument)
-    {
-        const char Quote = '"';
-        const char Backslash = '\\';
-
-        if (builder.Length != 0)
-        {
-            builder.Append(' ');
-        }
-
-        if (argument.Length != 0 && !ContainsWhitespaceOrQuote(argument))
-        {
-            builder.Append(argument);
-            return;
-        }
-
-        builder.Append(Quote);
-        int index = 0;
-        while (index < argument.Length)
-        {
-            char c = argument[index++];
-            if (c == Backslash)
+            if (environmentVariable.Key.StartsWith(ConnectBackEnvironmentVariablePrefix, StringComparison.Ordinal))
             {
-                int backslashCount = 1;
-                while (index < argument.Length && argument[index] == Backslash)
-                {
-                    index++;
-                    backslashCount++;
-                }
-
-                if (index == argument.Length)
-                {
-                    builder.Append(Backslash, backslashCount * 2);
-                }
-                else if (argument[index] == Quote)
-                {
-                    builder.Append(Backslash, (backslashCount * 2) + 1);
-                    builder.Append(Quote);
-                    index++;
-                }
-                else
-                {
-                    builder.Append(Backslash, backslashCount);
-                }
-
-                continue;
-            }
-
-            if (c == Quote)
-            {
-                builder.Append(Backslash);
-                builder.Append(Quote);
-                continue;
-            }
-
-            builder.Append(c);
-        }
-
-        builder.Append(Quote);
-    }
-
-    private static bool ContainsWhitespaceOrQuote(string value)
-    {
-        foreach (char c in value)
-        {
-            if (char.IsWhiteSpace(c) || c == '"')
-            {
-                return true;
+                yield return environmentVariable;
             }
         }
-
-        return false;
     }
 #else
     private static Task<ITestHostHandle> LaunchPackagedAsync(TestHostLaunchContext context, string manifestPath, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.PackagedApp.Resources;
@@ -7,35 +7,41 @@ using Microsoft.Testing.Platform.Extensions.TestHostControllers;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// An <see cref="ITestHostLauncher"/> for Windows test applications: it deploys a non-packaged
-/// (loose-layout) test host (for example, unpackaged WinUI) into an isolated directory and launches
-/// it from there, instead of starting the test host in place. Genuinely packaged (MSIX) layouts —
-/// UWP or packaged WinUI — are rejected for now (see the remarks).
+/// An <see cref="ITestHostLauncher"/> for Windows test applications. It handles two layouts:
+/// a non-packaged (loose-layout) host — for example unpackaged WinUI — which is deployed into an
+/// isolated directory and launched from there; and a genuinely packaged (MSIX) host — UWP or packaged
+/// WinUI — which cannot be started with <c>Process.Start</c> and is instead registered with the OS and
+/// activated by Application User Model ID (AUMID).
 /// </summary>
 /// <remarks>
 /// <para>
-/// Packaged Windows apps — produced by both UWP and packaged WinUI projects, and shipped as MSIX —
-/// cannot be started with a plain <c>Process.Start</c> from the build output. They share the same
-/// launch mechanism: the loose layout is registered with the <c>PackageManager</c> and the app is
-/// activated by Application User Model ID (AUMID) via <c>IApplicationActivationManager</c>. That
-/// mechanism is the reason VSTest's <c>UwpTestHostRuntimeProvider</c> exists (it serves both UWP and
-/// WinUI); see https://github.com/microsoft/testfx/issues/9933.
+/// A packaged Windows app cannot be started with a plain <c>Process.Start</c> from the build output.
+/// It must be registered with the <c>PackageManager</c> and activated by AUMID via
+/// <c>IApplicationActivationManager</c>. That is the mechanism VSTest's <c>UwpTestHostRuntimeProvider</c>
+/// implements on top of Visual-Studio-internal deployment components; this extension implements the
+/// equivalent using only public, redistributable Windows APIs (see
+/// https://github.com/microsoft/testfx/issues/9933).
 /// </para>
 /// <para>
-/// This reference implementation performs the deploy-and-launch step for a <em>non-packaged</em>
-/// (loose-layout) test host (stage the layout, then launch the produced executable from the
-/// deployment directory). A genuinely packaged layout — detected by the presence of an
-/// <c>AppxManifest.xml</c> — cannot be started with <c>Process.Start</c>; its AUMID-activation branch
-/// (registering the layout with <c>PackageManager.RegisterPackageByUriAsync</c> and calling
-/// <c>IApplicationActivationManager.ActivateApplication</c>) is a clearly-marked follow-up
-/// (https://github.com/microsoft/testfx/issues/9933), so for now such a layout is rejected with an
-/// actionable error rather than silently failing at launch. The AUMID that activation will use is
-/// already computed from the manifest by <see cref="AppxManifestInfo"/>.
+/// Because an AUMID-activated process is created by the Windows activation/PLM infrastructure rather
+/// than by the controller, it does not inherit the controller-to-host connect-back environment
+/// variables the platform prepared. The launcher hands those off out-of-band through the package's own
+/// writable data folder (see <see cref="PackagedAppConnectBackHandshake"/>) and forwards the
+/// platform-prepared command line as the activation arguments, which a packaged full-trust desktop app
+/// receives as <c>argv</c>.
+/// </para>
+/// <para>
+/// The full register-and-activate path ships only in the Windows build of this extension
+/// (<c>net*-windows10.0.19041.0</c>), where the <c>PackageManager</c> WinRT projection is available.
+/// The plain <c>net8.0</c>/<c>net9.0</c> build still deploys and launches non-packaged loose layouts,
+/// but rejects a packaged layout with an actionable error so a consumer that resolves that build is
+/// told to target a Windows TFM. Registering an unsigned build-output layout additionally requires
+/// Developer Mode (or sideloading) to be enabled on the machine.
 /// </para>
 /// <para>
 /// In all cases the platform owns argument/environment preparation, the controller-to-host IPC pipe,
 /// the PID handshake, and the lifetime-handler dispatch; this launcher only performs the
-/// deploy-and-create step and returns an <see cref="ITestHostHandle"/> the platform monitors.
+/// deploy/register-and-create step and returns an <see cref="ITestHostHandle"/> the platform monitors.
 /// </para>
 /// </remarks>
 internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
@@ -53,7 +59,7 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
     // in-process/Process.Start path instead of forcing the controller (deploy-and-launch) host.
     public Task<bool> IsEnabledAsync() => Task.FromResult(OperatingSystem.IsWindows());
 
-    public Task<ITestHostHandle> LaunchTestHostAsync(TestHostLaunchContext context, CancellationToken cancellationToken)
+    public async Task<ITestHostHandle> LaunchTestHostAsync(TestHostLaunchContext context, CancellationToken cancellationToken)
     {
         // Honor immediate cancellation before doing any (potentially expensive) deployment work.
         cancellationToken.ThrowIfCancellationRequested();
@@ -61,31 +67,187 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
         string sourceDirectory = Path.GetDirectoryName(context.FileName)
             ?? throw new InvalidOperationException($"Unable to determine the source directory of '{context.FileName}'.");
 
-        // A genuinely packaged (MSIX) app cannot be started with Process.Start: it must be registered
-        // with the PackageManager and activated by AUMID. That path is not implemented yet (see issue
-        // #9933), so fail fast with an actionable message — including the AUMID activation would use —
-        // instead of starting an executable that cannot host the run. The manifest lives at the package
-        // layout root, which may be an ancestor of the executable's directory (Application/@Executable
-        // can point into a subdirectory), so search upward rather than only the executable's directory.
+        // A packaged (MSIX) app is detected by the presence of an AppxManifest.xml. The manifest lives
+        // at the package layout root, which may be an ancestor of the executable's directory
+        // (Application/@Executable can point into a subdirectory), so search upward rather than only the
+        // executable's directory.
         string? manifestPath = AppxManifestInfo.FindManifestPath(sourceDirectory);
         if (manifestPath is not null)
         {
-            var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
-
-            // Resolve the application matching the executable the platform asked to launch so the
-            // reported identity is the one activation would actually use (a package can declare several
-            // applications). Fall back to the package family name when the manifest declares none.
-            AppxApplicationInfo? application = manifestInfo.ResolveApplication(Path.GetFileName(context.FileName));
-            throw new InvalidOperationException(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    ExtensionResources.PackagedAppLaunchNotSupported,
-                    application?.AppUserModelId ?? manifestInfo.PackageFamilyName,
-                    manifestPath));
+            return await LaunchPackagedAsync(context, manifestPath, cancellationToken).ConfigureAwait(false);
         }
 
         // The layout is not packaged (no AppxManifest.xml). Deploy the loose layout into an isolated
         // directory and launch the produced executable from there.
+        return LaunchLooseLayout(context, sourceDirectory, cancellationToken);
+    }
+
+#if PACKAGEDAPP_WINRT
+    private static async Task<ITestHostHandle> LaunchPackagedAsync(TestHostLaunchContext context, string manifestPath, CancellationToken cancellationToken)
+    {
+        var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
+
+        // Resolve the application matching the executable the platform asked to launch so activation
+        // targets the AUMID of the right app (a package can declare several applications). A package
+        // that declares no application has no AUMID to activate.
+        AppxApplicationInfo application = manifestInfo.ResolveApplication(Path.GetFileName(context.FileName))
+            ?? throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ExtensionResources.PackagedAppNoApplicationToActivate,
+                    manifestInfo.PackageFamilyName,
+                    manifestPath));
+
+        // Hand off the environment the platform prepared for the test host through the package's
+        // LocalState, keyed by the test host controller PID so concurrent runs of the same package do
+        // not collide. An AUMID-activated process is created by the Windows activation infrastructure and
+        // does not inherit the controller's process environment (which a plain Process.Start child would),
+        // so the full prepared environment — not just the connect-back additions — must be reproduced.
+        // The activated host applies it in-process before the platform's environment-variable-based
+        // connect-back runs (see PackagedAppConnectBackReader).
+        string? testHostControllerPid = PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(context.Arguments);
+        string? handshakePath = null;
+        if (testHostControllerPid is not null)
+        {
+            handshakePath = PackagedAppConnectBackHandshake.GetHandshakeFilePath(manifestInfo.PackageFamilyName, testHostControllerPid);
+            PackagedAppConnectBackHandshake.Write(handshakePath, context.EnvironmentVariables);
+        }
+
+        // Register the loose layout in place and activate it, forwarding the platform-prepared command
+        // line (which a packaged full-trust desktop app receives as argv). Activation returns the real
+        // process id, so the handle can monitor and terminate the actual activated process.
+        string activationArguments = BuildCommandLine(context.Arguments);
+        try
+        {
+            uint processId = await PackageDeployer
+                .RegisterAndActivateAsync(manifestPath, application.AppUserModelId, activationArguments, cancellationToken)
+                .ConfigureAwait(false);
+
+            return new ActivatedAppTestHostHandle(processId);
+        }
+        catch
+        {
+            // No host was activated to consume the hand-off, so remove it now; leaving it behind would
+            // let a later run — or a process that reuses this controller PID — pick up stale connect-back
+            // data. On success the activated host owns deleting the file once it has read it.
+            if (handshakePath is not null)
+            {
+                PackagedAppConnectBackHandshake.TryDelete(handshakePath);
+            }
+
+            throw;
+        }
+    }
+
+    // Reconstructs a single command line from the platform-prepared arguments using the Windows
+    // CommandLineToArgvW quoting rules, so the activated app parses back exactly the same argv.
+    private static string BuildCommandLine(IReadOnlyList<string> arguments)
+    {
+        var builder = new StringBuilder();
+        foreach (string argument in arguments)
+        {
+            AppendArgument(builder, argument);
+        }
+
+        return builder.ToString();
+    }
+
+    // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/PasteArguments.cs
+    private static void AppendArgument(StringBuilder builder, string argument)
+    {
+        const char Quote = '"';
+        const char Backslash = '\\';
+
+        if (builder.Length != 0)
+        {
+            builder.Append(' ');
+        }
+
+        if (argument.Length != 0 && !ContainsWhitespaceOrQuote(argument))
+        {
+            builder.Append(argument);
+            return;
+        }
+
+        builder.Append(Quote);
+        int index = 0;
+        while (index < argument.Length)
+        {
+            char c = argument[index++];
+            if (c == Backslash)
+            {
+                int backslashCount = 1;
+                while (index < argument.Length && argument[index] == Backslash)
+                {
+                    index++;
+                    backslashCount++;
+                }
+
+                if (index == argument.Length)
+                {
+                    builder.Append(Backslash, backslashCount * 2);
+                }
+                else if (argument[index] == Quote)
+                {
+                    builder.Append(Backslash, (backslashCount * 2) + 1);
+                    builder.Append(Quote);
+                    index++;
+                }
+                else
+                {
+                    builder.Append(Backslash, backslashCount);
+                }
+
+                continue;
+            }
+
+            if (c == Quote)
+            {
+                builder.Append(Backslash);
+                builder.Append(Quote);
+                continue;
+            }
+
+            builder.Append(c);
+        }
+
+        builder.Append(Quote);
+    }
+
+    private static bool ContainsWhitespaceOrQuote(string value)
+    {
+        foreach (char c in value)
+        {
+            if (char.IsWhiteSpace(c) || c == '"')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+#else
+    private static Task<ITestHostHandle> LaunchPackagedAsync(TestHostLaunchContext context, string manifestPath, CancellationToken cancellationToken)
+    {
+        // Registering and activating a packaged (MSIX) app needs the PackageManager WinRT projection,
+        // which is only available in the Windows build of this extension. When a consumer resolves the
+        // plain net8.0/net9.0 build, fail fast with an actionable message — including the AUMID that
+        // activation would use — pointing at the Windows TFM, instead of starting an executable that
+        // cannot host the run.
+        _ = cancellationToken;
+        var manifestInfo = AppxManifestInfo.ReadFromManifest(manifestPath);
+        AppxApplicationInfo? application = manifestInfo.ResolveApplication(Path.GetFileName(context.FileName));
+        throw new InvalidOperationException(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                ExtensionResources.PackagedAppLaunchNotSupported,
+                application?.AppUserModelId ?? manifestInfo.PackageFamilyName,
+                manifestPath));
+    }
+#endif
+
+    private static ITestHostHandle LaunchLooseLayout(TestHostLaunchContext context, string sourceDirectory, CancellationToken cancellationToken)
+    {
         // 1. Copy the app's loose layout into an isolated directory.
         string deploymentDirectory = Path.Combine(Path.GetTempPath(), "MTPPackagedAppDeployment", Guid.NewGuid().ToString("N"));
         CopyDirectory(sourceDirectory, deploymentDirectory, cancellationToken);
@@ -115,11 +277,9 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher
 
         // 3. Return a handle that deliberately does NOT surface the underlying process id, validating
         //    that the platform relies purely on the lifecycle contract
-        //    (WaitForExitAsync/ExitCode/HasExited/Terminate) and the IPC PID handshake. This
-        //    matches launch mechanisms where no local, queryable PID is available (e.g. an
-        //    AppContainer-sandboxed AUMID activation surfaced through a broker). The handle also owns
-        //    cleanup of the deployment directory once the host has exited.
-        return Task.FromResult<ITestHostHandle>(new PackagedAppTestHostHandle(process, deploymentDirectory));
+        //    (WaitForExitAsync/ExitCode/HasExited/Terminate) and the IPC PID handshake. The handle also
+        //    owns cleanup of the deployment directory once the host has exited.
+        return new PackagedAppTestHostHandle(process, deploymentDirectory);
     }
 
     private static void CopyDirectory(string sourceDirectory, string destinationDirectory, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PackagedAppExtensionDescription" xml:space="preserve">
-    <value>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</value>
+    <value>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</value>
   </data>
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>
@@ -130,6 +130,12 @@
     <value>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</value>
   </data>
   <data name="PackagedAppLaunchNotSupported" xml:space="preserve">
-    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</value>
+    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</value>
+  </data>
+  <data name="PackagedAppNoApplicationToActivate" xml:space="preserve">
+    <value>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</value>
+  </data>
+  <data name="PackagedAppRegistrationFailed" xml:space="preserve">
+    <value>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</value>
   </data>
 </root>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PackagedAppExtensionDescription" xml:space="preserve">
-    <value>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</value>
+    <value>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</value>
   </data>
   <data name="PackagedAppExtensionDisplayName" xml:space="preserve">
     <value>Packaged app test host launcher</value>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/ExtensionResources.resx
@@ -130,7 +130,7 @@
     <value>The packaged app manifest does not declare a valid &lt;Identity Name="..." Publisher="..." /&gt; element.</value>
   </data>
   <data name="PackagedAppLaunchNotSupported" xml:space="preserve">
-    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</value>
+    <value>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</value>
   </data>
   <data name="PackagedAppNoApplicationToActivate" xml:space="preserve">
     <value>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.cs.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.de.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.es.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.fr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.it.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ja.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ko.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pl.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.ru.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.tr.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension, which ships for net8.0-windows10.0.19041.0 and later. Target 'net8.0-windows10.0.19041.0' (or a later net*-windows Target Framework Moniker at platform version 10.0.19041.0 or higher) so NuGet selects that asset. The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppNoApplicationToActivate">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged, full-trust MSIX desktop test host and activates it by Application User Model ID. True UWP/AppContainer hosts are not supported. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDescription">
-        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</source>
-        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there. Launching a genuinely packaged (MSIX) app — UWP or packaged WinUI — by registering its layout and activating it by Application User Model ID is not implemented yet (see https://github.com/microsoft/testfx/issues/9933).</target>
+        <source>Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Deploys a non-packaged (loose-layout) Windows test host (for example, unpackaged WinUI) to an isolated directory and launches it from there, and — in the Windows build — registers a packaged (MSIX) test host and activates it by Application User Model ID. See https://github.com/microsoft/testfx/issues/9933.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppExtensionDisplayName">
@@ -23,8 +23,18 @@
         <note />
       </trans-unit>
       <trans-unit id="PackagedAppLaunchNotSupported">
-        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</source>
-        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Launching a packaged (MSIX) app requires registering the layout with the PackageManager and activating it by Application User Model ID, which this extension does not implement yet (see https://github.com/microsoft/testfx/issues/9933). Only non-packaged (loose-layout) test hosts can be launched today.</target>
+        <source>Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</source>
+        <target state="new">Cannot launch the packaged Windows app '{0}' (found '{1}'). Registering and activating a packaged (MSIX) app requires the Windows build of this extension (target a net*-windows Target Framework Moniker). The current build only launches non-packaged (loose-layout) test hosts. See https://github.com/microsoft/testfx/issues/9933.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppNoApplicationToActivate">
+        <source>Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</source>
+        <target state="new">Cannot activate the packaged Windows app '{0}' (found '{1}'): its manifest declares no &lt;Application&gt;, so there is no Application User Model ID to activate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagedAppRegistrationFailed">
+        <source>Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</source>
+        <target state="new">Failed to register the packaged Windows app layout '{0}'. Registering an unsigned build-output layout requires Developer Mode (or sideloading) to be enabled. Error: {1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
@@ -6,13 +6,14 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add non-packaged (loose-layout) Windows test host deployment support (for example, unpackaged WinUI).
+/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add Windows test host deployment support (non-packaged loose layouts such as unpackaged WinUI, and packaged MSIX apps launched by AUMID activation).
 /// </summary>
 public static class TestingPlatformBuilderHook
 {
     /// <summary>
-    /// Adds non-packaged (loose-layout) Windows test host deployment support (for example, unpackaged WinUI) to the Testing Platform Builder.
-    /// Genuinely packaged (MSIX) layouts — UWP or packaged WinUI — are not launched yet and are rejected with an actionable error (see https://github.com/microsoft/testfx/issues/9933).
+    /// Adds Windows test host deployment support to the Testing Platform Builder: it deploys and
+    /// launches non-packaged (loose-layout) hosts, and — in the Windows build — registers and activates
+    /// packaged (MSIX) hosts by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
     /// <param name="_">The command line arguments.</param>

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/TestingPlatformBuilderHook.cs
@@ -6,14 +6,14 @@ using Microsoft.Testing.Platform.Builder;
 namespace Microsoft.Testing.Extensions.PackagedApp;
 
 /// <summary>
-/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add Windows test host deployment support (non-packaged loose layouts such as unpackaged WinUI, and packaged MSIX apps launched by AUMID activation).
+/// This class is used by Microsoft.Testing.Platform.MSBuild to hook into the Testing Platform Builder to add Windows test host deployment support (non-packaged loose layouts such as unpackaged WinUI, and packaged, full-trust MSIX desktop apps launched by AUMID activation).
 /// </summary>
 public static class TestingPlatformBuilderHook
 {
     /// <summary>
     /// Adds Windows test host deployment support to the Testing Platform Builder: it deploys and
     /// launches non-packaged (loose-layout) hosts, and — in the Windows build — registers and activates
-    /// packaged (MSIX) hosts by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933).
+    /// packaged, full-trust MSIX desktop hosts by Application User Model ID (see https://github.com/microsoft/testfx/issues/9933).
     /// </summary>
     /// <param name="testApplicationBuilder">The test application builder.</param>
     /// <param name="_">The command line arguments.</param>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
@@ -85,6 +85,12 @@ public sealed class PackagedAppConnectBackHandshakeTests
     }
 
     [TestMethod]
+    public void GetHandshakeFileName_IncludesControllerPidAndExtension()
+    {
+        Assert.AreEqual("mtp-testhostcontroller-777.handshake", PackagedAppConnectBackHandshake.GetHandshakeFileName("777"));
+    }
+
+    [TestMethod]
     public void GetHandshakeFilePath_IsUnderPackageLocalStateAndIncludesControllerPid()
     {
         string path = PackagedAppConnectBackHandshake.GetHandshakeFilePath("Contoso.MyTestApp_8wekyb3d8bbwe", "4321");

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
@@ -86,9 +86,7 @@ public sealed class PackagedAppConnectBackHandshakeTests
 
     [TestMethod]
     public void GetHandshakeFileName_IncludesControllerPidAndExtension()
-    {
-        Assert.AreEqual("mtp-testhostcontroller-777.handshake", PackagedAppConnectBackHandshake.GetHandshakeFileName("777"));
-    }
+        => Assert.AreEqual("mtp-testhostcontroller-777.handshake", PackagedAppConnectBackHandshake.GetHandshakeFileName("777"));
 
     [TestMethod]
     public void GetHandshakeFilePath_IsUnderPackageLocalStateAndIncludesControllerPid()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppConnectBackHandshakeTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// The PackagedApp extension only targets .NET (net8.0/net9.0), so these tests are compiled only there.
+#if !NETFRAMEWORK
+
+using Microsoft.Testing.Extensions.PackagedApp;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class PackagedAppConnectBackHandshakeTests
+{
+    [TestMethod]
+    public void WriteThenReadAndDelete_RoundTripsEntriesAndDeletesFile()
+    {
+        string filePath = Path.Combine(Path.GetTempPath(), "PackagedAppHandshakeTests", Guid.NewGuid().ToString("N"), "test.handshake");
+        try
+        {
+            var entries = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                // A typical connect-back value, a value with characters that must survive encoding, an
+                // empty string, and a null must all round-trip exactly.
+                ["TESTINGPLATFORM_TESTHOSTCONTROLLER_PIPENAME_1234"] = "MONITORTOHOST_deadbeef",
+                ["WITH_SPECIAL_CHARS"] = "a=b;c\\d\r\ne\tf\u00e9",
+                ["EMPTY_VALUE"] = string.Empty,
+                ["NULL_VALUE"] = null,
+            };
+
+            PackagedAppConnectBackHandshake.Write(filePath, entries);
+
+            IReadOnlyDictionary<string, string?>? read = PackagedAppConnectBackHandshake.ReadAndDelete(filePath);
+
+            Assert.IsNotNull(read);
+            Assert.HasCount(entries.Count, read);
+            Assert.AreEqual("MONITORTOHOST_deadbeef", read["TESTINGPLATFORM_TESTHOSTCONTROLLER_PIPENAME_1234"]);
+            Assert.AreEqual("a=b;c\\d\r\ne\tf\u00e9", read["WITH_SPECIAL_CHARS"]);
+            Assert.AreEqual(string.Empty, read["EMPTY_VALUE"]);
+            Assert.IsNull(read["NULL_VALUE"]);
+
+            // The activated host consumes the hand-off exactly once.
+            Assert.IsFalse(File.Exists(filePath));
+        }
+        finally
+        {
+            string? directory = Path.GetDirectoryName(filePath);
+            if (directory is not null && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ReadAndDelete_ReturnsNull_WhenFileDoesNotExist()
+    {
+        string filePath = Path.Combine(Path.GetTempPath(), "PackagedAppHandshakeTests", Guid.NewGuid().ToString("N"), "missing.handshake");
+
+        Assert.IsNull(PackagedAppConnectBackHandshake.ReadAndDelete(filePath));
+    }
+
+    [TestMethod]
+    public void TryDelete_RemovesExistingFileAndIgnoresMissingFile()
+    {
+        string filePath = Path.Combine(Path.GetTempPath(), "PackagedAppHandshakeTests", Guid.NewGuid().ToString("N"), "cleanup.handshake");
+        PackagedAppConnectBackHandshake.Write(filePath, new Dictionary<string, string?>(StringComparer.Ordinal) { ["K"] = "V" });
+        try
+        {
+            Assert.IsTrue(File.Exists(filePath));
+
+            PackagedAppConnectBackHandshake.TryDelete(filePath);
+            Assert.IsFalse(File.Exists(filePath));
+
+            // Deleting an already-missing file must be a no-op, not throw.
+            PackagedAppConnectBackHandshake.TryDelete(filePath);
+        }
+        finally
+        {
+            string? directory = Path.GetDirectoryName(filePath);
+            if (directory is not null && Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void GetHandshakeFilePath_IsUnderPackageLocalStateAndIncludesControllerPid()
+    {
+        string path = PackagedAppConnectBackHandshake.GetHandshakeFilePath("Contoso.MyTestApp_8wekyb3d8bbwe", "4321");
+
+        // Both sides must derive the same, package-scoped path from the package family name and PID.
+        Assert.Contains(Path.Combine("Packages", "Contoso.MyTestApp_8wekyb3d8bbwe", "LocalState"), path);
+        Assert.Contains("4321", path);
+        Assert.EndsWith(".handshake", path);
+    }
+
+    [TestMethod]
+    public void TryGetTestHostControllerPid_ReturnsValue_WhenOptionPresent()
+    {
+        string[] arguments = ["--other", "value", "--internal-testhostcontroller-pid", "9876", "--more"];
+
+        Assert.AreEqual("9876", PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(arguments));
+    }
+
+    [TestMethod]
+    public void TryGetTestHostControllerPid_ReturnsNull_WhenOptionAbsent()
+    {
+        string[] arguments = ["--diagnostic", "--results-directory", "out"];
+
+        Assert.IsNull(PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(arguments));
+    }
+
+    [TestMethod]
+    public void TryGetTestHostControllerPid_ReturnsNull_WhenOptionIsLastWithoutValue()
+    {
+        // A trailing option with no following value must not throw or return a bogus PID.
+        string[] arguments = ["--internal-testhostcontroller-pid"];
+
+        Assert.IsNull(PackagedAppConnectBackHandshake.TryGetTestHostControllerPid(arguments));
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #9933.

Implements the actual packaged (MSIX) launch path in the standalone `Microsoft.Testing.Extensions.PackagedApp` extension, replacing the previous fail-fast branch. It uses **only public, redistributable Windows APIs** — no Visual-Studio-internal deployment components (`IVsAppContainerProjectDeploy2` / `IDeploymentServicesProvider`).

## What it does
On the Windows build, when the launcher detects a packaged layout (`AppxManifest.xml`) it now:

1. **Registers** the loose build-output layout in place via the public `Windows.Management.Deployment.PackageManager.RegisterPackageByUriAsync` (`RegisterPackageOptions.DeveloperMode`, cancellation-aware `AsTask`; validates `DeploymentResult.IsRegistered` and wraps faults with an actionable message).
2. **Activates** by Application User Model ID via the public COM `IApplicationActivationManager::ActivateApplication`, capturing the returned **real PID** so `ActivatedAppTestHostHandle` monitors/terminates the actual activated process.
3. **Bridges the connect-back gap.** An AUMID-activated process is created by the Windows activation infrastructure and does not inherit the controller's environment, so MTP's env-var-based connect-back (`TESTINGPLATFORM_TESTHOSTCONTROLLER_PIPENAME_<pid>`, …) breaks. The launcher writes **only the controller-to-host connect-back variables** (`TESTINGPLATFORM_TESTHOSTCONTROLLER_*` — pipe name, correlation id, parent PID, start time, skip-extension flag; deliberately *not* the full environment, so user data such as inline runsettings is never persisted) to a handshake file in the package's `LocalState` (keyed by controller PID), and forwards the platform command line as activation arguments (delivered as `argv` to packaged full-trust apps). The activated host reads them back in-process (`PackagedAppConnectBackReader`, invoked from `AddPackagedAppDeployment`), resolving its `LocalState` through the package-aware `ApplicationData.Current.LocalFolder` (which is redirected differently than the unpackaged controller's), before the platform's connect-back runs. This is a connect-back-only handoff, not full `Process.Start` environment semantics. **No platform/IPC changes required** for full-trust packaged hosts.

## Packaging / compatibility
The package is now **multi-targeted**:
- `net8.0;net9.0` — unchanged loose-layout deployment + fail-fast for a packaged layout (zero regression for existing consumers).
- `net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0` — the full register/activate path, gated behind the `PACKAGEDAPP_WINRT` compile constant where the `PackageManager` WinRT projection is available (`EnableWindowsTargeting` lets these TFMs compile on the Linux/macOS CI legs).

NuGet serves the Windows asset to consumers targeting a matching Windows TFM (e.g. the WinUI sample, which targets 19041) and the plain asset to everyone else, so no consumer breaks.

## Tests / validation
- All four TFMs build with 0 warnings / 0 errors; `dotnet pack` produces a well-formed package with per-TFM `lib` assets and build hooks.
- Added unit tests for the connect-back handshake (round-trip incl. null/empty/special chars, file-name/path derivation, arg parsing, cleanup); existing launcher and acceptance fail-fast expectations still hold (the actionable message still carries the AUMID + tracking-issue URL and now names the minimum `net8.0-windows10.0.19041.0` asset). 670 unit tests pass.
- Regenerated all `.xlf` files; updated Public/Internal API tracking (Windows-only surface in a conditional `InternalAPI/Windows/InternalAPI.Unshipped.txt`).

## Known limitations (documented in code)
- End-to-end registration/activation can only be validated on a **Developer-Mode Windows machine with a real MSIX-packaged test host** (registration/activation privileges), so it can't run in normal CI — matching the package's existing experimental (TPEXP / alpha) status.
- Targets full-trust packaged .NET desktop hosts. True UWP/AppContainer hosts are not supported by this connect-back transport (activation args are not delivered as `argv`, and the controller pipe is not granted the package SID).