### PR TITLE
Clean up acceptance test infrastructure

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AspireSdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/AspireSdkTests.cs
@@ -23,9 +23,7 @@ public sealed class AspireSdkTests : AcceptanceTestBase<AspireSdkTests.TestAsset
     public async Task EnableAspireProperty_WhenUsingVSTest_AllowsToRunAspireTests()
     {
         var testHost = TestHost.LocateFrom(AssetFixture.AspireProjectPath, TestAssetFixture.AspireProjectName, TargetFrameworks.NetCurrent);
-        string exeOrDllName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? testHost.FullName
-            : testHost.FullName + ".dll";
+        string exeOrDllName = GetTestExecutablePath(testHost);
         DotnetMuxerResult dotnetTestResult = await DotnetCli.RunAsync(
             $"test {exeOrDllName}",
             workingDirectory: AssetFixture.AspireProjectPath,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/FSharpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/FSharpTests.cs
@@ -12,7 +12,6 @@ namespace MSTest.Acceptance.IntegrationTests;
 /// (Microsoft.Testing.Platform) host.
 /// </summary>
 [TestClass]
-[OSCondition(OperatingSystems.Windows)]
 public sealed class FSharpTests : AcceptanceTestBase<FSharpTests.TestAssetFixture>
 {
     private const string ProjectName = "FSharpTestProject";
@@ -20,9 +19,10 @@ public sealed class FSharpTests : AcceptanceTestBase<FSharpTests.TestAssetFixtur
     public TestContext TestContext { get; set; } = default!;
 
     [TestMethod]
-    public async Task DiscoversFSharpTestWithSpaceAndDotInName()
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task DiscoversFSharpTestWithSpaceAndDotInName(string tfm)
     {
-        TestHost testHost = AssetFixture.GetTestHost();
+        TestHost testHost = AssetFixture.GetTestHost(tfm);
 
         TestHostResult listResult = await testHost.ExecuteAsync("--list-tests", cancellationToken: TestContext.CancellationToken);
         Assert.AreEqual(0, listResult.ExitCode, listResult.StandardOutput);
@@ -30,9 +30,10 @@ public sealed class FSharpTests : AcceptanceTestBase<FSharpTests.TestAssetFixtur
     }
 
     [TestMethod]
-    public async Task RunsFSharpTestWithSpaceAndDotInName()
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task RunsFSharpTestWithSpaceAndDotInName(string tfm)
     {
-        TestHost testHost = AssetFixture.GetTestHost();
+        TestHost testHost = AssetFixture.GetTestHost(tfm);
         TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
 
         Assert.AreEqual(0, result.ExitCode, result.StandardOutput);
@@ -46,12 +47,14 @@ public sealed class FSharpTests : AcceptanceTestBase<FSharpTests.TestAssetFixtur
         private readonly TempDirectory _tempDirectory = new();
         private TestAsset? _asset;
 
-        public TestHost GetTestHost()
-            => TestHost.LocateFrom(_asset!.TargetAssetPath, ProjectName, "net472");
+        public TestHost GetTestHost(string tfm)
+            => TestHost.LocateFrom(_asset!.TargetAssetPath, ProjectName, tfm);
 
         public async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            string code = SourceCode.PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
+            string code = SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
             _asset = await TestAsset.GenerateAssetAsync(ProjectName, code, _tempDirectory);
             await DotnetCli.RunAsync($"build \"{_asset.TargetAssetPath}\" -c Release", callerMemberName: ProjectName, cancellationToken: cancellationToken);
         }
@@ -67,7 +70,7 @@ public sealed class FSharpTests : AcceptanceTestBase<FSharpTests.TestAssetFixtur
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParallelExecutionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ParallelExecutionTests.cs
@@ -19,7 +19,6 @@ namespace MSTest.Acceptance.IntegrationTests;
 /// keeps execution serial, without relying on a flaky wall-clock threshold.
 /// </remarks>
 [TestClass]
-[OSCondition(OperatingSystems.Windows)]
 public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutionTests.TestAssetFixture>
 {
     private const string MethodParallelProjectName = "ParallelMethodsTestProject";
@@ -29,9 +28,10 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
     public TestContext TestContext { get; set; } = default!;
 
     [TestMethod]
-    public async Task AllMethodsShouldRunInParallel()
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task AllMethodsShouldRunInParallel(string tfm)
     {
-        TestHost testHost = AssetFixture.GetTestHost(MethodParallelProjectName);
+        TestHost testHost = AssetFixture.GetTestHost(MethodParallelProjectName, tfm);
 
         TestHostResult result = await testHost.ExecuteAsync("--output detailed", cancellationToken: TestContext.CancellationToken);
 
@@ -40,13 +40,14 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
         Assert.Contains("succeeded: 4", result.StandardOutput);
         Assert.Contains("SimpleTest12", result.StandardOutput);
         Assert.Contains("SimpleTest22", result.StandardOutput);
-        Assert.IsGreaterThanOrEqualTo(2, AssetFixture.ReadMaximumConcurrency(MethodParallelProjectName));
+        Assert.IsGreaterThanOrEqualTo(2, AssetFixture.ReadMaximumConcurrency(MethodParallelProjectName, tfm));
     }
 
     [TestMethod]
-    public async Task AllClassesShouldRunInParallel()
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task AllClassesShouldRunInParallel(string tfm)
     {
-        TestHost testHost = AssetFixture.GetTestHost(ClassParallelProjectName);
+        TestHost testHost = AssetFixture.GetTestHost(ClassParallelProjectName, tfm);
 
         TestHostResult result = await testHost.ExecuteAsync("--output detailed", cancellationToken: TestContext.CancellationToken);
 
@@ -56,13 +57,14 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
         Assert.Contains("SimpleTest12", result.StandardOutput);
         Assert.Contains("SimpleTest22", result.StandardOutput);
         Assert.Contains("SimpleTest32", result.StandardOutput);
-        Assert.IsGreaterThanOrEqualTo(2, AssetFixture.ReadMaximumConcurrency(ClassParallelProjectName));
+        Assert.IsGreaterThanOrEqualTo(2, AssetFixture.ReadMaximumConcurrency(ClassParallelProjectName, tfm));
     }
 
     [TestMethod]
-    public async Task NothingShouldRunInParallel()
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task NothingShouldRunInParallel(string tfm)
     {
-        TestHost testHost = AssetFixture.GetTestHost(DoNotParallelizeProjectName);
+        TestHost testHost = AssetFixture.GetTestHost(DoNotParallelizeProjectName, tfm);
 
         string settingsPath = AssetFixture.GetRunSettingsPath(DoNotParallelizeProjectName);
         TestHostResult result = await testHost.ExecuteAsync($"--settings \"{settingsPath}\" --output detailed", cancellationToken: TestContext.CancellationToken);
@@ -72,7 +74,7 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
         Assert.Contains("succeeded: 3", result.StandardOutput);
         Assert.Contains("SimpleTest12", result.StandardOutput);
         Assert.Contains("SimpleTest22", result.StandardOutput);
-        Assert.AreEqual(1, AssetFixture.ReadMaximumConcurrency(DoNotParallelizeProjectName));
+        Assert.AreEqual(1, AssetFixture.ReadMaximumConcurrency(DoNotParallelizeProjectName, tfm));
     }
 
     public sealed class TestAssetFixture : ITestAssetFixture
@@ -80,15 +82,15 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
         private readonly TempDirectory _tempDirectory = new();
         private readonly Dictionary<string, TestAsset> _assets = [];
 
-        public TestHost GetTestHost(string projectName)
-            => TestHost.LocateFrom(_assets[projectName].TargetAssetPath, projectName, "net462");
+        public TestHost GetTestHost(string projectName, string tfm)
+            => TestHost.LocateFrom(_assets[projectName].TargetAssetPath, projectName, tfm);
 
         public string GetRunSettingsPath(string projectName)
             => Path.Combine(_assets[projectName].TargetAssetPath, "parallel.runsettings");
 
-        public int ReadMaximumConcurrency(string projectName)
+        public int ReadMaximumConcurrency(string projectName, string tfm)
         {
-            string probePath = Path.Combine(GetTestHost(projectName).DirectoryName, "ParallelProbe.txt");
+            string probePath = Path.Combine(GetTestHost(projectName, tfm).DirectoryName, "ParallelProbe.txt");
             return int.Parse(File.ReadAllText(probePath), CultureInfo.InvariantCulture);
         }
 
@@ -101,7 +103,9 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
                 (DoNotParallelizeProjectName, DoNotParallelizeSourceCode),
             })
             {
-                string patched = code.PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
+                string patched = code
+                    .PatchTargetFrameworks(TargetFrameworks.All)
+                    .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
                 TestAsset asset = await TestAsset.GenerateAssetAsync(projectName, patched, _tempDirectory);
                 await DotnetCli.RunAsync($"build \"{asset.TargetAssetPath}\" -c Release", callerMemberName: projectName, cancellationToken: cancellationToken);
                 _assets.Add(projectName, asset);
@@ -125,7 +129,7 @@ public sealed class ParallelExecutionTests : AcceptanceTestBase<ParallelExecutio
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <EnableMSTestRunner>true</EnableMSTestRunner>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/PlaywrightSdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/PlaywrightSdkTests.cs
@@ -41,9 +41,7 @@ public sealed class PlaywrightSdkTests : AcceptanceTestBase<PlaywrightSdkTests.T
     public async Task EnablePlaywrightProperty_WhenUsingVSTest_AllowsToRunPlaywrightTests(string tfm)
     {
         var testHost = TestHost.LocateFrom(AssetFixture.PlaywrightProjectPath, TestAssetFixture.PlaywrightProjectName, tfm);
-        string exeOrDllName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? testHost.FullName
-            : testHost.FullName + ".dll";
+        string exeOrDllName = GetTestExecutablePath(testHost);
         DotnetMuxerResult dotnetTestResult = await DotnetCli.RunAsync(
             $"test {exeOrDllName}",
             workingDirectory: AssetFixture.PlaywrightProjectPath,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -26,7 +26,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_RunTests_SendsTelemetryWithSettingsAndAttributes(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, MTPAssetName, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_DiscoverTests_SendsTelemetryEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, MTPAssetName, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -92,7 +92,7 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
     public async Task MTP_WhenTelemetryDisabled_DoesNotSendMSTestEvent(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.MTPProjectPath, "bin", "Release", tfm, TestResultsFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, MTPAssetName, tfm);
 
         var testHost = TestHost.LocateFrom(AssetFixture.MTPProjectPath, MTPAssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -193,17 +193,6 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         string content = await reader.ReadToEndAsync();
 
         return (Regex.IsMatch(content, pattern), content);
-    }
-
-    // Build a regex matching the deterministic default diagnostic file name shape:
-    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
-    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
-    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
-    {
-        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        const string FileNamePlaceholder = "__DIAG_FILENAME__";
-        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
-        return combinedPath.Replace(FileNamePlaceholder, $@"{MTPAssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     #endregion

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
@@ -20,7 +20,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_WhenDiagnosticIsSpecified_ReportIsGeneratedInDefaultLocation(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", cancellationToken: TestContext.CancellationToken);
@@ -46,7 +46,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_WhenDiagnosticAndOutputDirectoryAreSpecified_ReportIsGeneratedInSpecifiedLocation(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, "test1");
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         Assert.IsTrue(Directory.CreateDirectory(diagPath).Exists);
 
@@ -109,7 +109,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_EnableWithEnvironmentVariables_Succeeded(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -127,7 +127,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_EnableWithEnvironmentVariables_Verbosity_Succeeded(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -213,7 +213,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_EnableWithEnvironmentVariables_SynchronousWrite_Succeeded(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -234,7 +234,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_EnableWithEnvironmentVariables_SynchronousWrite_NewName_Succeeded(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -255,7 +255,7 @@ public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixtu
     public async Task Diag_EnableWithEnvironmentVariables_SynchronousWrite_NewNameTakesPrecedence(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
 
@@ -327,17 +327,6 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
-    }
-
-    // Build a regex matching the deterministic default diagnostic file name shape:
-    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
-    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
-    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
-    {
-        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        const string FileNamePlaceholder = "__DIAG_FILENAME__";
-        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
-        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -35,6 +35,32 @@ public abstract class AcceptanceTestBase
                     ? "osx-x64"
                     : throw new NotSupportedException("Current OS is not supported");
 
+    protected static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string assetName, string tfm)
+    {
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        const string FileNamePlaceholder = "__DIAG_FILENAME__";
+        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{assetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
+    }
+
+    protected static string GetTestExecutablePath(Microsoft.Testing.TestInfrastructure.TestHost testHost)
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? testHost.FullName
+            : testHost.FullName + ".dll";
+
+    protected static async Task<Microsoft.Testing.TestInfrastructure.TestHost> CloneTestHostAsync(
+        Microsoft.Testing.TestInfrastructure.TestHost testHost,
+        TempDirectory clone,
+        string assetName)
+    {
+        await clone.CopyDirectoryAsync(
+            testHost.DirectoryName,
+            clone.Path,
+            retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+        return Microsoft.Testing.TestInfrastructure.TestHost.LocateFrom(clone.Path, assetName);
+    }
+
     public static string MSTestVersion { get; private set; }
 
     public static string MSTestSourceGenerationVersion { get; private set; }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryDisabledTests.cs
@@ -15,7 +15,7 @@ public sealed class TelemetryDisabledTests : AcceptanceTestBase<TelemetryDisable
     public async Task Telemetry_WhenEnableTelemetryIsFalse_WithTestApplicationOptions_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -53,17 +53,6 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
-    }
-
-    // Build a regex matching the deterministic default diagnostic file name shape:
-    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
-    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
-    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
-    {
-        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        const string FileNamePlaceholder = "__DIAG_FILENAME__";
-        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
-        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -15,7 +15,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_ByDefault_TelemetryIsEnabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync("--diagnostic", disableTelemetry: false, cancellationToken: TestContext.CancellationToken);
@@ -37,7 +37,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_WithEnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -66,7 +66,7 @@ public class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAssetFixture
     public async Task Telemetry_WhenOptingOutTelemetry_With_DOTNET_CLI_EnvironmentVariable_TelemetryIsDisabled(string tfm)
     {
         string diagPath = Path.Combine(AssetFixture.TargetAssetPath, "bin", "Release", tfm, AggregatedConfiguration.DefaultTestResultFolderName);
-        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, tfm);
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, tfm);
 
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         TestHostResult testHostResult = await testHost.ExecuteAsync(
@@ -111,17 +111,6 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
         using var reader = new StreamReader(path);
         string content = await reader.ReadToEndAsync();
         return (Regex.IsMatch(content, pattern), content);
-    }
-
-    // Build a regex matching the deterministic default diagnostic file name shape:
-    // "<asset-name>_<tfm>_<arch>_<yyMMddHHmmssfff>.diag". The arch token is taken from the
-    // current process (the testhost runs on the same machine, so its ProcessArchitecture matches).
-    private static string BuildDefaultDiagnosticFilePathPattern(string diagPath, string tfm)
-    {
-        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-        const string FileNamePlaceholder = "__DIAG_FILENAME__";
-        string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
-        return combinedPath.Replace(FileNamePlaceholder, $@"{AssetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestConfigEnvironmentVariablesTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestConfigEnvironmentVariablesTests.cs
@@ -14,8 +14,7 @@ public sealed class TestConfigEnvironmentVariablesTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         using TempDirectory clone = new();
-        await clone.CopyDirectoryAsync(testHost.DirectoryName, clone.Path, retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        testHost = TestInfrastructure.TestHost.LocateFrom(clone.Path, AssetName);
+        testHost = await CloneTestHostAsync(testHost, clone, AssetName);
 
         string configFile = Path.Combine(testHost.DirectoryName, $"{AssetName}.testconfig.json");
         await File.WriteAllTextAsync(
@@ -48,8 +47,7 @@ public sealed class TestConfigEnvironmentVariablesTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         using TempDirectory clone = new();
-        await clone.CopyDirectoryAsync(testHost.DirectoryName, clone.Path, retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        testHost = TestInfrastructure.TestHost.LocateFrom(clone.Path, AssetName);
+        testHost = await CloneTestHostAsync(testHost, clone, AssetName);
 
         string configFile = Path.Combine(testHost.DirectoryName, $"{AssetName}.testconfig.json");
         File.Delete(configFile);
@@ -71,8 +69,7 @@ public sealed class TestConfigEnvironmentVariablesTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         using TempDirectory clone = new();
-        await clone.CopyDirectoryAsync(testHost.DirectoryName, clone.Path, retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        testHost = TestInfrastructure.TestHost.LocateFrom(clone.Path, AssetName);
+        testHost = await CloneTestHostAsync(testHost, clone, AssetName);
 
         string configFile = Path.Combine(testHost.DirectoryName, $"{AssetName}.testconfig.json");
         await File.WriteAllTextAsync(

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/UnhandledExceptionPolicyTests.cs
@@ -35,8 +35,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "UnhandledExceptionPolicyTests", tfm);
         using TempDirectory clone = new();
-        await clone.CopyDirectoryAsync(testHost.DirectoryName, clone.Path, retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        testHost = TestInfrastructure.TestHost.LocateFrom(clone.Path, "UnhandledExceptionPolicyTests");
+        testHost = await CloneTestHostAsync(testHost, clone, "UnhandledExceptionPolicyTests");
         string configFileName = Path.Combine(testHost.DirectoryName, "UnhandledExceptionPolicyTests.testconfig.json");
         string contentFile = await File.ReadAllTextAsync(Path.Combine(testHost.DirectoryName, "UnhandledExceptionPolicyTests.testconfig.json"), TestContext.CancellationToken);
 
@@ -98,8 +97,7 @@ public class UnhandledExceptionPolicyTests : AcceptanceTestBase<UnhandledExcepti
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, "UnhandledExceptionPolicyTests", tfm);
         using TempDirectory clone = new();
-        await clone.CopyDirectoryAsync(testHost.DirectoryName, clone.Path, retainAttributes: !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
-        testHost = TestInfrastructure.TestHost.LocateFrom(clone.Path, "UnhandledExceptionPolicyTests");
+        testHost = await CloneTestHostAsync(testHost, clone, "UnhandledExceptionPolicyTests");
         string configFileName = Path.Combine(testHost.DirectoryName, "UnhandledExceptionPolicyTests.testconfig.json");
         string contentFile = await File.ReadAllTextAsync(Path.Combine(testHost.DirectoryName, "UnhandledExceptionPolicyTests.testconfig.json"), TestContext.CancellationToken);
 


### PR DESCRIPTION
## Summary
- extract shared helpers for diagnostic paths, test executable paths, and cloned test hosts
- remove unnecessary Windows-only conditions from F# and parallel execution acceptance tests
- run those scenarios across the supported OS-aware target framework matrix

## Validation
- `build.cmd -pack -configuration Debug`
- 32 targeted MSTest acceptance tests passed
- 99 targeted Microsoft.Testing.Platform acceptance tests passed