### PR TITLE
Add MSTEST0070 member name edge-case tests

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/MemberConditionShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/MemberConditionShouldBeValidAnalyzerTests.cs
@@ -690,4 +690,73 @@ public sealed class MemberConditionShouldBeValidAnalyzerTests
                 .WithLocation(0)
                 .WithArguments("Conditions", "Missing2"));
     }
+
+    [TestMethod]
+    public async Task WhenMemberNameIsEmptyString_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                public static bool IsReady => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MemberCondition(typeof(Conditions), "")]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenMemberNameIsWhitespace_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                public static bool IsReady => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MemberCondition(typeof(Conditions), "   ")]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenMemberNameIsEmptyInParamsArray_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public static class Conditions
+            {
+                public static bool IsReady => true;
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MemberCondition(typeof(Conditions), "IsReady", "")]
+                [TestMethod]
+                public void TestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
@@ -111,7 +111,9 @@ public sealed class TaskExtensionsTests
             }
         }).WithCancellationAsync(token);
 
+#pragma warning disable VSTHRD103 // Call async methods when in an async method
         cancellationTokenSource.Cancel();
+#pragma warning restore VSTHRD103 // Call async methods when in an async method
         OperationCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
         Assert.AreEqual(token, ex.CancellationToken);
         Assert.IsTrue(

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TaskExtensionsTests.cs
@@ -93,23 +93,26 @@ public sealed class TaskExtensionsTests
     public async Task CancellationAsyncWithReturnValue_ObserveException_Succeeds()
     {
         ManualResetEvent waitException = new(false);
-        CancellationToken token = new CancellationTokenSource(TimeSpan.FromSeconds(1)).Token;
-        OperationCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(async ()
-            => await Task.Run(async () =>
+        using CancellationTokenSource cancellationTokenSource = new();
+        CancellationToken token = cancellationTokenSource.Token;
+        Task<int> task = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+            try
             {
-                await Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
-                try
-                {
-                    return 2;
-                }
-                finally
-                {
-                    waitException.Set();
+                return 2;
+            }
+            finally
+            {
+                waitException.Set();
 #pragma warning disable CA2219 // Do not raise exceptions in finally clauses
-                    throw new InvalidOperationException();
+                throw new InvalidOperationException();
 #pragma warning restore CA2219 // Do not raise exceptions in finally clauses
-                }
-            }).WithCancellationAsync(token));
+            }
+        }).WithCancellationAsync(token);
+
+        cancellationTokenSource.Cancel();
+        OperationCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
         Assert.AreEqual(token, ex.CancellationToken);
         Assert.IsTrue(
             waitException.WaitOne(TimeSpan.FromSeconds(30)),


### PR DESCRIPTION
## Summary

- cover empty member names in `MemberConditionShouldBeValidAnalyzer`
- cover whitespace-only member names
- cover an empty member name after a valid entry in the params array
- stabilize the unrelated Windows `net462` cancellation test exposed by CI by replacing its timer race with explicit cancellation

## Validation

- all 28 `MemberConditionShouldBeValidAnalyzerTests` pass
- targeted `CancellationAsyncWithReturnValue_ObserveException_Succeeds` passes on `net462`
- the cancellation test passes 10 consecutive `net462` runs

Fixes #10026