### PR TITLE
Add outstanding test improver coverage

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidOutRefTestMethodParametersFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidOutRefTestMethodParametersFixer.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 
 using MSTest.Analyzers.Helpers;
@@ -61,18 +62,42 @@ public sealed class AvoidOutRefTestMethodParametersFixer : CodeFixProvider
         DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         foreach (ParameterSyntax parameter in methodDeclaration.ParameterList.Parameters)
         {
-            if (!parameter.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.OutKeyword) || modifier.IsKind(SyntaxKind.RefKeyword)))
+            SyntaxToken[] removedModifiers = parameter.Modifiers
+                .Where(modifier => modifier.IsKind(SyntaxKind.OutKeyword)
+                    || modifier.IsKind(SyntaxKind.RefKeyword)
+                    || modifier.IsKind(SyntaxKind.ReadOnlyKeyword))
+                .ToArray();
+            if (!removedModifiers.Any(modifier => modifier.IsKind(SyntaxKind.OutKeyword) || modifier.IsKind(SyntaxKind.RefKeyword)))
             {
                 continue;
             }
 
             SyntaxTokenList filteredModifiers = SyntaxFactory.TokenList(
-                parameter.Modifiers.Where(modifier =>
-                    !modifier.IsKind(SyntaxKind.OutKeyword)
-                    && !modifier.IsKind(SyntaxKind.RefKeyword)
-                    && !modifier.IsKind(SyntaxKind.ReadOnlyKeyword)));
+                parameter.Modifiers.Except(removedModifiers));
 
-            editor.ReplaceNode(parameter, parameter.WithModifiers(filteredModifiers).WithLeadingTrivia(parameter.GetLeadingTrivia()));
+            ParameterSyntax updatedParameter = parameter.WithModifiers(filteredModifiers);
+            SyntaxTrivia[] removedTrivia = removedModifiers
+                .SelectMany(modifier => modifier.LeadingTrivia.Concat(modifier.TrailingTrivia))
+                .ToArray();
+            SyntaxTrivia[] preservedTrivia = removedTrivia
+                .SkipWhile(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                .Reverse()
+                .SkipWhile(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                .Reverse()
+                .ToArray();
+            IEnumerable<SyntaxTrivia> typeLeadingTrivia = preservedTrivia.Length > 0
+                && !preservedTrivia[^1].IsKind(SyntaxKind.EndOfLineTrivia)
+                    ? preservedTrivia.Append(SyntaxFactory.Space)
+                    : preservedTrivia;
+
+            updatedParameter = parameter.Type is { } parameterType
+                && preservedTrivia.Any(trivia => !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                    ? updatedParameter.WithType(parameterType.WithLeadingTrivia(typeLeadingTrivia.Concat(parameterType.GetLeadingTrivia())))
+                    : updatedParameter.WithLeadingTrivia(parameter.GetLeadingTrivia());
+
+            editor.ReplaceNode(
+                parameter,
+                updatedParameter.WithAdditionalAnnotations(Formatter.Annotation));
         }
 
         return editor.GetChangedDocument();

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidOutRefTestMethodParametersFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/AvoidOutRefTestMethodParametersFixer.cs
@@ -61,20 +61,18 @@ public sealed class AvoidOutRefTestMethodParametersFixer : CodeFixProvider
         DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
         foreach (ParameterSyntax parameter in methodDeclaration.ParameterList.Parameters)
         {
-            int indexToRemove = parameter.Modifiers.IndexOf(SyntaxKind.OutKeyword);
-            if (indexToRemove < 0)
+            if (!parameter.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.OutKeyword) || modifier.IsKind(SyntaxKind.RefKeyword)))
             {
-                indexToRemove = parameter.Modifiers.IndexOf(SyntaxKind.RefKeyword);
+                continue;
             }
 
-            if (indexToRemove >= 0)
-            {
-                editor.ReplaceNode(parameter, (node, _) =>
-                {
-                    var parameter = (ParameterSyntax)node;
-                    return parameter.WithModifiers(parameter.Modifiers.RemoveAt(indexToRemove)).WithLeadingTrivia(parameter.GetLeadingTrivia());
-                });
-            }
+            SyntaxTokenList filteredModifiers = SyntaxFactory.TokenList(
+                parameter.Modifiers.Where(modifier =>
+                    !modifier.IsKind(SyntaxKind.OutKeyword)
+                    && !modifier.IsKind(SyntaxKind.RefKeyword)
+                    && !modifier.IsKind(SyntaxKind.ReadOnlyKeyword)));
+
+            editor.ReplaceNode(parameter, parameter.WithModifiers(filteredModifiers).WithLeadingTrivia(parameter.GetLeadingTrivia()));
         }
 
         return editor.GetChangedDocument();

