### PR TITLE
Inherit Arcade default DebugType instead of forcing embedded symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -49,10 +49,10 @@
     <DebugSymbols>true</DebugSymbols>
     <!--
       Let Arcade's ProjectDefaults.props decide the DebugType: 'portable' for official builds
-      (so a separate PDB is emitted and published as a .snupkg symbol package) and 'embedded'
-      for local/non-official builds. This matches dotnet/roslyn and dotnet/sdk. We intentionally
-      do NOT force 'embedded' here, which would bake symbols into shipped assemblies and prevent
-      symbol packages from being produced.
+      (so a separate PDB is emitted, which Arcade's publishing pipeline pushes to the symbol
+      servers) and 'embedded' for local/non-official builds. This matches dotnet/roslyn and
+      dotnet/sdk. We intentionally do NOT force 'embedded' here, which would bake symbols into
+      shipped assemblies and prevent symbols from being published to the symbol servers.
     -->
     <!-- Needs to be part of the building of prod code -->
     <MoqPublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</MoqPublicKey>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,7 +47,13 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <!-- PDB -->
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>embedded</DebugType>
+    <!--
+      Let Arcade's ProjectDefaults.props decide the DebugType: 'portable' for official builds
+      (so a separate PDB is emitted and published as a .snupkg symbol package) and 'embedded'
+      for local/non-official builds. This matches dotnet/roslyn and dotnet/sdk. We intentionally
+      do NOT force 'embedded' here, which would bake symbols into shipped assemblies and prevent
+      symbol packages from being produced.
+    -->
     <!-- Needs to be part of the building of prod code -->
     <MoqPublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</MoqPublicKey>
 


### PR DESCRIPTION
## What

Removes the unconditional `<DebugType>embedded</DebugType>` override in `Directory.Build.props`, letting the repo inherit Arcade's `ProjectDefaults.props` default instead:

```xml
<DebugType>portable</DebugType>
<DebugType Condition="'$(OfficialBuild)' != 'true'">embedded</DebugType>
```

So official builds now use **`portable`** (separate PDB) and local builds keep **`embedded`** for developer convenience.

## Why

The forced `embedded` applied to **every** configuration, including official/shipping builds. That baked symbols into the shipped assemblies and meant **no separate PDBs / symbol packages were produced**, so nothing flowed to the symbol servers (SymWeb/MSDL) via Arcade's publishing pipeline.

With portable PDBs on official builds, Arcade's post-build publishing (`PublishArtifactsInManifest`) will push the PDBs to the symbol servers automatically.

## Alignment with other .NET repos

| Repo | DebugType | 
|------|-----------|
| dotnet/runtime | forces `portable` always |
| dotnet/roslyn | inherits Arcade default (no override) |
| dotnet/sdk | inherits Arcade default (no override) |

None of them ship embedded symbols. This change matches roslyn/sdk (inherit the default).

Kept minimal — intentionally did **not** add `IncludeSymbols`/`SymbolPackageFormat` (matching roslyn); the portable PDB → symbol-server flow does not require them.