### PR TITLE
Refactor duplicate code in TestHostManager and TestHostControllersManager

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHost/TestHostManager.cs
@@ -38,25 +38,8 @@ internal sealed class TestHostManager : ITestHostManager
         _testFrameworkInvokerFactory = testFrameworkInvokerFactory ?? throw new ArgumentNullException(nameof(testFrameworkInvokerFactory));
     }
 
-    internal async Task<ActionResult<ITestFrameworkInvoker>> TryBuildTestAdapterInvokerAsync(ServiceProvider serviceProvider)
-    {
-        if (_testFrameworkInvokerFactory is null)
-        {
-            return ActionResult.Fail<ITestFrameworkInvoker>();
-        }
-
-        ITestFrameworkInvoker testAdapterInvoke = _testFrameworkInvokerFactory(serviceProvider);
-
-        // We initialize only if enabled
-        if (await testAdapterInvoke.IsEnabledAsync().ConfigureAwait(false))
-        {
-            await testAdapterInvoke.TryInitializeAsync().ConfigureAwait(false);
-
-            return ActionResult.Ok(testAdapterInvoke);
-        }
-
-        return ActionResult.Fail<ITestFrameworkInvoker>();
-    }
+    internal Task<ActionResult<ITestFrameworkInvoker>> TryBuildTestAdapterInvokerAsync(ServiceProvider serviceProvider)
+        => TryBuildSingletonExtensionAsync(_testFrameworkInvokerFactory, serviceProvider);
 
     public void AddTestExecutionFilterFactory(Func<IServiceProvider, ITestExecutionFilterFactory> testExecutionFilterFactory)
     {
@@ -68,24 +51,28 @@ internal sealed class TestHostManager : ITestHostManager
         _testExecutionFilterFactory = testExecutionFilterFactory ?? throw new ArgumentNullException(nameof(testExecutionFilterFactory));
     }
 
-    internal async Task<ActionResult<ITestExecutionFilterFactory>> TryBuildTestExecutionFilterFactoryAsync(ServiceProvider serviceProvider)
+    internal Task<ActionResult<ITestExecutionFilterFactory>> TryBuildTestExecutionFilterFactoryAsync(ServiceProvider serviceProvider)
+        => TryBuildSingletonExtensionAsync(_testExecutionFilterFactory, serviceProvider);
+
+    private static async Task<ActionResult<T>> TryBuildSingletonExtensionAsync<T>(Func<IServiceProvider, T>? factory, ServiceProvider serviceProvider)
+        where T : class, IExtension
     {
-        if (_testExecutionFilterFactory is null)
+        if (factory is null)
         {
-            return ActionResult.Fail<ITestExecutionFilterFactory>();
+            return ActionResult.Fail<T>();
         }
 
-        ITestExecutionFilterFactory testExecutionFilterFactory = _testExecutionFilterFactory(serviceProvider);
+        T extension = factory(serviceProvider);
 
         // We initialize only if enabled
-        if (await testExecutionFilterFactory.IsEnabledAsync().ConfigureAwait(false))
+        if (await extension.IsEnabledAsync().ConfigureAwait(false))
         {
-            await testExecutionFilterFactory.TryInitializeAsync().ConfigureAwait(false);
+            await extension.TryInitializeAsync().ConfigureAwait(false);
 
-            return ActionResult.Ok(testExecutionFilterFactory);
+            return ActionResult.Ok(extension);
         }
 
-        return ActionResult.Fail<ITestExecutionFilterFactory>();
+        return ActionResult.Fail<T>();
     }
 
     public void AddTestHostApplicationLifetime(Func<IServiceProvider, ITestHostApplicationLifetime> testHostApplicationLifetime)

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostControllersManager.cs
@@ -23,6 +23,14 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     private readonly List<ICompositeExtensionFactory> _alreadyBuiltServices = [];
     private readonly List<ICompositeExtensionFactory> _dataConsumersCompositeServiceFactories = [];
 
+    private static void ThrowIfBrowserPlatform()
+    {
+        if (OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
+        }
+    }
+
     [UnsupportedOSPlatform("browser")]
     public void AddEnvironmentVariableProvider(Func<IServiceProvider, ITestHostEnvironmentVariableProvider> environmentVariableProviderFactory)
         => AddEnvironmentVariableProvider(environmentVariableProviderFactory, insertAtStart: false);
