### PR TITLE
Don't run MTP test-asset executables under 'dotnet test'

### DIFF
--- a/test/IntegrationTests/TestAssets/MtpExeAsset.props
+++ b/test/IntegrationTests/TestAssets/MtpExeAsset.props
@@ -3,7 +3,13 @@
     <OutputType>Exe</OutputType>
     <LangVersion>preview</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+    <!-- These test assets contain intentionally failing tests (they are fixtures consumed by the
+         acceptance/integration tests). They must build as Microsoft.Testing.Platform executables so
+         vstest.console (18.10+) can host them through the translation layer, but they must NOT be
+         picked up and executed by CI's Debug Test step, which runs 'dotnet test' on TestFx.slnx with
+         -p:UsingDotNetTest=true. So we only mark them as testing-platform applications when NOT running
+         under 'dotnet test'. -->
+    <IsTestingPlatformApplication Condition=" '$(UsingDotNetTest)' != 'true' ">true</IsTestingPlatformApplication>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)_MtpEntryPoint.cs" Link="_MtpEntryPoint.cs" />


### PR DESCRIPTION
Fixes the failing **Build Windows Debug** check on #9726 (AzDO build 1510040, `Test` step, exit code 2).

## Root cause
The new `test/IntegrationTests/TestAssets/MtpExeAsset.props` sets `IsTestingPlatformApplication=true` **unconditionally** on the test-asset projects. Those assets are fixtures that contain intentionally-failing tests (consumed by the acceptance/integration tests). Because the flag is unconditional, CI's Debug Test step — which runs `dotnet test` on `TestFx.slnx` with `-p:UsingDotNetTest=true` — discovers and executes them, so their intentional failures (e.g. `CsvTestMethod`, `FailIfFilePresent`, `Timeout*`) fail the build.

## Fix
Guard the property on `UsingDotNetTest` so the assets are still built as MTP executables (needed for vstest.console 18.10+ translation-layer hosting) but are **not** picked up by `dotnet test`. This matches the existing pattern used by the samples (`samples/CtrfPlayground/Mtp`, `samples/WasiPlayground`).

```xml
<IsTestingPlatformApplication Condition=" '$(UsingDotNetTest)' != 'true' ">true</IsTestingPlatformApplication>
```

## Verification (local, repo SDK)
| State | `-p:UsingDotNetTest=true` | normal build |
|---|---|---|
| before | `IsTestingPlatformApplication=true` → asset runs, intentional tests fail (matches CI) | `true` |
| after | *empty* → `dotnet test` reports "No test projects were found" (skipped) | `true` (still an MTP exe) |

## Note
This addresses the "asset executables are run by `dotnet test`" category (the bulk of the red). A few remaining failures in #9726 are separate consequences of `OutputType=Exe` and the VSTest-removal feature work itself and need code changes rather than this config guard: `PlatformServices.Desktop.IntegrationTests` (locates assets by `.dll`), `MSTest.VstestConsoleWrapper.IntegrationTests` (translation-layer hosting), and the CppCli-via-VSTest acceptance test.
