### PR TITLE
Don't report MSTEST0065 on collection types that declare their own equality

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -56,12 +56,13 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             // May be null on very old target frameworks; when it is, only the IEquatable&lt;self&gt; check becomes a
             // no-op — the object.Equals override detection still runs.
             INamedTypeSymbol? equatableSymbol = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIEquatable1);
+            INamedTypeSymbol? equalityComparerSymbol = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsGenericEqualityComparer1);
 
-            context.RegisterOperationAction(context => AnalyzeInvocation(context, assertSymbol, genericEnumerableSymbol, equatableSymbol), OperationKind.Invocation);
+            context.RegisterOperationAction(context => AnalyzeInvocation(context, assertSymbol, genericEnumerableSymbol, equatableSymbol, equalityComparerSymbol), OperationKind.Invocation);
         });
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol assertSymbol, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
+    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol assertSymbol, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol, INamedTypeSymbol? equalityComparerSymbol)
     {
         var invocation = (IInvocationOperation)context.Operation;
         IMethodSymbol targetMethod = invocation.TargetMethod;
@@ -101,9 +102,11 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         //   * The check must be based on the *selected generic type argument* T, not the argument's runtime collection
         //     type. Widening to a base type (e.g. Assert.AreEqual&lt;object&gt;(collection, collection)) discards the
         //     collection's IEquatable&lt;self&gt; and falls back to reference equality — exactly the footgun the rule targets.
-        //   * It must not apply when the caller supplies an explicit comparer, because then EqualityComparer&lt;T&gt;.Default
-        //     (and therefore the type's own equality) is not used at all.
-        if (!HasComparerArgument(invocation) && DeclaresOwnEquality(comparedType, equatableSymbol))
+        //   * It must not apply when the caller supplies a *custom* comparer, because then EqualityComparer&lt;T&gt;.Default
+        //     (and therefore the type's own equality) is not used at all. A `null` comparer or an explicit
+        //     `EqualityComparer&lt;T&gt;.Default` argument is equivalent to the parameterless overload (Assert falls back to
+        //     the default comparer — see Assert.AreEqual.cs), so those keep the opt-out.
+        if (!HasCustomComparerArgument(invocation, equalityComparerSymbol) && DeclaresOwnEquality(comparedType, equatableSymbol))
         {
             return;
         }
@@ -123,14 +126,29 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
     }
 
-    private static bool HasComparerArgument(IInvocationOperation invocation)
+    // Returns true only when a `comparer` argument is supplied that is not provably the default comparer.
+    // `null` and `EqualityComparer<T>.Default` both dispatch to EqualityComparer<T>.Default at runtime, so they must
+    // keep the equality opt-out; any other comparer bypasses the type's own equality and should re-enable the diagnostic.
+    private static bool HasCustomComparerArgument(IInvocationOperation invocation, INamedTypeSymbol? equalityComparerSymbol)
     {
         foreach (IArgumentOperation argument in invocation.Arguments)
         {
-            if (argument.Parameter?.Name == "comparer")
+            if (argument.Parameter?.Name != "comparer")
             {
-                return true;
+                continue;
             }
+
+            IOperation value = argument.Value.WalkDownConversion();
+
+            // A null literal falls back to EqualityComparer<T>.Default in Assert, and a reference to
+            // `EqualityComparer<T>.Default` is that same default comparer — neither bypasses the type's own equality.
+            bool isDefaultComparer =
+                value is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } }
+                || (value is IPropertyReferenceOperation { Property: { Name: "Default", IsStatic: true } property }
+                    && equalityComparerSymbol is not null
+                    && SymbolEqualityComparer.Default.Equals(property.ContainingType.OriginalDefinition, equalityComparerSymbol));
+
+            return !isDefaultComparer;
         }
 
         return false;
@@ -155,38 +173,40 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol);
 
     private static bool DeclaresOwnEquality(ITypeSymbol type, INamedTypeSymbol? equatableSymbol)
