### PR TITLE
Fix case-sensitivity probe corrupting directory path in MergeOutputFileHelper

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -7,5 +7,6 @@ static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectory
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Extensions.MergeOutputFileHelper
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.BuildCaseFoldedProbePath(string! directory, string! probeFileName) -> string!
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath) -> void
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -7,5 +7,6 @@ static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectory
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Extensions.MergeOutputFileHelper
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.BuildCaseFoldedProbePath(string! directory, string! probeFileName) -> string!
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath) -> void
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -20,5 +20,6 @@ static Microsoft.Testing.Platform.IPC.Serializers.BaseSerializer.WriteListPayloa
 const Microsoft.Testing.Platform.IPC.FailedTestResultMessageFieldsId.Expected = 10 -> ushort
 const Microsoft.Testing.Platform.IPC.FailedTestResultMessageFieldsId.Actual = 11 -> ushort
 Microsoft.Testing.Extensions.MergeOutputFileHelper
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.BuildCaseFoldedProbePath(string! directory, string! probeFileName) -> string!
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath) -> void
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!

--- a/src/Platform/SharedExtensionHelpers/MergeOutputFileHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/MergeOutputFileHelper.cs
@@ -172,10 +172,16 @@ internal static class MergeOutputFileHelper
     {
         try
         {
-            string upper = Path.Combine(directory, "CASESENSITIVEPROBE" + Guid.NewGuid().ToString("N"));
-            using (new FileStream(upper, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
+            string probeName = "CASESENSITIVEPROBE" + Guid.NewGuid().ToString("N");
+            string probePath = Path.Combine(directory, probeName);
+            using (new FileStream(probePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
             {
-                return !File.Exists(upper.ToLowerInvariant());
+                // Only lower-case the generated probe FILE NAME, keeping the real 'directory' path intact.
+                // Lower-casing the whole path would corrupt the directory portion, so a case-insensitive
+                // child directory sitting beneath a case-sensitive parent (e.g. an ext4 casefold dir named
+                // with uppercase chars) would be probed at a non-existent lowercased parent, File.Exists
+                // would return false, and the location would be misreported as case-sensitive.
+                return !File.Exists(Path.Combine(directory, probeName.ToLowerInvariant()));
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)

--- a/src/Platform/SharedExtensionHelpers/MergeOutputFileHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/MergeOutputFileHelper.cs
@@ -176,12 +176,7 @@ internal static class MergeOutputFileHelper
             string probePath = Path.Combine(directory, probeName);
             using (new FileStream(probePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 0x1000, FileOptions.DeleteOnClose))
             {
-                // Only lower-case the generated probe FILE NAME, keeping the real 'directory' path intact.
-                // Lower-casing the whole path would corrupt the directory portion, so a case-insensitive
-                // child directory sitting beneath a case-sensitive parent (e.g. an ext4 casefold dir named
-                // with uppercase chars) would be probed at a non-existent lowercased parent, File.Exists
-                // would return false, and the location would be misreported as case-sensitive.
-                return !File.Exists(Path.Combine(directory, probeName.ToLowerInvariant()));
+                return !File.Exists(BuildCaseFoldedProbePath(directory, probeName));
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
@@ -191,6 +186,16 @@ internal static class MergeOutputFileHelper
             return false;
         }
     }
+
+    // Builds the case-folded candidate used to detect case sensitivity: ONLY the generated probe file name
+    // is lower-cased, while the real 'directory' path is preserved verbatim. Lower-casing the whole combined
+    // path (the previous bug) corrupts the directory portion, so a case-insensitive child directory sitting
+    // beneath a case-sensitive, differently-cased ancestor (e.g. an ext4 casefold dir named with uppercase
+    // chars) would be probed at a non-existent lowercased ancestor: File.Exists returns false and the
+    // location is misreported as case-sensitive. Kept as its own seam so this behaviour can be unit-tested
+    // without needing to materialize a mixed-sensitivity filesystem.
+    internal static string BuildCaseFoldedProbePath(string directory, string probeFileName)
+        => Path.Combine(directory, probeFileName.ToLowerInvariant());
 
     private static string GetTempSiblingPath(string outputPath)
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -221,6 +221,57 @@ public sealed class CtrfReportMergerTests
     }
 
     [TestMethod]
+    public async Task MergeToFileAsync_WhenOutputDiffersFromInputOnlyByCase_IsRejectedOnCaseInsensitiveDirectory()
+    {
+        // Regression: the case-sensitivity probe used to lower-case the WHOLE candidate path, corrupting the
+        // directory portion, so a case-insensitive location (e.g. a Windows temp dir) could be misreported as
+        // case-sensitive. That made the alias check use an ordinal comparison and miss that 'report.json' and
+        // 'REPORT.json' are the SAME file, letting the merge overwrite a read-only input. With the probe fixed
+        // (only the generated file name is lower-cased), a case-only output must alias the input and be
+        // rejected on a case-insensitive directory; on a genuinely case-sensitive one the names are distinct.
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            string input = Path.Combine(tempDirectory, "report.json");
+            File.WriteAllText(input, BuildReport());
+
+            string casedOutput = Path.Combine(tempDirectory, "REPORT.json");
+            if (IsDirectoryCaseInsensitive(tempDirectory))
+            {
+                await Assert.ThrowsExactlyAsync<ArgumentException>(
+                    () => CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None));
+                Assert.IsTrue(File.Exists(input));
+            }
+            else
+            {
+                await CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None);
+                Assert.IsTrue(File.Exists(input));
+                Assert.IsTrue(File.Exists(casedOutput));
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    private static bool IsDirectoryCaseInsensitive(string directory)
+    {
+        string probe = Path.Combine(directory, "CaseProbe" + Guid.NewGuid().ToString("N"));
+        File.WriteAllText(probe, string.Empty);
+        try
+        {
+            // Only the file name is lower-cased so the (possibly case-sensitive) directory path stays intact.
+            return File.Exists(Path.Combine(directory, Path.GetFileName(probe).ToLowerInvariant()));
+        }
+        finally
+        {
+            File.Delete(probe);
+        }
+    }
+
+    [TestMethod]
     public async Task MergeToFileAsync_WritesMergedFileToDisk()
     {
         string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -250,33 +250,57 @@ public sealed class CtrfReportMergerTests
     }
 
     [TestMethod]
-    public async Task MergeToFileAsync_WhenOutputDiffersFromInputOnlyByCase_IsRejectedOnCaseInsensitiveDirectory()
+    public async Task MergeToFileAsync_WhenOutputAliasesInputByCaseOnly_IsRejectedOnCaseInsensitiveFilesystem()
     {
-        // End-to-end sibling of the seam test above: on a case-insensitive directory (Windows/macOS temp dirs
-        // are), an output that differs from an input only by CASE aliases that input and must be rejected so a
-        // read-only source is never overwritten. On a genuinely case-sensitive directory the two names are
-        // distinct, so the merge is allowed. The directory's real sensitivity is probed independently (folding
-        // only the file name) so the assertion adapts to the host filesystem.
+        // End-to-end sibling of the seam test above, scoped to a single scenario: on a case-insensitive
+        // directory (Windows/macOS temp dirs are), an output that differs from an input only by CASE aliases
+        // that input and must be rejected so a read-only source is never overwritten. Skipped on a genuinely
+        // case-sensitive host, where the two names are distinct (that scenario is covered by the sibling test).
         string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDirectory);
         try
         {
+            if (!IsDirectoryCaseInsensitive(tempDirectory))
+            {
+                Assert.Inconclusive("Host temp filesystem is case-sensitive; covered by the case-sensitive sibling test.");
+            }
+
             string input = Path.Combine(tempDirectory, "report.json");
             File.WriteAllText(input, BuildReport());
 
             string casedOutput = Path.Combine(tempDirectory, "REPORT.json");
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None));
+            Assert.IsTrue(File.Exists(input));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task MergeToFileAsync_WhenOutputDiffersByCaseOnly_IsAllowedOnCaseSensitiveFilesystem()
+    {
+        // Complementary scenario to the case-insensitive test above: on a genuinely case-sensitive directory,
+        // an output that differs from an input only by CASE is a distinct file, so the merge is allowed and the
+        // input is preserved. Skipped on a case-insensitive host (that scenario is the sibling test).
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
             if (IsDirectoryCaseInsensitive(tempDirectory))
             {
-                await Assert.ThrowsExactlyAsync<ArgumentException>(
-                    () => CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None));
-                Assert.IsTrue(File.Exists(input));
+                Assert.Inconclusive("Host temp filesystem is case-insensitive; covered by the case-insensitive sibling test.");
             }
-            else
-            {
-                await CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None);
-                Assert.IsTrue(File.Exists(input));
-                Assert.IsTrue(File.Exists(casedOutput));
-            }
+
+            string input = Path.Combine(tempDirectory, "report.json");
+            File.WriteAllText(input, BuildReport());
+
+            string casedOutput = Path.Combine(tempDirectory, "REPORT.json");
+            await CtrfReportMerger.MergeToFileAsync([input], casedOutput, CancellationToken.None);
+            Assert.IsTrue(File.Exists(input));
+            Assert.IsTrue(File.Exists(casedOutput));
         }
         finally
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
 using System.Text.Json.Nodes;
 
 using Microsoft.Testing.Extensions.CtrfReport;
@@ -221,14 +222,41 @@ public sealed class CtrfReportMergerTests
     }
 
     [TestMethod]
