### PR TITLE
Don't flag Assert.AreEqual self-comparison for user-defined equality

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -58,13 +58,25 @@ internal static class AssertConditionAnalyzerHelper
             return false;
         }
 
-        // A null (or omitted) comparer is equivalent to EqualityComparer<T>.Default, so it does not change the
-        // equality semantics. Any other comparer (including a non-constant one) can return an arbitrary result.
-        // Strip only built-in conversions so a user-defined conversion cannot hide a null source that it turns
-        // into a non-null comparer.
-        return GetRawArgumentValueWithName(operation, comparerParameter.Name)?.WalkDownBuiltInConversion() is { } comparerArgument
-            && comparerArgument.ConstantValue is not { HasValue: true, Value: null };
+        // A null (or omitted) comparer, or an explicit EqualityComparer<T>.Default, is equivalent to the default
+        // comparer and does not change the equality semantics. Any other comparer (including a non-constant one)
+        // can return an arbitrary result. Strip only built-in conversions so a user-defined conversion cannot hide
+        // a null source that it turns into a non-null comparer.
+        IOperation? comparerArgument = GetRawArgumentValueWithName(operation, comparerParameter.Name)?.WalkDownBuiltInConversion();
+        return comparerArgument is not null
+            && comparerArgument.ConstantValue is not { HasValue: true, Value: null }
+            && !IsDefaultEqualityComparerReference(comparerArgument);
     }
+
+    private static bool IsDefaultEqualityComparerReference(IOperation operation)
+        => operation is IPropertyReferenceOperation
+        {
+            Property:
+            {
+                Name: "Default",
+                ContainingType: INamedTypeSymbol { Name: "EqualityComparer", ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } } },
+            },
+        };
 
     /// <summary>
     /// Gets the type <c>T</c> whose <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/> the

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -35,7 +35,7 @@ internal static class AssertConditionAnalyzerHelper
     /// </summary>
     internal static bool HasIdenticalExpectedAndActualWithBuiltInEquality(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
         => HasIdenticalExpectedAndActual(operation, expectedOrNotExpectedParameterName)
-        && IsProvablyReflexiveSelfEquality(GetArgumentWithName(operation, expectedOrNotExpectedParameterName)?.Type);
+        && IsProvablyReflexiveSelfEquality(GetComparedType(operation, expectedOrNotExpectedParameterName));
 
     /// <summary>
     /// Returns <see langword="true"/> when the invoked <c>Assert</c> overload accepts a caller-supplied
@@ -51,48 +51,61 @@ internal static class AssertConditionAnalyzerHelper
             });
 
     /// <summary>
