### PR TITLE
Add dedicated timeout configuration for GlobalTestInitialize/Cleanup fixtures

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 See full log [of v4.3.2...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.2...v4.4.0)
 
+### Added
+
+* Add dedicated timeout configuration for `[GlobalTestInitialize]` / `[GlobalTestCleanup]` fixtures via the `timeout:globalTestInitialize` / `timeout:globalTestCleanup` `testconfig.json` keys (RunSettings XML: `GlobalTestInitializeTimeout` / `GlobalTestCleanupTimeout`). These fall back to the per-test `testInitialize` / `testCleanup` timeouts when unset, and global fixture timeout/cancellation diagnostics now use dedicated messages ("Global test initialize/cleanup method ...") in [#9985](https://github.com/microsoft/testfx/issues/9985)
+
 ### Changed
 
 * Make MSTest's Microsoft.Testing.Platform path native-only: `MSTest.TestAdapter` no longer depends on `Microsoft.Testing.Extensions.VSTestBridge` and now references `Microsoft.Testing.Extensions.TrxReport.Abstractions`, `Microsoft.Testing.Extensions.Telemetry`, and `Microsoft.TestPlatform.ObjectModel` directly by @Evangelink in [#9755](https://github.com/microsoft/testfx/pull/9755)

--- a/docs/testconfig.schema.json
+++ b/docs/testconfig.schema.json
@@ -70,6 +70,16 @@
               "minimum": 1,
               "description": "Timeout, in milliseconds, for [TestCleanup] methods. Must be a strictly positive integer; a value of 0 or less is rejected with a warning and ignored. Omit this key to use the default (no timeout)."
             },
+            "globalTestInitialize": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [GlobalTestInitialize] methods. Falls back to 'testInitialize' when not set. Must be a strictly positive integer; a value of 0 or less is rejected with a warning and ignored. Omit this key to use the default (no timeout)."
+            },
+            "globalTestCleanup": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Timeout, in milliseconds, for [GlobalTestCleanup] methods. Falls back to 'testCleanup' when not set. Must be a strictly positive integer; a value of 0 or less is rejected with a warning and ignored. Omit this key to use the default (no timeout)."
+            },
             "useCooperativeCancellation": {
               "type": "boolean",
               "description": "When true, MSTest uses cooperative cancellation for timeouts instead of aborting the thread. Defaults to false."

--- a/docs/testconfig.schema.md
+++ b/docs/testconfig.schema.md
@@ -103,7 +103,8 @@ When you add, rename, or remove a configuration key in any of those, update
 ### `timeout:*` keys must be strictly positive
 
 The `mstest:timeout:*` keys (`test`, `assemblyInitialize`, `assemblyCleanup`, `classInitialize`,
-`classCleanup`, `testInitialize`, `testCleanup`) are timeouts expressed in **milliseconds** and must
+`classCleanup`, `testInitialize`, `testCleanup`, `globalTestInitialize`, `globalTestCleanup`) are
+timeouts expressed in **milliseconds** and must
 be a **strictly positive integer** (`>= 1`). This is enforced identically by both the
 `testconfig.json`/JSON parser (`ParseTimeoutSetting`) and the legacy `.runsettings` XML parser, so
 behavior is the same across formats and matches the schema's `"minimum": 1`.
@@ -127,3 +128,12 @@ To run without a timeout, **omit the key** rather than setting it to `0`; absenc
 means "no timeout" (the internal default). Because an explicit `0` would be redundant with omitting
 the key, it is treated as invalid input to surface likely mistakes (for example, a templated value
 that resolved to `0`).
+
+### Global test fixture timeouts fall back to the per-test keys
+
+`[GlobalTestInitialize]` and `[GlobalTestCleanup]` methods honor their own dedicated
+`timeout:globalTestInitialize` / `timeout:globalTestCleanup` keys (RunSettings XML:
+`GlobalTestInitializeTimeout` / `GlobalTestCleanupTimeout`). When a dedicated key is **not** set,
+they fall back to the corresponding per-test `timeout:testInitialize` / `timeout:testCleanup` key so
+existing configurations keep applying. As always, a method-level `[Timeout(...)]` attribute takes
+precedence over any config value.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Lifecycle.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestMethodInfo.Lifecycle.cs
@@ -277,8 +277,8 @@ internal partial class TestMethodInfo
             arguments: [TestContext],
             timeoutInfo,
             timeoutTokenSource,