-    {
-        switch (type)
+        => type switch
         {
-            case INamedTypeSymbol namedType:
-                return ImplementsSelfEquatable(namedType, namedType, equatableSymbol) || OverridesObjectEquals(namedType);
+            INamedTypeSymbol namedType => ImplementsSelfEquatable(namedType, namedType, equatableSymbol) || OverridesObjectEquals(namedType),
 
-            // EqualityComparer&lt;T&gt;.Default honors a `where T : IEquatable<T>` constraint, and a class constraint that
-            // overrides object.Equals is inherited by every T. A bare `where T : IEnumerable<...>` constraint has
-            // neither, so it stays the reference-equality footgun we still want to flag.
-            //
-            // The equality target stays `typeParameter` (T) while we traverse constraints. We must NOT recurse with the
-            // constraint as the new target: for `where T : ISelf` with `ISelf : IEquatable<ISelf>`, a concrete T need
-            // not implement IEquatable&lt;T&gt;, so EqualityComparer&lt;T&gt;.Default would still use reference equality.
-            case ITypeParameterSymbol typeParameter:
-                foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
-                {
-                    // Only named constraints are inspected. A transitive type-parameter constraint
-                    // (`where T : U where U : SomeSelfEquatingType`) is intentionally not followed: doing so risks
-                    // over-suppressing, and over-reporting a warning is the safer error for this rule than silently
-                    // missing the reference-equality footgun.
-                    if (constraintType is INamedTypeSymbol namedConstraint &&
-                        (ImplementsSelfEquatable(namedConstraint, typeParameter, equatableSymbol) || OverridesObjectEquals(namedConstraint)))
-                    {
-                        return true;
-                    }
-                }
+            // The equality target is the type parameter T itself (the type whose EqualityComparer<T>.Default is used).
+            ITypeParameterSymbol typeParameter => TypeParameterDeclaresOwnEquality(typeParameter, typeParameter, equatableSymbol),
 
-                return false;
+            _ => false,
+        };
 
-            default:
-                return false;
+    // EqualityComparer&lt;T&gt;.Default honors a `where T : IEquatable<T>` constraint, and a class constraint that overrides
+    // object.Equals is inherited by every T. A bare `where T : IEnumerable<...>` constraint has neither, so it stays the
+    // reference-equality footgun we still want to flag.
+    //
+    // `equalityTarget` stays the original type parameter T while we traverse constraints, including transitive
+    // type-parameter constraints (`where T : U where U : ...`). The IEquatable check must be against T: for
+    // `where T : ISelf` with `ISelf : IEquatable<ISelf>`, a concrete T need not implement IEquatable&lt;T&gt;, so it would
+    // still use reference equality. An object.Equals override on any reachable class constraint is inherited by T and so
+    // is honored regardless of the equality target.
+    private static bool TypeParameterDeclaresOwnEquality(ITypeParameterSymbol typeParameter, ITypeSymbol equalityTarget, INamedTypeSymbol? equatableSymbol)
+    {
+        foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
+        {
+            switch (constraintType)
+            {
+                case INamedTypeSymbol namedConstraint when ImplementsSelfEquatable(namedConstraint, equalityTarget, equatableSymbol) || OverridesObjectEquals(namedConstraint):
+                    return true;
+
+                case ITypeParameterSymbol nestedTypeParameter when TypeParameterDeclaresOwnEquality(nestedTypeParameter, equalityTarget, equatableSymbol):
+                    return true;
+            }
         }
+
+        return false;
     }
 
     // Returns true when `candidate` is or implements IEquatable&lt;equalityType&gt;, i.e. the equality contract that

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -92,10 +92,25 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         // patterns where the caller widened to a non-collection type (e.g. `Assert.AreEqual<object>(arr1, arr2)`
         // or `Assert.AreEqual((object)arr1, (object)arr2)`) which would otherwise silently use reference equality.
         ITypeSymbol comparedType = targetMethod.TypeArguments[0];
-        ITypeSymbol? reportedType = ShouldReport(comparedType, genericEnumerableSymbol, equatableSymbol)
+
+        // Opt out when the compared type declares its own equality (implements IEquatable&lt;itself&gt; or overrides
+        // object.Equals). The author has then deliberately chosen a custom, non-reference equality that Assert.AreEqual
+        // honors via EqualityComparer&lt;T&gt;.Default, so suggesting a sequence/structural comparison would second-guess
+        // a deliberate decision (see issue #9971). Two things are important here:
+        //   * The check must be based on the *selected generic type argument* T, not the argument's runtime collection
+        //     type. Widening to a base type (e.g. Assert.AreEqual&lt;object&gt;(collection, collection)) discards the
+        //     collection's IEquatable&lt;self&gt; and falls back to reference equality — exactly the footgun the rule targets.
+        //   * It must not apply when the caller supplies an explicit comparer, because then EqualityComparer&lt;T&gt;.Default
+        //     (and therefore the type's own equality) is not used at all.
+        if (!HasComparerArgument(invocation) && DeclaresOwnEquality(comparedType, equatableSymbol))
+        {
+            return;
+        }
+
+        ITypeSymbol? reportedType = ShouldReport(comparedType, genericEnumerableSymbol)
             ? comparedType
-            : GetCollectionArgumentType(invocation, firstParameterName, genericEnumerableSymbol, equatableSymbol)
-                ?? GetCollectionArgumentType(invocation, "actual", genericEnumerableSymbol, equatableSymbol);
+            : GetCollectionArgumentType(invocation, firstParameterName, genericEnumerableSymbol)
+                ?? GetCollectionArgumentType(invocation, "actual", genericEnumerableSymbol);
 
         if (reportedType is null)
         {
@@ -107,7 +122,20 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
     }
 
-    private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
+    private static bool HasComparerArgument(IInvocationOperation invocation)
+    {
+        foreach (IArgumentOperation argument in invocation.Arguments)
+        {
+            if (argument.Parameter?.Name == "comparer")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol)
     {
         IArgumentOperation? argument = invocation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == parameterName);
 
@@ -116,31 +144,74 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         // operand to a non-collection type (or vice versa), so the call-site static type — the result
         // of the user-defined conversion — is what the user wrote and what we should reason about.
         ITypeSymbol? argumentType = argument?.Value.WalkDownBuiltInConversion().Type;
-        return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol, equatableSymbol)
+        return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol)
             ? argumentType
             : null;
     }
 
-    private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
+    private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol)
         => comparedType.SpecialType != SpecialType.System_String
-            && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol)
-            // When the compared type declares its own equality (implements IEquatable&lt;itself&gt; or overrides
-            // object.Equals), the author has deliberately opted into a custom, non-reference equality. Assert.AreEqual
-            // then honors that intent via EqualityComparer&lt;T&gt;.Default, so suggesting a sequence/structural comparison
-            // would be second-guessing a deliberate decision (see issue #9971). We only warn on collection types that
-            // fall back to reference equality — the actual footgun this rule exists to catch.
-            && !DeclaresOwnEquality(comparedType, equatableSymbol);
+            && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol);
 
-    // Type parameters can't declare their own equality; their constraints drive ImplementsGenericEnumerable,
-    // but a bare `where T : IEnumerable<...>` is still the reference-equality footgun we want to flag.
     private static bool DeclaresOwnEquality(ITypeSymbol type, INamedTypeSymbol? equatableSymbol)