@@ -33,10 +41,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
 
     private void AddEnvironmentVariableProvider(Func<IServiceProvider, ITestHostEnvironmentVariableProvider> environmentVariableProviderFactory, bool insertAtStart)
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = environmentVariableProviderFactory ?? throw new ArgumentNullException(nameof(environmentVariableProviderFactory));
         if (insertAtStart)
@@ -54,10 +59,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddEnvironmentVariableProvider<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostEnvironmentVariableProvider
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = compositeServiceFactory ?? throw new ArgumentNullException(nameof(compositeServiceFactory));
         if (_environmentVariableProviderCompositeFactories.Contains(compositeServiceFactory))
@@ -72,10 +74,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     [UnsupportedOSPlatform("browser")]
     public void AddProcessLifetimeHandler(Func<IServiceProvider, ITestHostProcessLifetimeHandler> lifetimeHandler)
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = lifetimeHandler ?? throw new ArgumentNullException(nameof(lifetimeHandler));
         _lifetimeHandlerFactories.Add(lifetimeHandler);
@@ -86,10 +85,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddProcessLifetimeHandler<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostProcessLifetimeHandler
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = compositeServiceFactory ?? throw new ArgumentNullException(nameof(compositeServiceFactory));
         if (_lifetimeHandlerCompositeFactories.Contains(compositeServiceFactory))
@@ -104,10 +100,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     [UnsupportedOSPlatform("browser")]
     public void AddTestHostLauncher(Func<IServiceProvider, ITestHostLauncher> testHostLauncherFactory)
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = testHostLauncherFactory ?? throw new ArgumentNullException(nameof(testHostLauncherFactory));
         _testHostLauncherFactories.Add(testHostLauncherFactory);
@@ -118,10 +111,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddTestHostLauncher<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostLauncher
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = compositeServiceFactory ?? throw new ArgumentNullException(nameof(compositeServiceFactory));
         if (_testHostLauncherCompositeFactories.Contains(compositeServiceFactory))
@@ -137,10 +127,7 @@ internal sealed class TestHostControllersManager : ITestHostControllersManager
     public void AddDataConsumer<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, IDataConsumer
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            throw new PlatformNotSupportedException(PlatformResources.TestHostControllerProcessRestartNotSupportedOnWebAssembly);
-        }
+        ThrowIfBrowserPlatform();
 
         _ = compositeServiceFactory ?? throw new ArgumentNullException(nameof(compositeServiceFactory));
         if (_dataConsumersCompositeServiceFactories.Contains(compositeServiceFactory))


### PR DESCRIPTION
Fixes #9991 and #9990.

## Changes

### `TestHostManager` (#9991)
`TryBuildTestAdapterInvokerAsync` and `TryBuildTestExecutionFilterFactoryAsync` were structurally identical (null-check factory → instantiate → `IsEnabledAsync` → `TryInitializeAsync` → `ActionResult.Ok`/`Fail`). Extracted a single generic helper:

```csharp
private static async Task<ActionResult<T>> TryBuildSingletonExtensionAsync<T>(
    Func<IServiceProvider, T>? factory, ServiceProvider serviceProvider)
    where T : class, IExtension
```

Both public build methods are now one-line delegations to it. Both `ITestFrameworkInvoker` and `ITestExecutionFilterFactory` derive from `IExtension`, which exposes `IsEnabledAsync`/`TryInitializeAsync`.

### `TestHostControllersManager` (#9990)
The browser-guard block (`OperatingSystem.IsBrowser()` → throw `PlatformNotSupportedException`) was repeated across every `Add*` method. Extracted a `ThrowIfBrowserPlatform()` helper and replaced all call sites, giving a single point of maintenance for the guard.

## Verification
- `build.cmd -c Debug` on `Microsoft.Testing.Platform` succeeds with 0 warnings / 0 errors (net8.0, net9.0, netstandard2.0).
- No behavioral change: the extracted helpers preserve the exact original logic.