+    /// Gets the type <c>T</c> whose <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/> the
+    /// invoked <c>Assert.AreEqual</c>/<c>AreNotEqual</c> overload uses to compare the values. For the generic
+    /// overloads this is the method type argument (not the operand's static type, which may differ through an
+    /// implicit conversion); for non-generic overloads it is the declared parameter type.
+    /// </summary>
+    private static ITypeSymbol? GetComparedType(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => operation.TargetMethod.TypeArguments is [{ } typeArgument]
+            ? typeArgument
+            : operation.TargetMethod.Parameters.FirstOrDefault(parameter => parameter.Name == expectedOrNotExpectedParameterName)?.Type;
+
+    /// <summary>
     /// Returns <see langword="true"/> when a self-comparison of a value of <paramref name="type"/> using the
     /// default equality comparer is provably always equal.
     /// </summary>
     /// <remarks>
     /// <c>Assert.AreEqual</c>/<c>AreNotEqual</c> compare using <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/>,
     /// which dispatches to <see cref="System.IEquatable{T}"/><c>.Equals</c> when the type implements it, otherwise to the
-    /// virtual <see cref="object.Equals(object)"/>. The result is only provable when the runtime type is known exactly
-    /// (a value type or a sealed type) and that type does not customize equality with a potentially non-reflexive
-    /// override. A non-sealed reference type, an interface, or a type parameter can hold an instance whose overridden
-    /// equality is not reflexive, so nothing can be proven from the static type.
+    /// virtual <see cref="object.Equals(object)"/>. Reflexivity can only be proven conservatively:
+    /// <list type="bullet">
+    /// <item>primitives, <see cref="string"/>, and enums have reflexive built-in equality;</item>
+    /// <item>arrays and sealed reference types without customized equality use reflexive reference equality;</item>
+    /// <item>a non-sealed reference type, an interface, or a type parameter can hold an instance whose overridden
+    /// equality is not reflexive;</item>
+    /// <item>a non-primitive value type relying on the default field-based <c>ValueType.Equals</c> (or <c>Nullable&lt;T&gt;</c>,
+    /// which delegates to the underlying type) may compare a field whose equality is not reflexive, and a custom struct
+    /// override could itself be non-reflexive.</item>
+    /// </list>
     /// </remarks>
     private static bool IsProvablyReflexiveSelfEquality(ITypeSymbol? type)
     {
-        if (type is null)
+        if (type is null || type.TypeKind is TypeKind.TypeParameter)
         {
             return false;
         }
 
-        // A type parameter can be substituted with a type whose equality is not reflexive.
-        if (type.TypeKind is TypeKind.TypeParameter)
+        if (type.IsReferenceType)
         {
-            return false;
+            // Arrays always use reflexive reference equality (they never override Equals). Any other reference
+            // type is only provable when its runtime type is known exactly (sealed) and it does not customize
+            // equality with a potentially non-reflexive override. Non-sealed types, interfaces, and object can
+            // hold a derived instance whose overridden Equals is not reflexive.
+            return type.TypeKind is TypeKind.Array
+                || (type.IsSealed && !HasUserDefinedEquality(type));
         }
 
-        // Arrays are non-sealed reference types but always use reflexive reference equality
-        // (they never override Equals), so a self-comparison is provably always equal.
-        if (type.TypeKind is TypeKind.Array)
-        {
-            return true;
-        }
-
-        // A non-sealed reference type (including object, base classes, and interfaces) can hold a derived
-        // instance whose overridden Equals is not reflexive. Only value types and sealed types have an
-        // exactly-known runtime type.
-        return type is not { IsReferenceType: true, IsSealed: false }
-            && !HasUserDefinedEquality(type);
+        // Value types: only primitives (and enums) have provably reflexive built-in equality. Nullable<T> and
+        // structs relying on the default (or a custom) equality could be non-reflexive.
+        return type.OriginalDefinition.SpecialType is not SpecialType.System_Nullable_T
+            && (type.SpecialType is not SpecialType.None || type.TypeKind is TypeKind.Enum);
     }
 
     private static bool HasUserDefinedEquality(ITypeSymbol type)
     {
-        // Primitives, enums, and other well-known types have reflexive, built-in equality.
-        if (type.SpecialType != SpecialType.None || type.TypeKind is TypeKind.Enum)
+        // string overrides Equals but its equality is reflexive; it is handled as a primitive by the caller.
+        if (type.SpecialType != SpecialType.None)
         {
             return false;
         }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -60,7 +60,9 @@ internal static class AssertConditionAnalyzerHelper
 
         // A null (or omitted) comparer is equivalent to EqualityComparer<T>.Default, so it does not change the
         // equality semantics. Any other comparer (including a non-constant one) can return an arbitrary result.
-        return GetArgumentWithName(operation, comparerParameter.Name) is { } comparerArgument
+        // Strip only built-in conversions so a user-defined conversion cannot hide a null source that it turns
+        // into a non-null comparer.
+        return GetRawArgumentValueWithName(operation, comparerParameter.Name)?.WalkDownBuiltInConversion() is { } comparerArgument
             && comparerArgument.ConstantValue is not { HasValue: true, Value: null };
     }
 

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -38,17 +38,31 @@ internal static class AssertConditionAnalyzerHelper
         && IsProvablyReflexiveSelfEquality(GetComparedType(operation, expectedOrNotExpectedParameterName));
 
     /// <summary>
-    /// Returns <see langword="true"/> when the invoked <c>Assert</c> overload accepts a caller-supplied
-    /// <see cref="System.Collections.Generic.IEqualityComparer{T}"/>, in which case the comparison can
-    /// return any result and must not be treated as an always-true/always-false condition.
+    /// Returns <see langword="true"/> when the invoked <c>Assert</c> overload is passed a non-default
+    /// <see cref="System.Collections.Generic.IEqualityComparer{T}"/> argument, in which case the comparison can
+    /// return any result and must not be treated as an always-true/always-false condition. A <see langword="null"/>
+    /// comparer is treated by MSTest as <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/>, so it
+    /// does not change the equality semantics and is not considered a custom comparer here.
     /// </summary>
-    internal static bool HasEqualityComparerParameter(IInvocationOperation operation)
-        => operation.TargetMethod.Parameters.Any(static parameter =>
+    internal static bool HasNonDefaultEqualityComparerArgument(IInvocationOperation operation)
+    {
+        IParameterSymbol? comparerParameter = operation.TargetMethod.Parameters.FirstOrDefault(static parameter =>
             parameter.Type is INamedTypeSymbol
             {
                 Name: "IEqualityComparer",
                 ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } },
             });
+
+        if (comparerParameter is null)
+        {
+            return false;
+        }
+
+        // A null (or omitted) comparer is equivalent to EqualityComparer<T>.Default, so it does not change the
+        // equality semantics. Any other comparer (including a non-constant one) can return an arbitrary result.
+        return GetArgumentWithName(operation, comparerParameter.Name) is { } comparerArgument
+            && comparerArgument.ConstantValue is not { HasValue: true, Value: null };
+    }
 
     /// <summary>
     /// Gets the type <c>T</c> whose <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/> the

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -129,9 +129,9 @@ internal static class AssertConditionAnalyzerHelper
             current is { SpecialType: not SpecialType.System_Object and not SpecialType.System_ValueType };
             current = current.BaseType)
         {
-            foreach (ISymbol member in current.GetMembers())
+            foreach (ISymbol member in current.GetMembers(nameof(object.Equals)))
             {
-                if (member is IMethodSymbol { IsOverride: true, Name: nameof(object.Equals), Parameters: [{ Type.SpecialType: SpecialType.System_Object }] })
+                if (member is IMethodSymbol { IsOverride: true, Parameters: [{ Type.SpecialType: SpecialType.System_Object }] })
                 {
                     return true;
                 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;
@@ -53,7 +53,7 @@ internal static class AssertConditionAnalyzerHelper
                 ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } },
             });
 
