### PR TITLE
Add explicit retry attempt metadata to dotnet test protocol

### DIFF
--- a/docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md
+++ b/docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md
@@ -51,6 +51,9 @@ It is a *different* protocol from the [JSON-RPC server-mode protocol](./001-prot
   identifier: a single `dotnet test` command that launches several test applications (e.g. a
   multi-project run) gives each root test application its **own** Execution ID by default.
 - **Instance ID** — a GUID (`"N"` format) identifying one specific connecting process/`DotnetTestConnection`.
+- **Attempt number** — a 1-based retry generation within one Execution ID. Attempt `1` is the initial run.
+  Multiple test-host instances (for example, shards) can belong to the same attempt; a new Instance ID does
+  not by itself imply a retry.
 - **Session UID** — the MTP test session identifier for a run.
 
 ---
@@ -79,6 +82,7 @@ Rules and behavior:
 | Variable | Set by | Purpose |
 | --- | --- | --- |
 | `TESTINGPLATFORM_DOTNETTEST_EXECUTIONID` | The root test application on first connect (if not already set) | The Execution ID. Each root test-app process generates its own value in `AfterCommonServiceSetupAsync` (if unset) and propagates it via the environment **only to its child process tree** (its test host controller, orchestrator). So all handshakes *within one test-application execution* share it, but separate test applications launched by one multi-project `dotnet test` command normally get **different** IDs. If already present it is **not** overwritten. |
+| `TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER` | Retry orchestrator | The positive, 1-based retry attempt assigned to a child test host. A normal test host reports attempt `1` when the variable is absent. Invalid values fail before the handshake instead of being silently reinterpreted. |
 | `TESTINGPLATFORM_PIPE_DIRECTORY` | User (optional) | On Unix, overrides the directory used to place the domain-socket file, **for pipes created by testfx's `NamedPipeServer`** (see §3). It does **not** relocate a pipe created by the other side: the current `dotnet/sdk` data-pipe server still resolves Unix names as `Path.Combine("/tmp", name)` and does not honor this variable/`TMPDIR` (nor the 103-byte precheck). Since the SDK creates the data pipe, this variable effectively only affects pipes testfx itself creates (e.g. the sibling controller pipe). |
 
 ---
@@ -338,6 +342,7 @@ Property IDs (`HandshakeMessagePropertyNames`):
 | 10 | `ExecutionMode` | yes | `run`, `help`, or `discover` — lets the SDK detect mismatches (e.g. `--help` leaking into a run). |
 | 11 | `OrchestratorFeature` | orchestrator only | The orchestrator extension Uid (e.g. retry). |
 | 12 | `ServerControlPipeName` | **reply-only** | OS name of the reverse control pipe (see §12). |
+| 13 | `AttemptNumber` | test host only | Positive, 1-based retry attempt. Multiple Instance IDs may share one attempt. |
 
 ### 8.2 SDK → host: `HandshakeMessage` (reply)
 
@@ -365,7 +370,7 @@ The SDK picks the **highest version present in both sets** and returns that sing
 sequenceDiagram
     participant H as Test host
     participant S as dotnet test SDK
-    H->>S: HandshakeMessage(PID, OS, SupportedProtocolVersions="1.0.0;...;1.4.0", HostType, ExecutionId, InstanceId, ExecutionMode, ...)
+    H->>S: HandshakeMessage(PID, OS, SupportedProtocolVersions="1.0.0;...;1.4.0", HostType, ExecutionId, InstanceId, ExecutionMode, [AttemptNumber], ...)
     S->>S: pick highest mutually-supported version
     S-->>H: HandshakeMessage(SupportedProtocolVersions=<negotiated>, [IsIDE], [ServerControlPipeName])
     H->>H: validate compatibility; set IsIDE / forwarding / control-channel flags
@@ -642,8 +647,10 @@ handshake on the **same** Execution ID:
   cancel maps to cancelling its application token, which propagates to the orchestrated hosts.
 
 These are the root test-app process and its child process tree. Each advertises its own `InstanceId`;
-the shared `ExecutionId` lets the SDK correlate the processes **of that one execution**. A multi-project
-`dotnet test` command launches several such trees, each with its own Execution ID (see §1/§2).
+the shared `ExecutionId` lets the SDK correlate the processes **of that one execution**. Test hosts also
+advertise `AttemptNumber`: retry creates a later attempt, while sharding can create several Instance IDs
+within the same attempt. A multi-project `dotnet test` command launches several such trees, each with its
+own Execution ID (see §1/§2).
 
 ---
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 Microsoft.Testing.Platform.Helpers.ArgumentGuard

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
@@ -65,7 +65,7 @@ internal static class RetryTestHostRunner
 
         // Tell the launched test host which retry attempt it is, so it can report an explicit AttemptNumber in
         // its dotnet test handshake instead of the consumer having to infer it from a change in InstanceId.
-        processStartInfo.Environment[EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER] =
+        processStartInfo.EnvironmentVariables[EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER] =
             attemptCount.ToString(CultureInfo.InvariantCulture);
 
         await logger.LogDebugAsync($"Starting test host process, attempt {attemptCount}/{userMaxRetryCount}").ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
@@ -63,6 +63,11 @@ internal static class RetryTestHostRunner
             UseShellExecute = false,
         };
 
