### PR TITLE
docs: Rename testCases to tests in RunTestsParams interface

### DIFF
--- a/docs/mstest-runner-protocol/001-protocol-intro.md
+++ b/docs/mstest-runner-protocol/001-protocol-intro.md
@@ -555,7 +555,7 @@ Request:
 interface RunTestsParams {
     // The set of tests selected by the user to run.
     // If not specified all tests will run.
-    testCases?: TestNode[],
+    tests?: TestNode[],
 
     // Token which should be specified for all update notifications.
     // This way the client can under which the update notifications should be reported.


### PR DESCRIPTION
When developing the MTP testrunner for Stryker.NET I noticed a mistake in the docs. The real param for test filtering is named `tests`. This can be seen [here](https://github.com/microsoft/testfx/blob/fd744761254d82f054ebba7f8479af01f3822c5a/samples/Playground/ServerMode/v1.0.0/RunRequest.cs#L9). I've verified and test filtering only works when using `tests`, not `testCases` like specified in the docs.