### PR TITLE
[perf-improver] Cache analyzer SupportedDiagnostics

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/CollectionAssertToAssertAnalyzer.cs
@@ -63,7 +63,7 @@ public sealed class CollectionAssertToAssertAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     /// <inheritdoc />
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)

--- a/src/Analyzers/MSTest.Analyzers/StringAssertToAssertAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/StringAssertToAssertAnalyzer.cs
@@ -62,7 +62,7 @@ public sealed class StringAssertToAssertAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true);
 
     /// <inheritdoc />
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SupportedDiagnosticsCachingTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SupportedDiagnosticsCachingTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class SupportedDiagnosticsCachingTests
+{
+    [TestMethod]
+    public void CollectionAssertToAssertAnalyzer_CachesSupportedDiagnostics()
+        => AssertSupportedDiagnosticsAreCached(new CollectionAssertToAssertAnalyzer());
+
+    [TestMethod]
+    public void StringAssertToAssertAnalyzer_CachesSupportedDiagnostics()
+        => AssertSupportedDiagnosticsAreCached(new StringAssertToAssertAnalyzer());
+
+    private static void AssertSupportedDiagnosticsAreCached(DiagnosticAnalyzer analyzer)
+    {
+        ImmutableArray<DiagnosticDescriptor> supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+        Assert.AreEqual(supportedDiagnostics, analyzer.SupportedDiagnostics);
+    }
+}


### PR DESCRIPTION
## Summary

- Cache `SupportedDiagnostics` in `CollectionAssertToAssertAnalyzer` and `StringAssertToAssertAnalyzer` instead of recreating an `ImmutableArray` for each query.
- Add regression tests proving both analyzers return the cached array.

Roslyn queries `SupportedDiagnostics` repeatedly during analysis, so this removes two unnecessary allocations per analyzed file while preserving behavior and matching the pattern used by the other analyzers.

## Validation

- `MSTest.Analyzers.UnitTests` passed on `net472` and `net8.0`.
- Build completed with 0 warnings and 0 errors.

Closes #10055
Closes #10062
Tracked by #9604