+        // Tell the launched test host which retry attempt it is, so it can report an explicit AttemptNumber in
+        // its dotnet test handshake instead of the consumer having to infer it from a change in InstanceId.
+        processStartInfo.Environment[EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER] =
+            attemptCount.ToString(CultureInfo.InvariantCulture);
+
         await logger.LogDebugAsync($"Starting test host process, attempt {attemptCount}/{userMaxRetryCount}").ConfigureAwait(false);
         using IProcess testHostProcess = serviceProvider.GetProcessHandler().Start(processStartInfo)
             ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ExtensionResources.RetryFailedTestsCannotStartProcessErrorMessage, processStartInfo.FileName));

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.TrxArtifactKind = "microsoft.testing.trx" -> string!
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.Merge(System.Collections.Generic.IReadOnlyList<System.Xml.Linq.XDocument!>! inputReports, System.Guid runId, string! runName) -> System.Xml.Linq.XDocument!

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
@@ -51,8 +51,7 @@ internal static class EnvironmentVariableConstants
     public const string TESTINGPLATFORM_DOTNETTEST_EXECUTIONID = nameof(TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
 
     // Carries the 1-based retry attempt number from the retry orchestrator to each launched test host, which
-    // then reports it back to dotnet test through the AttemptNumber handshake property. Absent for normal
-    // (non-orchestrated) runs, in which case the test host reports attempt 1. See issues #5361 and #6337.
+    // then reports it back to dotnet test through the AttemptNumber handshake property.
     public const string TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = nameof(TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER);
     public const string DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY = nameof(DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY);
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
@@ -49,6 +49,11 @@ internal static class EnvironmentVariableConstants
 
     // dotnet test
     public const string TESTINGPLATFORM_DOTNETTEST_EXECUTIONID = nameof(TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
+
+    // Carries the 1-based retry attempt number from the retry orchestrator to each launched test host, which
+    // then reports it back to dotnet test through the AttemptNumber handshake property. Absent for normal
+    // (non-orchestrated) runs, in which case the test host reports attempt 1. See issues #5361 and #6337.
+    public const string TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = nameof(TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER);
     public const string DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY = nameof(DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY);
 
     // Unhandled Exception

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -14,7 +14,9 @@ const Microsoft.Testing.Platform.IPC.HandshakeMessagePropertyNames.AttemptNumber
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int
 Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.AssemblyRunStarted(string! assembly, string? targetFramework, string? architecture, string! executionId, string! instanceId, int attemptNumber) -> void
 Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.GetAttemptNumber(string! instanceId) -> int
+Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.GetOrCreateTestNodeResultsState(System.Func<Microsoft.Testing.Platform.OutputDevice.Terminal.TestNodeResultsState!>! factory) -> Microsoft.Testing.Platform.OutputDevice.Terminal.TestNodeResultsState!
 Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.NotifyHandshake(string! instanceId, int attemptNumber) -> void
+Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.ReportDiscoveredTest(string? displayName) -> void
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
 Microsoft.Testing.Platform.Logging.FileLogger.FileLogger(Microsoft.Testing.Platform.Logging.FileLoggerOptions! options, Microsoft.Testing.Platform.Logging.LogLevel logLevel, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IConsole! console, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Helpers.IFileStreamFactory! fileStreamFactory, System.TimeSpan? flushTimeout = null) -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -12,6 +12,9 @@ Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Kind.init -> void
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 const Microsoft.Testing.Platform.IPC.HandshakeMessagePropertyNames.AttemptNumber = 13 -> byte
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int
+Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.AssemblyRunStarted(string! assembly, string? targetFramework, string? architecture, string! executionId, string! instanceId, int attemptNumber) -> void
+Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.GetAttemptNumber(string! instanceId) -> int
+Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState.NotifyHandshake(string! instanceId, int attemptNumber) -> void
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
 Microsoft.Testing.Platform.Logging.FileLogger.FileLogger(Microsoft.Testing.Platform.Logging.FileLoggerOptions! options, Microsoft.Testing.Platform.Logging.LogLevel logLevel, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IConsole! console, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Helpers.IFileStreamFactory! fileStreamFactory, System.TimeSpan? flushTimeout = null) -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Platform.IPC.DotnetTestDataConsumer.CreateFileArtifactMessages(string? executionId, Microsoft.Testing.Platform.Extensions.Messages.FileArtifact! fileArtifact) -> Microsoft.Testing.Platform.IPC.Models.FileArtifactMessages!
 static Microsoft.Testing.Platform.IPC.DotnetTestDataConsumer.CreateFileArtifactMessages(string? executionId, Microsoft.Testing.Platform.Extensions.Messages.SessionFileArtifact! sessionFileArtifact) -> Microsoft.Testing.Platform.IPC.Models.FileArtifactMessages!
@@ -9,6 +10,7 @@ Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Kind.init -> void
 *REMOVED*Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Deconstruct(out string? FullPath, out string? DisplayName, out string? Description, out string? TestUid, out string? TestDisplayName, out string? SessionUid) -> void
 *REMOVED*Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid) -> void
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
+const Microsoft.Testing.Platform.IPC.HandshakeMessagePropertyNames.AttemptNumber = 13 -> byte
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!
 Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -21,16 +21,27 @@ internal sealed partial class TerminalTestReporter
     }
 
     public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId)
-    {
-        // Each (re-)start registers its instance id as a retry attempt; the first attempt is the normal run. The
-        // in-process host starts a single assembly with a single fixed instance id (one attempt).
-        TestProgressState assemblyRun = GetOrAddAssemblyRun(assembly, targetFramework, architecture, executionId);
-        assemblyRun.NotifyHandshake(instanceId);
+        => AssemblyRunStarted(assembly, targetFramework, architecture, executionId, instanceId, attemptNumber: null);
 
-        // Defensive: even if the orchestrator did not flag the run as a retry up front (e.g. the retry parameter
-        // could not be parsed), a second handshake for the same assembly means a retry is happening. Flip _isRetry
-        // so the per-test "(try N)" annotation and the summary's "(+N retried)" suffix are shown. The in-process
-        // host only ever handshakes once (TryCount stays 1), so this never trips for it.
+    public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId, int attemptNumber)
+        => AssemblyRunStarted(assembly, targetFramework, architecture, executionId, instanceId, (int?)attemptNumber);
+
+    private void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId, int? attemptNumber)
+    {
+        TestProgressState assemblyRun = GetOrAddAssemblyRun(assembly, targetFramework, architecture, executionId);
+        if (attemptNumber.HasValue)
+        {
+            assemblyRun.NotifyHandshake(instanceId, attemptNumber.Value);
+        }
+        else
+        {
+            assemblyRun.NotifyHandshake(instanceId);
+        }
+
+        int currentAttemptNumber = assemblyRun.GetAttemptNumber(instanceId);
+
+        // Legacy peers may not identify the retry orchestrator up front. Detect an explicit or inferred attempt
+        // greater than one so their retry annotations and summary remain correct.
         _isRetry |= assemblyRun.TryCount > 1;
 
         // Orchestrator-only: print the per-assembly "Running tests from <assembly>" banner (or "Discovering tests
@@ -43,7 +54,7 @@ internal sealed partial class TerminalTestReporter
                 if (_isRetry)
                 {
                     terminal.SetColor(TerminalColor.DarkGray);
-                    terminal.Append($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, assemblyRun.TryCount)}) ");
+                    terminal.Append($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, currentAttemptNumber)}) ");
                     terminal.ResetColor();
                 }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Messaging.cs
