### PR TITLE
Make macOS PR job non-blocking

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,10 @@ variables:
   # while macOS failures stay visible via --report-azdo (AzDO Tests tab) and the published TestResults
   # artifact, so signal is preserved without gating merges on macOS-specific flakiness/slowness. Windows
   # and Linux do not use this trailer and remain hard blockers.
+  # The consumers add an explicit separating space before this expansion, so the value must NOT rely on
+  # a leading space of its own.
   - name: _MacOSNonBlockingTrailer
-    value: ' || echo "##vso[task.logissue type=warning]macOS is non-blocking for PRs; this failure does not block the merge. See the Tests tab and the published TestResults artifact for details."'
+    value: '|| echo "##vso[task.logissue type=warning]macOS is non-blocking for PRs; this failure does not block the merge. See the Tests tab and the published TestResults artifact for details."'
 
 stages:
 
@@ -358,7 +360,7 @@ stages:
             /p:Test=false
             /p:Publish=false
             /p:NonWindowsBuild=true
-            /p:FastAcceptanceTest=true$(_MacOSNonBlockingTrailer)
+            /p:FastAcceptanceTest=true $(_MacOSNonBlockingTrailer)
           displayName: Build
 
         - ${{ if eq(parameters.SkipTests, False) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,15 @@ variables:
   # Placeholders ({asm}/{tfm}) are resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
   - name: _ReleaseUnitTestReportArgs
     value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-azdo-slow-test-history 30 --report-azdo-slow-test-history-min-sample 10 --report-azdo-slow-test-history-multiplier 3.0 --report-azdo-flaky-history 30 --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
+  # Shell trailer appended to the macOS build/test commands so a failure exits 0 and keeps the overall
+  # pipeline result "Succeeded". This is required to make macOS genuinely non-blocking for PRs: job- or
+  # step-level continueOnError only yields "PartiallySucceeded", which Azure Repos build-validation
+  # policies treat as a failure and still block the merge. Swallowing the exit code keeps the run green
+  # while macOS failures stay visible via --report-azdo (AzDO Tests tab) and the published TestResults
+  # artifact, so signal is preserved without gating merges on macOS-specific flakiness/slowness. Windows
+  # and Linux do not use this trailer and remain hard blockers.
+  - name: _MacOSNonBlockingTrailer
+    value: ' || echo "##vso[task.logissue type=warning]macOS is non-blocking for PRs; this failure does not block the merge. See the Tests tab and the published TestResults artifact for details."'
 
 stages:
 
@@ -324,11 +333,11 @@ stages:
       - job: MacOS
         dependsOn: DetectChanges
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
-        # macOS agents are historically slow and flaky, so this job is intentionally non-blocking for PRs:
-        # continueOnError makes the job run and publish its results, but a failure surfaces as a warning
-        # (job result "SucceededWithIssues") instead of failing the build. This keeps macOS signal visible
-        # without gating merges on macOS-specific flakiness. Windows and Linux remain hard blockers.
-        continueOnError: true
+        # macOS agents are historically slow and flaky, so this job is intentionally non-blocking for PRs.
+        # Rather than continueOnError (which yields "PartiallySucceeded" and is still blocked by Azure Repos
+        # build-validation policies), every macOS command appends $(_MacOSNonBlockingTrailer) so a failure
+        # exits 0 and the overall run stays "Succeeded". Failures remain visible via --report-azdo (Tests
+        # tab) and the published TestResults artifact. See _MacOSNonBlockingTrailer for the full rationale.
         timeoutInMinutes: 90
         pool:
           name: Azure Pipelines
@@ -349,13 +358,14 @@ stages:
             /p:Test=false
             /p:Publish=false
             /p:NonWindowsBuild=true
-            /p:FastAcceptanceTest=true
+            /p:FastAcceptanceTest=true$(_MacOSNonBlockingTrailer)
           displayName: Build
 
         - ${{ if eq(parameters.SkipTests, False) }}:
           - template: /eng/pipelines/steps/test-non-windows.yml
             parameters:
               osName: MacOS
+              testFailureTrailer: $(_MacOSNonBlockingTrailer)
 
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -324,6 +324,11 @@ stages:
       - job: MacOS
         dependsOn: DetectChanges
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        # macOS agents are historically slow and flaky, so this job is intentionally non-blocking for PRs:
+        # continueOnError makes the job run and publish its results, but a failure surfaces as a warning
+        # (job result "SucceededWithIssues") instead of failing the build. This keeps macOS signal visible
+        # without gating merges on macOS-specific flakiness. Windows and Linux remain hard blockers.
+        continueOnError: true
         timeoutInMinutes: 90
         pool:
           name: Azure Pipelines

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,17 +65,30 @@ variables:
   # Placeholders ({asm}/{tfm}) are resolved by Microsoft.Testing.Platform.Services.ArtifactNamingHelper.
   - name: _ReleaseUnitTestReportArgs
     value: '--report-trx --report-trx-filename "{asm}_{tfm}.trx" --report-ctrf --report-ctrf-filename "{asm}_{tfm}.ctrf.json" --report-azdo --report-azdo-summary --report-azdo-slow-test-history 30 --report-azdo-slow-test-history-min-sample 10 --report-azdo-slow-test-history-multiplier 3.0 --report-azdo-flaky-history 30 --report-junit --report-junit-filename "{asm}_{tfm}.xml" --hangdump --hangdump-timeout 15m'
-  # Shell trailer appended to the macOS build/test commands so a failure exits 0 and keeps the overall
-  # pipeline result "Succeeded". This is required to make macOS genuinely non-blocking for PRs: job- or
-  # step-level continueOnError only yields "PartiallySucceeded", which Azure Repos build-validation
+  # Shell trailer appended to the macOS build/test commands so that, ON PR RUNS, a failed command exits 0
+  # and keeps the overall pipeline result "Succeeded". This is required to make macOS non-blocking for PRs:
+  # job- or step-level continueOnError only yields "PartiallySucceeded", which Azure Repos build-validation
   # policies treat as a failure and still block the merge. Swallowing the exit code keeps the run green
   # while macOS failures stay visible via --report-azdo (AzDO Tests tab) and the published TestResults
   # artifact, so signal is preserved without gating merges on macOS-specific flakiness/slowness. Windows
   # and Linux do not use this trailer and remain hard blockers.
+  #
+  # The exit code is ONLY swallowed when BUILD_REASON is "PullRequest". On manual/scheduled/CI queues there
+  # is no merge to unblock, so the original exit code is preserved and a real macOS regression still fails
+  # the run (see the DetectChanges fail-safe for non-PR triggers around the SYSTEM_PULLREQUEST_TARGETBRANCH
+  # handling below).
+  #
+  # KNOWN LIMITATION: this only converts command EXIT CODES. It cannot rescue the job from the 90-minute
+  # timeout (hung agent), agent loss, or a failure in the unconditional publish/copy tasks — any of those
+  # still fails/cancels the macOS matrix job and therefore the overall build. Fully covering those cases
+  # would require running macOS as a separate, non-required pipeline/status check (or removing it from the
+  # required PR pipeline). That larger change is intentionally out of scope here; this trailer addresses the
+  # dominant flaky-test-failure case while keeping macOS visible on every PR.
+  #
   # The consumers add an explicit separating space before this expansion, so the value must NOT rely on
   # a leading space of its own.
   - name: _MacOSNonBlockingTrailer
-    value: '|| echo "##vso[task.logissue type=warning]macOS is non-blocking for PRs; this failure does not block the merge. See the Tests tab and the published TestResults artifact for details."'
+    value: '|| { ec=$?; if [ "$BUILD_REASON" = "PullRequest" ]; then echo "##vso[task.logissue type=warning]macOS is non-blocking for PRs; this failure does not block the merge. See the Tests tab and the published TestResults artifact for details."; else exit $ec; fi; }'
 
 stages:
 
@@ -337,9 +350,12 @@ stages:
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
         # macOS agents are historically slow and flaky, so this job is intentionally non-blocking for PRs.
         # Rather than continueOnError (which yields "PartiallySucceeded" and is still blocked by Azure Repos
-        # build-validation policies), every macOS command appends $(_MacOSNonBlockingTrailer) so a failure
-        # exits 0 and the overall run stays "Succeeded". Failures remain visible via --report-azdo (Tests
-        # tab) and the published TestResults artifact. See _MacOSNonBlockingTrailer for the full rationale.
+        # build-validation policies), every macOS command appends $(_MacOSNonBlockingTrailer) so a failed
+        # command exits 0 on PR runs and the overall run stays "Succeeded" (on non-PR runs the exit code is
+        # preserved). Failures remain visible via --report-azdo (Tests tab) and the published TestResults
+        # artifact. NOTE: this only swallows command exit codes — a 90-minute timeout, agent loss, or a
+        # publish-task failure still fails this job and blocks. See _MacOSNonBlockingTrailer for the full
+        # rationale and the documented limitation.
         timeoutInMinutes: 90
         pool:
           name: Azure Pipelines

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -9,12 +9,13 @@ parameters:
   values:
   - Linux
   - MacOS
-# Shell trailer appended to the two `dotnet test` commands below. Defaults to empty so Linux fails the
-# job (and thus the run) on any test failure, keeping it a hard PR blocker. The macOS job passes
-# $(_MacOSNonBlockingTrailer) (" || echo ...") so a macOS test failure exits 0 and the overall run stays
-# "Succeeded" — the only way to make macOS genuinely non-blocking, because job/step-level continueOnError
-# only produces "PartiallySucceeded", which Azure Repos build-validation policies still treat as a block.
-# macOS failures remain visible via --report-azdo (Tests tab) and the published TestResults artifact.
+# Shell trailer appended (with an explicit separating space) to the two `dotnet test` commands below.
+# Defaults to empty so Linux fails the job (and thus the run) on any test failure, keeping it a hard PR
+# blocker. The macOS job passes $(_MacOSNonBlockingTrailer) ("|| echo ...") so a macOS test failure exits
+# 0 and the overall run stays "Succeeded" — the only way to make macOS genuinely non-blocking, because
+# job/step-level continueOnError only produces "PartiallySucceeded", which Azure Repos build-validation
+# policies still treat as a block. macOS failures remain visible via --report-azdo (Tests tab) and the
+# published TestResults artifact.
 - name: testFailureTrailer
   type: string
   default: ''
@@ -29,7 +30,7 @@ steps:
 # by Microsoft.Testing.Platform actually reaches the live build log; with the default (true), the
 # output is buffered into a per-module .log file and only surfaced on failure, so no live progress
 # is visible during long-running test sessions.
-- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false${{ parameters.testFailureTrailer }}
+- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false ${{ parameters.testFailureTrailer }}
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
@@ -59,7 +60,7 @@ steps:
 #   --coverage — coverage upload is Debug-only (see "Merge coverage" / "Publish coverage to
 #     Azure DevOps" steps in azure-pipelines.yml), so collecting coverage in Release would just
 #     write unused .coverage files.
-- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) $(_ReleaseUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace${{ parameters.testFailureTrailer }}
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) $(_ReleaseUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace ${{ parameters.testFailureTrailer }}
   name: TestRelease
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -11,11 +11,12 @@ parameters:
   - MacOS
 # Shell trailer appended (with an explicit separating space) to the two `dotnet test` commands below.
 # Defaults to empty so Linux fails the job (and thus the run) on any test failure, keeping it a hard PR
-# blocker. The macOS job passes $(_MacOSNonBlockingTrailer) ("|| echo ...") so a macOS test failure exits
-# 0 and the overall run stays "Succeeded" — the only way to make macOS genuinely non-blocking, because
-# job/step-level continueOnError only produces "PartiallySucceeded", which Azure Repos build-validation
-# policies still treat as a block. macOS failures remain visible via --report-azdo (Tests tab) and the
-# published TestResults artifact.
+# blocker. The macOS job passes $(_MacOSNonBlockingTrailer) ("|| { ... }"), which swallows the exit code
+# ONLY on PR runs (BUILD_REASON = PullRequest) so a macOS test failure keeps the overall run "Succeeded" —
+# the only way to make macOS non-blocking, because job/step-level continueOnError only produces
+# "PartiallySucceeded", which Azure Repos build-validation policies still treat as a block. macOS failures
+# remain visible via --report-azdo (Tests tab) and the published TestResults artifact. This only converts
+# exit codes; timeout/agent-loss/publish failures are not covered (see _MacOSNonBlockingTrailer).
 - name: testFailureTrailer
   type: string
   default: ''

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -9,6 +9,15 @@ parameters:
   values:
   - Linux
   - MacOS
+# Shell trailer appended to the two `dotnet test` commands below. Defaults to empty so Linux fails the
+# job (and thus the run) on any test failure, keeping it a hard PR blocker. The macOS job passes
+# $(_MacOSNonBlockingTrailer) (" || echo ...") so a macOS test failure exits 0 and the overall run stays
+# "Succeeded" — the only way to make macOS genuinely non-blocking, because job/step-level continueOnError
+# only produces "PartiallySucceeded", which Azure Repos build-validation policies still treat as a block.
+# macOS failures remain visible via --report-azdo (Tests tab) and the published TestResults artifact.
+- name: testFailureTrailer
+  type: string
+  default: ''
 
 steps:
 # Because the build step is using -ci flag, restore is done in a local .packages directory.
@@ -20,7 +29,7 @@ steps:
 # by Microsoft.Testing.Platform actually reaches the live build log; with the default (true), the
 # output is buffered into a per-module .log file and only surfaced on failure, so no live progress
 # is visible during long-running test sessions.
-- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false${{ parameters.testFailureTrailer }}
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))
@@ -50,7 +59,7 @@ steps:
 #   --coverage — coverage upload is Debug-only (see "Merge coverage" / "Publish coverage to
 #     Azure DevOps" steps in azure-pipelines.yml), so collecting coverage in Release would just
 #     write unused .coverage files.
-- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) $(_ReleaseUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace
+- script: dotnet test --no-build --test-modules "artifacts/bin/*UnitTests*/$(_BuildConfig)/**/*UnitTests.dll" --results-directory $(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig) $(_ReleaseUnitTestReportArgs) --diagnostic --diagnostic-output-directory $(BUILD.SOURCESDIRECTORY)/artifacts/log/$(_BuildConfig) --diagnostic-verbosity trace${{ parameters.testFailureTrailer }}
   name: TestRelease
   displayName: Test (unit tests only)
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))


### PR DESCRIPTION
## Why

macOS agents are historically slow and flaky, which makes them a frequent (and often false-positive) blocker for PRs.

## What

Makes the `MacOS` job in `azure-pipelines.yml` non-blocking **for PR runs** by swallowing macOS command exit codes.

Note: job/step-level `continueOnError` is **not** sufficient — it yields a `PartiallySucceeded` run, which Azure Repos build-validation policies still treat as a block. Instead, each macOS build/test command appends a shell trailer (`_MacOSNonBlockingTrailer`) that, **only when `BUILD_REASON = PullRequest`**, prints a warning and exits `0` so the overall run stays `Succeeded`. On manual/scheduled/CI queues the original exit code is preserved, so a real macOS regression still fails those runs.

- The macOS job **still runs** and publishes its test results/binlogs, so the signal is preserved.
- On PRs, a macOS test/build **command failure** surfaces as a **warning** and does **not** block the merge.
- **Windows and Linux remain hard blockers.** The shared `eng/pipelines/steps/test-non-windows.yml` template gains a `testFailureTrailer` parameter that defaults to empty; only the macOS job passes the non-blocking trailer.
- macOS failures remain visible via `--report-azdo` (AzDO Tests tab) and the published `TestResults` artifact.

## Known limitation

This trailer only converts command **exit codes**. It does **not** rescue the job from the 90-minute **timeout** (hung agent), **agent loss**, or a failure in the unconditional **publish/copy tasks** — any of those still fails/cancels the macOS matrix job and therefore the overall build. Fully covering those cases requires running macOS as a **separate, non-required pipeline/status check** (or removing it from the required PR pipeline) plus a branch-policy change in the Azure DevOps UI. That larger, out-of-repo change is intentionally left as a follow-up; this PR addresses the dominant flaky-test-failure case while keeping macOS visible on every PR.