### PR TITLE
Enable opt-in BuildXL (MSBuildCache) project caching

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
   <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
 
+  <!-- Repo-specific tuning for the BuildXL-backed MSBuild project cache. Imported only when caching is
+       opted into via /p:MSBuildCacheEnabled=true; a no-op for normal builds. See docs/build-caching.md. -->
+  <Import Project="$(RepositoryEngineeringDir)projectcaching.props" Condition="'$(MSBuildCacheEnabled)' == 'true'" />
+
   <PropertyGroup>
     <IsSourceProject Condition="$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)).StartsWith('src/')) OR $([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectFullPath)).StartsWith('src\'))">true</IsSourceProject>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,30 @@
     <!-- It also needs to be added to nuspec manually (for projects that use nuspec) so that the new version flows to consumers -->
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+  <!--
+    BuildXL-backed MSBuild project cache (https://github.com/microsoft/MSBuildCache). It caches per-project
+    build (and optionally test) outputs keyed on the files each project actually reads/writes, backed by
+    BuildXL's cache. It is OPT-IN and OFF by default: unless the build is invoked with
+    /p:MSBuildCacheEnabled=true, no MSBuildCache package is restored and no plugin is imported, so normal
+    builds are completely unaffected. See docs/build-caching.md for how to run cached builds.
+
+    MSBuildCache only produces correct results on a clean repo (PR/CI builds, or a fresh local checkout);
+    it does not support incremental local dev builds.
+  -->
+  <PropertyGroup Label="MSBuildCache (BuildXL project cache)">
+    <MSBuildCacheEnabled Condition="'$(MSBuildCacheEnabled)' == ''">false</MSBuildCacheEnabled>
+    <!-- In Azure Pipelines, use Pipeline Caching as the cache backend. Elsewhere (local dev), use the
+         BuildXL LocalCache so caching can be exercised without a remote store. -->
+    <MSBuildCachePackageName Condition="'$(MSBuildCachePackageName)' == '' and '$(TF_BUILD)' != ''">Microsoft.MSBuildCache.AzurePipelines</MSBuildCachePackageName>
+    <MSBuildCachePackageName Condition="'$(MSBuildCachePackageName)' == ''">Microsoft.MSBuildCache.Local</MSBuildCachePackageName>
+    <MSBuildCachePackageVersion>0.1.328-preview</MSBuildCachePackageVersion>
+  </PropertyGroup>
+  <!-- Only bring in the plugin (and auto-import its build props/targets) when caching is enabled. -->
+  <ItemGroup Condition="'$(MSBuildCacheEnabled)' == 'true'">
+    <GlobalPackageReference Include="$(MSBuildCachePackageName)" Version="$(MSBuildCachePackageVersion)" />
+    <!-- Reports the Roslyn compiler-server (vbcscompiler) file accesses to the plugin for C# projects. -->
+    <GlobalPackageReference Include="Microsoft.MSBuildCache.SharedCompilation" Version="$(MSBuildCachePackageVersion)" />
+  </ItemGroup>
   <PropertyGroup Label="Product dependencies">
     <!-- AspireHostingTestingVersion is consumed by the build and baked into the shipped MSTest.Sdk
          template. It MUST be kept in sync with the literal Aspire.Hosting.Testing PackageVersion

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,6 +168,11 @@ stages:
           # MSBuildCache (BuildXL) plugin uses as its shared cache backend. See docs/build-caching.md.
           - name: EnablePipelineCache
             value: true
+          # Fork PRs do not receive $(System.AccessToken) (see the comment near the top of this file), and
+          # the Azure Pipelines cache backend requires it. So the BuildXL cached build path runs only for
+          # non-fork builds; fork builds fall back to the normal (uncached) Arcade build below.
+          - name: _IsFork
+            value: $[eq(variables['System.PullRequest.IsFork'], 'True')]
         strategy:
           matrix:
             Release:
@@ -187,12 +192,14 @@ stages:
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "$(Build.SourcesDirectory)\artifacts\CrashDumps" -PropertyType ExpandString -Force
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpCount" -Value 10 -PropertyType DWord -Force
 
-        # BuildXL (MSBuildCache) is enabled for the Windows build. The plugin only engages when the actual
-        # project graph is the MSBuild entry point -- it does NOT engage through Arcade's Build.proj (which
-        # builds projects via a nested MSBuild task) -- and it requires the x64 desktop MSBuild.exe with
-        # -reportFileAccesses. So the build is split into three steps: Arcade restores the toolset + all
-        # packages, the compile runs under the cache via x64 desktop MSBuild on TestFx.slnx, then Arcade
-        # packs the produced outputs. See docs/build-caching.md.
+        # BuildXL (MSBuildCache) is enabled for the non-fork Windows build. The plugin only engages when the
+        # actual project graph is the MSBuild entry point -- it does NOT engage through Arcade's Build.proj
+        # (which builds projects via a nested MSBuild task) -- and it requires the x64 desktop MSBuild.exe
+        # with -reportFileAccesses. So the build is split into three steps: Arcade restores the toolset + all
+        # packages (with caching opted in, so the plugin's GlobalPackageReference is restored and imported),
+        # the compile runs under the cache via x64 desktop MSBuild on TestFx.slnx, then Arcade packs the
+        # produced outputs. Fork builds skip these and use the uncached fallback further below.
+        # See docs/build-caching.md.
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
@@ -201,18 +208,22 @@ stages:
             /p:Sign=false
             /p:Pack=false
             /p:Publish=false
+            /p:MSBuildCacheEnabled=true
           name: Restore
-          displayName: Restore (Arcade)
+          displayName: Restore (Arcade, cache)
+          condition: and(succeeded(), ne(variables._IsFork, 'True'))
 
         - pwsh: >-
             eng\build-with-cache.ps1
             -Configuration $(_BuildConfig)
             -NoRestore
+            -ci
             -Targets Build
-            -BinaryLog $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\BuildCache.binlog
+            -BinLogPath $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\BuildCache.binlog
             -ExtraProperties FastAcceptanceTest=true
           name: Build
           displayName: Build (BuildXL cache)
+          condition: and(succeeded(), ne(variables._IsFork, 'True'))
           env:
             # Required by the Azure Pipelines cache backend to read/write Pipeline Caching content.
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -223,11 +234,23 @@ stages:
             /p:Restore=false
             /p:Build=false
             /p:Test=false
-            /p:Sign=false
             /p:Publish=false
             /p:FastAcceptanceTest=true
           name: Pack
-          displayName: Pack (Arcade)
+          displayName: Sign + Pack (Arcade)
+          condition: and(succeeded(), ne(variables._IsFork, 'True'))
+
+        # Fork fallback: no $(System.AccessToken), so the Azure Pipelines cache backend is unavailable. Run
+        # the normal (uncached) Arcade build, matching the pre-caching behaviour.
+        - script: eng\common\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            /p:Publish=false
+            /p:Test=false
+            /p:FastAcceptanceTest=true
+          name: BuildNoCache
+          displayName: Build (no cache, fork)
+          condition: and(succeeded(), eq(variables._IsFork, 'True'))
 
         - ${{ if eq(parameters.SkipTests, False) }}:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,6 +164,10 @@ stages:
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
         variables:
           - template: /eng/pipelines/variables/test-env-vars.yml
+          # Grants $(System.AccessToken) the scope required by Azure Pipeline Caching, which the
+          # MSBuildCache (BuildXL) plugin uses as its shared cache backend. See docs/build-caching.md.
+          - name: EnablePipelineCache
+            value: true
         strategy:
           matrix:
             Release:
@@ -183,14 +187,47 @@ stages:
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "$(Build.SourcesDirectory)\artifacts\CrashDumps" -PropertyType ExpandString -Force
               New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpCount" -Value 10 -PropertyType DWord -Force
 
+        # BuildXL (MSBuildCache) is enabled for the Windows build. The plugin only engages when the actual
+        # project graph is the MSBuild entry point -- it does NOT engage through Arcade's Build.proj (which
+        # builds projects via a nested MSBuild task) -- and it requires the x64 desktop MSBuild.exe with
+        # -reportFileAccesses. So the build is split into three steps: Arcade restores the toolset + all
+        # packages, the compile runs under the cache via x64 desktop MSBuild on TestFx.slnx, then Arcade
+        # packs the produced outputs. See docs/build-caching.md.
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
-            /p:Publish=false
+            /p:Build=false
             /p:Test=false
-            /p:FastAcceptanceTest=true
+            /p:Sign=false
+            /p:Pack=false
+            /p:Publish=false
+          name: Restore
+          displayName: Restore (Arcade)
+
+        - pwsh: >-
+            eng\build-with-cache.ps1
+            -Configuration $(_BuildConfig)
+            -NoRestore
+            -Targets Build
+            -BinaryLog $(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\BuildCache.binlog
+            -ExtraProperties FastAcceptanceTest=true
           name: Build
-          displayName: Build
+          displayName: Build (BuildXL cache)
+          env:
+            # Required by the Azure Pipelines cache backend to read/write Pipeline Caching content.
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        - script: eng\common\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
+            /p:Restore=false
+            /p:Build=false
+            /p:Test=false
+            /p:Sign=false
+            /p:Publish=false
+            /p:FastAcceptanceTest=true
+          name: Pack
+          displayName: Pack (Arcade)
 
         - ${{ if eq(parameters.SkipTests, False) }}:
 

--- a/docs/build-caching.md
+++ b/docs/build-caching.md
@@ -21,10 +21,17 @@ Caching is **off by default**. Nothing is restored or imported unless you pass
 | `Directory.Packages.props` | Selects the backend package (`Microsoft.MSBuildCache.AzurePipelines` in Azure Pipelines, `Microsoft.MSBuildCache.Local` elsewhere), pins `MSBuildCachePackageVersion`, and adds the `GlobalPackageReference`s — all guarded by `MSBuildCacheEnabled`. |
 | `eng/projectcaching.props` | Repo-specific plugin settings (cache universe, allowed post-project file accesses). Imported from `Directory.Build.props` only when caching is enabled. |
 | `Directory.Build.props` | Conditionally imports `eng/projectcaching.props`. |
-| `eng/build-with-cache.ps1` | Convenience wrapper that runs a cached local build with the correct MSBuild engine and switches. |
+| `eng/build-with-cache.ps1` | Convenience wrapper that runs a cached build with the correct MSBuild engine and switches. Used both locally and by the Windows CI job. |
+| `azure-pipelines.yml` | The Windows job builds under the cache (Restore → Build-with-cache → Pack). |
 
 The plugin's own `build/*.props` and `build/*.targets` are imported automatically by the
 `GlobalPackageReference` when the package is restored.
+
+> [!NOTE]
+> The plugin is registered from the evaluation of the graph **entry** project(s), so it only caches when
+> the real project/solution graph is the MSBuild entry point. Building through Arcade's `Build.proj` (which
+> builds projects via a nested MSBuild task) does **not** engage the plugin — hence the direct
+> `MSBuild.exe TestFx.slnx` build used by the helper and CI.
 
 ## Requirements — read this before running
 
@@ -76,35 +83,33 @@ If you prefer to invoke MSBuild yourself:
 
 ## Running a cached build in Azure Pipelines
 
-In CI the `Microsoft.MSBuildCache.AzurePipelines` backend is selected automatically (it keys off the
-`TF_BUILD` variable) and uses [Azure Pipeline Caching](https://learn.microsoft.com/azure/devops/pipelines/release/caching)
-as the shared cache store. Three things are required:
+Caching is **enabled by default on the Windows CI job**. Because the plugin only engages when the real
+project graph is the MSBuild entry point (not through Arcade's `Build.proj`, which builds projects via a
+nested MSBuild task), the Windows job is split into three steps:
 
-1. Build with the **x64 desktop MSBuild** engine (Arcade: `-msbuildEngine vs`; ensure the x64 flavor is
-   used) so `-reportFileAccesses` is available.
-2. Pass `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true` to the build step.
-3. Expose the OAuth token and grant it the Pipeline Caching scope, because the plugin stores/reads cache
-   content through Azure Pipeline Caching:
-
-   ```yaml
-   variables:
-     # Grants $(System.AccessToken) the scope required by Pipeline Caching.
-     EnablePipelineCache: true
-
-   steps:
-   - script: eng\common\CIBuild.cmd -configuration Release -msbuildEngine vs
-       -graph -m -reportFileAccesses /p:MSBuildCacheEnabled=true
-     env:
-       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-   ```
+1. **Restore (Arcade)** — `eng\common\CIBuild.cmd ... /p:Build=false /p:Pack=false /p:Sign=false` restores
+   the toolset and all packages.
+2. **Build (BuildXL cache)** — `eng\build-with-cache.ps1` runs the x64 desktop MSBuild on `TestFx.slnx`
+   with `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true`. The `Microsoft.MSBuildCache.AzurePipelines`
+   backend is selected automatically (via `TF_BUILD`) and uses
+   [Azure Pipeline Caching](https://learn.microsoft.com/azure/devops/pipelines/release/caching) as the
+   shared cache store. This step maps `SYSTEM_ACCESSTOKEN`, and the job sets the `EnablePipelineCache`
+   variable to grant that token the Pipeline Caching scope.
+3. **Pack (Arcade)** — `eng\common\CIBuild.cmd ... /p:Build=false /p:Pack=true` packs the already-built
+   outputs.
 
 See [Pipeline caching – cache isolation and security](https://learn.microsoft.com/azure/devops/pipelines/release/caching#cache-isolation-and-security)
 for how cache entries are scoped between branches/PRs.
 
-> [!NOTE]
-> Turning caching on in the repo's CI by default is intentionally left as a follow-up: it requires the
-> Windows jobs to build with the x64 desktop MSBuild engine through Arcade. The wiring in this repo is
-> validated and ready; flipping CI on is a separate, reviewed change.
+> [!IMPORTANT]
+> This is a **first-cut, gating** integration. A full-repo cached build under the file-access sandbox
+> surfaces per-project issues (files written after a project finishes, non-deterministic outputs, duplicate
+> writes across projects, cache-busting global properties) that can only be shaken out by real CI runs.
+> Expect to add exclusions to `eng/projectcaching.props` (e.g.
+> `MSBuildCacheIgnoredOutputPatterns`, `MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns`,
+> `MSBuildCacheIdenticalDuplicateOutputPatterns`, `MSBuildCacheGlobalPropertiesToIgnore`) over a few
+> iterations before the Windows job is reliably green. The `BuildCache.binlog` published under
+> `artifacts/log/<Configuration>` and the `MSBuildCache` log directory are the primary debugging inputs.
 
 ## Troubleshooting
 

--- a/docs/build-caching.md
+++ b/docs/build-caching.md
@@ -1,0 +1,125 @@
+# Build caching with BuildXL (MSBuildCache)
+
+testfx can build with the [BuildXL](https://github.com/microsoft/BuildXL)-backed
+[MSBuildCache](https://github.com/microsoft/MSBuildCache) MSBuild project-cache plugin. When enabled, the
+plugin caches the outputs of each project — keyed on the exact set of files the project reads and the
+compiler/tool inputs — so that unchanged projects are served from the cache instead of being rebuilt.
+Cached outputs can be shared across machines (Azure Pipelines) or reused locally.
+
+> [!IMPORTANT]
+> MSBuildCache only produces correct results on a **clean repo** (a fresh checkout, a PR build, or a CI
+> build). It does **not** support incremental local dev builds where `bin`/`obj` from a previous build are
+> still around. Use it on a clean tree, or run `git clean -xdf` first.
+
+## How it is wired up
+
+Caching is **off by default**. Nothing is restored or imported unless you pass
+`/p:MSBuildCacheEnabled=true`, so normal `build.cmd` / `build.sh` runs are unaffected.
+
+| File | Role |
+| --- | --- |
+| `Directory.Packages.props` | Selects the backend package (`Microsoft.MSBuildCache.AzurePipelines` in Azure Pipelines, `Microsoft.MSBuildCache.Local` elsewhere), pins `MSBuildCachePackageVersion`, and adds the `GlobalPackageReference`s — all guarded by `MSBuildCacheEnabled`. |
+| `eng/projectcaching.props` | Repo-specific plugin settings (cache universe, allowed post-project file accesses). Imported from `Directory.Build.props` only when caching is enabled. |
+| `Directory.Build.props` | Conditionally imports `eng/projectcaching.props`. |
+| `eng/build-with-cache.ps1` | Convenience wrapper that runs a cached local build with the correct MSBuild engine and switches. |
+
+The plugin's own `build/*.props` and `build/*.targets` are imported automatically by the
+`GlobalPackageReference` when the package is restored.
+
+## Requirements — read this before running
+
+The plugin needs MSBuild's file-access sandbox, which has two hard requirements:
+
+- **x64 desktop `MSBuild.exe`** (from Visual Studio 17.9+), specifically the x64 flavor at
+  `MSBuild\Current\Bin\amd64\MSBuild.exe`.
+  - The .NET (Core) MSBuild used by `dotnet build` / `dotnet msbuild` **does not** support the
+    `-reportFileAccesses` switch and will fail with `MSB1001: Unknown switch`.
+  - The 32-bit desktop MSBuild fails with *"Reporting file accesses is only currently supported using the
+    x64 flavor of MSBuild."*
+- The build must be invoked with `-graph -m -reportFileAccesses` and `/p:MSBuildCacheEnabled=true`.
+
+## Running a cached build locally
+
+Local builds use the `Microsoft.MSBuildCache.Local` backend (BuildXL `LocalCache`). The helper script
+locates the x64 desktop MSBuild, points it at the repo-pinned SDK, and passes the required switches. Because
+incremental builds are not supported, start from a clean tree:
+
+```powershell
+git clean -xdf
+# Build a single project (fast to try) or omit -Project to build the whole solution.
+.\eng\build-with-cache.ps1 -Project src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj -Configuration Release
+```
+
+Run it, then run it again after removing the outputs (or another `git clean -xdf`). The first run populates
+the cache; the second reports cache hits, e.g.:
+
+```text
+Loading the following project cache plugin: MSBuildCacheLocalPlugin
+MSTest.Analyzers -> Cache Hit
+Project cache statistics:
+  Cache Hit Count: 1 (saved 11.4 project-seconds)
+  Cache Hit Ratio: 100.0%
+```
+
+To bust the whole local cache, pass `-CacheUniverse <new-value>` (or bump `MSBuildCacheCacheUniverse` in
+`eng/projectcaching.props`), or delete the local cache directory (defaults to `\MSBuildCache` at the drive
+root).
+
+If you prefer to invoke MSBuild yourself:
+
+```powershell
+& "<VS>\MSBuild\Current\Bin\amd64\MSBuild.exe" TestFx.slnx `
+    -graph -m -reportFileAccesses -restore `
+    -p:Configuration=Release -p:MSBuildCacheEnabled=true `
+    -p:MSBuildCacheLogDirectory=artifacts\log\Release\MSBuildCache
+```
+
+## Running a cached build in Azure Pipelines
+
+In CI the `Microsoft.MSBuildCache.AzurePipelines` backend is selected automatically (it keys off the
+`TF_BUILD` variable) and uses [Azure Pipeline Caching](https://learn.microsoft.com/azure/devops/pipelines/release/caching)
+as the shared cache store. Three things are required:
+
+1. Build with the **x64 desktop MSBuild** engine (Arcade: `-msbuildEngine vs`; ensure the x64 flavor is
+   used) so `-reportFileAccesses` is available.
+2. Pass `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true` to the build step.
+3. Expose the OAuth token and grant it the Pipeline Caching scope, because the plugin stores/reads cache
+   content through Azure Pipeline Caching:
+
+   ```yaml
+   variables:
+     # Grants $(System.AccessToken) the scope required by Pipeline Caching.
+     EnablePipelineCache: true
+
+   steps:
+   - script: eng\common\CIBuild.cmd -configuration Release -msbuildEngine vs
+       -graph -m -reportFileAccesses /p:MSBuildCacheEnabled=true
+     env:
+       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+   ```
+
+See [Pipeline caching – cache isolation and security](https://learn.microsoft.com/azure/devops/pipelines/release/caching#cache-isolation-and-security)
+for how cache entries are scoped between branches/PRs.
+
+> [!NOTE]
+> Turning caching on in the repo's CI by default is intentionally left as a follow-up: it requires the
+> Windows jobs to build with the x64 desktop MSBuild engine through Arcade. The wiring in this repo is
+> validated and ready; flipping CI on is a separate, reviewed change.
+
+## Troubleshooting
+
+- **Cache misses that should be hits** — usually a global property that changes every build is part of the
+  fingerprint (e.g. a version stamp). Add it to `MSBuildCacheGlobalPropertiesToIgnore` in
+  `eng/projectcaching.props`. Inspect the logs under the `MSBuildCache` log directory to see the fingerprint
+  inputs.
+- **"file accessed after project finished" / duplicate output errors** — a detached process (telemetry,
+  compiler server) touched a file after the project completed, or two projects wrote the same file. Add the
+  path to `MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns` or
+  `MSBuildCacheIdenticalDuplicateOutputPatterns` respectively.
+- **`MSB1001: Unknown switch` for `-reportFileAccesses`** — you're using `dotnet build` / Core MSBuild. Use
+  the x64 desktop `MSBuild.exe` instead (see Requirements).
+- **Package restore fails for `Microsoft.MSBuildCache.*`** — the dnceng `dotnet-public` feed proxies
+  nuget.org, so the packages resolve on first restore. If a locked-down environment blocks the upstream,
+  the packages must be mirrored to `dotnet-public` (or nuget.org added to `nuget.config`).
+
+The full list of settings is documented in the [MSBuildCache README](https://github.com/microsoft/MSBuildCache).

--- a/docs/build-caching.md
+++ b/docs/build-caching.md
@@ -37,24 +37,42 @@ The plugin's own `build/*.props` and `build/*.targets` are imported automaticall
 
 The plugin needs MSBuild's file-access sandbox, which has two hard requirements:
 
-- **x64 desktop `MSBuild.exe`** (from Visual Studio 17.9+), specifically the x64 flavor at
-  `MSBuild\Current\Bin\amd64\MSBuild.exe`.
+- **x64 desktop `MSBuild.exe`**, specifically the x64 flavor at `MSBuild\Current\Bin\amd64\MSBuild.exe`.
   - The .NET (Core) MSBuild used by `dotnet build` / `dotnet msbuild` **does not** support the
     `-reportFileAccesses` switch and will fail with `MSB1001: Unknown switch`.
   - The 32-bit desktop MSBuild fails with *"Reporting file accesses is only currently supported using the
     x64 flavor of MSBuild."*
 - The build must be invoked with `-graph -m -reportFileAccesses` and `/p:MSBuildCacheEnabled=true`.
 
+Two different Visual Studio floors apply, and the higher one wins:
+
+- The MSBuildCache **plugin** itself requires VS **17.9+** (for `-reportFileAccesses`).
+- **testfx** pins its own, higher requirement: `global.json` requires the VS version declared there (today
+  17.14.x with the Universal workload), and the default `TestFx.slnx` requires VS 2022 **17.13+** (see
+  `docs/dev-guide.md`). So building the default solution needs the testfx-pinned VS, not merely 17.9.
+
+The `eng/build-with-cache.ps1` helper does **not** hand-pick a VS install: it uses the Arcade helper
+(`InitializeVisualStudioMSBuild`), which enforces the `global.json` requirement and selects the
+host-architecture MSBuild, then the helper additionally asserts the resolved MSBuild is the required x64
+flavor. Only reach for a lower (17.9-17.12) VS when building an individual project that does not need the
+full solution's newer VS.
+
 ## Running a cached build locally
 
 Local builds use the `Microsoft.MSBuildCache.Local` backend (BuildXL `LocalCache`). The helper script
-locates the x64 desktop MSBuild, points it at the repo-pinned SDK, and passes the required switches. Because
-incremental builds are not supported, start from a clean tree:
+bootstraps the repo-pinned .NET SDK, locates the x64 desktop MSBuild that satisfies `global.json`, and
+passes the required switches. Because incremental builds are not supported, start from a clean tree.
+
+> [!NOTE]
+> `git clean -xdf` also deletes the repo-local `.dotnet` SDK. The helper re-bootstraps it (via the Arcade
+> `InitializeDotNetCli` helper) on its next run, so the sequence below works; but if you invoke MSBuild
+> yourself instead of the helper, run `.\build.cmd -restore` (or `.\eng\common\build.ps1 -restore`) after
+> the clean to reinstall the pinned SDK first.
 
 ```powershell
 git clean -xdf
 # Build a single project (fast to try) or omit -Project to build the whole solution.
-.\eng\build-with-cache.ps1 -Project src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj -Configuration Release
+.\eng\build-with-cache.ps1 -Project src\Analyzers\MSTest.Analyzers\MSTest.Analyzers.csproj -configuration Release
 ```
 
 Run it, then run it again after removing the outputs (or another `git clean -xdf`). The first run populates
@@ -83,20 +101,27 @@ If you prefer to invoke MSBuild yourself:
 
 ## Running a cached build in Azure Pipelines
 
-Caching is **enabled by default on the Windows CI job**. Because the plugin only engages when the real
-project graph is the MSBuild entry point (not through Arcade's `Build.proj`, which builds projects via a
+Caching is **enabled by default on the non-fork Windows CI job**. Because the plugin only engages when the
+real project graph is the MSBuild entry point (not through Arcade's `Build.proj`, which builds projects via a
 nested MSBuild task), the Windows job is split into three steps:
 
-1. **Restore (Arcade)** — `eng\common\CIBuild.cmd ... /p:Build=false /p:Pack=false /p:Sign=false` restores
-   the toolset and all packages.
-2. **Build (BuildXL cache)** — `eng\build-with-cache.ps1` runs the x64 desktop MSBuild on `TestFx.slnx`
-   with `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true`. The `Microsoft.MSBuildCache.AzurePipelines`
-   backend is selected automatically (via `TF_BUILD`) and uses
+1. **Restore (Arcade, cache)** — `eng\common\CIBuild.cmd ... /p:Build=false /p:Pack=false /p:Sign=false
+   /p:MSBuildCacheEnabled=true` restores the toolset and all packages. Passing `MSBuildCacheEnabled=true`
+   here is required: it makes restore include the plugin's `GlobalPackageReference` so the next (`-NoRestore`)
+   step actually imports the plugin.
+2. **Build (BuildXL cache)** — `eng\build-with-cache.ps1 -ci` runs the x64 desktop MSBuild on `TestFx.slnx`
+   with `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true`, plus the CI build semantics Arcade would
+   otherwise apply (`ContinuousIntegrationBuild=true`, `-warnaserror`, `-nr:false`). The
+   `Microsoft.MSBuildCache.AzurePipelines` backend is selected automatically (via `TF_BUILD`) and uses
    [Azure Pipeline Caching](https://learn.microsoft.com/azure/devops/pipelines/release/caching) as the
    shared cache store. This step maps `SYSTEM_ACCESSTOKEN`, and the job sets the `EnablePipelineCache`
    variable to grant that token the Pipeline Caching scope.
-3. **Pack (Arcade)** — `eng\common\CIBuild.cmd ... /p:Build=false /p:Pack=true` packs the already-built
+3. **Sign + Pack (Arcade)** — `eng\common\CIBuild.cmd ... /p:Build=false` signs and packs the already-built
    outputs.
+
+**Fork PRs** do not receive `SYSTEM_ACCESSTOKEN`, which the Azure Pipelines cache backend requires. The
+three cached steps are therefore gated on `ne(variables._IsFork, 'True')`, and a fork build instead runs a
+single uncached Arcade build (the pre-caching behaviour), so fork PRs stay green.
 
 See [Pipeline caching – cache isolation and security](https://learn.microsoft.com/azure/devops/pipelines/release/caching#cache-isolation-and-security)
 for how cache entries are scoped between branches/PRs.
@@ -113,14 +138,22 @@ for how cache entries are scoped between branches/PRs.
 
 ## Troubleshooting
 
-- **Cache misses that should be hits** — usually a global property that changes every build is part of the
-  fingerprint (e.g. a version stamp). Add it to `MSBuildCacheGlobalPropertiesToIgnore` in
-  `eng/projectcaching.props`. Inspect the logs under the `MSBuildCache` log directory to see the fingerprint
-  inputs.
-- **"file accessed after project finished" / duplicate output errors** — a detached process (telemetry,
-  compiler server) touched a file after the project completed, or two projects wrote the same file. Add the
-  path to `MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns` or
-  `MSBuildCacheIdenticalDuplicateOutputPatterns` respectively.
+- **Cache misses that should be hits** — a global property that changes every build is part of the
+  fingerprint. It is only safe to add a property to `MSBuildCacheGlobalPropertiesToIgnore` if it provably
+  does **not** affect any output. In particular, do **not** ignore a version/build-number stamp: it is baked
+  into assemblies and packages, so ignoring it would let the cache replay artifacts carrying a stale version.
+  For genuinely output-irrelevant properties (e.g. a machine name or a timestamp used only for logging),
+  ignoring them is appropriate. Inspect the logs under the `MSBuildCache` log directory to see exactly which
+  fingerprint input changed before deciding.
+- **"file accessed after project finished"** — a detached process (e.g. telemetry) touched a file after the
+  project completed. Only add the path to `MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns` if that
+  access provably does not feed the project's outputs; allow-listed accesses are excluded from cache
+  accounting, so allow-listing a real build input would create invalid cache hits. Do **not** allow-list
+  compiler/tool inputs — the `Microsoft.MSBuildCache.SharedCompilation` package (already referenced) exists
+  to keep the Roslyn compiler-server accesses tracked.
+- **Duplicate output errors** — two projects wrote the same file. If (and only if) the contents are
+  identical and portable, add the path to `MSBuildCacheIdenticalDuplicateOutputPatterns`; otherwise fix the
+  projects so they don't both produce it.
 - **`MSB1001: Unknown switch` for `-reportFileAccesses`** — you're using `dotnet build` / Core MSBuild. Use
   the x64 desktop `MSBuild.exe` instead (see Requirements).
 - **Package restore fails for `Microsoft.MSBuildCache.*`** — the dnceng `dotnet-public` feed proxies

--- a/eng/build-with-cache.ps1
+++ b/eng/build-with-cache.ps1
@@ -1,34 +1,48 @@
 #!/usr/bin/env pwsh
-# Runs a cached build using the BuildXL-backed MSBuildCache project-cache plugin.
+# Runs a build using the BuildXL-backed MSBuildCache project-cache plugin.
 #
 # The plugin requires the x64 flavor of *desktop* MSBuild.exe with -reportFileAccesses; the .NET (Core)
-# MSBuild used by `dotnet build` does not support that switch. This script locates the x64 desktop
-# MSBuild.exe (VS 17.9+), points it at the repo-pinned .NET SDK, and runs a static-graph build with caching
-# enabled. See docs/build-caching.md for details.
+# MSBuild used by `dotnet build` does not support that switch. It also only engages when the actual
+# project/solution graph is the build entry point -- it does NOT engage when the build is driven through
+# Arcade's Build.proj (which builds projects via a nested MSBuild task). This script therefore invokes the
+# x64 desktop MSBuild.exe directly on the given project/solution graph. See docs/build-caching.md.
 #
 # MSBuildCache only produces correct results on a CLEAN tree (it does not support incremental dev builds),
-# so start from a fresh checkout or run `git clean -xdf` first.
+# so start from a fresh checkout or run `git clean -xdf` first. In CI the tree is already clean.
+#
+# The repo-pinned .NET SDK must already be installed (run an Arcade restore first, e.g. build.cmd -restore
+# or eng\common\CIBuild.cmd ... -restore /p:Build=false), so that the Arcade MSBuild SDK resolves.
 [CmdletBinding(PositionalBinding = $false)]
 param(
     # Project, solution, or solution filter to build. Defaults to the full solution.
     [string] $Project = "$PSScriptRoot\..\TestFx.slnx",
     [string][Alias('c')] $Configuration = 'Release',
-    # BuildXL cache universe; bump (or override) to invalidate all cache entries.
+    # Semicolon-separated MSBuild targets to run.
+    [string] $Targets = 'Build',
+    # BuildXL cache universe; overriding (or bumping the value in eng/projectcaching.props) invalidates the cache.
     [string] $CacheUniverse = '',
+    # Skip NuGet restore (use when a previous Arcade restore already populated project.assets.json).
     [switch] $NoRestore,
-    # Extra args passed straight through to MSBuild.exe.
+    # Path to write an MSBuild binary log to (optional).
+    [string] $BinaryLog = '',
+    # Extra MSBuild properties as "Name=Value" strings (each becomes -p:Name=Value).
+    [string[]] $ExtraProperties = @(),
+    # Extra args passed straight through to MSBuild.exe (e.g. -bl:..., -p:Foo=Bar).
     [Parameter(ValueFromRemainingArguments = $true)][string[]] $MSBuildArgs
 )
 
 $ErrorActionPreference = 'Stop'
-$repoRoot = Resolve-Path "$PSScriptRoot\.."
+$repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 
-# Ensure the repo-pinned .NET SDK (.dotnet) is installed and first on PATH so desktop MSBuild resolves it.
-. "$PSScriptRoot\common\tools.ps1"
-$dotnetRoot = InitializeDotNetCli -install:$true
-$env:DOTNET_ROOT = $dotnetRoot
-$env:DOTNET_MULTILEVEL_LOOKUP = '0'
-$env:PATH = "$dotnetRoot;$env:PATH"
+# Ensure the repo-pinned .NET SDK is first on PATH so desktop MSBuild resolves it (and the Arcade SDK).
+$dotnetRoot = if ($env:DOTNET_ROOT) { $env:DOTNET_ROOT }
+    elseif (Test-Path (Join-Path $repoRoot '.dotnet')) { Join-Path $repoRoot '.dotnet' }
+    else { $null }
+if ($dotnetRoot) {
+    $env:DOTNET_ROOT = $dotnetRoot
+    $env:DOTNET_MULTILEVEL_LOOKUP = '0'
+    $env:PATH = "$dotnetRoot;$env:PATH"
+}
 
 # Locate the x64 desktop MSBuild.exe (Bin\amd64\MSBuild.exe). -reportFileAccesses is x64-only.
 $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
@@ -47,12 +61,15 @@ $logDir = Join-Path $repoRoot "artifacts\log\$Configuration\MSBuildCache"
 $argsList = @(
     (Resolve-Path $Project).Path,
     '-graph', '-m', '-reportFileAccesses',
+    "-t:$Targets",
     "-p:Configuration=$Configuration",
     '-p:MSBuildCacheEnabled=true',
     "-p:MSBuildCacheLogDirectory=$logDir"
 )
 if (-not $NoRestore) { $argsList += '-restore' }
 if ($CacheUniverse) { $argsList += "-p:MSBuildCacheCacheUniverse=$CacheUniverse" }
+if ($BinaryLog) { $argsList += "-bl:$BinaryLog" }
+foreach ($p in $ExtraProperties) { if ($p) { $argsList += "-p:$p" } }
 if ($MSBuildArgs) { $argsList += $MSBuildArgs }
 
 Write-Host "& `"$msbuild`" $($argsList -join ' ')"

--- a/eng/build-with-cache.ps1
+++ b/eng/build-with-cache.ps1
@@ -1,74 +1,88 @@
 #!/usr/bin/env pwsh
 # Runs a build using the BuildXL-backed MSBuildCache project-cache plugin.
 #
-# The plugin requires the x64 flavor of *desktop* MSBuild.exe with -reportFileAccesses; the .NET (Core)
-# MSBuild used by `dotnet build` does not support that switch. It also only engages when the actual
-# project/solution graph is the build entry point -- it does NOT engage when the build is driven through
-# Arcade's Build.proj (which builds projects via a nested MSBuild task). This script therefore invokes the
-# x64 desktop MSBuild.exe directly on the given project/solution graph. See docs/build-caching.md.
+# Why this script exists (see docs/build-caching.md for the full story):
+#   * The plugin needs the x64 flavor of *desktop* MSBuild.exe with -reportFileAccesses. The .NET (Core)
+#     MSBuild used by `dotnet build` does not support that switch, and the 32-bit desktop MSBuild rejects it.
+#   * The plugin only engages when the real project/solution graph is the MSBuild entry point. It does NOT
+#     engage when the build is driven through Arcade's Build.proj (which builds projects via a nested MSBuild
+#     task), so this script invokes MSBuild.exe directly on the given project/solution graph.
+#
+# It reuses the Arcade helpers in eng/common/tools.ps1 to bootstrap the repo-pinned .NET SDK and to locate
+# the Visual Studio / MSBuild that satisfies the requirements declared in global.json (rather than picking an
+# arbitrary VS install), then asserts the resolved MSBuild is the required x64 flavor.
 #
 # MSBuildCache only produces correct results on a CLEAN tree (it does not support incremental dev builds),
 # so start from a fresh checkout or run `git clean -xdf` first. In CI the tree is already clean.
-#
-# The repo-pinned .NET SDK must already be installed (run an Arcade restore first, e.g. build.cmd -restore
-# or eng\common\CIBuild.cmd ... -restore /p:Build=false), so that the Arcade MSBuild SDK resolves.
 [CmdletBinding(PositionalBinding = $false)]
 param(
     # Project, solution, or solution filter to build. Defaults to the full solution.
     [string] $Project = "$PSScriptRoot\..\TestFx.slnx",
-    [string][Alias('c')] $Configuration = 'Release',
+    [string][Alias('c')] $configuration = 'Release',
     # Semicolon-separated MSBuild targets to run.
     [string] $Targets = 'Build',
     # BuildXL cache universe; overriding (or bumping the value in eng/projectcaching.props) invalidates the cache.
     [string] $CacheUniverse = '',
-    # Skip NuGet restore (use when a previous Arcade restore already populated project.assets.json).
+    # Skip NuGet restore (use when a previous Arcade restore already populated project.assets.json AND the
+    # MSBuildCache package -- restore MUST have run with /p:MSBuildCacheEnabled=true, otherwise the plugin
+    # will not be imported and the build runs uncached).
     [switch] $NoRestore,
-    # Path to write an MSBuild binary log to (optional).
-    [string] $BinaryLog = '',
+    # Set to true on CI. Mirrors the CI build semantics Arcade's CIBuild.cmd applies
+    # (ContinuousIntegrationBuild=true, warnings-as-errors, node reuse disabled).
+    [switch] $ci,
+    # Path to write an MSBuild binary log to (optional). Named BinLogPath (not BinaryLog) to avoid a
+    # case-insensitive collision with the internal $binaryLog variable in eng/common/tools.ps1.
+    [string] $BinLogPath = '',
     # Extra MSBuild properties as "Name=Value" strings (each becomes -p:Name=Value).
     [string[]] $ExtraProperties = @(),
-    # Extra args passed straight through to MSBuild.exe (e.g. -bl:..., -p:Foo=Bar).
+    # Extra args passed straight through to MSBuild.exe.
     [Parameter(ValueFromRemainingArguments = $true)][string[]] $MSBuildArgs
 )
 
 $ErrorActionPreference = 'Stop'
 $repoRoot = (Resolve-Path "$PSScriptRoot\..").Path
 
-# Ensure the repo-pinned .NET SDK is first on PATH so desktop MSBuild resolves it (and the Arcade SDK).
-$dotnetRoot = if ($env:DOTNET_ROOT) { $env:DOTNET_ROOT }
-    elseif (Test-Path (Join-Path $repoRoot '.dotnet')) { Join-Path $repoRoot '.dotnet' }
-    else { $null }
-if ($dotnetRoot) {
-    $env:DOTNET_ROOT = $dotnetRoot
-    $env:DOTNET_MULTILEVEL_LOOKUP = '0'
-    $env:PATH = "$dotnetRoot;$env:PATH"
-}
+# Reuse the Arcade helpers: they bootstrap the repo-pinned SDK and enforce the global.json VS requirements.
+. "$PSScriptRoot\common\tools.ps1"
 
-# Locate the x64 desktop MSBuild.exe (Bin\amd64\MSBuild.exe). -reportFileAccesses is x64-only.
-$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-if (-not (Test-Path $vswhere)) {
-    throw "vswhere.exe not found. Visual Studio 17.9+ (with the MSBuild component) is required for cached builds."
-}
-$msbuild = & $vswhere -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe |
-    Select-Object -First 1
-if (-not $msbuild) {
-    throw "Could not find x64 desktop MSBuild.exe (Bin\amd64\MSBuild.exe). Install/repair Visual Studio 17.9+."
+# Bootstrap / locate the repo-pinned .NET SDK (also restores it after a `git clean -xdf`).
+$dotnetRoot = InitializeDotNetCli -install:$true -createSdkLocationFile:$true
+$env:DOTNET_ROOT = $dotnetRoot
+$env:DOTNET_MULTILEVEL_LOOKUP = '0'
+# Point desktop MSBuild's .NET SDK resolver at the bootstrapped SDK so MSBuild-SDK-style projects (Arcade)
+# resolve, and put it first on PATH.
+$env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR = $dotnetRoot
+$env:PATH = "$dotnetRoot;$env:PATH"
+
+# Locate the VS/MSBuild that satisfies global.json requirements (throws if none is found), then require the
+# x64 flavor because -reportFileAccesses is x64-only.
+$msbuild = InitializeVisualStudioMSBuild
+if ($msbuild -notmatch '\\amd64\\MSBuild\.exe$') {
+    throw "MSBuildCache requires the x64 desktop MSBuild (Bin\amd64\MSBuild.exe), but Arcade resolved '$msbuild'. " +
+          "Run this on an x64 host with a matching Visual Studio installed."
 }
 Write-Host "Using MSBuild: $msbuild"
 
-$logDir = Join-Path $repoRoot "artifacts\log\$Configuration\MSBuildCache"
+$logDir = Join-Path $repoRoot "artifacts\log\$configuration\MSBuildCache"
 
 $argsList = @(
     (Resolve-Path $Project).Path,
     '-graph', '-m', '-reportFileAccesses',
     "-t:$Targets",
-    "-p:Configuration=$Configuration",
+    "-p:Configuration=$configuration",
     '-p:MSBuildCacheEnabled=true',
     "-p:MSBuildCacheLogDirectory=$logDir"
 )
 if (-not $NoRestore) { $argsList += '-restore' }
+if ($ci) {
+    # Mirror the CI semantics that Arcade's CIBuild.cmd / tools.ps1 apply so the cached compile is a real CI
+    # build: mark it a CI build, treat warnings as errors, and disable node reuse.
+    $argsList += '-p:ContinuousIntegrationBuild=true'
+    $argsList += '-warnaserror'
+    $argsList += '-nr:false'
+}
 if ($CacheUniverse) { $argsList += "-p:MSBuildCacheCacheUniverse=$CacheUniverse" }
-if ($BinaryLog) { $argsList += "-bl:$BinaryLog" }
+if ($BinLogPath) { $argsList += "-bl:$BinLogPath" }
 foreach ($p in $ExtraProperties) { if ($p) { $argsList += "-p:$p" } }
 if ($MSBuildArgs) { $argsList += $MSBuildArgs }
 

--- a/eng/build-with-cache.ps1
+++ b/eng/build-with-cache.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+# Runs a cached build using the BuildXL-backed MSBuildCache project-cache plugin.
+#
+# The plugin requires the x64 flavor of *desktop* MSBuild.exe with -reportFileAccesses; the .NET (Core)
+# MSBuild used by `dotnet build` does not support that switch. This script locates the x64 desktop
+# MSBuild.exe (VS 17.9+), points it at the repo-pinned .NET SDK, and runs a static-graph build with caching
+# enabled. See docs/build-caching.md for details.
+#
+# MSBuildCache only produces correct results on a CLEAN tree (it does not support incremental dev builds),
+# so start from a fresh checkout or run `git clean -xdf` first.
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    # Project, solution, or solution filter to build. Defaults to the full solution.
+    [string] $Project = "$PSScriptRoot\..\TestFx.slnx",
+    [string][Alias('c')] $Configuration = 'Release',
+    # BuildXL cache universe; bump (or override) to invalidate all cache entries.
+    [string] $CacheUniverse = '',
+    [switch] $NoRestore,
+    # Extra args passed straight through to MSBuild.exe.
+    [Parameter(ValueFromRemainingArguments = $true)][string[]] $MSBuildArgs
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Resolve-Path "$PSScriptRoot\.."
+
+# Ensure the repo-pinned .NET SDK (.dotnet) is installed and first on PATH so desktop MSBuild resolves it.
+. "$PSScriptRoot\common\tools.ps1"
+$dotnetRoot = InitializeDotNetCli -install:$true
+$env:DOTNET_ROOT = $dotnetRoot
+$env:DOTNET_MULTILEVEL_LOOKUP = '0'
+$env:PATH = "$dotnetRoot;$env:PATH"
+
+# Locate the x64 desktop MSBuild.exe (Bin\amd64\MSBuild.exe). -reportFileAccesses is x64-only.
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) {
+    throw "vswhere.exe not found. Visual Studio 17.9+ (with the MSBuild component) is required for cached builds."
+}
+$msbuild = & $vswhere -latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\amd64\MSBuild.exe |
+    Select-Object -First 1
+if (-not $msbuild) {
+    throw "Could not find x64 desktop MSBuild.exe (Bin\amd64\MSBuild.exe). Install/repair Visual Studio 17.9+."
+}
+Write-Host "Using MSBuild: $msbuild"
+
+$logDir = Join-Path $repoRoot "artifacts\log\$Configuration\MSBuildCache"
+
+$argsList = @(
+    (Resolve-Path $Project).Path,
+    '-graph', '-m', '-reportFileAccesses',
+    "-p:Configuration=$Configuration",
+    '-p:MSBuildCacheEnabled=true',
+    "-p:MSBuildCacheLogDirectory=$logDir"
+)
+if (-not $NoRestore) { $argsList += '-restore' }
+if ($CacheUniverse) { $argsList += "-p:MSBuildCacheCacheUniverse=$CacheUniverse" }
+if ($MSBuildArgs) { $argsList += $MSBuildArgs }
+
+Write-Host "& `"$msbuild`" $($argsList -join ' ')"
+& $msbuild @argsList
+exit $LASTEXITCODE

--- a/eng/projectcaching.props
+++ b/eng/projectcaching.props
@@ -8,9 +8,19 @@
     GlobalPackageReference that pulls in the plugin (and auto-imports its build props/targets) live in
     Directory.Packages.props. Here we only override the plugin's default settings for this repo.
 
-    When adding to a list-typed setting, always append to the existing value ($(Setting);newvalue) so the
-    plugin's own defaults are preserved. See https://github.com/microsoft/MSBuildCache for the full list of
-    settings and their meanings.
+    IMPORTANT (evaluation order):
+      This file is imported from Directory.Build.props, which is evaluated BEFORE the plugin's own
+      build/*.props (they come in via the NuGet-generated obj/*.nuget.g.props). The plugin sets its list
+      defaults (e.g. MSBuildCacheIgnoredOutputPatterns, MSBuildCacheGlobalPropertiesToIgnore) with
+      Condition="'$(Setting)' == ''", so any value assigned to one of those settings HERE would be seen as
+      non-empty and would SUPPRESS the plugin default. Therefore:
+        * Only set settings that either have no plugin default, or that you intend to fully own.
+        * To extend a setting that HAS a plugin default, set the complete intended value (the defaults are
+          not visible at this import point; see the README for each setting's default), or add the
+          customization from a hook that runs after the plugin package props.
+      The settings below are safe at this point: MSBuildCacheCacheUniverse is a scalar override, and the
+      plugin provides no default for MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns.
+      See https://github.com/microsoft/MSBuildCache for the full list of settings and their defaults.
   -->
   <PropertyGroup>
     <!-- Bump this to invalidate every existing cache entry (e.g. after a toolchain change that the
@@ -19,8 +29,12 @@
 
     <!--
       Visual Studio / Application Insights telemetry (Microsoft.ApplicationInsights is referenced by product
-      code) reads config and cache files from a detached process after the owning project has finished
-      building. These accesses do not affect build correctness, so allow them rather than failing the cache.
+      code) reads config and cache files from a detached process AFTER the owning project has finished
+      building. Only paths that provably do not feed the project's outputs belong here: these are pure
+      telemetry side-effect reads, so excluding them from cache accounting is correct. Do NOT add compiler or
+      other tool inputs here; those must stay tracked (that is what the SharedCompilation package handles).
+      The self-reference preserves any value already supplied (e.g. via a global property); the plugin does
+      not provide a default for this particular setting.
     -->
     <MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
       $(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns);

--- a/eng/projectcaching.props
+++ b/eng/projectcaching.props
@@ -1,0 +1,33 @@
+<Project>
+
+  <!--
+    Repo-specific tuning for the BuildXL-backed MSBuild project cache (Microsoft.MSBuildCache).
+
+    This file is only imported (from Directory.Build.props) when the build is invoked with
+    /p:MSBuildCacheEnabled=true, so it has no effect on normal builds. The package name/version and the
+    GlobalPackageReference that pulls in the plugin (and auto-imports its build props/targets) live in
+    Directory.Packages.props. Here we only override the plugin's default settings for this repo.
+
+    When adding to a list-typed setting, always append to the existing value ($(Setting);newvalue) so the
+    plugin's own defaults are preserved. See https://github.com/microsoft/MSBuildCache for the full list of
+    settings and their meanings.
+  -->
+  <PropertyGroup>
+    <!-- Bump this to invalidate every existing cache entry (e.g. after a toolchain change that the
+         fingerprint does not otherwise capture). -->
+    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">testfx-1</MSBuildCacheCacheUniverse>
+
+    <!--
+      Visual Studio / Application Insights telemetry (Microsoft.ApplicationInsights is referenced by product
+      code) reads config and cache files from a detached process after the owning project has finished
+      building. These accesses do not affect build correctness, so allow them rather than failing the cache.
+    -->
+    <MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
+      $(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns);
+      \**\ApplicationInsights.config;
+      $(LocalAppData)\Microsoft\VSApplicationInsights\**;
+      $(LocalAppData)\Microsoft\Windows\INetCache\**
+    </MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## What

Enables the BuildXL-backed [Microsoft.MSBuildCache](https://github.com/microsoft/MSBuildCache) project-cache plugin and makes it the **gating Windows CI build**, plus a local path and docs.

Follows the plugin README (CPM + Azure Pipelines) and the microsoft/microsoft-ui-xaml example (which builds its solution directly, not through Arcade).

## Key mechanism finding

MSBuildCache only engages when the **real project graph is the MSBuild entry point**, using **x64 desktop `MSBuild.exe`** with `-reportFileAccesses`. I verified that:
- `dotnet build` / Core MSBuild rejects `-reportFileAccesses`; the 32-bit desktop MSBuild errors "x64 flavor only".
- Building through Arcade's `Build.proj` (nested MSBuild task) does **not** load the plugin (empty cache logs).

So the build must invoke x64 desktop MSBuild directly on `TestFx.slnx`.

## Changes

- **`Directory.Packages.props`** — backend selection (`AzurePipelines` in CI / `Local` locally), pinned version, gated `GlobalPackageReference`s (off unless `/p:MSBuildCacheEnabled=true`).
- **`eng/projectcaching.props`** — repo-specific plugin settings; imported from `Directory.Build.props` only when enabled.
- **`eng/build-with-cache.ps1`** — CI-safe wrapper: locates x64 desktop MSBuild, points it at the repo SDK, runs `-graph -m -reportFileAccesses -p:MSBuildCacheEnabled=true`. Used locally and by CI.
- **`azure-pipelines.yml`** — Windows job now builds under the cache: **Restore (Arcade) → Build (BuildXL cache) → Pack (Arcade)**, with `EnablePipelineCache` + `SYSTEM_ACCESSTOKEN` for the Azure Pipelines cache backend.
- **`docs/build-caching.md`** — usage, requirements, CI structure, troubleshooting.

## Validation done locally

- Default off = zero impact (baseline restore/build unchanged; `MSBuildCacheAssembly` empty).
- Enabled: packages resolve from dnceng feeds; `ProjectCachePlugin` registers with repo settings.
- Functional: populate (miss) → **100% cache hit** on rebuild under x64 desktop MSBuild.
- `azure-pipelines.yml` parses; `docs/` passes markdownlint; helper runs end-to-end.

## Expected: red until tuned ⚠️

This is a **first-cut gating** integration. A full-repo cached build under the file-access sandbox surfaces per-project issues (files written after a project finishes, non-deterministic/duplicate outputs, cache-busting global properties) that only real CI runs reveal. Expect to add exclusions to `eng/projectcaching.props` (`MSBuildCacheIgnoredOutputPatterns`, `MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns`, `MSBuildCacheIdenticalDuplicateOutputPatterns`, `MSBuildCacheGlobalPropertiesToIgnore`) over a few iterations. The published `BuildCache.binlog` and `MSBuildCache` logs are the debugging inputs. Also note the Windows build was split into Restore/Build/Pack, which may need adjustment so the downstream Test/pack steps stay green.