@@ -70,8 +70,9 @@ internal sealed partial class TerminalTestReporter
 
         if (_options.ShowActiveTests)
         {
-            asm.TestNodeResultsState ??= new(Interlocked.Increment(ref _counter));
-            asm.TestNodeResultsState.AddRunningTestNode(
+            TestNodeResultsState testNodeResultsState = asm.GetOrCreateTestNodeResultsState(
+                () => new(Interlocked.Increment(ref _counter)));
+            testNodeResultsState.AddRunningTestNode(
                 Interlocked.Increment(ref _counter), testNodeUid, MakeControlCharactersVisible(displayName, true), CreateStopwatch());
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Summary.cs
@@ -237,7 +237,7 @@ internal sealed partial class TerminalTestReporter
             throw ApplicationStateGuard.Unreachable();
         }
 
-        asm.DiscoveredTests++;
+        asm.ReportDiscoveredTest(displayName: null);
         _terminalWithProgress.UpdateWorker(asm.SlotIndex);
     }
 
@@ -250,9 +250,7 @@ internal sealed partial class TerminalTestReporter
 
         // In discovery mode TotalTests is computed from DiscoveredTests; in execution mode it is computed from the
         // passed/skipped/failed tally as tests complete. So we only need to bump the discovered count here.
-        asm.DiscoveredTests++;
-
-        asm.DiscoveredTestDisplayNames.Add(MakeControlCharactersVisible(displayName, true));
+        asm.ReportDiscoveredTest(MakeControlCharactersVisible(displayName, true));
 
         _terminalWithProgress.UpdateWorker(asm.SlotIndex);
     }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.TestCompletion.cs
@@ -130,9 +130,8 @@ internal sealed partial class TerminalTestReporter
         _terminalWithProgress.NotifyTestCompleted();
         if (outcome != TestOutcome.Passed || GetShowPassedTests())
         {
-            // Capture the attempt number (1-based) at completion time so the per-test "(try N)" annotation reflects
-            // the retry attempt this result belongs to.
-            int attempt = asm.TryCount;
+            // Resolve the attempt from the result's instance so multiple instances can participate in one attempt.
+            int attempt = asm.GetAttemptNumber(instanceId);
             _terminalWithProgress.WriteToTerminal(terminal => RenderTestCompleted(
                 terminal,
                 attempt,

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
@@ -22,9 +22,9 @@ internal sealed class TestProgressState
     // uid under a new instance id) replace rather than double-count the earlier attempt's result.
     private readonly Dictionary<string, TestNodeInfoEntry> _testUidToResults = [];
 
-    // Maps each instance id seen for this assembly to its 1-based attempt number. Each new instance id is a retry
-    // attempt; the highest attempt number always equals TryCount. In most runs there is exactly one (no retry).
-    // This lookup is O(1) because GetAttemptNumberFromInstanceId is called for every reported test result.
+    // Maps each instance id seen for this assembly to its 1-based attempt number. New protocol peers report the
+    // attempt explicitly, allowing multiple instances (for example, shards) to belong to the same attempt. Legacy
+    // peers omit it, in which case each new instance is inferred to be the next retry attempt.
     private readonly Dictionary<string, int> _instanceIdToAttemptNumber = [];
 
     // Records the last-seen (display name, duration) for every test node, keyed by test node uid, so the
@@ -85,7 +85,7 @@ internal sealed class TestProgressState
     /// <summary>Gets or sets a value indicating whether the assembly run completed successfully (set by the orchestrator on completion).</summary>
     public bool Success { get; internal set; }
 
-    /// <summary>Gets the number of attempts (handshakes) seen for this assembly; greater than 1 indicates retries.</summary>
+    /// <summary>Gets the highest attempt number seen for this assembly; greater than 1 indicates retries.</summary>
     public int TryCount { get; private set; }
 
     public void ReportPassingTest(string testNodeUid, string instanceId)
@@ -129,23 +129,46 @@ internal sealed class TestProgressState
                 .Take(count)];
 
     /// <summary>
-    /// Registers a handshake for the given <paramref name="instanceId"/>. A previously unseen instance id is a new
-    /// retry attempt and bumps <see cref="TryCount"/>; re-seeing the current attempt is a no-op.
+    /// Registers a legacy handshake for the given <paramref name="instanceId"/>. A previously unseen instance id is
+    /// inferred to be a new retry attempt; re-seeing an instance id is a no-op.
     /// </summary>
     internal void NotifyHandshake(string instanceId)
+        => NotifyHandshakeCore(instanceId, attemptNumber: null);
+
+    /// <summary>
+    /// Registers a handshake with an explicit 1-based <paramref name="attemptNumber"/>. Different instances can
+    /// belong to the same attempt, while one instance cannot change attempts after it has been registered.
+    /// </summary>
+    internal void NotifyHandshake(string instanceId, int attemptNumber)
+        => NotifyHandshakeCore(instanceId, attemptNumber);
+
+    private int NotifyHandshakeCore(string instanceId, int? attemptNumber)
     {
-        if (!_instanceIdToAttemptNumber.TryGetValue(instanceId, out int attemptNumber))
+        if (_instanceIdToAttemptNumber.TryGetValue(instanceId, out int registeredAttemptNumber))
         {
-            // A previously unseen instance id is a new attempt; attempt numbers are 1-based and the latest always
-            // equals TryCount.
-            TryCount++;
-            _instanceIdToAttemptNumber[instanceId] = TryCount;
+            return !attemptNumber.HasValue || attemptNumber.Value == registeredAttemptNumber
+                ? registeredAttemptNumber
+                : throw ApplicationStateGuard.Unreachable();
         }
-        else if (attemptNumber != TryCount)
+
+        int resolvedAttemptNumber;
+        if (attemptNumber.HasValue)
         {
-            // We received a handshake for an instance id that is not the most recent one — unexpected ordering.
-            throw ApplicationStateGuard.Unreachable();
+            if (attemptNumber.Value < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(attemptNumber));
+            }
+
+            resolvedAttemptNumber = attemptNumber.Value;
         }
+        else
+        {
+            resolvedAttemptNumber = TryCount + 1;
+        }
+
+        _instanceIdToAttemptNumber.Add(instanceId, resolvedAttemptNumber);
+        TryCount = Math.Max(TryCount, resolvedAttemptNumber);
+        return resolvedAttemptNumber;
     }
 
     private void ReportGenericTestResult(
@@ -154,7 +177,7 @@ internal sealed class TestProgressState
         Func<TestNodeInfoEntry, TestNodeInfoEntry> incrementTestNodeInfoEntry,
         Action<TestProgressState> incrementCountAction)
     {
-        int currentAttemptNumber = GetAttemptNumberFromInstanceId(instanceId);
+        int currentAttemptNumber = GetAttemptNumber(instanceId);
 
         if (_testUidToResults.TryGetValue(testNodeUid, out TestNodeInfoEntry value))
         {
@@ -186,7 +209,7 @@ internal sealed class TestProgressState
         incrementCountAction(this);
     }
 
-    private int GetAttemptNumberFromInstanceId(string instanceId)
+    internal int GetAttemptNumber(string instanceId)
         => _instanceIdToAttemptNumber.TryGetValue(instanceId, out int attemptNumber)
             ? attemptNumber
             : throw ApplicationStateGuard.Unreachable();

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestProgressState.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 [Embedded]
 internal sealed class TestProgressState
 {
-    // THREADING: this type is intentionally not internally synchronized. Each TestProgressState instance is owned by
-    // a single executionId; the reporter looks it up from a ConcurrentDictionary (_assemblies), but the Microsoft
-    // Testing Platform message pipeline delivers events for a given executionId on a single consumer, so the mutating
-    // members below (the dictionaries and the Passed/Skipped/Failed/Retried/TryCount counters) are only ever
-    // touched by one thread at a time for a given instance. Do not call these members concurrently for the same
-    // assembly without adding synchronization.
+    // Multiple test-host instances can report one attempt concurrently (for example, shards), so all per-execution
+    // result, attempt, duration, and discovery state is protected by this lock.
+#if NET9_0_OR_GREATER
+    private readonly Lock _lock = new();
+#else
+    private readonly object _lock = new();
+#endif
 
     // Tracks the per-test-node tally and the attempt it belongs to, so retries (which re-report the same test node
     // uid under a new instance id) replace rather than double-count the earlier attempt's result.
@@ -33,6 +34,17 @@ internal sealed class TestProgressState
     // Only populated when the slowest-tests feature is enabled (the reporter gates the RecordTestDuration call),
     // so a run without the feature pays no memory cost here.
     private readonly Dictionary<string, (string DisplayName, TimeSpan Duration)> _testUidToDuration = [];
+    private readonly List<string> _discoveredTestDisplayNames = [];
+    private int _discoveredTests;
+    private int _failedTests;
+    private int _passedTests;
+    private int _skippedTests;
+    private int _retriedFailedTests;
+    private int _tryCount;
+    private TestNodeResultsState? _testNodeResultsState;
+#pragma warning disable IDE0032 // Use auto property - synchronized access requires a backing field.
+    private bool _success;
+#pragma warning restore IDE0032
 
     public TestProgressState(long id, string assembly, string? targetFramework, string? architecture, IStopwatch stopwatch, bool isDiscovery)
     {
@@ -56,21 +68,100 @@ internal sealed class TestProgressState
 
     public IStopwatch Stopwatch { get; }
 
-    public int DiscoveredTests { get; internal set; }
+    public int DiscoveredTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _discoveredTests;
+            }
+        }
 
-    public int FailedTests { get; private set; }
+        internal set
+        {
+            lock (_lock)
+            {
+                _discoveredTests = value;
+            }
+        }
+    }
 
-    public int PassedTests { get; private set; }
+    public int FailedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _failedTests;
+            }
+        }
+    }
 