-            Resource.TestInitializeWasCancelled,
-            Resource.TestInitializeTimedOut).ConfigureAwait(false);
+            Resource.GlobalTestInitializeWasCancelled,
+            Resource.GlobalTestInitializeTimedOut).ConfigureAwait(false);
 
     private async SynchronizationContextPreservingTask<TestFailedException?> InvokeCleanupMethodAsync(MethodInfo methodInfo, object classInstance, CancellationTokenSource? timeoutTokenSource)
     {
@@ -305,8 +305,8 @@ internal partial class TestMethodInfo
             arguments: [TestContext],
             timeoutInfo,
             timeoutTokenSource,
-            Resource.TestCleanupWasCancelled,
-            Resource.TestCleanupTimedOut).ConfigureAwait(false);
+            Resource.GlobalTestCleanupWasCancelled,
+            Resource.GlobalTestCleanupTimedOut).ConfigureAwait(false);
 
     private async SynchronizationContextPreservingTask<TestFailedException?> InvokeFixtureMethodAsync(
         MethodInfo methodInfo,

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TimeoutInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TimeoutInfo.cs
@@ -35,6 +35,15 @@ internal readonly struct TimeoutInfo
                 FixtureKind.ClassCleanup => MSTestSettings.CurrentSettings.ClassCleanupTimeout,
                 FixtureKind.TestInitialize => MSTestSettings.CurrentSettings.TestInitializeTimeout,
                 FixtureKind.TestCleanup => MSTestSettings.CurrentSettings.TestCleanupTimeout,
+
+                // Global test fixtures prefer their dedicated timeout, but fall back to the per-test
+                // initialize/cleanup timeout so existing configurations keep applying to them.
+                FixtureKind.GlobalTestInitialize => MSTestSettings.CurrentSettings.GlobalTestInitializeTimeout > 0
+                    ? MSTestSettings.CurrentSettings.GlobalTestInitializeTimeout
+                    : MSTestSettings.CurrentSettings.TestInitializeTimeout,
+                FixtureKind.GlobalTestCleanup => MSTestSettings.CurrentSettings.GlobalTestCleanupTimeout > 0
+                    ? MSTestSettings.CurrentSettings.GlobalTestCleanupTimeout
+                    : MSTestSettings.CurrentSettings.TestCleanupTimeout,
                 _ => throw new NotSupportedException("Unsupported fixture kind " + fixtureKind),
             },
             MSTestSettings.CurrentSettings.CooperativeCancellationTimeout);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.AssemblyInfo.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TypeCache.AssemblyInfo.cs
@@ -94,12 +94,12 @@ internal sealed partial class TypeCache
 
                     if (isValid && isGlobalTestInitialize)
                     {
-                        assemblyInfo.GlobalTestInitializations.Add((methodInfo, @this.TryGetTimeoutInfo(methodInfo, FixtureKind.TestInitialize)));
+                        assemblyInfo.GlobalTestInitializations.Add((methodInfo, @this.TryGetTimeoutInfo(methodInfo, FixtureKind.GlobalTestInitialize)));
                     }
 
                     if (isValid && isGlobalTestCleanup)
                     {
-                        assemblyInfo.GlobalTestCleanups.Add((methodInfo, @this.TryGetTimeoutInfo(methodInfo, FixtureKind.TestCleanup)));
+                        assemblyInfo.GlobalTestCleanups.Add((methodInfo, @this.TryGetTimeoutInfo(methodInfo, FixtureKind.GlobalTestCleanup)));
                     }
                 }
             }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/FixtureKind.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/FixtureKind.cs
@@ -12,4 +12,6 @@ internal enum FixtureKind
     ClassCleanup,
     TestInitialize,
     TestCleanup,
+    GlobalTestInitialize,
+    GlobalTestCleanup,
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,8 @@
 #nullable enable
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.FixtureKind.GlobalTestCleanup = 7 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.FixtureKind
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.FixtureKind.GlobalTestInitialize = 6 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.FixtureKind
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.GlobalTestCleanupTimeout.get -> int
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.GlobalTestInitializeTimeout.get -> int
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.get -> System.Guid?
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.set -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ParameterMetadataScanCount.get -> int

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.Configuration.cs
@@ -208,6 +208,8 @@ internal sealed partial class MSTestSettings
         ParseTimeoutSetting(configuration, "timeout:classCleanup", logger, value => settings.ClassCleanupTimeout = value);
         ParseTimeoutSetting(configuration, "timeout:testInitialize", logger, value => settings.TestInitializeTimeout = value);
         ParseTimeoutSetting(configuration, "timeout:testCleanup", logger, value => settings.TestCleanupTimeout = value);
