### PR TITLE
Remove duplicate test output forwarding

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorRouter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleErrorRouter.cs
@@ -13,11 +13,11 @@ internal sealed class ConsoleErrorRouter : ConsoleRouter
     }
 
     protected override void WriteToTestContext(TestContextImplementation testContext, char value)
-        => testContext.WriteConsoleErr(value);
+        => testContext.StandardErrorBuilder.Append(value);
 
     protected override void WriteToTestContext(TestContextImplementation testContext, string? value)
-        => testContext.WriteConsoleErr(value);
+        => testContext.StandardErrorBuilder.Append(value);
 
     protected override void WriteToTestContext(TestContextImplementation testContext, char[] buffer, int index, int count)
-        => testContext.WriteConsoleErr(buffer, index, count);
+        => testContext.StandardErrorBuilder.Append(buffer, index, count);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutRouter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/ConsoleOutRouter.cs
@@ -13,11 +13,11 @@ internal sealed class ConsoleOutRouter : ConsoleRouter
     }
 
     protected override void WriteToTestContext(TestContextImplementation testContext, char value)
-        => testContext.WriteConsoleOut(value);
+        => testContext.StandardOutputBuilder.Append(value);
 
     protected override void WriteToTestContext(TestContextImplementation testContext, string? value)
-        => testContext.WriteConsoleOut(value);
+        => testContext.StandardOutputBuilder.Append(value);
 
     protected override void WriteToTestContext(TestContextImplementation testContext, char[] buffer, int index, int count)