-        => type is INamedTypeSymbol namedType
-            && ((equatableSymbol is not null &&
-                    namedType.AllInterfaces.Any(i =>
-                        SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, equatableSymbol) &&
-                        i.TypeArguments.Length == 1 &&
-                        SymbolEqualityComparer.Default.Equals(i.TypeArguments[0], namedType)))
-                || OverridesObjectEquals(namedType));
+    {
+        switch (type)
+        {
+            case INamedTypeSymbol namedType:
+                return ImplementsSelfEquatable(namedType, namedType, equatableSymbol) || OverridesObjectEquals(namedType);
+
+            // EqualityComparer&lt;T&gt;.Default honors an `IEquatable<T>` constraint, and a class constraint that itself
+            // declares its own equality is likewise usable. A bare `where T : IEnumerable<...>` constraint has neither,
+            // so it stays the reference-equality footgun we still want to flag.
+            case ITypeParameterSymbol typeParameter:
+                foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
+                {
+                    if ((constraintType is INamedTypeSymbol namedConstraint && ImplementsSelfEquatable(namedConstraint, typeParameter, equatableSymbol))
+                        || DeclaresOwnEquality(constraintType, equatableSymbol))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            default:
+                return false;
+        }
+    }
+
+    // Returns true when `candidate` is or implements IEquatable&lt;equalityType&gt;, i.e. the equality contract that
+    // EqualityComparer&lt;equalityType&gt;.Default would dispatch to. `equalityType` is the type whose default comparer
+    // is used (the compared type or the type parameter); `candidate` is the type (or constraint) we inspect.
+    private static bool ImplementsSelfEquatable(INamedTypeSymbol candidate, ITypeSymbol equalityType, INamedTypeSymbol? equatableSymbol)
+    {
+        if (equatableSymbol is null)
+        {
+            return false;
+        }
+
+        // The candidate can be the IEquatable&lt;T&gt; interface itself (e.g. a `where T : IEquatable<T>` constraint)
+        // or a type that lists it among its implemented interfaces (e.g. `class C : IEquatable<C>`).
+        if (IsEquatableOf(candidate, equalityType, equatableSymbol))
+        {
+            return true;
+        }
+
+        foreach (INamedTypeSymbol implemented in candidate.AllInterfaces)
+        {
+            if (IsEquatableOf(implemented, equalityType, equatableSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsEquatableOf(INamedTypeSymbol type, ITypeSymbol equalityType, INamedTypeSymbol equatableSymbol)
+        => SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, equatableSymbol)
+            && type.TypeArguments.Length == 1
+            && SymbolEqualityComparer.Default.Equals(type.TypeArguments[0], equalityType);
 
     private static bool OverridesObjectEquals(INamedTypeSymbol type)
     {
@@ -149,7 +220,8 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             foreach (ISymbol member in current.GetMembers(nameof(Equals)))
             {
                 if (member is IMethodSymbol { IsOverride: true, Parameters.Length: 1, ReturnType.SpecialType: SpecialType.System_Boolean } method &&
-                    method.Parameters[0].Type.SpecialType == SpecialType.System_Object)
+                    method.Parameters[0].Type.SpecialType == SpecialType.System_Object &&
+                    OverrideRootIsObjectEquals(method))
                 {
                     return true;
                 }
@@ -157,6 +229,21 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         }
 
         return false;
+    }
+
+    // `IsOverride` only proves the method overrides *some* virtual slot. A base class can declare
+    // `new virtual bool Equals(object)`, and a derived override of that member is not an override of
+    // object.Equals — EqualityComparer&lt;T&gt;.Default still dispatches the unchanged object.Equals slot
+    // (reference equality). Follow the override chain to its root and require it to be object.Equals.
+    private static bool OverrideRootIsObjectEquals(IMethodSymbol method)
+    {
+        IMethodSymbol root = method;
+        while (root.OverriddenMethod is { } overridden)
+        {
+            root = overridden;
+        }
+
+        return root.ContainingType?.SpecialType == SpecialType.System_Object;
     }
 
     private static bool HasNullLiteralArgument(IInvocationOperation invocation, string parameterName)

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -53,11 +53,14 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
                 return;
             }
 
-            context.RegisterOperationAction(context => AnalyzeInvocation(context, assertSymbol, genericEnumerableSymbol), OperationKind.Invocation);
+            // May be null on very old target frameworks; the equality-opt-out check simply becomes a no-op then.
+            INamedTypeSymbol? equatableSymbol = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIEquatable1);
+
+            context.RegisterOperationAction(context => AnalyzeInvocation(context, assertSymbol, genericEnumerableSymbol, equatableSymbol), OperationKind.Invocation);
         });
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol assertSymbol, INamedTypeSymbol genericEnumerableSymbol)
+    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol assertSymbol, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
     {
         var invocation = (IInvocationOperation)context.Operation;
         IMethodSymbol targetMethod = invocation.TargetMethod;
@@ -89,10 +92,10 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         // patterns where the caller widened to a non-collection type (e.g. `Assert.AreEqual<object>(arr1, arr2)`
         // or `Assert.AreEqual((object)arr1, (object)arr2)`) which would otherwise silently use reference equality.
         ITypeSymbol comparedType = targetMethod.TypeArguments[0];
-        ITypeSymbol? reportedType = ShouldReport(comparedType, genericEnumerableSymbol)
+        ITypeSymbol? reportedType = ShouldReport(comparedType, genericEnumerableSymbol, equatableSymbol)
             ? comparedType
-            : GetCollectionArgumentType(invocation, firstParameterName, genericEnumerableSymbol)
-                ?? GetCollectionArgumentType(invocation, "actual", genericEnumerableSymbol);
+            : GetCollectionArgumentType(invocation, firstParameterName, genericEnumerableSymbol, equatableSymbol)
+                ?? GetCollectionArgumentType(invocation, "actual", genericEnumerableSymbol, equatableSymbol);
 
         if (reportedType is null)
         {
@@ -104,7 +107,7 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
     }
 
-    private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol)
+    private static ITypeSymbol? GetCollectionArgumentType(IInvocationOperation invocation, string parameterName, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
     {
         IArgumentOperation? argument = invocation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == parameterName);
 
@@ -113,14 +116,48 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         // operand to a non-collection type (or vice versa), so the call-site static type — the result
         // of the user-defined conversion — is what the user wrote and what we should reason about.
         ITypeSymbol? argumentType = argument?.Value.WalkDownBuiltInConversion().Type;
-        return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol)
+        return argumentType is not null && ShouldReport(argumentType, genericEnumerableSymbol, equatableSymbol)
             ? argumentType
             : null;
     }
 