+        ParseTimeoutSetting(configuration, "timeout:globalTestInitialize", logger, value => settings.GlobalTestInitializeTimeout = value);
+        ParseTimeoutSetting(configuration, "timeout:globalTestCleanup", logger, value => settings.GlobalTestCleanupTimeout = value);
 
         if (configuration["mstest:parallelism:workers"] is string workers)
         {

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.RunSettingsXml.cs
@@ -31,6 +31,8 @@ internal sealed partial class MSTestSettings
         CurrentSettings.ParallelizationWorkers = settings.ParallelizationWorkers;
         CurrentSettings.TestCleanupTimeout = settings.TestCleanupTimeout;
         CurrentSettings.TestInitializeTimeout = settings.TestInitializeTimeout;
+        CurrentSettings.GlobalTestCleanupTimeout = settings.GlobalTestCleanupTimeout;
+        CurrentSettings.GlobalTestInitializeTimeout = settings.GlobalTestInitializeTimeout;
         CurrentSettings.TestTimeout = settings.TestTimeout;
         CurrentSettings.TreatDiscoveryWarningsAsErrors = settings.TreatDiscoveryWarningsAsErrors;
         CurrentSettings.LaunchDebuggerOnAssertionFailure = settings.LaunchDebuggerOnAssertionFailure;
@@ -139,6 +141,12 @@ internal sealed partial class MSTestSettings
                         break;
                     case "TESTCLEANUPTIMEOUT":
                         ParseTimeoutSetting(reader.ReadInnerXml(), "TestCleanupTimeout", logger, v => settings.TestCleanupTimeout = v);
+                        break;
+                    case "GLOBALTESTINITIALIZETIMEOUT":
+                        ParseTimeoutSetting(reader.ReadInnerXml(), "GlobalTestInitializeTimeout", logger, v => settings.GlobalTestInitializeTimeout = v);
+                        break;
+                    case "GLOBALTESTCLEANUPTIMEOUT":
+                        ParseTimeoutSetting(reader.ReadInnerXml(), "GlobalTestCleanupTimeout", logger, v => settings.GlobalTestCleanupTimeout = v);
                         break;
                     case "COOPERATIVECANCELLATIONTIMEOUT":
                         ParseBoolSetting(reader.ReadInnerXml(), "CooperativeCancellationTimeout", logger, v => settings.CooperativeCancellationTimeout = v);

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestSettings.cs
@@ -44,6 +44,8 @@ internal sealed partial class MSTestSettings
         ClassCleanupTimeout = 0;
         TestInitializeTimeout = 0;
         TestCleanupTimeout = 0;
+        GlobalTestInitializeTimeout = 0;
+        GlobalTestCleanupTimeout = 0;
         CooperativeCancellationTimeout = false;
         OrderTestsByNameInClass = false;
         RandomizeTestOrder = false;
@@ -144,14 +146,24 @@ internal sealed partial class MSTestSettings
     internal int ClassCleanupTimeout { get; private set; }
 
     /// <summary>
-    ///  Gets specified global TestInitializeTimeout timeout.
+    ///  Gets specified TestInitialize timeout.
     /// </summary>
     internal int TestInitializeTimeout { get; private set; }
 
     /// <summary>
-    ///  Gets specified global TestCleanupTimeout timeout.
+    ///  Gets specified TestCleanup timeout.
     /// </summary>
     internal int TestCleanupTimeout { get; private set; }
+
+    /// <summary>
+    ///  Gets specified GlobalTestInitialize timeout. Falls back to <see cref="TestInitializeTimeout"/> when not set.
+    /// </summary>
+    internal int GlobalTestInitializeTimeout { get; private set; }
+
+    /// <summary>
+    ///  Gets specified GlobalTestCleanup timeout. Falls back to <see cref="TestCleanupTimeout"/> when not set.
+    /// </summary>
+    internal int GlobalTestCleanupTimeout { get; private set; }
 
     /// <summary>
     /// Gets a value indicating whether all timeouts should be cooperative.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/Resource.resx
@@ -316,6 +316,22 @@ but received {4} argument(s), with types '{5}'.</value>
     <value>Found two conflicting types for generic parameter '{0}'. The conflicting types are '{1}' and '{2}'.</value>
     <comment>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</comment>
   </data>
+  <data name="GlobalTestCleanupTimedOut" xml:space="preserve">
+    <value>Global test cleanup method '{0}.{1}' timed out after {2}ms</value>
+    <comment>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</comment>
+  </data>
+  <data name="GlobalTestCleanupWasCancelled" xml:space="preserve">
+    <value>Global test cleanup method '{0}.{1}' was canceled</value>
+    <comment>{0} is the type name. {1} is the global test cleanup method name.</comment>
+  </data>
+  <data name="GlobalTestInitializeTimedOut" xml:space="preserve">
+    <value>Global test initialize method '{0}.{1}' timed out after {2}ms</value>
+    <comment>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</comment>
+  </data>
+  <data name="GlobalTestInitializeWasCancelled" xml:space="preserve">
+    <value>Global test initialize method '{0}.{1}' was canceled</value>
+    <comment>{0} is the type name. {1} is the global test initialize method name.</comment>
+  </data>
   <data name="InvalidParallelScopeValue" xml:space="preserve">
     <value>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</value>
     <comment>{0} is the invalid scope value. {1} is the supported scope list. {Locked="Scope"}</comment>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.cs.xlf
@@ -228,6 +228,26 @@ byl však přijat tento počet argumentů: {4} s typy {5}.</target>
         <target state="translated">Byly nalezeny dva konfliktní typy pro obecný parametr {0}. Konfliktní typy jsou {1} a {2}.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Pro procesy 'Scope' je zadaná neplatná hodnota {0}. Podporované obory jsou {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.de.xlf
@@ -228,6 +228,26 @@ aber empfing {4} Argument(e) mit den Typen „{5}“.</target>
         <target state="translated">Es wurden zwei in Konflikt stehende Typen für den generischen Parameter „{0}“ gefunden. Die in Konflikt stehenden Typen sind „{1}“ und „{2}“.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Ungültiger Wert "{0}" für "Scope" angegeben. Unterstützte Bereiche: {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.es.xlf
@@ -228,6 +228,26 @@ pero recibió {4} argumentos, con los tipos '{5}'.</target>
         <target state="translated">Se encontraron dos tipos en conflicto para el parámetro genérico '{0}'. Los tipos en conflicto son '{1}' y ''{2}.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Valor no válido "{0}" especificado para "Scope". Los ámbitos admitidos son {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.fr.xlf
@@ -228,6 +228,26 @@ mais a reçu {4} argument(s), avec les types « {5} ».</target>
         <target state="translated">Deux types en conflit ont été trouvés pour le paramètre générique « {0} ». Les types en conflit sont « {1} » et « {2} ».</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Valeur non valide « {0} » spécifiée pour « Scope ». Les étendues prises en charge sont {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.it.xlf
@@ -228,6 +228,26 @@ ma ha ricevuto {4} argomenti, con tipi '{5}'.</target>
         <target state="translated">Sono stati trovati due tipi in conflitto per il parametro generico '{0}'. I tipi in conflitto sono '{1}' e '{2}'.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Il valore '{0}', specificato per 'Scope', non è valido. I valori supportati per Scope sono {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ja.xlf
@@ -229,6 +229,26 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">ジェネリック パラメーター '{0}' に 2 つの競合する型が見つかりました。競合する型は '{1}' および '{2}' です。</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">無効な値 '{0}' が 'Scope' に指定されました。サポートされているスコープは {1} です。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ko.xlf
@@ -228,6 +228,26 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">제네릭 매개 변수 '{0}'에 대해 충돌하는 두 가지 형식을 찾았습니다. 충돌하는 형식은 '{1}' 및 ''{2}입니다.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">'Scope'에 대해 잘못된 값 '{0}'이(가) 지정되었습니다. 지원되는 범위는 {1}입니다.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pl.xlf
@@ -228,6 +228,26 @@ ale odebrał argumenty {4} z typami „{5}”.</target>
         <target state="translated">Znaleziono dwa typy powodujące konflikt dla parametru ogólnego „{0}”. Typy powodujące konflikt to „{1}” i „{2}”.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Określono nieprawidłową wartość „{0}” dla właściwości „Scope”. Obsługiwane zakresy to {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.pt-BR.xlf
@@ -228,6 +228,26 @@ mas {4} argumentos recebidos, com tipos '{5}'.</target>
         <target state="translated">Foram encontrados dois tipos conflitantes para o parâmetro genérico "{0}". Os tipos conflitantes são "{1}" e "{2}".</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">Valor inválido '{0}' especificado para 'Scope'. Os escopos compatíveis são {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.ru.xlf
@@ -228,6 +228,26 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">Обнаружены два конфликтующих типа для универсального параметра "{0}". Конфликтующие типы: "{1}" и "{2}".</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">В поле "Scope" указано недопустимое значение "{0}". Поддерживаемые области: {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.tr.xlf
@@ -228,6 +228,26 @@ ancak, '{5}' türünde {4} bağımsız değişken aldı.</target>
         <target state="translated">'{0}' genel parametresi için iki çakışan tür bulundu. Çakışan türler '{1}' ile '{2}'.</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">'Scope' için geçersiz '{0}' değeri belirtildi. Desteklenen kapsamlar {1}.</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hans.xlf
@@ -228,6 +228,26 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">发现泛型参数“{0}”有两种冲突类型。冲突类型为“{1}”和“{2}”。</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">为 ‘Scope’ 指定的值 ‘{0}’ 无效。受支持的范围为 {1}。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Resources/xlf/Resource.zh-Hant.xlf
@@ -228,6 +228,26 @@ but received {4} argument(s), with types '{5}'.</source>
         <target state="translated">發現泛型參數 '{0}' 有兩個衝突類型。衝突類型為 '{1}' 和 '{2}'。</target>
         <note>{0} is the generic parameter name. {1} is the first conflicting type. {2} is the second conflicting type.</note>
       </trans-unit>
+      <trans-unit id="GlobalTestCleanupTimedOut">
+        <source>Global test cleanup method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test cleanup method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestCleanupWasCancelled">
+        <source>Global test cleanup method '{0}.{1}' was canceled</source>
+        <target state="new">Global test cleanup method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test cleanup method name.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeTimedOut">
+        <source>Global test initialize method '{0}.{1}' timed out after {2}ms</source>
+        <target state="new">Global test initialize method '{0}.{1}' timed out after {2}ms</target>
+        <note>{0} is the type name. {1} is the global test initialize method name. {2} is the timeout in milliseconds.</note>
+      </trans-unit>
+      <trans-unit id="GlobalTestInitializeWasCancelled">
+        <source>Global test initialize method '{0}.{1}' was canceled</source>
+        <target state="new">Global test initialize method '{0}.{1}' was canceled</target>
+        <note>{0} is the type name. {1} is the global test initialize method name.</note>
+      </trans-unit>
       <trans-unit id="InvalidParallelScopeValue">
         <source>Invalid value '{0}' specified for 'Scope'. Supported scopes are {1}.</source>
         <target state="translated">為 'Scope' 指定的值 '{0}' 無效。支援的範圍為 {1}。</target>

--- a/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
@@ -385,6 +385,8 @@ internal sealed class MSTestTelemetryDataCollector
         metrics["mstest.setting.class_cleanup_timeout"] = (double)settings.ClassCleanupTimeout;
         metrics["mstest.setting.test_initialize_timeout"] = (double)settings.TestInitializeTimeout;
         metrics["mstest.setting.test_cleanup_timeout"] = (double)settings.TestCleanupTimeout;
+        metrics["mstest.setting.global_test_initialize_timeout"] = (double)settings.GlobalTestInitializeTimeout;
+        metrics["mstest.setting.global_test_cleanup_timeout"] = (double)settings.GlobalTestCleanupTimeout;
         metrics["mstest.setting.cooperative_cancellation"] = AsTelemetryBool(settings.CooperativeCancellationTimeout);
 
         // Behavior

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GlobalFixtureTimeoutFromConfigTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/GlobalFixtureTimeoutFromConfigTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
+using Microsoft.Testing.Platform.Helpers;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class GlobalFixtureTimeoutFromConfigTests : AcceptanceTestBase<GlobalFixtureTimeoutFromConfigTests.TestAssetFixture>
+{
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitializeTimeout_FromRunSettings_AppliesToGlobalTestInitialize(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            environmentVariables: new() { ["LONG_WAIT_GLOBALINIT"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
+        testHostResult.AssertOutputContains("Global test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestCleanupTimeout_FromRunSettings_AppliesToGlobalTestCleanup(string tfm)
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            environmentVariables: new() { ["LONG_WAIT_GLOBALCLEANUP"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
+        testHostResult.AssertOutputContains("Global test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task GlobalTestInitializeTimeout_FromRunSettings_DoesNotApplyToTestInitialize(string tfm)
+    {
+        // Only the global-fixture timeout is configured. A slow per-test [TestInitialize] must NOT be
+        // subject to it — proving the dedicated key does not leak into per-test initialize.
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            "--settings my.runsettings",
+            environmentVariables: new() { ["SHORT_WAIT_TESTINIT"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputContains("TestInit completed");
+        testHostResult.AssertOutputDoesNotContain("Test initialize method 'TestClass.TestInit' timed out");
+    }
+
+    public sealed class TestAssetFixture : TestAssetFixtureBase
+    {
+        public const string ProjectName = "GlobalFixtureTimeoutFromConfig";
+
+        public string TargetAssetPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchCodeWithReplace("$ProjectName$", ProjectName)
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
+
+        private const string SourceCode = """
+#file $ProjectName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="*.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>
+
+#file my.runsettings
+<RunSettings>
+  <MSTest>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+    <GlobalTestInitializeTimeout>1000</GlobalTestInitializeTimeout>
+    <GlobalTestCleanupTimeout>1000</GlobalTestCleanupTimeout>
+  </MSTest>
+</RunSettings>
+
+#file UnitTest1.cs
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class TestClass
+{
+    public TestContext TestContext { get; set; }
+
+    [GlobalTestInitialize]
+    public static async Task GlobalTestInit(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_GLOBALINIT") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    [GlobalTestCleanup]
+    public static async Task GlobalTestCleanup(TestContext testContext)
+    {
+        if (Environment.GetEnvironmentVariable("LONG_WAIT_GLOBALCLEANUP") == "1")
+        {
+            await Task.Delay(10_000);
+        }
+        else
+        {
+            await Task.CompletedTask;
+        }
+    }
+
+    [TestInitialize]
+    public async Task TestInit()
+    {
+        if (Environment.GetEnvironmentVariable("SHORT_WAIT_TESTINIT") == "1")
+        {
+            // Intentionally longer than the configured global timeout (1000ms): if that global key
+            // leaked into [TestInitialize], this would time out. It must complete instead.
+            await Task.Delay(2_000);
+        }
+
+        Console.WriteLine("TestInit completed");
+    }
+
+    [TestMethod]
+    public void TestMethod()
+    {
+    }
+}
+""";
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeGlobalTestCancellationTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutCooperativeGlobalTestCancellationTests.cs
@@ -20,7 +20,7 @@ public sealed class TimeoutCooperativeGlobalTestCancellationTests : AcceptanceTe
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertOutputContains("GlobalTestInit started");
-        testHostResult.AssertOutputContains("Test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
+        testHostResult.AssertOutputContains("Global test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
         testHostResult.AssertOutputDoesNotContain("GlobalTestInit Thread.Sleep completed");
         testHostResult.AssertOutputDoesNotContain("GlobalTestInit completed");
     }
@@ -37,7 +37,7 @@ public sealed class TimeoutCooperativeGlobalTestCancellationTests : AcceptanceTe
 
         testHostResult.AssertOutputContains("GlobalTestInit started");
         testHostResult.AssertOutputContains("GlobalTestInit Thread.Sleep completed");
-        testHostResult.AssertOutputContains("Test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
+        testHostResult.AssertOutputContains("Global test initialize method 'TestClass.GlobalTestInit' timed out after 1000ms");
         testHostResult.AssertOutputDoesNotContain("GlobalTestInit completed");
     }
 
@@ -52,7 +52,7 @@ public sealed class TimeoutCooperativeGlobalTestCancellationTests : AcceptanceTe
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertOutputContains("GlobalTestCleanup started");
-        testHostResult.AssertOutputContains("Test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
+        testHostResult.AssertOutputContains("Global test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
         testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup Thread.Sleep completed");
         testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup completed");
     }
@@ -69,7 +69,7 @@ public sealed class TimeoutCooperativeGlobalTestCancellationTests : AcceptanceTe
 
         testHostResult.AssertOutputContains("GlobalTestCleanup started");
         testHostResult.AssertOutputContains("GlobalTestCleanup Thread.Sleep completed");
-        testHostResult.AssertOutputContains("Test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
+        testHostResult.AssertOutputContains("Global test cleanup method 'TestClass.GlobalTestCleanup' timed out after 1000ms");
         testHostResult.AssertOutputDoesNotContain("GlobalTestCleanup completed");
     }
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenCanceledTests.cs
@@ -14,8 +14,8 @@ public sealed class TimeoutWhenCanceledTests : AcceptanceTestBase<TimeoutWhenCan
         ["assemblyInit"] = ("TestClass.AssemblyInit", "Assembly initialize", "ASSEMBLYINIT", "AssemblyInitializeTimeout"),
         ["classInit"] = ("TestClass.ClassInit", "Class initialize", "CLASSINIT", "ClassInitializeTimeout"),
         ["baseClassInit"] = ("TestClassBase.ClassInitBase", "Class initialize", "BASE_CLASSINIT", "ClassInitializeTimeout"),
-        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
-        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
+        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Global test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
+        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Global test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
     };
 
     [TestMethod]

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
@@ -19,8 +19,8 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
         ["baseClassCleanup"] = ("TestClassBase.ClassCleanupBase", "Class cleanup", "BASE_CLASSCLEANUP", "ClassCleanupTimeout"),
         ["testInit"] = ("TestClass.TestInit", "Test initialize", "TESTINIT", "TestInitializeTimeout"),
         ["testCleanup"] = ("TestClass.TestCleanupMethod", "Test cleanup", "TESTCLEANUP", "TestCleanupTimeout"),
-        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
-        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
+        ["globalTestInit"] = ("TestClass.GlobalTestInit", "Global test initialize", "GLOBALTESTINIT", "TestInitializeTimeout"),
+        ["globalTestCleanup"] = ("TestClass.GlobalTestCleanupMethod", "Global test cleanup", "GLOBALTESTCLEANUP", "TestCleanupTimeout"),
     };
 
     [TestMethod]

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/MSTestSettingsTests.cs
@@ -17,6 +17,8 @@ using Moq;
 using TestFramework.ForTestingMSTest;
 
 using ExecutionScope = Microsoft.VisualStudio.TestTools.UnitTesting.ExecutionScope;
+using FixtureKind = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.FixtureKind;
+using TimeoutInfo = Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TimeoutInfo;
 #pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests;
@@ -1234,6 +1236,8 @@ public class MSTestSettingsTests : TestContainer
             { "mstest:timeout:classCleanup", "200" },
             { "mstest:timeout:testInitialize", "100" },
             { "mstest:timeout:testCleanup", "100" },
+            { "mstest:timeout:globalTestInitialize", "150" },
+            { "mstest:timeout:globalTestCleanup", "150" },
             { "mstest:timeout:test", "60" },
             { "mstest:timeout:useCooperativeCancellation", "true" },
             { "mstest:parallelism:enabled", "true" },
@@ -1276,10 +1280,76 @@ public class MSTestSettingsTests : TestContainer
         settings.ClassCleanupTimeout.Should().Be(200);
         settings.TestInitializeTimeout.Should().Be(100);
         settings.TestCleanupTimeout.Should().Be(100);
+        settings.GlobalTestInitializeTimeout.Should().Be(150);
+        settings.GlobalTestCleanupTimeout.Should().Be(150);
 
         settings.DisableParallelization.Should().BeFalse();
         settings.ParallelizationWorkers.Should().Be(4);
         settings.ParallelizationScope.Should().Be(ExecutionScope.ClassLevel);
+    }
+
+    public void RunSettings_WithGlobalFixtureTimeouts_ValuesAreSetCorrectly()
+    {
+        string runSettingsXml =
+            """
+            <RunSettings>
+                <MSTestV2>
+                    <GlobalTestInitializeTimeout>150</GlobalTestInitializeTimeout>
+                    <GlobalTestCleanupTimeout>250</GlobalTestCleanupTimeout>
+                </MSTestV2>
+            </RunSettings>
+            """;
+
+        MSTestSettings adapterSettings = MSTestSettings.GetSettings(runSettingsXml, MSTestSettings.SettingsNameAlias, _mockMessageLogger.Object.ToAdapterMessageLogger())!;
+
+        adapterSettings.GlobalTestInitializeTimeout.Should().Be(150);
+        adapterSettings.GlobalTestCleanupTimeout.Should().Be(250);
+    }
+
+    public void GlobalFixtureTimeout_WhenDedicatedKeySet_IsUsedInsteadOfSharedTestKey()
+    {
+        var settings = new MSTestSettings();
+        MSTestSettings.SetSettingsFromConfig(
+            BuildConfig(new()
+            {
+                { "mstest:timeout:testInitialize", "100" },
+                { "mstest:timeout:testCleanup", "200" },
+                { "mstest:timeout:globalTestInitialize", "1100" },
+                { "mstest:timeout:globalTestCleanup", "2200" },
+            }),
+            _mockMessageLogger.Object.ToAdapterMessageLogger(),
+            settings);
+        MSTestSettings.PopulateSettings(settings);
+
+        // The dedicated global keys take precedence over the per-test initialize/cleanup keys.
+        TimeoutInfo.FromFixtureSettings(FixtureKind.GlobalTestInitialize).Timeout.Should().Be(1100);
+        TimeoutInfo.FromFixtureSettings(FixtureKind.GlobalTestCleanup).Timeout.Should().Be(2200);
+    }
+
+    public void GlobalFixtureTimeout_WhenDedicatedKeyNotSet_FallsBackToSharedTestKey()
+    {
+        var settings = new MSTestSettings();
+        MSTestSettings.SetSettingsFromConfig(
+            BuildConfig(new()
+            {
+                { "mstest:timeout:testInitialize", "100" },
+                { "mstest:timeout:testCleanup", "200" },
+            }),
+            _mockMessageLogger.Object.ToAdapterMessageLogger(),
+            settings);
+        MSTestSettings.PopulateSettings(settings);
+
+        // With no dedicated global key, global fixtures keep honoring the per-test initialize/cleanup keys.
+        TimeoutInfo.FromFixtureSettings(FixtureKind.GlobalTestInitialize).Timeout.Should().Be(100);
+        TimeoutInfo.FromFixtureSettings(FixtureKind.GlobalTestCleanup).Timeout.Should().Be(200);
+    }
+
+    private static IConfiguration BuildConfig(Dictionary<string, string> values)
+    {
+        var mockConfig = new Mock<IConfiguration>();
+        mockConfig.Setup(config => config[It.IsAny<string>()])
+                  .Returns((string key) => values.TryGetValue(key, out string? value) ? value : null);
+        return mockConfig.Object;
     }
 
     public void ConfigJson_WithDeprecatedFlatOrderTestsByNameInClassKey_ValueIsSetAndWarningIsEmitted()


### PR DESCRIPTION
Fixes #9985.

`[GlobalTestInitialize]` and `[GlobalTestCleanup]` fixtures previously had no dedicated timeout configuration surface — they silently shared the per-test `[TestInitialize]`/`[TestCleanup]` timeout keys, and their timeout/cancellation messages were identical to the per-test ones. This adds the missing surface, matching what `[AssemblyInitialize/Cleanup]` and `[ClassInitialize/Cleanup]` already have.

## Changes

**Configuration**
- New `MSTestSettings.GlobalTestInitializeTimeout` / `GlobalTestCleanupTimeout` properties.
- `testconfig.json`: `mstest:timeout:globalTestInitialize` / `globalTestCleanup`.
- RunSettings XML: `<GlobalTestInitializeTimeout>` / `<GlobalTestCleanupTimeout>`.
- **Backward-compatible fallback**: a global fixture uses its dedicated key when set, otherwise falls back to the corresponding per-test `testInitialize`/`testCleanup` key, so existing configurations keep applying. A method-level `[Timeout(...)]` still takes precedence over config.

**Diagnostics**
- New `FixtureKind.GlobalTestInitialize` / `GlobalTestCleanup` members, wired through `TypeCache` and `TimeoutInfo.FromFixtureSettings`.
- Dedicated resource strings so timeouts/cancellations now report e.g. `Global test initialize method '…' timed out after 1000ms` instead of the per-test wording (XLF regenerated via `UpdateXlf`).
- Two new telemetry metrics (`mstest.setting.global_test_initialize_timeout` / `..._cleanup_timeout`).

**Tests**
- Unit tests for parsing plus the precedence (dedicated key wins) and fallback (per-test key when unset) behavior.
- New `GlobalFixtureTimeoutFromConfigTests` acceptance suite proving the config key drives the global timeout and does **not** leak into `[TestInitialize]`.
- Updated existing global-fixture timeout/cancel acceptance assertions to the new wording.

**Docs**
- `docs/testconfig.schema.json`, `docs/testconfig.schema.md` (with a fallback note), and `docs/Changelog.md`.

## Design note
I chose fallback-to-per-test rather than making the dedicated keys fully independent, to avoid a silent breaking change for anyone currently relying on `testInitialize`/`testCleanup` applying to global fixtures.

## Validation
Full repo build clean; 903 adapter unit tests pass; the affected + new acceptance tests pass (net8.0/net9.0/net462 assets). Reviewed across three rounds (expert MSTest reviewer, general code review, rubber-duck) — all clean after addressing minor nits (doc-comment cleanup, exit-code assertions on the positive acceptance tests, reduced test wait).