-        if (comparerParameter is null)
+        if (comparerParameter is not { Type: INamedTypeSymbol { TypeArguments: [{ } comparerElementType] } })
         {
             return false;
         }
@@ -65,18 +65,15 @@ internal static class AssertConditionAnalyzerHelper
         IOperation? comparerArgument = GetRawArgumentValueWithName(operation, comparerParameter.Name)?.WalkDownBuiltInConversion();
         return comparerArgument is not null
             && comparerArgument.ConstantValue is not { HasValue: true, Value: null }
-            && !IsDefaultEqualityComparerReference(comparerArgument);
+            && !IsDefaultEqualityComparerReference(comparerArgument, comparerElementType);
     }
 
-    private static bool IsDefaultEqualityComparerReference(IOperation operation)
-        => operation is IPropertyReferenceOperation
-        {
-            Property:
-            {
-                Name: "Default",
-                ContainingType: INamedTypeSymbol { Name: "EqualityComparer", ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } } },
-            },
-        };
+    // EqualityComparer<X>.Default is only the default comparer for T when X is T. IEqualityComparer<T> is
+    // contravariant, so e.g. EqualityComparer<Base>.Default can be passed as IEqualityComparer<Derived>, in
+    // which case it is a non-default comparer that may return a different result.
+    private static bool IsDefaultEqualityComparerReference(IOperation operation, ITypeSymbol comparerElementType)
+        => operation is IPropertyReferenceOperation { Property: { Name: "Default", ContainingType: INamedTypeSymbol { Name: "EqualityComparer", TypeArguments: [{ } elementType], ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } } } } }
+            && SymbolEqualityComparer.Default.Equals(elementType, comparerElementType);
 
     /// <summary>
     /// Gets the type <c>T</c> whose <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/> the

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -28,6 +28,65 @@ internal static class AssertConditionAnalyzerHelper
         && GetRawArgumentValueWithName(operation, ActualParameterName) is { } actualArgument
         && expectedArgument.IsEquivalentReferenceTo(actualArgument);
 
