### PR TITLE
Dedup TestCaseFilter CLI option provider

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
@@ -25,6 +25,9 @@ Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.UpdateAs
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.ValidateTestHostEnvironmentVariablesAsync(Microsoft.Testing.Platform.Extensions.TestHostControllers.IReadOnlyEnvironmentVariables! environmentVariables) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.Version.get -> string!
 Microsoft.Testing.Extensions.RunSettingsProviderHelper
+const Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase.TestCaseFilterOptionName = "filter" -> string!
+Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase
+Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase.TestCaseFilterCommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, string! optionDescription) -> void
 const Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase.TestRunParameterOptionName = "test-parameter" -> string!
 Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase
 Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase.TestRunParametersCommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, string! optionDescription, string! argumentIsNotParameterErrorFormat) -> void

--- a/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
+++ b/src/Adapter/MSTest.TestAdapter/MSTest.TestAdapter.csproj
@@ -117,6 +117,7 @@
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsConfigurationProviderBase.cs" Link="Shared\RunSettingsConfigurationProviderBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsEnvironmentVariableProviderBase.cs" Link="Shared\RunSettingsEnvironmentVariableProviderBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestRunParametersCommandLineOptionsProviderBase.cs" Link="Shared\TestRunParametersCommandLineOptionsProviderBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestCaseFilterCommandLineOptionsProviderBase.cs" Link="Shared\TestCaseFilterCommandLineOptionsProviderBase.cs" />
     <Compile Include="$(RepoRoot)src/Polyfills/**/*.cs" Link="Polyfills\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestCaseFilterCommandLineOptionsProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestCaseFilterCommandLineOptionsProvider.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !WINDOWS_UWP
