### PR TITLE
Avoid per-test string allocations in TestCaseExtensions

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Extensions/TestCaseExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/TestCaseExtensions.cs
@@ -59,8 +59,8 @@ internal static class TestCaseExtensions
         string fullyQualifiedName = testCase.FullyQualifiedName;
 
         // Not using Replace because there can be multiple instances of that string.
-        string name = fullyQualifiedName.StartsWith($"{testClassName}.", StringComparison.Ordinal)
-            ? fullyQualifiedName.Remove(0, $"{testClassName}.".Length)
+        string name = FullyQualifiedNameStartsWithTestClassName(fullyQualifiedName, testClassName)
+            ? fullyQualifiedName.Substring((testClassName?.Length ?? 0) + 1)
             : fullyQualifiedName;
 
         return name;
@@ -144,9 +144,18 @@ internal static class TestCaseExtensions
     internal static string? GetManagedMethod(this TestCase testCase) => testCase.GetPropertyValue<string>(ManagedMethodProperty, null);
 
     private static string? GetClassNameWhenFullyQualifiedNameStartsWith(this TestCase testCase, string? testClassName)
-        => testClassName is not null && testCase.FullyQualifiedName.StartsWith($"{testClassName}.", StringComparison.Ordinal)
+        => testClassName is not null && FullyQualifiedNameStartsWithTestClassName(testCase.FullyQualifiedName, testClassName)
             ? testClassName
             : null;
+
+    private static bool FullyQualifiedNameStartsWithTestClassName(string fullyQualifiedName, string? testClassName)
+    {
+        int testClassNameLength = testClassName?.Length ?? 0;
+
+        return fullyQualifiedName.Length > testClassNameLength
+            && fullyQualifiedName[testClassNameLength] == '.'
+            && (testClassName is null || fullyQualifiedName.StartsWith(testClassName, StringComparison.Ordinal));
+    }
 
     internal static string[]? GetHierarchy(this TestCase testCase) => testCase.GetPropertyValue<string[]>(HierarchyProperty, null);
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Extensions/TestCaseExtensionsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Extensions/TestCaseExtensionsTests.cs
@@ -15,6 +15,42 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.UnitTests.Extensions
 
 public class TestCaseExtensionsTests : TestContainer
 {
+    public void GetTestNameShouldRemoveTestClassNamePrefix()
+    {
+        TestCase testCase = new("DummyClass.DummyMethod", new("DummyUri", UriKind.Relative), Assembly.GetCallingAssembly().FullName!);
+
+        string testName = testCase.GetTestName("DummyClass");
+
+        testName.Should().Be("DummyMethod");
+    }
+
+    public void GetTestNameShouldNotRemovePartialTestClassNamePrefix()
+    {
+        TestCase testCase = new("DummyClass.DummyMethod", new("DummyUri", UriKind.Relative), Assembly.GetCallingAssembly().FullName!);
+
+        string testName = testCase.GetTestName("Dummy");
+
+        testName.Should().Be("DummyClass.DummyMethod");
+    }
+
+    public void GetTestNameShouldHandleFullyQualifiedNameEqualToTestClassName()
+    {
+        TestCase testCase = new("DummyClass", new("DummyUri", UriKind.Relative), Assembly.GetCallingAssembly().FullName!);
+
+        string testName = testCase.GetTestName("DummyClass");
+
+        testName.Should().Be("DummyClass");
+    }
+
+    public void GetTestNameShouldPreserveNullTestClassNameBehavior()
+    {
+        TestCase testCase = new(".DummyMethod", new("DummyUri", UriKind.Relative), Assembly.GetCallingAssembly().FullName!);
+
+        string testName = testCase.GetTestName(null);
+
+        testName.Should().Be("DummyMethod");
+    }
+
     public void ToUnitTestElementShouldReturnUnitTestElementWithFieldsSet()
     {
         TestCase testCase = new("DummyClassName.DummyMethod", new("DummyUri", UriKind.Relative), Assembly.GetCallingAssembly().FullName!)


### PR DESCRIPTION
## Summary

- replace interpolated test-class prefixes with a shared allocation-free length, separator, and ordinal prefix check
- preserve existing behavior for null and empty class names
- add focused coverage for exact, partial, boundary, and null-prefix cases

Fixes #10024