### PR TITLE
Deduplicate TestContext output buffer initialization

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -518,11 +518,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
         => GetOrCreate(ref _testContextMessageStringBuilder);
 
     private static SynchronizedStringBuilder GetOrCreate(ref SynchronizedStringBuilder? builder)
-    {
-        _ = builder ?? Interlocked.CompareExchange(ref builder, new SynchronizedStringBuilder(), null)!;
-
-        return builder;
-    }
+        => LazyInitializer.EnsureInitialized(ref builder, static () => new())!;
 
     private void WriteLive(string? message, bool appendLine)
     {


### PR DESCRIPTION
The output buffers in `TestContextImplementation` repeated the same atomic lazy-initialization pattern, making future changes prone to copy-paste divergence.

This consolidates initialization through a shared `LazyInitializer.EnsureInitialized` helper while retaining the named accessors and existing thread-safe publication behavior.

Addresses #10053.