-    public int SkippedTests { get; private set; }
+    public int PassedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _passedTests;
+            }
+        }
+    }
+
+    public int SkippedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _skippedTests;
+            }
+        }
+    }
 
     /// <summary>Gets the number of tests whose earlier-attempt failure was superseded by a later retry; rendered as the "/r{N}" segment.</summary>
-    public int RetriedFailedTests { get; private set; }
+    public int RetriedFailedTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _retriedFailedTests;
+            }
+        }
+    }
 
     /// <summary>Gets the total number of tests: the discovered count in discovery mode, otherwise the live passed/skipped/failed tally.</summary>
-    public int TotalTests => IsDiscovery ? DiscoveredTests : PassedTests + SkippedTests + FailedTests;
+    public int TotalTests
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return IsDiscovery ? _discoveredTests : _passedTests + _skippedTests + _failedTests;
+            }
+        }
+    }
 
-    public TestNodeResultsState? TestNodeResultsState { get; internal set; }
+    public TestNodeResultsState? TestNodeResultsState
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _testNodeResultsState;
+            }
+        }
+
+        internal set
+        {
+            lock (_lock)
+            {
+                _testNodeResultsState = value;
+            }
+        }
+    }
 
     public int SlotIndex { get; internal set; }
 
@@ -78,24 +169,88 @@ internal sealed class TestProgressState
 
     public long Version { get; internal set; }
 
-    public List<string> DiscoveredTestDisplayNames { get; internal set; } = [];
+    public List<string> DiscoveredTestDisplayNames
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _discoveredTestDisplayNames];
+            }
+        }
+
+        internal set
+        {
+            lock (_lock)
+            {
+                _discoveredTestDisplayNames.Clear();
+                _discoveredTestDisplayNames.AddRange(value);
+            }
+        }
+    }
 
     public bool IsDiscovery { get; }
 
     /// <summary>Gets or sets a value indicating whether the assembly run completed successfully (set by the orchestrator on completion).</summary>
-    public bool Success { get; internal set; }
+    public bool Success
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _success;
+            }
+        }
+
+        internal set
+        {
+            lock (_lock)
+            {
+                _success = value;
+            }
+        }
+    }
 
     /// <summary>Gets the highest attempt number seen for this assembly; greater than 1 indicates retries.</summary>
-    public int TryCount { get; private set; }
+    public int TryCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _tryCount;
+            }
+        }
+    }
 
     public void ReportPassingTest(string testNodeUid, string instanceId)
-        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Passed = entry.Passed + 1 }, static @this => @this.PassedTests++);
+        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Passed = entry.Passed + 1 }, static @this => @this._passedTests++);
 
     public void ReportSkippedTest(string testNodeUid, string instanceId)
-        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Skipped = entry.Skipped + 1 }, static @this => @this.SkippedTests++);
+        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Skipped = entry.Skipped + 1 }, static @this => @this._skippedTests++);
 
     public void ReportFailedTest(string testNodeUid, string instanceId)
-        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Failed = entry.Failed + 1 }, static @this => @this.FailedTests++);
+        => ReportGenericTestResult(testNodeUid, instanceId, static entry => entry with { Failed = entry.Failed + 1 }, static @this => @this._failedTests++);
+
+    internal void ReportDiscoveredTest(string? displayName)
+    {
+        lock (_lock)
+        {
+            _discoveredTests++;
+            if (displayName is not null)
+            {
+                _discoveredTestDisplayNames.Add(displayName);
+            }
+        }
+    }
+
+    internal TestNodeResultsState GetOrCreateTestNodeResultsState(Func<TestNodeResultsState> factory)
+    {
+        lock (_lock)
+        {
+            return _testNodeResultsState ??= factory();
+        }
+    }
 
     /// <summary>
     /// Records (or clears) the last-seen duration reported for a test node so it can be ranked in the "slowest