-        => testContext.WriteConsoleOut(buffer, index, count);
+        => testContext.StandardOutputBuilder.Append(buffer, index, count);
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
@@ -27,7 +27,7 @@ internal sealed class TraceTextWriter : TextWriter
         TestOutputCaptureMode mode = _modeProvider();
         if (mode != TestOutputCaptureMode.None && TestContext.Current as TestContextImplementation is { } testContext)
         {
-            testContext.WriteTrace(value);
+            testContext.TraceBuilder.Append(value);
             if (mode == TestOutputCaptureMode.Live)
             {
                 _console.Write(value);
@@ -40,7 +40,7 @@ internal sealed class TraceTextWriter : TextWriter
         TestOutputCaptureMode mode = _modeProvider();
         if (mode != TestOutputCaptureMode.None && TestContext.Current as TestContextImplementation is { } testContext)
         {
-            testContext.WriteTrace(value);
+            testContext.TraceBuilder.Append(value);
             if (mode == TestOutputCaptureMode.Live)
             {
                 _console.Write(value);

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.cs
@@ -69,7 +69,7 @@ internal sealed partial class UnitTestRunner
         // Bridge the adapter setting to the TestFramework for assertion failure behavior.
         AssertionFailureSettings.LaunchDebuggerOnAssertionFailure = MSTestSettings.CurrentSettings.LaunchDebuggerOnAssertionFailure;
 
-        Logger.OnLogMessage += message => (TestContext.Current as TestContextImplementation)?.WriteConsoleOut(message);
+        Logger.OnLogMessage += message => (TestContext.Current as TestContextImplementation)?.StandardOutputBuilder.Append(message);
 
         ConfigureOutputRouting(MSTestSettings.CurrentSettings.OutputCaptureMode);
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -3,6 +3,14 @@
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleOutRouter.ConsoleOutRouter(System.IO.TextWriter! originalConsoleOut) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleRouter.ConsoleRouter(System.IO.TextWriter! originalConsole) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TraceTextWriter.TraceTextWriter() -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(char value) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(char[]! buffer, int index, int count) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(string? value) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleOut(char value) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleOut(char[]! buffer, int index, int count) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleOut(string? value) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteTrace(char value) -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteTrace(string? value) -> void
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleErrorRouter.ConsoleErrorRouter(System.IO.TextWriter! originalConsoleErr, System.Func<Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode>! modeProvider) -> void
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleOutRouter.ConsoleOutRouter(System.IO.TextWriter! originalConsoleOut, System.Func<Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode>! modeProvider) -> void
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleRouter.ConsoleRouter(System.IO.TextWriter! originalConsole, System.Func<Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode>! modeProvider) -> void
@@ -19,6 +27,9 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Live = 2 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.None = 0 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Result = 1 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardErrorBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardOutputBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.TraceBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ParameterMetadataScanCount.get -> int
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ResetParameterMetadataCacheForTesting() -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.SetParameterMetadataScanCallbackForTesting(System.Action? callback) -> void

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -227,7 +227,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     public override void Write(string? message)
     {
         string? msg = message?.Replace("\0", "\\0");
-        GetTestContextMessagesStringBuilder().Append(msg);
+        TestContextMessageBuilder.Append(msg);
         WriteLive(msg, appendLine: false);
     }
 
@@ -240,7 +240,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     public override void Write(string format, params object?[] args)
     {
         string message = string.Format(CultureInfo.CurrentCulture, format.Replace("\0", "\\0"), args);
-        GetTestContextMessagesStringBuilder().Append(message);
+        TestContextMessageBuilder.Append(message);
         WriteLive(message, appendLine: false);
     }
 
@@ -252,7 +252,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     public override void WriteLine(string? message)
     {
         string? msg = message?.Replace("\0", "\\0");
-        GetTestContextMessagesStringBuilder().AppendLine(msg);
+        TestContextMessageBuilder.AppendLine(msg);
         WriteLive(msg, appendLine: true);
     }
 
@@ -265,7 +265,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     public override void WriteLine(string format, params object?[] args)
     {
         string message = string.Format(CultureInfo.CurrentCulture, format.Replace("\0", "\\0"), args);
-        GetTestContextMessagesStringBuilder().AppendLine(message);
+        TestContextMessageBuilder.AppendLine(message);
         WriteLive(message, appendLine: true);
     }
 
@@ -505,52 +505,23 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     internal static void ConfigureLiveOutputWriter(TextWriter liveOutputWriter)
         => Volatile.Write(ref s_liveOutputWriter, liveOutputWriter);
 
-    internal void WriteConsoleOut(char value)
-        => GetOutStringBuilder().Append(value);
+    internal SynchronizedStringBuilder StandardOutputBuilder
+        => GetOrCreate(ref _stdOutStringBuilder);
 
-    internal void WriteConsoleOut(string? value)
-        => GetOutStringBuilder().Append(value);
+    internal SynchronizedStringBuilder StandardErrorBuilder
+        => GetOrCreate(ref _stdErrStringBuilder);
 
-    internal void WriteConsoleOut(char[] buffer, int index, int count)
-        => GetOutStringBuilder().Append(buffer, index, count);
+    internal SynchronizedStringBuilder TraceBuilder
+        => GetOrCreate(ref _traceStringBuilder);
 
-    internal void WriteConsoleErr(char value)
-        => GetErrStringBuilder().Append(value);
+    private SynchronizedStringBuilder TestContextMessageBuilder
+        => GetOrCreate(ref _testContextMessageStringBuilder);
 
-    internal void WriteConsoleErr(string? value)
-        => GetErrStringBuilder().Append(value);
-
-    internal void WriteConsoleErr(char[] buffer, int index, int count)
-        => GetErrStringBuilder().Append(buffer, index, count);
-
-    internal void WriteTrace(char value)
-        => GetTraceStringBuilder().Append(value);
-
-    internal void WriteTrace(string? value)
-        => GetTraceStringBuilder().Append(value);
-
-    private SynchronizedStringBuilder GetOutStringBuilder()
+    private static SynchronizedStringBuilder GetOrCreate(ref SynchronizedStringBuilder? builder)
     {
-        _ = _stdOutStringBuilder ?? Interlocked.CompareExchange(ref _stdOutStringBuilder, new SynchronizedStringBuilder(), null)!;
-        return _stdOutStringBuilder;
-    }
+        _ = builder ?? Interlocked.CompareExchange(ref builder, new SynchronizedStringBuilder(), null)!;
 
-    private SynchronizedStringBuilder GetErrStringBuilder()
-    {
-        _ = _stdErrStringBuilder ?? Interlocked.CompareExchange(ref _stdErrStringBuilder, new SynchronizedStringBuilder(), null)!;
-        return _stdErrStringBuilder;
-    }
-
-    private SynchronizedStringBuilder GetTraceStringBuilder()
-    {
-        _ = _traceStringBuilder ?? Interlocked.CompareExchange(ref _traceStringBuilder, new SynchronizedStringBuilder(), null)!;
-        return _traceStringBuilder;
-    }
-
-    private SynchronizedStringBuilder GetTestContextMessagesStringBuilder()
-    {
-        _ = _testContextMessageStringBuilder ?? Interlocked.CompareExchange(ref _testContextMessageStringBuilder, new SynchronizedStringBuilder(), null)!;
-        return _testContextMessageStringBuilder;
+        return builder;
     }
 
     private void WriteLive(string? message, bool appendLine)

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -1920,6 +1920,8 @@ public class TestMethodInfoTests : TestContainer
 
         result1.DebugTrace.Should().Be("trace_output");
         result2.DebugTrace.Should().Be("trace_output");
+        result1.LogError.Should().BeNull();
+        result2.LogError.Should().BeNull();
     }
 
     public void Ctor_WhenMethodHasMultipleRetryBaseAttributes_ThrowsTypeInspectionException()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodInfoTests.cs
@@ -407,7 +407,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task TestMethodInfoInvokeShouldClearStdOutAfterReporting()
     {
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteConsoleOut("output1");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.StandardOutputBuilder.Append("output1");
 
         var method = new TestMethodInfo(
             _methodInfo,
@@ -420,7 +420,7 @@ public class TestMethodInfoTests : TestContainer
         TestResult result1 = await method.InvokeAsync(null);
         result1.LogOutput.Should().Contain("output1");
 
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteConsoleOut("output2");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.StandardOutputBuilder.Append("output2");
         TestResult result2 = await method.InvokeAsync(null);
 
         result2.LogOutput.Should().Contain("output2");
@@ -429,7 +429,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task TestMethodInfoInvokeShouldClearStdErrAfterReporting()
     {
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteConsoleErr("error1");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.StandardErrorBuilder.Append("error1");
 
         var method = new TestMethodInfo(
             _methodInfo,
@@ -442,7 +442,7 @@ public class TestMethodInfoTests : TestContainer
         TestResult result1 = await method.InvokeAsync(null);
         result1.LogError.Should().Contain("error1");
 
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteConsoleErr("error2");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.StandardErrorBuilder.Append("error2");
         TestResult result2 = await method.InvokeAsync(null);
 
         result2.LogError.Should().Contain("error2");
@@ -451,7 +451,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task TestMethodInfoInvokeShouldClearDebugTraceAfterReporting()
     {
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteTrace("trace1");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.TraceBuilder.Append("trace1");
 
         var method = new TestMethodInfo(
             _methodInfo,
@@ -464,7 +464,7 @@ public class TestMethodInfoTests : TestContainer
         TestResult result1 = await method.InvokeAsync(null);
         result1.DebugTrace.Should().Contain("trace1");
 
-        DummyTestClass.TestMethodBody = o => _testContextImplementation.WriteTrace("trace2");
+        DummyTestClass.TestMethodBody = o => _testContextImplementation.TraceBuilder.Append("trace2");
         TestResult result2 = await method.InvokeAsync(null);
 
         result2.DebugTrace.Should().Contain("trace2");
@@ -1891,7 +1891,7 @@ public class TestMethodInfoTests : TestContainer
     // TestContextImplementationTests.GetAndClear{Output,Error,Trace}_ShouldReturnContentThenClearBuffer.
     public async Task InvokeAsync_ShouldNotAccumulateLogOutputAcrossMultipleInvocations()
     {
-        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleOut("invocation_output");
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.StandardOutputBuilder.Append("invocation_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);
         TestResult result2 = await _testMethodInfo.InvokeAsync(null);
@@ -1902,7 +1902,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task InvokeAsync_ShouldNotAccumulateLogErrorAcrossMultipleInvocations()
     {
-        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteConsoleErr("error_output");
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.StandardErrorBuilder.Append("error_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);
         TestResult result2 = await _testMethodInfo.InvokeAsync(null);
@@ -1913,7 +1913,7 @@ public class TestMethodInfoTests : TestContainer
 
     public async Task InvokeAsync_ShouldNotAccumulateDebugTraceAcrossMultipleInvocations()
     {
-        DummyTestClass.TestMethodBody = _ => _testContextImplementation.WriteTrace("trace_output");
+        DummyTestClass.TestMethodBody = _ => _testContextImplementation.TraceBuilder.Append("trace_output");
 
         TestResult result1 = await _testMethodInfo.InvokeAsync(null);
         TestResult result2 = await _testMethodInfo.InvokeAsync(null);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/TestMethodRunnerTests.cs
@@ -493,7 +493,7 @@ public class TestMethodRunnerTests : TestContainer
 
             // Write a fairly large chunk of console output. If contexts were shared, the next
             // iteration would observe a non-zero existing length.
-            current.WriteConsoleOut(new string('x', 1024));
+            current.StandardOutputBuilder.Append(new string('x', 1024));
             return new TestResult { Outcome = UnitTestOutcome.Passed };
         });
         var testMethodRunner = new TestMethodRunner(testMethodInfo, _testMethod, _testContextImplementation);

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/TestContextImplementationTests.cs
@@ -364,7 +364,7 @@ public class TestContextImplementationTests : TestContainer
     public void GetAndClearOutput_ShouldReturnContentThenClearBuffer()
     {
         _testContextImplementation = CreateTestContextImplementation();
-        _testContextImplementation.WriteConsoleOut("hello");
+        _testContextImplementation.StandardOutputBuilder.Append("hello");
 
         string? first = _testContextImplementation.GetAndClearOutput();
         string? second = _testContextImplementation.GetAndClearOutput();
@@ -376,7 +376,7 @@ public class TestContextImplementationTests : TestContainer
     public void GetAndClearError_ShouldReturnContentThenClearBuffer()
     {
         _testContextImplementation = CreateTestContextImplementation();
-        _testContextImplementation.WriteConsoleErr("hello");
+        _testContextImplementation.StandardErrorBuilder.Append("hello");
 
         string? first = _testContextImplementation.GetAndClearError();
         string? second = _testContextImplementation.GetAndClearError();
@@ -388,7 +388,7 @@ public class TestContextImplementationTests : TestContainer
     public void GetAndClearTrace_ShouldReturnContentThenClearBuffer()
     {
         _testContextImplementation = CreateTestContextImplementation();
-        _testContextImplementation.WriteTrace("hello");
+        _testContextImplementation.TraceBuilder.Append("hello");
 
         string? first = _testContextImplementation.GetAndClearTrace();
         string? second = _testContextImplementation.GetAndClearTrace();
@@ -404,8 +404,8 @@ public class TestContextImplementationTests : TestContainer
         {
             for (int i = 0; i < 100; i++)
             {
-                testContextImplementation.WriteConsoleOut(new string('a', 1000000));
-                testContextImplementation.WriteConsoleErr(new string('b', 1000000));
+                testContextImplementation.StandardOutputBuilder.Append(new string('a', 1000000));
+                testContextImplementation.StandardErrorBuilder.Append(new string('b', 1000000));
             }
         });
 
@@ -631,9 +631,9 @@ public class TestContextImplementationTests : TestContainer
     public void CloneForDataDrivenIterationShouldStartWithNoAccumulatedOutput()
     {
         _testContextImplementation = CreateTestContextImplementation();
-        _testContextImplementation.WriteConsoleOut("orig-out");
-        _testContextImplementation.WriteConsoleErr("orig-err");
-        _testContextImplementation.WriteTrace("orig-trace");
+        _testContextImplementation.StandardOutputBuilder.Append("orig-out");
+        _testContextImplementation.StandardErrorBuilder.Append("orig-err");
+        _testContextImplementation.TraceBuilder.Append("orig-trace");
         _testContextImplementation.WriteLine("orig-diag");
 
         TestContextImplementation clone = _testContextImplementation.CloneForDataDrivenIteration();
@@ -646,7 +646,7 @@ public class TestContextImplementationTests : TestContainer
 
         // The clone's output buffers are independent: writing to the clone does not flow back
         // to the original.
-        clone.WriteConsoleOut("clone-only");
+        clone.StandardOutputBuilder.Append("clone-only");
         _testContextImplementation.GetAndClearOutput().Should().Be("orig-out");
         clone.GetAndClearOutput().Should().Be("clone-only");
     }


### PR DESCRIPTION
## Summary
- expose the synchronized stdout, stderr, and trace builders directly to their internal routing call sites
- replace four repeated lazy-initialization accessors with one `GetOrCreate` helper
- remove the eight duplicated `Write*` forwarding overloads and update the internal API baseline

## Validation
- `MSTestAdapter.PlatformServices.UnitTests` passed on net462, net48, net8.0, net9.0, and net8.0-windows10.0.18362.0
- build completed with 0 warnings and 0 errors

Closes #10054
Closes #10060
Closes #10065
Closes #10066