### PR TITLE
test: add edge case for MSTEST0052 — non-test-method with explicit DynamicDataSourceType

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidExplicitDynamicDataSourceTypeTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidExplicitDynamicDataSourceTypeTests.cs
@@ -315,4 +315,41 @@ public sealed class AvoidExplicitDynamicDataSourceTypeTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenDynamicDataWithExplicitSourceTypeIsOnNonTestMethod_Diagnostic()
+    {
+        // The analyzer registers on SymbolKind.Method and fires on any method decorated with
+        // [DynamicData(..., DynamicDataSourceType.*)] — there is no guard requiring [TestMethod].
+        // The fix simply removes the DynamicDataSourceType argument regardless.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [[|DynamicData("Data", DynamicDataSourceType.Property)|]]
+                public void HelperMethod(object[] o) { }
+
+                static IEnumerable<object[]> Data => new[] { new object[] { 1 } };
+            }
+            """;
+
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [DynamicData("Data")]
+                public void HelperMethod(object[] o) { }
+
+                static IEnumerable<object[]> Data => new[] { new object[] { 1 } };
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
## Goal

Add a missing edge-case test for `MSTEST0052` (`AvoidExplicitDynamicDataSourceTypeAnalyzer`) documenting that the analyzer fires on **any** method decorated with `[DynamicData(..., DynamicDataSourceType.*)]` — not only `[TestMethod]` methods.

The analyzer registers on `SymbolKind.Method` with no guard requiring `[TestMethod]`, so a helper/non-test method with an explicit `DynamicDataSourceType` is also flagged and fixed. This behavior was previously undocumented by tests.

## Change

Added `WhenDynamicDataWithExplicitSourceTypeIsOnNonTestMethod_Diagnostic` to `AvoidExplicitDynamicDataSourceTypeTests.cs`, verifying:
- Diagnostic fires on a method inside a `[TestClass]` that has `[DynamicData(..., DynamicDataSourceType.Property)]` but **no** `[TestMethod]`.
- Code fix removes the `DynamicDataSourceType.Property` argument, leaving `[DynamicData("Data")]`.

## Test status

All `AvoidExplicitDynamicDataSourceTypeTests` tests pass on `net8.0` and `net472` (Debug).

Fixes #9986