@@ -106,13 +261,16 @@ internal sealed class TestProgressState
     /// </summary>
     public void RecordTestDuration(string testNodeUid, string displayName, TimeSpan? duration)
     {
-        if (duration.HasValue)
+        lock (_lock)
         {
-            _testUidToDuration[testNodeUid] = (displayName, duration.Value);
-        }
-        else
-        {
-            _testUidToDuration.Remove(testNodeUid);
+            if (duration.HasValue)
+            {
+                _testUidToDuration[testNodeUid] = (displayName, duration.Value);
+            }
+            else
+            {
+                _testUidToDuration.Remove(testNodeUid);
+            }
         }
     }
 
@@ -121,12 +279,17 @@ internal sealed class TestProgressState
     /// display name (ordinal) so the ranking is deterministic for snapshot-based tests.
     /// </summary>
     public IReadOnlyList<(string DisplayName, TimeSpan Duration)> GetSlowestTests(int count)
-        => count <= 0 || _testUidToDuration.Count == 0
-            ? []
-            : [.. _testUidToDuration.Values
-                .OrderByDescending(static entry => entry.Duration)
-                .ThenBy(static entry => entry.DisplayName, StringComparer.Ordinal)
-                .Take(count)];
+    {
+        lock (_lock)
+        {
+            return count <= 0 || _testUidToDuration.Count == 0
+                ? []
+                : [.. _testUidToDuration.Values
+                    .OrderByDescending(static entry => entry.Duration)
+                    .ThenBy(static entry => entry.DisplayName, StringComparer.Ordinal)
+                    .Take(count)];
+        }
+    }
 
     /// <summary>
     /// Registers a legacy handshake for the given <paramref name="instanceId"/>. A previously unseen instance id is
@@ -144,31 +307,34 @@ internal sealed class TestProgressState
 
     private int NotifyHandshakeCore(string instanceId, int? attemptNumber)
     {
-        if (_instanceIdToAttemptNumber.TryGetValue(instanceId, out int registeredAttemptNumber))
+        lock (_lock)
         {
-            return !attemptNumber.HasValue || attemptNumber.Value == registeredAttemptNumber
-                ? registeredAttemptNumber
-                : throw ApplicationStateGuard.Unreachable();
-        }
-
-        int resolvedAttemptNumber;
-        if (attemptNumber.HasValue)
-        {
-            if (attemptNumber.Value < 1)
+            if (_instanceIdToAttemptNumber.TryGetValue(instanceId, out int registeredAttemptNumber))
             {
-                throw new ArgumentOutOfRangeException(nameof(attemptNumber));
+                return !attemptNumber.HasValue || attemptNumber.Value == registeredAttemptNumber
+                    ? registeredAttemptNumber
+                    : throw ApplicationStateGuard.Unreachable();
             }
 
-            resolvedAttemptNumber = attemptNumber.Value;
-        }
-        else
-        {
-            resolvedAttemptNumber = TryCount + 1;
-        }
+            int resolvedAttemptNumber;
+            if (attemptNumber.HasValue)
+            {
+                if (attemptNumber.Value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(attemptNumber));
+                }
 
-        _instanceIdToAttemptNumber.Add(instanceId, resolvedAttemptNumber);
-        TryCount = Math.Max(TryCount, resolvedAttemptNumber);
-        return resolvedAttemptNumber;
+                resolvedAttemptNumber = attemptNumber.Value;
+            }
+            else
+            {
+                resolvedAttemptNumber = _tryCount + 1;
+            }
+
+            _instanceIdToAttemptNumber.Add(instanceId, resolvedAttemptNumber);
+            _tryCount = Math.Max(_tryCount, resolvedAttemptNumber);
+            return resolvedAttemptNumber;
+        }
     }
 
     private void ReportGenericTestResult(
@@ -177,39 +343,50 @@ internal sealed class TestProgressState
         Func<TestNodeInfoEntry, TestNodeInfoEntry> incrementTestNodeInfoEntry,
         Action<TestProgressState> incrementCountAction)
     {
-        int currentAttemptNumber = GetAttemptNumber(instanceId);
-
-        if (_testUidToResults.TryGetValue(testNodeUid, out TestNodeInfoEntry value))
+        lock (_lock)
         {
-            if (value.LastAttemptNumber == currentAttemptNumber)
+            int currentAttemptNumber = GetAttemptNumberCore(instanceId);
+
+            if (_testUidToResults.TryGetValue(testNodeUid, out TestNodeInfoEntry value))
             {
-                // Another result for the same test node in the same attempt — just increment.
-                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
-            }
-            else if (currentAttemptNumber > value.LastAttemptNumber)
-            {
-                // Retry: discard the previous attempt's contribution to the live tally and re-count this attempt.
-                RetriedFailedTests += value.Failed;
-                PassedTests -= value.Passed;
-                SkippedTests -= value.Skipped;
-                FailedTests -= value.Failed;
-                _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+                if (value.LastAttemptNumber == currentAttemptNumber)
+                {
+                    // Another result for the same test node in the same attempt — just increment.
+                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry(value);
+                }
+                else if (currentAttemptNumber > value.LastAttemptNumber)
+                {
+                    // Retry: discard the previous attempt's contribution to the live tally and re-count this attempt.
+                    _retriedFailedTests += value.Failed;
+                    _passedTests -= value.Passed;
+                    _skippedTests -= value.Skipped;
+                    _failedTests -= value.Failed;
+                    _testUidToResults[testNodeUid] = incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber));
+                }
+                else
+                {
+                    // A result for an attempt older than the latest one we saw — unexpected ordering.
+                    throw ApplicationStateGuard.Unreachable();
+                }
             }
             else
             {
-                // A result for an attempt older than the latest one we saw — unexpected ordering.
-                throw ApplicationStateGuard.Unreachable();
+                _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
             }
-        }
-        else
-        {
-            _testUidToResults.Add(testNodeUid, incrementTestNodeInfoEntry((Passed: 0, Skipped: 0, Failed: 0, LastAttemptNumber: currentAttemptNumber)));
-        }
 
-        incrementCountAction(this);
+            incrementCountAction(this);
+        }
     }
 
     internal int GetAttemptNumber(string instanceId)
+    {
+        lock (_lock)
+        {
+            return GetAttemptNumberCore(instanceId);
+        }
+    }
+
+    private int GetAttemptNumberCore(string instanceId)
         => _instanceIdToAttemptNumber.TryGetValue(instanceId, out int attemptNumber)
             ? attemptNumber
             : throw ApplicationStateGuard.Unreachable();

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -126,8 +126,12 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             { HandshakeMessagePropertyNames.ExecutionId,  _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID) ?? string.Empty },
             { HandshakeMessagePropertyNames.InstanceId, InstanceId },
             { HandshakeMessagePropertyNames.ExecutionMode, GetExecutionMode() },