-using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Resources;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatformAdapter;
@@ -14,12 +13,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestingPlatform
 /// bridge's <c>TestCaseFilterCommandLineOptionsProvider</c> (identical option name and description).
 /// </summary>
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "We can use MTP from this folder")]
-internal sealed class MSTestTestCaseFilterCommandLineOptionsProvider : CommandLineOptionsProviderBase
+internal sealed class MSTestTestCaseFilterCommandLineOptionsProvider : TestCaseFilterCommandLineOptionsProviderBase
 {
-    public const string TestCaseFilterOptionName = "filter";
-
     public MSTestTestCaseFilterCommandLineOptionsProvider(IExtension extension)
-        : base(extension, [new CommandLineOption(TestCaseFilterOptionName, PlatformAdapterResources.TestCaseFilterOptionDescription, ArgumentArity.ExactlyOne, false)])
+        : base(extension, PlatformAdapterResources.TestCaseFilterOptionDescription)
     {
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/CommandLine/TestCaseFilterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/CommandLine/TestCaseFilterCommandLineOptionsProvider.cs
@@ -2,25 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.VSTestBridge.Resources;
-using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.CommandLine;
 
 namespace Microsoft.Testing.Extensions.VSTestBridge.CommandLine;
 
 /// <summary>
 /// A command line service provider bringing support for the VSTest test case.
 /// </summary>
-internal sealed class TestCaseFilterCommandLineOptionsProvider : CommandLineOptionsProviderBase
+internal sealed class TestCaseFilterCommandLineOptionsProvider : TestCaseFilterCommandLineOptionsProviderBase
 {
-    public const string TestCaseFilterOptionName = "filter";
-
     public TestCaseFilterCommandLineOptionsProvider(IExtension extension)
-        : base(
-            extension,
-            [
-                new(TestCaseFilterOptionName, ExtensionResources.TestCaseFilterOptionDescription, ArgumentArity.ExactlyOne, false)
-            ])
+        : base(extension, ExtensionResources.TestCaseFilterOptionDescription)
     {
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
@@ -25,6 +25,9 @@ Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.UpdateAs
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.ValidateTestHostEnvironmentVariablesAsync(Microsoft.Testing.Platform.Extensions.TestHostControllers.IReadOnlyEnvironmentVariables! environmentVariables) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ValidationResult>!
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.Version.get -> string!
 Microsoft.Testing.Extensions.RunSettingsProviderHelper
+const Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase.TestCaseFilterOptionName = "filter" -> string!
+Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase
+Microsoft.Testing.Extensions.TestCaseFilterCommandLineOptionsProviderBase.TestCaseFilterCommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, string! optionDescription) -> void
 const Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase.TestRunParameterOptionName = "test-parameter" -> string!
 Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase
 Microsoft.Testing.Extensions.TestRunParametersCommandLineOptionsProviderBase.TestRunParametersCommandLineOptionsProviderBase(Microsoft.Testing.Platform.Extensions.IExtension! extension, string! optionDescription, string! argumentIsNotParameterErrorFormat) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Microsoft.Testing.Extensions.VSTestBridge.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/Microsoft.Testing.Extensions.VSTestBridge.csproj
@@ -16,6 +16,7 @@
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsConfigurationProviderBase.cs" Link="Helpers\RunSettingsConfigurationProviderBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\RunSettingsEnvironmentVariableProviderBase.cs" Link="Helpers\RunSettingsEnvironmentVariableProviderBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestRunParametersCommandLineOptionsProviderBase.cs" Link="Helpers\TestRunParametersCommandLineOptionsProviderBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestCaseFilterCommandLineOptionsProviderBase.cs" Link="Helpers\TestCaseFilterCommandLineOptionsProviderBase.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform/SharedExtensionHelpers/TestCaseFilterCommandLineOptionsProviderBase.cs
+++ b/src/Platform/SharedExtensionHelpers/TestCaseFilterCommandLineOptionsProviderBase.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+
+namespace Microsoft.Testing.Extensions;
+
+/// <summary>
+/// Resource-independent base for the command-line provider that supports the VSTest <c>--filter</c> (test case filter)
+/// option. It owns the option registration; the concrete providers only supply the localized option description.
+/// Shared by the VSTest bridge and the MSTest adapter's native Microsoft.Testing.Platform integration so both surface
+/// an identical <c>--filter</c> option.
+/// </summary>
+[SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "The shared helper is linked into projects that are allowed to use MTP APIs")]
+internal abstract class TestCaseFilterCommandLineOptionsProviderBase : CommandLineOptionsProviderBase
+{
+    public const string TestCaseFilterOptionName = "filter";
+
+    protected TestCaseFilterCommandLineOptionsProviderBase(IExtension extension, string optionDescription)
+        : base(extension, [new CommandLineOption(TestCaseFilterOptionName, optionDescription, ArgumentArity.ExactlyOne, false)])
+    {
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Addresses the duplicate-code findings in #9955 and #9990.

### #9955 — TestCaseFilter CLI provider duplication
`MSTestTestCaseFilterCommandLineOptionsProvider` (MSTest adapter) and `TestCaseFilterCommandLineOptionsProvider` (VSTestBridge) were near-identical copies, each declaring the `filter` option name and building the same `CommandLineOption` registration.

This PR extracts a resource-independent `TestCaseFilterCommandLineOptionsProviderBase` into `src/Platform/SharedExtensionHelpers/` (linked into both projects), mirroring the existing `TestRunParametersCommandLineOptionsProviderBase` / `RunSettings*Base` pattern. The base owns the `--filter` option name and registration; each concrete provider now only supplies its localized description.

The `TestRunParameters` half of #9955 was already deduplicated earlier (#9969), so only the `--filter` providers remained.

### #9990 — Repeated browser guard in `TestHostControllersManager`
Already resolved on `main` by the `ThrowIfBrowserPlatform()` helper introduced in #9999. No further changes needed.

## Notes
- No change to the `--filter` option name, description resource, or arity, so `--help` / `--info` acceptance expectations are unaffected.
- Inherited `TestCaseFilterOptionName` const references (e.g. in `ContextAdapterBase`, `MSTestFilterContext`, and unit tests) continue to resolve via inheritance.
- `InternalAPI.Unshipped.txt` updated in both projects for the new shared base type.

## Validation
- Built `Microsoft.Testing.Extensions.VSTestBridge`, `MSTest.TestAdapter`, and `Microsoft.Testing.Extensions.VSTestBridge.UnitTests` cleanly (net462/net8.0/net9.0); InternalAPI analyzers pass.

Fixes #9955
Fixes #9990

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 718e96c4-50c3-45e3-8c3c-7c6920075c4a