### PR TITLE
refactor: simplify visibility check in TestClassShouldBeValidAnalyzer

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/TestClassShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/TestClassShouldBeValidAnalyzer.cs
@@ -73,12 +73,11 @@ public sealed class TestClassShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         if (namedTypeSymbol.GetResultantVisibility() is { } resultantVisibility)
         {
-            if (!canDiscoverInternals && resultantVisibility != SymbolVisibility.Public)
-            {
-                context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(TestClassShouldBeValidRule, namedTypeSymbol.Name));
-                return;
-            }
-            else if (canDiscoverInternals && resultantVisibility == SymbolVisibility.Private)
+            bool isVisibilityInvalid = canDiscoverInternals
+                ? resultantVisibility == SymbolVisibility.Private
+                : resultantVisibility != SymbolVisibility.Public;
+
+            if (isVisibilityInvalid)
             {
                 context.ReportDiagnostic(namedTypeSymbol.CreateDiagnostic(TestClassShouldBeValidRule, namedTypeSymbol.Name));
                 return;


### PR DESCRIPTION
## Summary

Simplifies the `TestClassShouldBeValidAnalyzer` by consolidating the two `if`/`else if` branches in `AnalyzeSymbol` that had identical bodies (`ReportDiagnostic` + `return`) into a single condition, computing `isVisibilityInvalid` upfront.

## Changes

- `src/Analyzers/MSTest.Analyzers/TestClassShouldBeValidAnalyzer.cs` — collapsed duplicate diagnostic-reporting branches.

## Behavior

No functional changes — the visibility validation logic is identical:
- When internals **cannot** be discovered: invalid if visibility is not `Public`.
- When internals **can** be discovered: invalid if visibility is `Private`.

## Testing

- ✅ `MSTest.Analyzers` builds cleanly (0 warnings, 0 errors).
- Existing `TestClassShouldBeValidAnalyzerTests.cs` covers all visibility scenarios.

Fixes #9973