-            { HandshakeMessagePropertyNames.AttemptNumber, GetAttemptNumber() },
         };
+
+        if (hostType is HandshakeMessageHostTypes.TestHost or HandshakeMessageHostTypes.ServerTestHost)
+        {
+            properties.Add(HandshakeMessagePropertyNames.AttemptNumber, GetAttemptNumber());
+        }
 
         if (additionalHandshakeProperties is not null)
         {
@@ -171,16 +175,14 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
                 ? HandshakeMessageExecutionModes.Discover
                 : HandshakeMessageExecutionModes.Run;
 
-    // The 1-based attempt number for this test host. The retry orchestrator sets
-    // TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER on each launched attempt; a normal (non-orchestrated) run has no
-    // such variable and reports attempt 1. A malformed value defensively falls back to 1 rather than failing the
-    // handshake.
     private string GetAttemptNumber()
     {
         string? value = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER);
-        return !RoslynString.IsNullOrEmpty(value) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int attempt) && attempt >= 1
-            ? value
-            : "1";
+        return RoslynString.IsNullOrEmpty(value)
+            ? "1"
+            : int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int attemptNumber) && attemptNumber >= 1
+                ? attemptNumber.ToString(CultureInfo.InvariantCulture)
+                : throw new InvalidOperationException($"Environment variable '{EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER}' must contain a positive integer.");
     }
 
     public static bool IsVersionCompatible(string protocolVersion, string supportedProtocolVersions) => supportedProtocolVersions.Split(';').Contains(protocolVersion);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/DotnetTestConnection.cs
@@ -126,6 +126,7 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             { HandshakeMessagePropertyNames.ExecutionId,  _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID) ?? string.Empty },
             { HandshakeMessagePropertyNames.InstanceId, InstanceId },
             { HandshakeMessagePropertyNames.ExecutionMode, GetExecutionMode() },
+            { HandshakeMessagePropertyNames.AttemptNumber, GetAttemptNumber() },
         };
 
         if (additionalHandshakeProperties is not null)
@@ -169,6 +170,18 @@ internal sealed class DotnetTestConnection : IPushOnlyProtocol, IDisposable
             : _commandLineHandler.IsOptionSet(PlatformCommandLineProvider.DiscoverTestsOptionKey)
                 ? HandshakeMessageExecutionModes.Discover
                 : HandshakeMessageExecutionModes.Run;
+
+    // The 1-based attempt number for this test host. The retry orchestrator sets
+    // TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER on each launched attempt; a normal (non-orchestrated) run has no
+    // such variable and reports attempt 1. A malformed value defensively falls back to 1 rather than failing the
+    // handshake.
+    private string GetAttemptNumber()
+    {
+        string? value = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER);
+        return !RoslynString.IsNullOrEmpty(value) && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int attempt) && attempt >= 1
+            ? value
+            : "1";
+    }
 
     public static bool IsVersionCompatible(string protocolVersion, string supportedProtocolVersions) => supportedProtocolVersions.Split(';').Contains(protocolVersion);
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -80,15 +80,13 @@ internal static class HandshakeMessagePropertyNames
     internal const byte ServerControlPipeName = 12;
 
     // The 1-based attempt number of the test host in a retry sequence: 1 for the initial run and every
-    // non-retried run, incremented by the retry orchestrator for each subsequent attempt. Sent by the test
-    // host in its handshake so consumers (e.g. dotnet test in the SDK) can attribute results to an attempt
-    // explicitly instead of inferring it from a change in InstanceId. See issues #5361 and #6337.
+    // non-retried run, incremented by the retry orchestrator for each subsequent attempt. Multiple test-host
+    // instances, such as shards, can belong to the same attempt. Only test hosts send this property.
     //
     // The value is carried from the orchestrator to each launched test host through the
-    // TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER environment variable. When the variable is absent (a normal,
-    // non-orchestrated run) the test host reports "1". This is an additive, capability-style property:
-    // consumers that do not understand it simply ignore it, so it is not gated on the negotiated protocol
-    // version.
+    // TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER environment variable. When the variable is absent, the test host
+    // reports "1". This is an additive, capability-style property: consumers that do not understand it ignore it,
+    // so it is not gated on the negotiated protocol version.
     internal const byte AttemptNumber = 13;
 }
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs
@@ -78,6 +78,18 @@ internal static class HandshakeMessagePropertyNames
     //     pipe drop as "host gone => cancel", so closing the control pipe before the data session ends would be
     //     interpreted as a cancellation.
     internal const byte ServerControlPipeName = 12;
+
+    // The 1-based attempt number of the test host in a retry sequence: 1 for the initial run and every
+    // non-retried run, incremented by the retry orchestrator for each subsequent attempt. Sent by the test
+    // host in its handshake so consumers (e.g. dotnet test in the SDK) can attribute results to an attempt
+    // explicitly instead of inferring it from a change in InstanceId. See issues #5361 and #6337.
+    //
+    // The value is carried from the orchestrator to each launched test host through the
+    // TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER environment variable. When the variable is absent (a normal,
+    // non-orchestrated run) the test host reports "1". This is an additive, capability-style property:
+    // consumers that do not understand it simply ignore it, so it is not gated on the negotiated protocol
+    // version.
+    internal const byte AttemptNumber = 13;
 }
 
 [Embedded]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeBaselineTests.cs
@@ -57,6 +57,31 @@ public class DotnetTestPipeBaselineTests : AcceptanceTestBase<DotnetTestPipeBase
             FakeDotnetTestSdk.DefaultSupportedProtocolVersions,
             result.NegotiatedProtocolVersion,
             "An old SDK that only supports 1.0.0 should negotiate down to '1.0.0'.");