-    private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol)
+    private static bool ShouldReport(ITypeSymbol comparedType, INamedTypeSymbol genericEnumerableSymbol, INamedTypeSymbol? equatableSymbol)
         => comparedType.SpecialType != SpecialType.System_String
-            && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol);
+            && ImplementsGenericEnumerable(comparedType, genericEnumerableSymbol)
+            // When the compared type declares its own equality (implements IEquatable&lt;itself&gt; or overrides
+            // object.Equals), the author has deliberately opted into a custom, non-reference equality. Assert.AreEqual
+            // then honors that intent via EqualityComparer&lt;T&gt;.Default, so suggesting a sequence/structural comparison
+            // would be second-guessing a deliberate decision (see issue #9971). We only warn on collection types that
+            // fall back to reference equality — the actual footgun this rule exists to catch.
+            && !DeclaresOwnEquality(comparedType, equatableSymbol);
+
+    // Type parameters can't declare their own equality; their constraints drive ImplementsGenericEnumerable,
+    // but a bare `where T : IEnumerable<...>` is still the reference-equality footgun we want to flag.
+    private static bool DeclaresOwnEquality(ITypeSymbol type, INamedTypeSymbol? equatableSymbol)
+        => type is INamedTypeSymbol namedType
+            && ((equatableSymbol is not null &&
+                    namedType.AllInterfaces.Any(i =>
+                        SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, equatableSymbol) &&
+                        i.TypeArguments.Length == 1 &&
+                        SymbolEqualityComparer.Default.Equals(i.TypeArguments[0], namedType)))
+                || OverridesObjectEquals(namedType));
+
+    private static bool OverridesObjectEquals(INamedTypeSymbol type)
+    {
+        for (INamedTypeSymbol? current = type; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers(nameof(Equals)))
+            {
+                if (member is IMethodSymbol { IsOverride: true, Parameters.Length: 1, ReturnType.SpecialType: SpecialType.System_Boolean } method &&
+                    method.Parameters[0].Type.SpecialType == SpecialType.System_Object)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 
     private static bool HasNullLiteralArgument(IInvocationOperation invocation, string parameterName)
     {

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -160,14 +160,18 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             case INamedTypeSymbol namedType:
                 return ImplementsSelfEquatable(namedType, namedType, equatableSymbol) || OverridesObjectEquals(namedType);
 
-            // EqualityComparer&lt;T&gt;.Default honors an `IEquatable<T>` constraint, and a class constraint that itself
-            // declares its own equality is likewise usable. A bare `where T : IEnumerable<...>` constraint has neither,
-            // so it stays the reference-equality footgun we still want to flag.
+            // EqualityComparer&lt;T&gt;.Default honors a `where T : IEquatable<T>` constraint, and a class constraint that
+            // overrides object.Equals is inherited by every T. A bare `where T : IEnumerable<...>` constraint has
+            // neither, so it stays the reference-equality footgun we still want to flag.
+            //
+            // The equality target stays `typeParameter` (T) while we traverse constraints. We must NOT recurse with the
+            // constraint as the new target: for `where T : ISelf` with `ISelf : IEquatable<ISelf>`, a concrete T need
+            // not implement IEquatable&lt;T&gt;, so EqualityComparer&lt;T&gt;.Default would still use reference equality.
             case ITypeParameterSymbol typeParameter:
                 foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
                 {
-                    if ((constraintType is INamedTypeSymbol namedConstraint && ImplementsSelfEquatable(namedConstraint, typeParameter, equatableSymbol))
-                        || DeclaresOwnEquality(constraintType, equatableSymbol))
+                    if (constraintType is INamedTypeSymbol namedConstraint &&
+                        (ImplementsSelfEquatable(namedConstraint, typeParameter, equatableSymbol) || OverridesObjectEquals(namedConstraint)))
                     {
                         return true;
                     }
@@ -215,7 +219,13 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
 
     private static bool OverridesObjectEquals(INamedTypeSymbol type)
     {
-        for (INamedTypeSymbol? current = type; current is not null && current.SpecialType != SpecialType.System_Object; current = current.BaseType)
+        // Stop before object AND ValueType: System.ValueType overrides object.Equals, so walking into it would treat
+        // every struct that implements IEnumerable<T> as declaring its own equality even when it has no Equals of its
+        // own (its backing array/list field would then be compared by reference). An explicit struct override is found
+        // on the concrete type before we reach ValueType.
+        for (INamedTypeSymbol? current = type;
+            current is not null && current.SpecialType is not (SpecialType.System_Object or SpecialType.System_ValueType or SpecialType.System_Enum);
+            current = current.BaseType)
         {
             foreach (ISymbol member in current.GetMembers(nameof(Equals)))
             {

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -53,7 +53,8 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
                 return;
             }
 
-            // May be null on very old target frameworks; the equality-opt-out check simply becomes a no-op then.
+            // May be null on very old target frameworks; when it is, only the IEquatable&lt;self&gt; check becomes a
+            // no-op — the object.Equals override detection still runs.
             INamedTypeSymbol? equatableSymbol = compilation.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemIEquatable1);
 
             context.RegisterOperationAction(context => AnalyzeInvocation(context, assertSymbol, genericEnumerableSymbol, equatableSymbol), OperationKind.Invocation);
@@ -170,6 +171,10 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             case ITypeParameterSymbol typeParameter:
                 foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
                 {
+                    // Only named constraints are inspected. A transitive type-parameter constraint
+                    // (`where T : U where U : SomeSelfEquatingType`) is intentionally not followed: doing so risks
+                    // over-suppressing, and over-reporting a warning is the safer error for this rule than silently
+                    // missing the reference-equality footgun.
                     if (constraintType is INamedTypeSymbol namedConstraint &&
                         (ImplementsSelfEquatable(namedConstraint, typeParameter, equatableSymbol) || OverridesObjectEquals(namedConstraint)))
                     {

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -138,7 +138,10 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
                 continue;
             }
 
-            IOperation value = argument.Value.WalkDownConversion();
+            // Only peel built-in conversions (identity, implicit reference, boxing). A user-defined conversion actually
+            // executes and can turn a null source into a custom comparer, so it must be treated as opaque — otherwise a
+            // null underneath a user-defined operator would be misclassified as the default comparer.
+            IOperation value = argument.Value.WalkDownBuiltInConversion();
 
             // Any constant-null comparer (null literal, `default`, `default(IEqualityComparer<T>)`, a const null field, …)
             // falls back to EqualityComparer<T>.Default in Assert, and a reference to `EqualityComparer<T>.Default` is that

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -140,10 +140,11 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
 
             IOperation value = argument.Value.WalkDownConversion();
 
-            // A null literal falls back to EqualityComparer<T>.Default in Assert, and a reference to
-            // `EqualityComparer<T>.Default` is that same default comparer — neither bypasses the type's own equality.
+            // Any constant-null comparer (null literal, `default`, `default(IEqualityComparer<T>)`, a const null field, …)
+            // falls back to EqualityComparer<T>.Default in Assert, and a reference to `EqualityComparer<T>.Default` is that
+            // same default comparer — neither bypasses the type's own equality.
             bool isDefaultComparer =
-                value is ILiteralOperation { ConstantValue: { HasValue: true, Value: null } }
+                value.ConstantValue is { HasValue: true, Value: null }
                 || (value is IPropertyReferenceOperation { Property: { Name: "Default", IsStatic: true } property }
                     && equalityComparerSymbol is not null
                     && SymbolEqualityComparer.Default.Equals(property.ContainingType.OriginalDefinition, equalityComparerSymbol));

--- a/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidAssertAreEqualOnCollectionsAnalyzer.cs
@@ -106,7 +106,7 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         //     (and therefore the type's own equality) is not used at all. A `null` comparer or an explicit
         //     `EqualityComparer&lt;T&gt;.Default` argument is equivalent to the parameterless overload (Assert falls back to
         //     the default comparer — see Assert.AreEqual.cs), so those keep the opt-out.
-        if (!HasCustomComparerArgument(invocation, equalityComparerSymbol) && DeclaresOwnEquality(comparedType, equatableSymbol))
+        if (!HasCustomComparerArgument(invocation, comparedType, equalityComparerSymbol) && DeclaresOwnEquality(comparedType, equatableSymbol))
         {
             return;
         }
@@ -126,10 +126,11 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
         context.ReportDiagnostic(invocation.CreateDiagnostic(Rule, methodName, comparedTypeDisplay));
     }
 
-    // Returns true only when a `comparer` argument is supplied that is not provably the default comparer.
-    // `null` and `EqualityComparer<T>.Default` both dispatch to EqualityComparer<T>.Default at runtime, so they must
-    // keep the equality opt-out; any other comparer bypasses the type's own equality and should re-enable the diagnostic.
-    private static bool HasCustomComparerArgument(IInvocationOperation invocation, INamedTypeSymbol? equalityComparerSymbol)
+    // Returns true only when a `comparer` argument is supplied that is not provably the default comparer for the
+    // selected type argument T. `null` and `EqualityComparer<T>.Default` both dispatch to EqualityComparer<T>.Default at
+    // runtime, so they must keep the equality opt-out; any other comparer bypasses the type's own equality and should
+    // re-enable the diagnostic.
+    private static bool HasCustomComparerArgument(IInvocationOperation invocation, ITypeSymbol comparedType, INamedTypeSymbol? equalityComparerSymbol)
     {
         foreach (IArgumentOperation argument in invocation.Arguments)
         {
@@ -146,11 +147,17 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzer : DiagnosticAnalyze
             // Any constant-null comparer (null literal, `default`, `default(IEqualityComparer<T>)`, a const null field, …)
             // falls back to EqualityComparer<T>.Default in Assert, and a reference to `EqualityComparer<T>.Default` is that
             // same default comparer — neither bypasses the type's own equality.
+            //
+            // The reference must be `EqualityComparer<T>.Default` for the *selected* T: `IEqualityComparer<in T>` is
+            // contravariant, so `Assert.AreEqual<Derived>(d1, d2, EqualityComparer<Base>.Default)` compiles, but that base
+            // comparer dispatches to Base's equality — not Derived's — so it is a custom comparer for T = Derived.
             bool isDefaultComparer =
                 value.ConstantValue is { HasValue: true, Value: null }
                 || (value is IPropertyReferenceOperation { Property: { Name: "Default", IsStatic: true } property }
                     && equalityComparerSymbol is not null
-                    && SymbolEqualityComparer.Default.Equals(property.ContainingType.OriginalDefinition, equalityComparerSymbol));
+                    && SymbolEqualityComparer.Default.Equals(property.ContainingType.OriginalDefinition, equalityComparerSymbol)
+                    && property.ContainingType.TypeArguments.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(property.ContainingType.TypeArguments[0], comparedType));
 
             return !isDefaultComparer;
         }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -53,6 +53,7 @@ internal static class WellKnownTypeNames
     public const string SystemFunc1 = "System.Func`1";
     public const string SystemIAsyncDisposable = "System.IAsyncDisposable";
     public const string SystemIDisposable = "System.IDisposable";
+    public const string SystemIEquatable1 = "System.IEquatable`1";
     public const string SystemLinqEnumerable = "System.Linq.Enumerable";
     public const string SystemLinqExpressionsExpression1 = "System.Linq.Expressions.Expression`1";
     public const string SystemOperatingSystem = "System.OperatingSystem";

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -47,6 +47,7 @@ internal static class WellKnownTypeNames
     public const string MicrosoftVisualStudioTestToolsUnitTestingWorkItemAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute";
 
     public const string System = "System";
+    public const string SystemCollectionsGenericEqualityComparer1 = "System.Collections.Generic.EqualityComparer`1";
     public const string SystemCollectionsGenericIEnumerable1 = "System.Collections.Generic.IEnumerable`1";
     public const string SystemCollectionsIDictionary = "System.Collections.IDictionary";
     public const string SystemDescriptionAttribute = "System.ComponentModel.DescriptionAttribute";

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -1251,6 +1251,80 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionWithExplicitInterfaceIEquatable_DoNotReportDiagnostic()
+    {
+        // Explicit interface implementation of IEquatable<self> is still the equality EqualityComparer<T>.Default
+        // dispatches to (via AllInterfaces), so the opt-out applies.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    bool IEquatable<MyCollection>.Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreNotEqualOnCollectionImplementingIEquatableButWidenedToObject_ReportDiagnostic()
+    {
+        // AreNotEqual mirror of the widened-to-object case: EqualityComparer<object>.Default ignores
+        // IEquatable<MyCollection>, so this is still the reference-equality footgun and must be reported.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    {|#0:Assert.AreNotEqual<object>(c1, c2)|};
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreNotEqual", "MyCollection"));
+    }
+
     private static DiagnosticResult ExpectedDiagnostic(string methodName, string typeName)
         => VerifyCS.Diagnostic().WithLocation(0).WithArguments(methodName, typeName);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -1113,6 +1113,144 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
     }
 
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnStructCollectionWithoutOwnEquality_ReportDiagnostic()
+    {
+        // A struct implementing IEnumerable<T> inherits ValueType.Equals but declares no equality of its own,
+        // so EqualityComparer<T>.Default falls back to field-wise (here reference) comparison of the backing list.
+        // The walk must stop before System.ValueType so this is still reported.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = default;
+                    MyCollection c2 = default;
+                    {|#0:Assert.AreEqual(c1, c2)|};
+                }
+
+                private struct MyCollection : IEnumerable<int>
+                {
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnStructCollectionOverridingObjectEquals_DoNotReportDiagnostic()
+    {
+        // A struct that explicitly overrides object.Equals is found on the concrete type before ValueType, so its
+        // intentional equality is honored and MSTEST0065 is suppressed.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = default;
+                    MyCollection c2 = default;
+                    Assert.AreEqual(c1, c2);
+                }
+
+                private struct MyCollection : IEnumerable<int>
+                {
+                    public override bool Equals(object? obj) => true;
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnTypeParameterConstrainedToSelfEquatingType_ReportDiagnostic()
+    {
+        // `where T : ISelf` with `ISelf : IEquatable<ISelf>` does NOT guarantee T implements IEquatable<T>:
+        // a concrete T is only required to be assignable to ISelf. EqualityComparer<T>.Default therefore may still
+        // use reference equality, so the diagnostic must be preserved (the constraint's own IEquatable<ISelf> is not T's).
+        string code = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod<T>(T a, T b) where T : ISelf
+                {
+                    {|#0:Assert.AreEqual(a, b)|};
+                }
+
+                public interface ISelf : IEnumerable<int>, IEquatable<ISelf>
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "T"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnTypeParameterConstrainedToClassOverridingObjectEquals_DoNotReportDiagnostic()
+    {
+        // A class constraint that overrides object.Equals is inherited by every T, so EqualityComparer<T>.Default
+        // uses that intentional equality.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod<T>(T a, T b) where T : BaseCollection
+                {
+                    Assert.AreEqual(a, b);
+                }
+
+                public class BaseCollection : IEnumerable<int>
+                {
+                    public override bool Equals(object? obj) => true;
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
     private static DiagnosticResult ExpectedDiagnostic(string methodName, string typeName)
         => VerifyCS.Diagnostic().WithLocation(0).WithArguments(methodName, typeName);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -826,6 +826,160 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatable_DoNotReportDiagnostic()
+    {
+        // The type is a collection but declares its own equality via IEquatable<self>, so Assert.AreEqual
+        // honors that intentional equality. Suggesting a sequence comparison would second-guess the author (issue #9971).
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public override bool Equals(object? obj) => obj is MyCollection other && Equals(other);
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreNotEqualOnCollectionImplementingIEquatable_DoNotReportDiagnostic()
+    {
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreNotEqual(c1, c2);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public override bool Equals(object? obj) => obj is MyCollection other && Equals(other);
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionOverridingObjectEquals_DoNotReportDiagnostic()
+    {
+        // Overriding object.Equals is the same intentional-equality signal as IEquatable<self>.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>
+                {
+                    public override bool Equals(object? obj) => obj is MyCollection;
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableOfOtherType_ReportDiagnostic()
+    {
+        // IEquatable<SomethingElse> is not used by EqualityComparer<MyCollection>.Default, so the type still
+        // falls back to reference equality — the footgun the rule targets.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    {|#0:Assert.AreEqual(c1, c2)|};
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<string>
+                {
+                    public bool Equals(string? other) => false;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
     private static DiagnosticResult ExpectedDiagnostic(string methodName, string typeName)
         => VerifyCS.Diagnostic().WithLocation(0).WithArguments(methodName, typeName);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -853,10 +853,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
                 {
                     public bool Equals(MyCollection? other) => true;
 
-                    public override bool Equals(object? obj) => obj is MyCollection other && Equals(other);
-
-                    public override int GetHashCode() => 0;
-
                     public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
 
                     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -891,10 +887,6 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
                 private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
                 {
                     public bool Equals(MyCollection? other) => true;
-
-                    public override bool Equals(object? obj) => obj is MyCollection other && Equals(other);
-
-                    public override int GetHashCode() => 0;
 
                     public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
 
@@ -969,6 +961,147 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
                 private sealed class MyCollection : IEnumerable<int>, IEquatable<string>
                 {
                     public bool Equals(string? other) => false;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableButWidenedToObject_ReportDiagnostic()
+    {
+        // The collection declares its own equality via IEquatable<self>, but the call is widened to object.
+        // EqualityComparer<object>.Default ignores IEquatable<MyCollection> and uses reference equality, so this
+        // is still the footgun the rule targets. The opt-out must key off the selected generic type argument.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    {|#0:Assert.AreEqual<object>(c1, c2)|};
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithExplicitComparer_ReportDiagnostic()
+    {
+        // When an explicit comparer is supplied, EqualityComparer<MyCollection>.Default (and thus the type's own
+        // IEquatable<self>) is not used, so the opt-out must not apply and MSTEST0065 should still fire.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    {|#0:Assert.AreEqual(c1, c2, EqualityComparer<MyCollection>.Default)|};
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnTypeParameterConstrainedToIEquatable_DoNotReportDiagnostic()
+    {
+        // `where T : IEnumerable<int>, IEquatable<T>` guarantees EqualityComparer<T>.Default honors IEquatable<T>,
+        // so the comparison uses the constrained equality, not reference equality.
+        string code = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod<T>(T a, T b) where T : IEnumerable<int>, IEquatable<T>
+                {
+                    Assert.AreEqual(a, b);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionOverridingNewVirtualEquals_ReportDiagnostic()
+    {
+        // The base declares `new virtual bool Equals(object)` (a different slot from object.Equals), and the
+        // collection overrides that. EqualityComparer<MyCollection>.Default still dispatches the unchanged
+        // object.Equals slot (reference equality), so this must NOT be treated as declaring its own equality.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    {|#0:Assert.AreEqual(c1, c2)|};
+                }
+
+                private class Base
+                {
+                    public new virtual bool Equals(object? obj) => true;
+                }
+
+                private sealed class MyCollection : Base, IEnumerable<int>
+                {
+                    public override bool Equals(object? obj) => true;
 
                     public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -1129,6 +1129,43 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithDefaultComparerExpression_DoNotReportDiagnostic()
+    {
+        // `default(IEqualityComparer<MyCollection>)` constant-folds to null, which Assert replaces with
+        // EqualityComparer<MyCollection>.Default, so it keeps the opt-out just like a null literal.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2, default(IEqualityComparer<MyCollection>)!);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenUsingAssertAreEqualOnTypeParameterConstrainedToIEquatable_DoNotReportDiagnostic()
     {
         // `where T : IEnumerable<int>, IEquatable<T>` guarantees EqualityComparer<T>.Default honors IEquatable<T>,

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -1011,10 +1011,10 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithExplicitComparer_ReportDiagnostic()
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithCustomComparer_ReportDiagnostic()
     {
-        // When an explicit comparer is supplied, EqualityComparer<MyCollection>.Default (and thus the type's own
-        // IEquatable<self>) is not used, so the opt-out must not apply and MSTEST0065 should still fire.
+        // A genuinely custom comparer bypasses the type's own IEquatable<self>, so the opt-out must not apply and
+        // MSTEST0065 should still fire.
         string code = """
             #nullable enable
             using System;
@@ -1030,7 +1030,14 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
                 {
                     MyCollection c1 = new();
                     MyCollection c2 = new();
-                    {|#0:Assert.AreEqual(c1, c2, EqualityComparer<MyCollection>.Default)|};
+                    {|#0:Assert.AreEqual(c1, c2, new CustomComparer())|};
+                }
+
+                private sealed class CustomComparer : IEqualityComparer<MyCollection>
+                {
+                    public bool Equals(MyCollection? x, MyCollection? y) => true;
+
+                    public int GetHashCode(MyCollection obj) => 0;
                 }
 
                 private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
@@ -1045,6 +1052,80 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
             """;
 
         await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "MyCollection"));
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithExplicitDefaultComparer_DoNotReportDiagnostic()
+    {
+        // `EqualityComparer<MyCollection>.Default` dispatches to the type's own IEquatable<self>, so it is equivalent
+        // to the parameterless overload and keeps the opt-out.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2, EqualityComparer<MyCollection>.Default);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithNullComparer_DoNotReportDiagnostic()
+    {
+        // A null comparer is replaced with EqualityComparer<MyCollection>.Default by Assert, so it is equivalent to the
+        // parameterless overload and keeps the opt-out.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    MyCollection c1 = new();
+                    MyCollection c2 = new();
+                    Assert.AreEqual(c1, c2, (IEqualityComparer<MyCollection>)null!);
+                }
+
+                private sealed class MyCollection : IEnumerable<int>, IEquatable<MyCollection>
+                {
+                    public bool Equals(MyCollection? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
     [TestMethod]
@@ -1117,8 +1198,8 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     public async Task WhenUsingAssertAreEqualOnStructCollectionWithoutOwnEquality_ReportDiagnostic()
     {
         // A struct implementing IEnumerable<T> inherits ValueType.Equals but declares no equality of its own,
-        // so EqualityComparer<T>.Default falls back to field-wise (here reference) comparison of the backing list.
-        // The walk must stop before System.ValueType so this is still reported.
+        // so EqualityComparer<T>.Default falls back to ValueType's field-wise (reflection-based) comparison rather
+        // than any intentional equality. The walk must stop before System.ValueType so this is still reported.
         string code = """
             #nullable enable
             using System.Collections;
@@ -1249,6 +1330,85 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
             """;
 
         await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnTypeParameterWithTransitiveClassConstraintOverridingObjectEquals_DoNotReportDiagnostic()
+    {
+        // Transitive type-parameter constraint: `where T : U where U : BaseCollection`. Every concrete T derives from
+        // BaseCollection and inherits its object.Equals override, so EqualityComparer<T>.Default uses that equality.
+        // The constraint traversal must follow the nested type parameter U to reach BaseCollection.
+        string code = """
+            #nullable enable
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod<T, U>(T a, T b) where T : U where U : BaseCollection
+                {
+                    Assert.AreEqual(a, b);
+                }
+
+                public class BaseCollection : IEnumerable<int>
+                {
+                    public override bool Equals(object? obj) => true;
+
+                    public override int GetHashCode() => 0;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableOfBaseType_ReportDiagnostic()
+    {
+        // IEquatable<T> is invariant: EqualityComparer<Derived>.Default requires Derived to implement
+        // IEquatable<Derived> exactly. A collection implementing only IEquatable<Base> (and not overriding
+        // object.Equals) still falls back to reference equality, so this must be reported.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Derived c1 = new();
+                    Derived c2 = new();
+                    {|#0:Assert.AreEqual(c1, c2)|};
+                }
+
+                private class Base
+                {
+                }
+
+                private sealed class Derived : Base, IEnumerable<int>, IEquatable<Base>
+                {
+                    public bool Equals(Base? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "Derived"));
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreEqualOnCollectionsAnalyzerTests.cs
@@ -1092,6 +1092,48 @@ public sealed class AvoidAssertAreEqualOnCollectionsAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenUsingAssertAreEqualOnCollectionWithBaseTypeDefaultComparer_ReportDiagnostic()
+    {
+        // IEqualityComparer<in T> is contravariant, so EqualityComparer<Base>.Default compiles as the comparer for a
+        // Derived argument. But it dispatches to Base's equality, not Derived's IEquatable<Derived>, so it is a custom
+        // comparer for T = Derived and MSTEST0065 must still fire.
+        string code = """
+            #nullable enable
+            using System;
+            using System.Collections;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Derived c1 = new();
+                    Derived c2 = new();
+                    {|#0:Assert.AreEqual(c1, c2, EqualityComparer<Base>.Default)|};
+                }
+
+                private class Base
+                {
+                }
+
+                private sealed class Derived : Base, IEnumerable<int>, IEquatable<Derived>
+                {
+                    public bool Equals(Derived? other) => true;
+
+                    public IEnumerator<int> GetEnumerator() => new List<int>().GetEnumerator();
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code, ExpectedDiagnostic("Assert.AreEqual", "Derived"));
+    }
+
+    [TestMethod]
     public async Task WhenUsingAssertAreEqualOnCollectionImplementingIEquatableWithNullComparer_DoNotReportDiagnostic()
     {
         // A null comparer is replaced with EqualityComparer<MyCollection>.Default by Assert, so it is equivalent to the


### PR DESCRIPTION
Fixes #9971

## Problem

MSTEST0065 (`AvoidAssertAreEqualOnCollections`) fires purely because the compared type implements `IEnumerable<T>`. It doesn't check whether the type also defines its own equality. For a type that is *both* a collection *and* meaningfully `IEquatable<T>` (or overrides `object.Equals`), `Assert.AreEqual` is the correct call — but the rule flagged it anyway, producing false positives that forced people to disable the whole rule.

## Approach

The analyzer fundamentally can't read intent: `Assert.AreEqual(a, b)` on a collection that is also `IEquatable<T>` is genuinely ambiguous (type equality vs. element/content equality). So the question isn't "how do we detect intent" but "which way do we err when we can't tell?".

For a default-on **Warning**, false positives are more expensive than false negatives (a noisy warning gets suppressed wholesale). When a type implements `IEquatable<self>` or overrides `object.Equals`, the author deliberately opted into a custom, non-reference equality that `Assert.AreEqual` honors via `EqualityComparer<T>.Default` — the strongest static signal we're *not* in accidental-reference-equality territory. So we suppress there.

## Changes

`AvoidAssertAreEqualOnCollectionsAnalyzer` no longer reports when the compared type declares its own equality. Precise semantics (mirroring `(comparer ?? EqualityComparer<T>.Default).Equals(...)`):

- Opt-out keys off the **selected generic type argument `T`**, not the argument's runtime collection type — widening (`Assert.AreEqual<object>(c, c)`) still reports.
- Opt-out is **skipped only for a genuinely custom comparer**. A `null`/`default`/`default(IEqualityComparer<T>)` comparer or an explicit `EqualityComparer<T>.Default` argument is equivalent to the parameterless overload (`Assert` falls back to the default comparer — `Assert.AreEqual.cs:146`), so those keep the opt-out.
- `IEquatable<T>` detection requires the exact self type argument. `IEquatable<T>` is **invariant**, so a collection implementing only `IEquatable<Base>` (used as a derived type) still uses reference equality via `EqualityComparer<Derived>.Default` and is correctly reported; explicit-interface implementations count.
- `object.Equals` detection follows the override chain to its root and requires it to be `System.Object.Equals` (a derived override of a base `new virtual bool Equals(object)` does not count), and stops before `System.ValueType`/`System.Enum` so struct collections with no equality of their own still report.
- Type-parameter constraints: `where T : IEquatable<T>` (self) or a class constraint overriding `object.Equals` suppress; a bare `where T : IEnumerable<...>`, or `where T : ISelf` where `ISelf : IEquatable<ISelf>` (a concrete `T` need not implement `IEquatable<T>`), still report. Transitive type-parameter constraints (`where T : U where U : ...`) are followed, keeping `T` as the equality target.

## Known, accepted slippage

Types like `ImmutableArray<T>` implement `IEquatable<T>` but compare by the underlying array reference, so they're no longer flagged even though element-wise is usually what you'd want. There's no static way to tell "IEquatable meaning content" from "IEquatable meaning identity", and chasing it just reintroduces intent-guessing.

## Verification

- Analyzer + test project build clean.
- Full `AvoidAssertAreEqualOnCollectionsAnalyzerTests`: 49/49 pass (covers widened-to-object, custom/null/default/`default(...)`/explicit-default comparer, `IEquatable<self>` incl. explicit-interface and `IEquatable<Base>`-only, `object.Equals` override, `new virtual Equals` base, struct with/without own equality, and the various direct and transitive type-parameter constraint forms — for both `AreEqual` and `AreNotEqual`).