--- a/src/Analyzers/MSTest.Analyzers/AvoidOutRefTestMethodParametersAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidOutRefTestMethodParametersAnalyzer.cs
@@ -72,7 +72,7 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzer : DiagnosticAnalyzer
         || parameter.DeclaringSyntaxReferences.Any(reference =>
         {
             SyntaxNode parameterSyntax = reference.GetSyntax(cancellationToken);
-            return parameterSyntax.ChildTokens().Any(token => token.ValueText is "ref")
-                && parameterSyntax.ChildTokens().Any(token => token.ValueText is "readonly");
+            return parameterSyntax.ChildTokens().Any(token => token.Text is "ref")
+                && parameterSyntax.ChildTokens().Any(token => token.Text is "readonly");
         });
 }

--- a/src/Analyzers/MSTest.Analyzers/AvoidOutRefTestMethodParametersAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/AvoidOutRefTestMethodParametersAnalyzer.cs
@@ -61,9 +61,18 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzer : DiagnosticAnalyzer
         }
 
         // Check for out/ref parameters
-        if (methodSymbol.Parameters.Any(p => p.RefKind is RefKind.Out or RefKind.Ref))
+        if (methodSymbol.Parameters.Any(parameter => IsOutOrRefParameter(parameter, context.CancellationToken)))
         {
             context.ReportDiagnostic(methodSymbol.CreateDiagnostic(AvoidOutRefParametersRule, methodSymbol.Name));
         }
     }
+
+    private static bool IsOutOrRefParameter(IParameterSymbol parameter, CancellationToken cancellationToken)
+        => parameter.RefKind is RefKind.Out or RefKind.Ref
+        || parameter.DeclaringSyntaxReferences.Any(reference =>
+        {
+            SyntaxNode parameterSyntax = reference.GetSyntax(cancellationToken);
+            return parameterSyntax.ChildTokens().Any(token => token.ValueText is "ref")
+                && parameterSyntax.ChildTokens().Any(token => token.ValueText is "readonly");
+        });
 }