+        Assert.AreEqual(
+            "1",
+            result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.AttemptNumber],
+            "A non-retried test host should report attempt 1.");
+    }
+
+    [TestMethod]
+    public async Task DotnetTestPipe_InvalidAttemptNumber_FailsBeforeHandshake()
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent);
+
+        FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+            testHost,
+            environmentVariables: new()
+            {
+                { "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER", "0" },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        Assert.AreNotEqual((int)ExitCode.Success, result.TestHostResult.ExitCode);
+        Assert.IsNull(result.ReceivedHandshake, "An invalid attempt number must fail before a handshake is sent.");
+        Assert.Contains(
+            "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER",
+            result.TestHostResult.StandardOutput + result.TestHostResult.StandardError);
     }
 
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeOrchestratorHandshakeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeOrchestratorHandshakeTests.cs
@@ -36,24 +36,45 @@ public class DotnetTestPipeOrchestratorHandshakeTests : AcceptanceTestBase<Dotne
         FakeDotnetTestSdkMultiConnectionResult result = await FakeDotnetTestSdkMultiConnection.RunAsync(
             testHost,
             extraArguments: $"--retry-failed-tests 3 --results-directory {resultDirectory}",
-            environmentVariables: new() { { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" } },
+            environmentVariables: new()
+            {
+                { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
+                { "RETRY_MARKER_DIRECTORY", resultDirectory },
+            },
             cancellationToken: TestContext.CancellationToken);
 
-        // The orchestrator process and the single (passing) test host it spawned should both have
-        // connected and handshaked.
+        result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+
         Dictionary<byte, string> orchestratorHandshake = Assert.ContainsSingle(result.HandshakesWithHostType(TestHostOrchestratorHostType));
 
         Assert.IsTrue(
             orchestratorHandshake.TryGetValue(DotnetTestPipeProtocol.HandshakeProperties.OrchestratorFeature, out string? feature),
             "Orchestrator handshake is missing the OrchestratorFeature property.");
         Assert.AreEqual(RetryOrchestratorFeature, feature);
-
-        // The actual test host (spawned by the orchestrator) handshakes as a plain TestHost and must
-        // NOT carry an orchestrator feature.
-        Dictionary<byte, string> testHostHandshake = Assert.ContainsSingle(result.HandshakesWithHostType(TestHostHostType));
         Assert.IsFalse(
-            testHostHandshake.ContainsKey(DotnetTestPipeProtocol.HandshakeProperties.OrchestratorFeature),
-            "Test host handshake should not carry the OrchestratorFeature property.");
+            orchestratorHandshake.ContainsKey(DotnetTestPipeProtocol.HandshakeProperties.AttemptNumber),
+            "The orchestrator itself should not report a test-host attempt number.");
+
+        Dictionary<byte, string>[] testHostHandshakes =
+        [
+            .. result.HandshakesWithHostType(TestHostHostType)
+                .OrderBy(handshake => int.Parse(handshake[DotnetTestPipeProtocol.HandshakeProperties.AttemptNumber], CultureInfo.InvariantCulture)),
+        ];
+
+        Assert.HasCount(2, testHostHandshakes);
+        Assert.AreEqual("1", testHostHandshakes[0][DotnetTestPipeProtocol.HandshakeProperties.AttemptNumber]);
+        Assert.AreEqual("2", testHostHandshakes[1][DotnetTestPipeProtocol.HandshakeProperties.AttemptNumber]);
+        Assert.AreEqual(
+            testHostHandshakes[0][DotnetTestPipeProtocol.HandshakeProperties.ExecutionId],
+            testHostHandshakes[1][DotnetTestPipeProtocol.HandshakeProperties.ExecutionId],
+            "All retry attempts should remain part of the same logical execution.");
+        Assert.AreNotEqual(
+            testHostHandshakes[0][DotnetTestPipeProtocol.HandshakeProperties.InstanceId],
+            testHostHandshakes[1][DotnetTestPipeProtocol.HandshakeProperties.InstanceId],
+            "Each retry attempt runs in a distinct test-host process.");
+        Assert.IsTrue(
+            testHostHandshakes.All(handshake => !handshake.ContainsKey(DotnetTestPipeProtocol.HandshakeProperties.OrchestratorFeature)),
+            "Test host handshakes should not carry the OrchestratorFeature property.");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
@@ -80,6 +101,7 @@ public class DotnetTestPipeOrchestratorHandshakeTests : AcceptanceTestBase<Dotne
 using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 
 public class Program
@@ -94,21 +116,43 @@ public class Program
     }
 }
 