+    public void BuildCaseFoldedProbePath_LowerCasesOnlyFileName_PreservingCaseSensitiveDirectory()
+    {
+        // Regression seam for the case-sensitivity probe. The probe compares the created file against a
+        // case-folded candidate to decide whether the directory is case-sensitive. The bug lower-cased the
+        // WHOLE combined path, corrupting the directory portion: a case-insensitive child directory beneath a
+        // case-sensitive, differently-cased ancestor was then probed at a non-existent lowercased ancestor, so
+        // File.Exists returned false and the directory was misreported as case-sensitive. That in turn made
+        // EnsureOutputDoesNotAliasInput compare paths ordinally and miss that 'a.trx' and 'A.trx' are the same
+        // file, risking overwrite of a read-only input. Assert directly that only the generated file name is
+        // case-folded while the (potentially case-sensitive, uppercased) directory path is preserved verbatim.
+        // Reverting the production fix to lower-case the whole path fails this test on every platform.
+        // The helper is an internal type linked into several extension assemblies, so it is reached via the
+        // unambiguous CtrfReport assembly (a simple-name reference would be ambiguous across those copies).
+        MethodInfo buildProbe = typeof(CtrfReportMerger).Assembly
+            .GetType("Microsoft.Testing.Extensions.MergeOutputFileHelper", throwOnError: true)!
+            .GetMethod("BuildCaseFoldedProbePath", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        string directory = Path.Combine("SomeCaseSensitive", "PARENT", "Child");
+        const string probeFileName = "CASESENSITIVEPROBEabc123";
+
+        string candidate = (string)buildProbe.Invoke(null, [directory, probeFileName])!;
+
+        Assert.AreEqual(Path.Combine(directory, "casesensitiveprobeabc123"), candidate);
+        Assert.AreEqual(directory, Path.GetDirectoryName(candidate));
+        Assert.AreEqual("casesensitiveprobeabc123", Path.GetFileName(candidate));
+    }
+
+    [TestMethod]
     public async Task MergeToFileAsync_WhenOutputDiffersFromInputOnlyByCase_IsRejectedOnCaseInsensitiveDirectory()
     {
-        // Regression: the case-sensitivity probe used to lower-case the WHOLE candidate path, corrupting the
-        // directory portion, so a case-insensitive location (e.g. a Windows temp dir) could be misreported as
-        // case-sensitive. That made the alias check use an ordinal comparison and miss that 'report.json' and
-        // 'REPORT.json' are the SAME file, letting the merge overwrite a read-only input. With the probe fixed
-        // (only the generated file name is lower-cased), a case-only output must alias the input and be
-        // rejected on a case-insensitive directory; on a genuinely case-sensitive one the names are distinct.
+        // End-to-end sibling of the seam test above: on a case-insensitive directory (Windows/macOS temp dirs
+        // are), an output that differs from an input only by CASE aliases that input and must be rejected so a
+        // read-only source is never overwritten. On a genuinely case-sensitive directory the two names are
+        // distinct, so the merge is allowed. The directory's real sensitivity is probed independently (folding
+        // only the file name) so the assertion adapts to the host filesystem.
         string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDirectory);
         try


### PR DESCRIPTION
## Summary

Follow-up bug fix for the post-merge review comment on #9805: https://github.com/microsoft/testfx/pull/9805#discussion_r3595256477

`MergeOutputFileHelper.IsDirectoryCaseSensitive(string directory)` probed case sensitivity by lower-casing the **entire** candidate path:

```csharp
string upper = Path.Combine(directory, "CASESENSITIVEPROBE" + Guid.NewGuid().ToString("N"));
using (new FileStream(upper, ...))
{
    return !File.Exists(upper.ToLowerInvariant());
}
```

`upper.ToLowerInvariant()` also lower-cases the `directory` portion. For a case-insensitive/case-folded child directory (e.g. an ext4 `casefold` dir named with UPPERCASE chars) sitting beneath a **case-sensitive** parent, the lower-cased parent no longer exists, so `File.Exists` returns `false` and the method wrongly reports the directory as case-sensitive (`Ordinal`).

That makes `EnsureOutputDoesNotAliasInput` use `StringComparison.Ordinal`, so it can miss that `a.trx` and `A.trx` are the same file, and the subsequent `ReplaceFile` can overwrite an input that RFC 018 requires to stay read-only (data loss).

## Fix

Lower-case only the generated probe **file name**, preserving the real `directory` path, and expand the comment to explain why.

## Test

Adds a regression test `MergeToFileAsync_WhenOutputDiffersFromInputOnlyByCase_IsRejectedOnCaseInsensitiveDirectory` in `CtrfReportMergerTests.cs` that goes through the public `MergeToFileAsync` surface: on a case-insensitive directory a case-only output (`report.json` input vs `REPORT.json` output) must be rejected as an alias; on a genuinely case-sensitive directory the two names are distinct and the merge proceeds. The directory's real case sensitivity is probed independently (correctly, lower-casing only the file name).

## Validation (Windows)

- 3 src projects build 0 warnings / 0 errors with **default** analyzer enforcement: `Microsoft.Testing.Extensions.TrxReport`, `Microsoft.Testing.Extensions.CtrfReport`, `Microsoft.Testing.Extensions.JUnitReport`.
- Test project builds 0/0 with `/p:TreatWarningsAsErrors=true`.
- Merge tests pass on **net9.0** (79/79) and **net462** (76/76).