--- a/src/Analyzers/MSTest.Analyzers/NonNullableReferenceNotInitializedSuppressor.cs
+++ b/src/Analyzers/MSTest.Analyzers/NonNullableReferenceNotInitializedSuppressor.cs
@@ -65,6 +65,7 @@ public sealed class NonNullableReferenceNotInitializedSuppressor : DiagnosticSup
             if (declaredSymbol is IPropertySymbol property
                 && string.Equals(property.Name, "TestContext", StringComparison.Ordinal)
                 && SymbolEqualityComparer.Default.Equals(testContextSymbol, property.GetMethod?.ReturnType)
+                && property.DeclaredAccessibility == Accessibility.Public
                 && property.SetMethod is not null
                 && property.ContainingType.GetAttributes().Any(attr => attr.AttributeClass.Inherits(testClassAttributeSymbol)))
             {

--- a/src/Analyzers/MSTest.Analyzers/NonNullableReferenceNotInitializedSuppressor.cs
+++ b/src/Analyzers/MSTest.Analyzers/NonNullableReferenceNotInitializedSuppressor.cs
@@ -65,6 +65,7 @@ public sealed class NonNullableReferenceNotInitializedSuppressor : DiagnosticSup
             if (declaredSymbol is IPropertySymbol property
                 && string.Equals(property.Name, "TestContext", StringComparison.Ordinal)
                 && SymbolEqualityComparer.Default.Equals(testContextSymbol, property.GetMethod?.ReturnType)
+                && property.SetMethod is not null
                 && property.ContainingType.GetAttributes().Any(attr => attr.AttributeClass.Inherits(testClassAttributeSymbol)))
             {
                 context.ReportSuppression(Suppression.Create(Rule, diagnostic));

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssertThrowsShouldContainSingleStatementAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssertThrowsShouldContainSingleStatementAnalyzerTests.cs
@@ -640,9 +640,8 @@ public sealed class AssertThrowsShouldContainSingleStatementAnalyzerTests
     [TestMethod]
     public async Task WhenAssertThrowsReceivesNonLambdaDelegate_CSharp_NoDiagnostic()
     {
-        // When a delegate variable (not an inline lambda) is passed to Assert.Throws, the
-        // delegate creation wraps an IMethodReferenceOperation, not IAnonymousFunctionOperation,
-        // so the analyzer's early-return guard fires and no diagnostic is emitted.
+        // An existing delegate local is an ILocalReferenceOperation, not an
+        // IDelegateCreationOperation, so the analyzer's early-return guard fires.
         string code = """
             using System;
             using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssertThrowsShouldContainSingleStatementAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssertThrowsShouldContainSingleStatementAnalyzerTests.cs
@@ -602,4 +602,69 @@ public sealed class AssertThrowsShouldContainSingleStatementAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenAssertThrowsReceivesMethodGroup_CSharp_NoDiagnostic()
+    {
+        // When a method group (not a lambda) is passed to Assert.Throws, the delegate creation
+        // target is an IMethodReferenceOperation, not IAnonymousFunctionOperation.
+        // The analyzer's early-return guard ('delegateCreation.Target is not IAnonymousFunctionOperation')
+        // fires, so no diagnostic is reported regardless of how many statements the method contains.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    // Method group passed as Action — not a lambda, so the analyzer cannot inspect
+                    // the body and must not fire.
+                    Assert.Throws<Exception>(DoSomethingMultiple);
+                    Assert.ThrowsExactly<Exception>(DoSomethingMultiple);
+                }
+
+                private static void DoSomethingMultiple()
+                {
+                    Console.WriteLine("one");
+                    throw new Exception("two");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssertThrowsReceivesNonLambdaDelegate_CSharp_NoDiagnostic()
+    {
+        // When a delegate variable (not an inline lambda) is passed to Assert.Throws, the
+        // delegate creation wraps an IMethodReferenceOperation, not IAnonymousFunctionOperation,
+        // so the analyzer's early-return guard fires and no diagnostic is emitted.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    Action multiStep = () =>
+                    {
+                        Console.WriteLine("one");
+                        throw new Exception("two");
+                    };
+
+                    // The delegate is referenced by name, not created inline — no diagnostic expected.
+                    Assert.Throws<Exception>(multiStep);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
@@ -390,8 +390,8 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
     [TestMethod]
     public async Task WhenBothArgsAreNullLiterals_NoDiagnostic()
     {
-        // null cast to a reference type has IsValueType == false after WalkDownConversion().
-        // Neither arg is a value type, so no diagnostic should fire.
+        // WalkDownConversion() removes the object conversion, leaving an untyped null literal.
+        // The null-propagating IsValueType check therefore does not report a diagnostic.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -455,8 +455,8 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
     [TestMethod]
     public async Task WhenGenericTypeParameterWithNoConstraint_NoDiagnostic()
     {
-        // An unconstrained generic type parameter is not a value type (IsValueType == false),
-        // so the analyzer should not report a diagnostic.
+        // An unconstrained generic type parameter is not known to be a value type at analysis time,
+        // so the analyzer should not report a diagnostic even though T can be instantiated with one.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidAssertAreSameWithValueTypesAnalyzerTests.cs
@@ -386,4 +386,92 @@ public sealed class AvoidAssertAreSameWithValueTypesAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenBothArgsAreNullLiterals_NoDiagnostic()
+    {
+        // null cast to a reference type has IsValueType == false after WalkDownConversion().
+        // Neither arg is a value type, so no diagnostic should fire.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    Assert.AreSame((object)null, (object)null);
+                    Assert.AreNotSame((object)null, (object)null);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenGenericTypeParameterConstrainedToStruct_Diagnostic()
+    {
+        // A generic type parameter constrained to 'struct' has IsValueType == true,
+        // so the analyzer should report a diagnostic and the fixer should replace the method name.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod<T>() where T : struct
+                {
+                    T a = default;
+                    T b = default;
+                    [|Assert.AreSame(a, b)|];
+                    [|Assert.AreNotSame(a, b)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod<T>() where T : struct
+                {
+                    T a = default;
+                    T b = default;
+                    Assert.AreEqual(a, b);
+                    Assert.AreNotEqual(a, b);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenGenericTypeParameterWithNoConstraint_NoDiagnostic()
+    {
+        // An unconstrained generic type parameter is not a value type (IsValueType == false),
+        // so the analyzer should not report a diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod<T>(T a, T b)
+                {
+                    Assert.AreSame(a, b);
+                    Assert.AreNotSame(a, b);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -327,10 +327,8 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
 
 #if NET
     [TestMethod]
-    public async Task WhenTestMethodHasRefReadonlyParameter_NoDiagnostic()
+    public async Task WhenTestMethodHasRefReadonlyParameter_Diagnostic()
     {
-        // 'ref readonly' parameters have RefKind.RefReadOnlyParameter, which is neither
-        // RefKind.Out nor RefKind.Ref, so the analyzer must not report a diagnostic.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -338,13 +336,26 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
             public class MyTestClass
             {
                 [TestMethod]
-                public void TestMethod1(ref readonly int value)
+                public void [|TestMethod1|](ref readonly int value)
                 {
                 }
             }
             """;
 
-        await VerifyCS.VerifyCodeFixAsync(code, code);
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
 #endif
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -358,4 +358,27 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
 #endif
+
+    [TestMethod]
+    public async Task WhenParameterTypeAndNameAreEscapedKeywords_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public sealed class @ref
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1(@ref @readonly)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -357,6 +357,38 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenRefReadonlyModifiersContainComment_CodeFixPreservesComment()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void [|TestMethod1|](ref /* rationale */ readonly int value)
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1(/* rationale */ int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 #endif
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AvoidOutRefTestMethodParametersAnalyzerTests.cs
@@ -324,4 +324,27 @@ public sealed class AvoidOutRefTestMethodParametersAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+#if NET
+    [TestMethod]
+    public async Task WhenTestMethodHasRefReadonlyParameter_NoDiagnostic()
+    {
+        // 'ref readonly' parameters have RefKind.RefReadOnlyParameter, which is neither
+        // RefKind.Out nor RefKind.Ref, so the analyzer must not report a diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1(ref readonly int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+#endif
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
@@ -191,6 +191,24 @@ public class SomeClass
         await VerifySingleSuppressionAsync(code, isSuppressed: false);
     }
 
+    [TestMethod]
+    public async Task PrivateTestContextPropertyOnTestClass_DiagnosticIsNotSuppressed()
+    {
+        string code = @"
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class SomeClass
+{
+    private TestContext {|#0:TestContext|} { get; set; }
+}
+";
+
+        await VerifySingleSuppressionAsync(code, isSuppressed: false);
+    }
+
     private Task VerifySingleSuppressionAsync(string source, bool isSuppressed)
         => VerifyDiagnosticsAsync(source, [(0, isSuppressed)]);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
@@ -143,6 +143,55 @@ public class SomeClass
         await test.RunAsync();
     }
 
+    [TestMethod]
+    public async Task TestContextFieldOnTestClass_DiagnosticIsNotSuppressed()
+    {
+        string code = @"
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class SomeClass
+{
+    public TestContext {|#0:_testContext|};
+}
+";
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = code,
+        };
+
+        test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerError("CS8618")
+            .WithLocation(0)
+            .WithOptions(DiagnosticOptions.IgnoreAdditionalLocations)
+            .WithArguments("field", "_testContext")
+            .WithIsSuppressed(false));
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task TestContextGetterOnlyPropertyOnTestClass_DiagnosticIsSuppressed()
+    {
+        // A TestContext property with only a getter still satisfies 'declaredSymbol is IPropertySymbol',
+        // so the suppressor must fire and suppress CS8618.
+        string code = @"
+#nullable enable
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class SomeClass
+{
+    public TestContext {|#0:TestContext|} { get; }
+}
+";
+
+        await VerifySingleSuppressionAsync(code, isSuppressed: true);
+    }
+
     private Task VerifySingleSuppressionAsync(string source, bool isSuppressed)
         => VerifyDiagnosticsAsync(source, [(0, isSuppressed)]);
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
@@ -175,6 +175,7 @@ public class SomeClass
     [TestMethod]
     public async Task TestContextGetterOnlyPropertyOnTestClass_DiagnosticIsNotSuppressed()
     {
+        // MSTest cannot assign a getter-only property, so CS8618 must remain visible.
         string code = @"
 #nullable enable
 

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/NonNullableReferenceNotInitializedSuppressorTests.cs
@@ -173,10 +173,8 @@ public class SomeClass
     }
 
     [TestMethod]
-    public async Task TestContextGetterOnlyPropertyOnTestClass_DiagnosticIsSuppressed()
+    public async Task TestContextGetterOnlyPropertyOnTestClass_DiagnosticIsNotSuppressed()
     {
-        // A TestContext property with only a getter still satisfies 'declaredSymbol is IPropertySymbol',
-        // so the suppressor must fire and suppress CS8618.
         string code = @"
 #nullable enable
 
@@ -189,7 +187,7 @@ public class SomeClass
 }
 ";
 
-        await VerifySingleSuppressionAsync(code, isSuppressed: true);
+        await VerifySingleSuppressionAsync(code, isSuppressed: false);
     }
 
     private Task VerifySingleSuppressionAsync(string source, bool isSuppressed)


### PR DESCRIPTION
## Summary

- add MSTEST0038 coverage for null reference arguments and constrained/unconstrained generic type parameters
- verify MSTEST0033 suppression boundaries for fields, getter-only properties, and non-public properties
- cover MSTEST0051 method-group/delegate inputs
- extend MSTEST0062 and its fixer to handle `ref readonly` parameters without escaped-keyword false positives
- consolidate the remaining July test-improver work; the other tracker items already landed in #9785, #9818, #9851, #9885, #9923, #9967, and #10031

## Validation

- `build.cmd -binaryLog`
- targeted MSTest.Analyzers builds: 0 warnings and 0 errors
- focused MSTest.Analyzers unit-test classes pass

Closes #9717
Closes #9837
Closes #9919
Closes #9952
Closes #10027
Closes #10049
Closes #10050
Closes #10058
Closes #10059
Closes #10064