-public class DummyTestFramework : ITestFramework
+public class DummyTestFramework : ITestFramework, IDataProducer
 {
     public string Uid => nameof(DummyTestFramework);
     public string Version => "2.0.0";
     public string DisplayName => nameof(DummyTestFramework);
     public string Description => nameof(DummyTestFramework);
+    public Type[] DataTypesProduced => new[] { typeof(TestNodeUpdateMessage) };
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
     public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
         => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
     public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
         => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
-    public Task ExecuteRequestAsync(ExecuteRequestContext context)
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
     {
+        string markerDirectory = Environment.GetEnvironmentVariable("RETRY_MARKER_DIRECTORY")!;
+        Directory.CreateDirectory(markerDirectory);
+        string markerPath = Path.Combine(markerDirectory, "first-attempt.failed");
+        bool isFirstAttempt = !File.Exists(markerPath);
+        if (isFirstAttempt)
+        {
+            File.WriteAllText(markerPath, string.Empty);
+        }
+
+        TestNodeStateProperty state = isFirstAttempt
+            ? new FailedTestNodeStateProperty()
+            : PassedTestNodeStateProperty.CachedInstance;
+        await context.MessageBus.PublishAsync(
+            this,
+            new TestNodeUpdateMessage(
+                context.Request.Session.SessionUid,
+                new TestNode
+                {
+                    Uid = "flaky",
+                    DisplayName = "FlakyTest",
+                    Properties = new(state),
+                }));
         context.Complete();
-        return Task.CompletedTask;
     }
 }
 """;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -61,6 +61,7 @@ internal static class DotnetTestPipeProtocol
         public const byte ExecutionMode = 10;
         public const byte OrchestratorFeature = 11;
         public const byte ServerControlPipeName = 12;
+        public const byte AttemptNumber = 13;
     }
 
     public static class ServerControlKinds

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolContractTests.cs
@@ -81,6 +81,7 @@ public sealed class DotnetTestProtocolContractTests
             [HandshakeMessagePropertyNames.ExecutionMode] = nameof(HandshakeMessagePropertyNames.ExecutionMode),
             [HandshakeMessagePropertyNames.OrchestratorFeature] = nameof(HandshakeMessagePropertyNames.OrchestratorFeature),
             [HandshakeMessagePropertyNames.ServerControlPipeName] = nameof(HandshakeMessagePropertyNames.ServerControlPipeName),
+            [HandshakeMessagePropertyNames.AttemptNumber] = nameof(HandshakeMessagePropertyNames.AttemptNumber),
         };
 
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.PID), properties[0]);
@@ -96,6 +97,7 @@ public sealed class DotnetTestProtocolContractTests
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionMode), properties[10]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.OrchestratorFeature), properties[11]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ServerControlPipeName), properties[12]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.AttemptNumber), properties[13]);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -264,6 +264,7 @@ public sealed class ProtocolTests
             { HandshakeMessagePropertyNames.ExecutionMode, nameof(HandshakeMessagePropertyNames.ExecutionMode) },
             { HandshakeMessagePropertyNames.OrchestratorFeature, nameof(HandshakeMessagePropertyNames.OrchestratorFeature) },
             { HandshakeMessagePropertyNames.ServerControlPipeName, nameof(HandshakeMessagePropertyNames.ServerControlPipeName) },
+            { HandshakeMessagePropertyNames.AttemptNumber, nameof(HandshakeMessagePropertyNames.AttemptNumber) },
         };
 
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.PID), properties[0]);
@@ -279,6 +280,7 @@ public sealed class ProtocolTests
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ExecutionMode), properties[10]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.OrchestratorFeature), properties[11]);
         Assert.AreEqual(nameof(HandshakeMessagePropertyNames.ServerControlPipeName), properties[12]);
+        Assert.AreEqual(nameof(HandshakeMessagePropertyNames.AttemptNumber), properties[13]);
     }
 
     // The HandshakeMessageExecutionModes string values flow over IPC to

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1843,10 +1843,17 @@ public sealed class TerminalTestReporterTests
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\ShardedFlaky.dll" : "/repo/ShardedFlaky.dll";
         const string executionId = "exec-sharded";
 
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-1", attemptNumber: 1);
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-2", attemptNumber: 1);
-        ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-1", "flaky", TestOutcome.Fail);
-        ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-2", "passing", TestOutcome.Passed);
+        Parallel.Invoke(
+            () =>
+            {
+                terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-1", attemptNumber: 1);
+                ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-1", "flaky", TestOutcome.Fail);
+            },
+            () =>
+            {
+                terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-2", attemptNumber: 1);
+                ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-2", "passing", TestOutcome.Passed);
+            });
 
         terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-2-shard-1", attemptNumber: 2);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-2-shard-1", "flaky", TestOutcome.Passed);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1380,7 +1380,7 @@ public sealed class TerminalTestReporterTests
 
         string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\MyTests.dll" : "/repo/MyTests.dll";
         const string executionId = "exec-1";
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1", attemptNumber: 1);
 
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-1", testUid: "t-pass-1", TestOutcome.Passed);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-1", testUid: "t-pass-2", TestOutcome.Passed);
@@ -1530,8 +1530,7 @@ public sealed class TerminalTestReporterTests
 
     // Ported from the dotnet/sdk TerminalTestReporterTests: when an assembly's tests were retried, the per-assembly
     // summary appends a "/r{N}" segment so the user can tell the final counts came from retries. Attempt 1 fails the
-    // test; attempt 2 (a new instance id under the same execution id) passes it, so the final tally is 1 passed with
-    // 1 retried.
+    // test; attempt 2 passes it, so the final tally is 1 passed with 1 retried.
     [TestMethod]
     public void AssemblyRunCompleted_WhenTestsWereRetried_ShowsRetriedCount()
     {
@@ -1550,11 +1549,11 @@ public sealed class TerminalTestReporterTests
         const string executionId = "exec-flaky";
 
         // Attempt 1: register the first instance and report a failure.
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1", attemptNumber: 1);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
 
-        // Attempt 2: a new instance id triggers a retry; the failing test now passes.
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        // Attempt 2: the explicit attempt number identifies the retry; the failing test now passes.
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2", attemptNumber: 2);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
 
         terminalReporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
@@ -1587,11 +1586,11 @@ public sealed class TerminalTestReporterTests
         const string executionId = "exec-flaky";
 
         // Attempt 1 fails the test...
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1");
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-1", attemptNumber: 1);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-1", testUid: "flaky-1", TestOutcome.Fail);
 
-        // ...attempt 2 (new instance id) retries and passes it.
-        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2");
+        // ...attempt 2 retries and passes it.
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, instanceId: "inst-2", attemptNumber: 2);
         ReportOrchestratorTest(terminalReporter, assembly, executionId, instanceId: "inst-2", testUid: "flaky-1", TestOutcome.Passed);
 
         terminalReporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
@@ -1832,6 +1831,31 @@ public sealed class TerminalTestReporterTests
         // RetriedFailedTests - tests that failed then passed on retry - which is 0 here, not the attempt count.)
         string assemblyLine = GetAssemblySummaryLine(stringBuilderConsole.Output, assembly);
         Assert.Contains(ExpectedCounts(1, 0, 0), assemblyLine);
+    }
+
+    [TestMethod]
+    public void AssemblyRunStarted_WithMultipleInstancesInOneAttempt_DoesNotTreatShardsAsRetries()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: true);
+
+        string assembly = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"C:\repo\ShardedFlaky.dll" : "/repo/ShardedFlaky.dll";
+        const string executionId = "exec-sharded";
+
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-1", attemptNumber: 1);
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-1-shard-2", attemptNumber: 1);
+        ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-1", "flaky", TestOutcome.Fail);
+        ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-1-shard-2", "passing", TestOutcome.Passed);
+
+        terminalReporter.AssemblyRunStarted(assembly, "net9.0", "x64", executionId, "attempt-2-shard-1", attemptNumber: 2);
+        ReportOrchestratorTest(terminalReporter, assembly, executionId, "attempt-2-shard-1", "flaky", TestOutcome.Passed);
+        terminalReporter.AssemblyRunCompleted(executionId, exitCode: 0, outputData: null, errorData: null);
+
+        string output = stringBuilderConsole.Output;
+        Assert.Contains(ExpectedCounts(2, 0, 0, retried: 1), GetAssemblySummaryLine(output, assembly));
+        Assert.Contains($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, 2)})", output);
+        Assert.DoesNotContain($"({string.Format(CultureInfo.CurrentCulture, TerminalResources.Try, 3)})", output);
     }
 
     [TestMethod]


### PR DESCRIPTION
Retry attempts are currently inferred from new `InstanceId` values, which conflates process identity with retry identity and prevents multiple test-host instances, such as shards, from participating in the same attempt.

This change adds an optional, 1-based `AttemptNumber` to test-host handshakes and propagates it from the retry orchestrator to child hosts. The shared terminal reporter now maps each instance to its explicit attempt, allows multiple instances per attempt, and retains instance-order inference for compatibility with older peers. The wire contract documentation and protocol, reporter, and pipe acceptance coverage are updated accordingly.

A follow-up in dotnet/sdk will consume the new handshake property and remove command-line-based retry detection.

Related to #5361.
Related to #6337.