+    /// <summary>
+    /// Returns <see langword="true"/> when <c>expected</c>/<c>notExpected</c> and <c>actual</c> are the
+    /// same side-effect-free reference (see <see cref="HasIdenticalExpectedAndActual"/>) <em>and</em> the
+    /// compared type does not route equality through user code.
+    /// </summary>
+    /// <remarks>
+    /// <c>Assert.AreEqual</c>/<c>AreNotEqual</c> compare using <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/>,
+    /// which calls user-provided equality when the type overrides <see cref="object.Equals(object)"/> or implements
+    /// <see cref="System.IEquatable{T}"/>. In those cases a self-comparison can legitimately be used to test the type's
+    /// equality contract and might not always evaluate to the same result, so it must not be reported as an
+    /// always-true/always-false condition.
+    /// </remarks>
+    internal static bool HasIdenticalExpectedAndActualWithBuiltInEquality(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => HasIdenticalExpectedAndActual(operation, expectedOrNotExpectedParameterName)
+        && !HasUserDefinedEquality(GetArgumentWithName(operation, expectedOrNotExpectedParameterName)?.Type);
+
+    private static bool HasUserDefinedEquality(ITypeSymbol? type)
+    {
+        // Primitives, enums, and other well-known types have reflexive, built-in equality.
+        if (type is null || type.SpecialType != SpecialType.None || type.TypeKind is TypeKind.Enum)
+        {
+            return false;
+        }
+
+        // A type parameter can be substituted with any type, including one whose equality is not
+        // reflexive, so we cannot prove the comparison is always true. Treat it conservatively.
+        if (type.TypeKind is TypeKind.TypeParameter)
+        {
+            return true;
+        }
+
+        // Assert.AreEqual/AreNotEqual compare with EqualityComparer<T>.Default, which dispatches to
+        // IEquatable<T>.Equals when the type implements it, otherwise to the virtual object.Equals.
+        // The == operator is never consulted, so it is intentionally not checked here.
+        for (ITypeSymbol? current = type;
+            current is { SpecialType: not SpecialType.System_Object and not SpecialType.System_ValueType };
+            current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers())
+            {
+                if (member is IMethodSymbol { IsOverride: true, Name: nameof(object.Equals), Parameters: [{ Type.SpecialType: SpecialType.System_Object }] })
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (INamedTypeSymbol @interface in type.AllInterfaces)
+        {
+            if (@interface is { Name: "IEquatable", TypeArguments: [{ } typeArgument], ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } }
+                && SymbolEqualityComparer.Default.Equals(typeArgument, type))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     internal static IOperation? GetArgumentWithName(IInvocationOperation operation, string name)
         => operation.Arguments.FirstOrDefault(arg => arg.Parameter?.Name == name)?.Value.WalkDownConversion();
 

--- a/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/AssertConditionAnalyzerHelper.cs
@@ -30,38 +30,74 @@ internal static class AssertConditionAnalyzerHelper
 
     /// <summary>
     /// Returns <see langword="true"/> when <c>expected</c>/<c>notExpected</c> and <c>actual</c> are the
-    /// same side-effect-free reference (see <see cref="HasIdenticalExpectedAndActual"/>) <em>and</em> the
-    /// compared type does not route equality through user code.
+    /// same side-effect-free reference (see <see cref="HasIdenticalExpectedAndActual"/>) <em>and</em> a
+    /// self-comparison of that value using the default equality comparer is provably always equal.
+    /// </summary>
+    internal static bool HasIdenticalExpectedAndActualWithBuiltInEquality(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
+        => HasIdenticalExpectedAndActual(operation, expectedOrNotExpectedParameterName)
+        && IsProvablyReflexiveSelfEquality(GetArgumentWithName(operation, expectedOrNotExpectedParameterName)?.Type);
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the invoked <c>Assert</c> overload accepts a caller-supplied
+    /// <see cref="System.Collections.Generic.IEqualityComparer{T}"/>, in which case the comparison can
+    /// return any result and must not be treated as an always-true/always-false condition.
+    /// </summary>
+    internal static bool HasEqualityComparerParameter(IInvocationOperation operation)
+        => operation.TargetMethod.Parameters.Any(static parameter =>
+            parameter.Type is INamedTypeSymbol
+            {
+                Name: "IEqualityComparer",
+                ContainingNamespace: { Name: "Generic", ContainingNamespace: { Name: "Collections", ContainingNamespace: { Name: "System", ContainingNamespace.IsGlobalNamespace: true } } },
+            });
+
+    /// <summary>
+    /// Returns <see langword="true"/> when a self-comparison of a value of <paramref name="type"/> using the
+    /// default equality comparer is provably always equal.
     /// </summary>
     /// <remarks>
     /// <c>Assert.AreEqual</c>/<c>AreNotEqual</c> compare using <see cref="System.Collections.Generic.EqualityComparer{T}.Default"/>,
-    /// which calls user-provided equality when the type overrides <see cref="object.Equals(object)"/> or implements
-    /// <see cref="System.IEquatable{T}"/>. In those cases a self-comparison can legitimately be used to test the type's
-    /// equality contract and might not always evaluate to the same result, so it must not be reported as an
-    /// always-true/always-false condition.
+    /// which dispatches to <see cref="System.IEquatable{T}"/><c>.Equals</c> when the type implements it, otherwise to the
+    /// virtual <see cref="object.Equals(object)"/>. The result is only provable when the runtime type is known exactly
+    /// (a value type or a sealed type) and that type does not customize equality with a potentially non-reflexive
+    /// override. A non-sealed reference type, an interface, or a type parameter can hold an instance whose overridden
+    /// equality is not reflexive, so nothing can be proven from the static type.
     /// </remarks>
-    internal static bool HasIdenticalExpectedAndActualWithBuiltInEquality(IInvocationOperation operation, string expectedOrNotExpectedParameterName)
-        => HasIdenticalExpectedAndActual(operation, expectedOrNotExpectedParameterName)
-        && !HasUserDefinedEquality(GetArgumentWithName(operation, expectedOrNotExpectedParameterName)?.Type);
-
-    private static bool HasUserDefinedEquality(ITypeSymbol? type)
+    private static bool IsProvablyReflexiveSelfEquality(ITypeSymbol? type)
     {
-        // Primitives, enums, and other well-known types have reflexive, built-in equality.
-        if (type is null || type.SpecialType != SpecialType.None || type.TypeKind is TypeKind.Enum)
+        if (type is null)
         {
             return false;
         }
 
-        // A type parameter can be substituted with any type, including one whose equality is not
-        // reflexive, so we cannot prove the comparison is always true. Treat it conservatively.
+        // A type parameter can be substituted with a type whose equality is not reflexive.
         if (type.TypeKind is TypeKind.TypeParameter)
+        {
+            return false;
+        }
+
+        // Arrays are non-sealed reference types but always use reflexive reference equality
+        // (they never override Equals), so a self-comparison is provably always equal.
+        if (type.TypeKind is TypeKind.Array)
         {
             return true;
         }
 
-        // Assert.AreEqual/AreNotEqual compare with EqualityComparer<T>.Default, which dispatches to
-        // IEquatable<T>.Equals when the type implements it, otherwise to the virtual object.Equals.
-        // The == operator is never consulted, so it is intentionally not checked here.
+        // A non-sealed reference type (including object, base classes, and interfaces) can hold a derived
+        // instance whose overridden Equals is not reflexive. Only value types and sealed types have an
+        // exactly-known runtime type.
+        return type is not { IsReferenceType: true, IsSealed: false }
+            && !HasUserDefinedEquality(type);
+    }
+
+    private static bool HasUserDefinedEquality(ITypeSymbol type)
+    {
+        // Primitives, enums, and other well-known types have reflexive, built-in equality.
+        if (type.SpecialType != SpecialType.None || type.TypeKind is TypeKind.Enum)
+        {
+            return false;
+        }
+
+        // The == operator is never consulted by EqualityComparer<T>.Default, so it is intentionally not checked here.
         for (ITypeSymbol? current = type;
             current is { SpecialType: not SpecialType.System_Object and not SpecialType.System_ValueType };
             current = current.BaseType)

--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -78,9 +78,11 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
         {
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
-            "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
-            "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
-                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
+            "AreEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+                && AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
+            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+                && (AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
+                    || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName)),
             "AreNotSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
             "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),

--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -78,9 +78,9 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
         {
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
-            "AreEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+            "AreEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
                 && AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
-            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
                 && (AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
                     || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName)),
             "AreNotSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),

--- a/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/PreferAssertFailOverAlwaysFalseConditionsAnalyzer.cs
@@ -80,7 +80,7 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzer : Diagnost
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
             "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
-                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
+                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
             "AreNotSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName),
             "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -67,9 +67,11 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
         {
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
-            "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
-                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
-            "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
+            "AreEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+                && (AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
+                    || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.ExpectedParameterName)),
+            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+                && AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
             "AreSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },
             "IsNotNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { } valueArgumentOperation && AssertConditionAnalyzerHelper.IsNotNullableType(valueArgumentOperation),

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -67,10 +67,10 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
         {
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
-            "AreEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+            "AreEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
                 && (AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
                     || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.ExpectedParameterName)),
-            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasEqualityComparerParameter(operation)
+            "AreNotEqual" => !AssertConditionAnalyzerHelper.HasNonDefaultEqualityComparerArgument(operation)
                 && AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
             "AreSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },

--- a/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/ReviewAlwaysTrueAssertConditionAnalyzer.cs
@@ -68,7 +68,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzer : DiagnosticAnalyzer
             "IsTrue" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: true } },
             "IsFalse" => AssertConditionAnalyzerHelper.GetConditionArgument(operation) is { ConstantValue: { HasValue: true, Value: false } },
             "AreEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.ExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.Equal
-                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
+                || AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActualWithBuiltInEquality(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
             "AreNotEqual" => AssertConditionAnalyzerHelper.GetEqualityStatus(operation, AssertConditionAnalyzerHelper.NotExpectedParameterName) == AssertConditionAnalyzerHelper.EqualityStatus.NotEqual,
             "AreSame" => AssertConditionAnalyzerHelper.HasIdenticalExpectedAndActual(operation, AssertConditionAnalyzerHelper.ExpectedParameterName),
             "IsNull" => AssertConditionAnalyzerHelper.GetValueArgument(operation) is { ConstantValue: { HasValue: true, Value: null } },

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -2023,4 +2023,60 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedNonEqualConstantsWithCustomComparer_NoDiagnostic()
+    {
+        // A caller-supplied comparer can return any result, so the comparison is not provably always false.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual(1, 2, new AlwaysEqualComparer());
+                }
+
+                private sealed class AlwaysEqualComparer : IEqualityComparer<int>
+                {
+                    public bool Equals(int x, int y) => true;
+                    public int GetHashCode(int obj) => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithCustomComparer_NoDiagnostic()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.AreNotEqual(x, x, new AlwaysEqualComparer());
+                }
+
+                private sealed class AlwaysEqualComparer : IEqualityComparer<int>
+                {
+                    public bool Equals(int x, int y) => true;
+                    public int GetHashCode(int obj) => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -2118,4 +2118,43 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithDefaultEqualityComparer_Diagnostic()
+    {
+        // EqualityComparer<T>.Default passed explicitly is the default comparer, so the self-comparison is
+        // still provably always false and must be flagged.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreNotEqual(x, x, EqualityComparer<int>.Default)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -2079,4 +2079,43 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithNullComparer_Diagnostic()
+    {
+        // MSTest treats a null comparer as EqualityComparer<T>.Default, so the self-comparison is still
+        // provably always false and must be flagged.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreNotEqual(x, x, (IEqualityComparer<int>)null)|];
+                }
+            }
+            """;
+        string fixedCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.Fail();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests.cs
@@ -1951,4 +1951,76 @@ public sealed class PreferAssertFailOverAlwaysFalseConditionsAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithOverriddenEquals_NoDiagnostic()
+    {
+        // The type overrides object.Equals, so Assert.AreNotEqual routes through user code and the
+        // self-comparison is a legitimate way to exercise the equality contract (see issue #9972).
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    Assert.AreNotEqual(x, x);
+                }
+
+                private sealed class MyType
+                {
+                    public override bool Equals(object obj) => false;
+                    public override int GetHashCode() => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreNotEqualIsPassedSameLocalWithoutCustomEquality_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    [|Assert.AreNotEqual(x, x)|];
+                }
+
+                private sealed class MyType
+                {
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    Assert.Fail();
+                }
+
+                private sealed class MyType
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1543,6 +1543,8 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
     [TestMethod]
     public async Task WhenAssertAreEqualIsPassedSameLocalWithEquatable_NoDiagnostic()
     {
+        // A sealed type implementing IEquatable<self> (without overriding object.Equals) routes equality
+        // through user code, so it must not be flagged. This exercises the IEquatable<T> detection branch.
         string code = """
             using System;
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1557,7 +1559,7 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
                     Assert.AreEqual(x, x);
                 }
 
-                private struct MyType : IEquatable<MyType>
+                private sealed class MyType : IEquatable<MyType>
                 {
                     public bool Equals(MyType other) => true;
                 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1997,4 +1997,39 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedContravariantDefaultComparer_NoDiagnostic()
+    {
+        // IEqualityComparer<T> is contravariant, so EqualityComparer<Base>.Default can be passed where an
+        // IEqualityComparer<Derived> is expected. That is NOT EqualityComparer<Derived>.Default and can return a
+        // different (non-reflexive) result, so it must not be treated as the default comparer.
+        string code = """
+            using System;
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new Derived();
+                    Assert.AreEqual<Derived>(x, x, EqualityComparer<Base>.Default);
+                }
+
+                private class Base : IEquatable<Base>
+                {
+                    public bool Equals(Base other) => false;
+                }
+
+                private sealed class Derived : Base
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1808,4 +1808,118 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameDateTime_Diagnostic()
+    {
+        // DateTime is a primitive-like value type with reflexive built-in equality, so a self-comparison
+        // is genuinely always true and should still be flagged.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    DateTime x = DateTime.Now;
+                    [|Assert.AreEqual(x, x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameValueWithPolymorphicComparerType_NoDiagnostic()
+    {
+        // The comparison uses EqualityComparer<Base>.Default (the method type argument), which invokes the
+        // non-reflexive IEquatable<Base>, even though the operand's static type is the sealed Derived.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new Derived();
+                    Assert.AreEqual<Base>(x, x);
+                }
+
+                private class Base : IEquatable<Base>
+                {
+                    public bool Equals(Base other) => false;
+                }
+
+                private sealed class Derived : Base
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameStructWithNonReflexiveField_NoDiagnostic()
+    {
+        // A struct using the default field-based ValueType.Equals compares its fields via their equality,
+        // so a field whose Equals is not reflexive makes the self-comparison return false.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new Wrapper();
+                    Assert.AreEqual(x, x);
+                }
+
+                private struct Wrapper
+                {
+                    public NeverEqual Field;
+                }
+
+                private sealed class NeverEqual
+                {
+                    public override bool Equals(object obj) => false;
+                    public override int GetHashCode() => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameNullable_NoDiagnostic()
+    {
+        // Nullable<T> delegates equality to the underlying T, which may not be reflexive, so it is treated
+        // conservatively.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int? x = 1;
+                    Assert.AreEqual(x, x);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1924,4 +1924,28 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithNullComparer_Diagnostic()
+    {
+        // MSTest treats a null comparer as EqualityComparer<T>.Default, so the self-comparison is still
+        // provably always true and must be flagged.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreEqual(x, x, (IEqualityComparer<int>)null)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1973,4 +1973,28 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithDefaultEqualityComparer_Diagnostic()
+    {
+        // EqualityComparer<T>.Default passed explicitly is the default comparer, so the self-comparison is
+        // still provably always true and must be flagged.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreEqual(x, x, EqualityComparer<int>.Default)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1948,4 +1948,29 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithDefaultComparer_Diagnostic()
+    {
+        // default(IEqualityComparer<int>) is null, which MSTest treats as EqualityComparer<T>.Default, so the
+        // self-comparison is still provably always true. Only built-in conversions are stripped when inspecting
+        // the comparer argument.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    [|Assert.AreEqual(x, x, default(IEqualityComparer<int>))|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1682,4 +1682,130 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameArray_Diagnostic()
+    {
+        // Arrays use reference equality, so a self-comparison is genuinely always true.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new int[0];
+                    [|Assert.AreEqual(x, x)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalOfPolymorphicType_NoDiagnostic()
+    {
+        // A non-sealed reference type can hold a derived instance whose overridden Equals is not
+        // reflexive, so equality cannot be proven from the static type.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    object x = new object();
+                    Assert.AreEqual(x, x);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalOfNonSealedType_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    Assert.AreEqual(x, x);
+                }
+
+                private class MyType
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedEqualConstantsWithCustomComparer_NoDiagnostic()
+    {
+        // A caller-supplied comparer can return any result, so the comparison is not provably always true.
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreEqual(1, 1, new NeverEqualComparer());
+                }
+
+                private sealed class NeverEqualComparer : IEqualityComparer<int>
+                {
+                    public bool Equals(int x, int y) => false;
+                    public int GetHashCode(int obj) => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithCustomComparer_NoDiagnostic()
+    {
+        string code = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    int x = 1;
+                    Assert.AreEqual(x, x, new NeverEqualComparer());
+                }
+
+                private sealed class NeverEqualComparer : IEqualityComparer<int>
+                {
+                    public bool Equals(int x, int y) => false;
+                    public int GetHashCode(int obj) => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/ReviewAlwaysTrueAssertConditionAnalyzerTests.cs
@@ -1510,4 +1510,176 @@ public sealed class ReviewAlwaysTrueAssertConditionAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithOverriddenEquals_NoDiagnostic()
+    {
+        // The type overrides object.Equals, so Assert.AreEqual routes through user code and the
+        // self-comparison is a legitimate way to exercise the equality contract (see issue #9972).
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    Assert.AreEqual(x, x);
+                }
+
+                private sealed class MyType
+                {
+                    public override bool Equals(object obj) => obj is MyType;
+                    public override int GetHashCode() => 0;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithEquatable_NoDiagnostic()
+    {
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    Assert.AreEqual(x, x);
+                }
+
+                private struct MyType : IEquatable<MyType>
+                {
+                    public bool Equals(MyType other) => true;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithOnlyEqualityOperator_Diagnostic()
+    {
+        // EqualityComparer<T>.Default (used by Assert.AreEqual) never calls operator ==; it uses
+        // IEquatable<T>.Equals or the virtual object.Equals. A type that only overloads == (without
+        // overriding Equals or implementing IEquatable<T>) still compares by reference, so the
+        // self-comparison is genuinely always true and must be flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    [|Assert.AreEqual(x, x)|];
+                }
+
+            #pragma warning disable CS0660, CS0661
+                private sealed class MyType
+                {
+                    public static bool operator ==(MyType left, MyType right) => true;
+                    public static bool operator !=(MyType left, MyType right) => false;
+                }
+            #pragma warning restore CS0660, CS0661
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithEquatableOfOtherType_Diagnostic()
+    {
+        // The type implements IEquatable<string>, not IEquatable<MyType>, so EqualityComparer<MyType>.Default
+        // falls back to reference equality and the self-comparison is genuinely always true.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    [|Assert.AreEqual(x, x)|];
+                }
+
+                private sealed class MyType : IEquatable<string>
+                {
+                    public bool Equals(string other) => true;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameGenericTypeParameter_NoDiagnostic()
+    {
+        // T can be substituted with a type whose equality is not reflexive, so we cannot prove the
+        // comparison is always true.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Helper(1);
+                }
+
+                private static void Helper<T>(T value)
+                {
+                    Assert.AreEqual(value, value);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertAreEqualIsPassedSameLocalWithoutCustomEquality_Diagnostic()
+    {
+        // A reference type that does not customize equality falls back to reference equality,
+        // so a self-comparison is genuinely always true and should still be flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    var x = new MyType();
+                    [|Assert.AreEqual(x, x)|];
+                }
+
+                private sealed class MyType
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
Fixes #9972

## Problem

`MSTEST0032` (`ReviewAlwaysTrueAssertConditionAnalyzer`) and `MSTEST0025` (`PreferAssertFailOverAlwaysFalseConditionsAnalyzer`) flagged `Assert.AreEqual(x, x)` / `Assert.AreNotEqual(x, x)` as always-true / always-false based on a **purely syntactic** identical-argument check.

But `Assert.AreEqual` compares via `EqualityComparer<T>.Default`, which routes through **user code** when the compared type overrides `object.Equals` or implements `IEquatable<T>`. For such types, self-comparison is a legitimate way to exercise the equality contract (reflexivity) and might not evaluate to a constant, so flagging it is a false positive — exactly the scenario reported in #9972.

## Fix

- Added `HasUserDefinedEquality(ITypeSymbol?)` and a guarded `HasIdenticalExpectedAndActualWithBuiltInEquality` helper.
- `AreEqual` (MSTEST0032) and `AreNotEqual` (MSTEST0025) now use the guarded check, so self-comparison is only reported when equality is **not** user-defined.
- `AreSame` / `AreNotSame` are unchanged — reference identity is genuinely reflexive and stays flagged.

### Detection semantics
Equality detection matches how `EqualityComparer<T>.Default` actually dispatches at runtime:
- an `object.Equals(object)` **override** (walking base types), or
- `IEquatable<T>` implemented **for the compared type itself** (`IEquatable<SomethingElse>` correctly still gets flagged).

Notably, `operator ==` is **not** consulted, because `EqualityComparer<T>.Default` never calls it. Generic type parameters are treated conservatively (never flagged) since they can be substituted with a non-reflexive type.

### Behavior preserved
Self-comparison of primitives, enums, and reference types **without** custom equality is still flagged.

## Tests

Added coverage to both analyzer test classes: overridden `Equals`, `IEquatable<self>`, `IEquatable<other>` (still flagged), `==`-only (still flagged), generic type parameter (not flagged), and no-custom-equality (still flagged). All 149 tests in the two analyzer test classes pass.

No public API, resource (`.resx`/`.xlf`), or documentation changes required (the new helper is `internal`; no new diagnostic ID).