### PR TITLE
Invalidate generated source cache on MSBuild task updates

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -111,6 +111,14 @@
   <UsingTask TaskName="Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask"
          AssemblyFile="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll"/>
 
+  <Target Name="_GetTestingPlatformMSBuildTaskFileHash"
+          DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint;_CalculateGenerateSelfRegisteredExtensions"
+          Condition=" '$(GenerateTestingPlatformEntryPoint)' == 'true' Or '$(GenerateSelfRegisteredExtensions)' == 'true' ">
+    <GetFileHash Files="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll">
+      <Output TaskParameter="Items" ItemName="_TestingPlatformMSBuildTaskFileWithHash" />
+    </GetFileHash>
+  </Target>
+
   <Target Name="_CalculateGenerateTestingPlatformEntryPoint">
     <PropertyGroup>
       <!-- We add this to a target to allow setting IsTestingPlatformApplication as late as possible -->
@@ -120,7 +128,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateTestingPlatformEntryPointFileInputCache" DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint">
+  <Target Name="_GenerateTestingPlatformEntryPointFileInputCache" DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint;_GetTestingPlatformMSBuildTaskFileHash">
     <PropertyGroup>
       <!-- Cache file to check -->
       <_GenerateTestingPlatformEntryPointInputsCachFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).gentestingplatformentrypointinputcache.cache</_GenerateTestingPlatformEntryPointInputsCachFilePath>
@@ -131,6 +139,7 @@
       <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="@(TestingPlatformBuilderHook)"/>
       <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="$(RootNamespace)"/>
       <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="$(GenerateTestingPlatformEntryPoint)" />
+      <_GenerateTestingPlatformEntryPointInputsCacheToHash Include="@(_TestingPlatformMSBuildTaskFileWithHash->'%(FileHash)')" />
 
       <!-- Export the items name for the _GenerateTestingPlatformInjectEntryPoint task-->
       <GenerateTestingPlatformEntryPointInputsCacheFilePath Include="$(_GenerateTestingPlatformEntryPointInputsCachFilePath)" />
@@ -213,7 +222,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateSelfRegisteredExtensionsFileInputCache" DependsOnTargets="_CalculateGenerateSelfRegisteredExtensions">
+  <Target Name="_GenerateSelfRegisteredExtensionsFileInputCache" DependsOnTargets="_CalculateGenerateSelfRegisteredExtensions;_GetTestingPlatformMSBuildTaskFileHash">
     <PropertyGroup>
       <!-- Cache file to check -->
       <_GenerateSelfRegisteredExtensionsInputsCachFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).genautoregisteredextensionsinputcache.cache</_GenerateSelfRegisteredExtensionsInputsCachFilePath>
@@ -224,6 +233,7 @@
       <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="@(TestingPlatformBuilderHook)"/>
       <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="$(RootNamespace)"/>
       <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="$(GenerateSelfRegisteredExtensions)"/>
+      <_GenerateSelfRegisteredExtensionsInputsCacheToHash Include="@(_TestingPlatformMSBuildTaskFileWithHash->'%(FileHash)')" />
 
       <!-- Export the items name for the _GenerateSelfRegisteredExtensions task-->
       <GenerateSelfRegisteredExtensionsInputsCacheFilePath Include="$(_GenerateSelfRegisteredExtensionsInputsCachFilePath)" />

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -111,10 +111,18 @@
   <UsingTask TaskName="Microsoft.Testing.Platform.MSBuild.TestingPlatformEntryPointTask"
          AssemblyFile="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll"/>
 
-  <Target Name="_GetTestingPlatformMSBuildTaskFileHash"
-          DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint;_CalculateGenerateSelfRegisteredExtensions"
-          Condition=" '$(GenerateTestingPlatformEntryPoint)' == 'true' Or '$(GenerateSelfRegisteredExtensions)' == 'true' ">
-    <GetFileHash Files="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll">
+  <Target Name="_GetTestingPlatformMSBuildTaskFileHashForEntryPoint"
+          DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint">
+    <GetFileHash Files="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll"
+                 Condition=" '$(GenerateTestingPlatformEntryPoint)' == 'true' And '@(_TestingPlatformMSBuildTaskFileWithHash)' == '' ">
+      <Output TaskParameter="Items" ItemName="_TestingPlatformMSBuildTaskFileWithHash" />
+    </GetFileHash>
+  </Target>
+
+  <Target Name="_GetTestingPlatformMSBuildTaskFileHashForSelfRegisteredExtensions"
+          DependsOnTargets="_CalculateGenerateSelfRegisteredExtensions">
+    <GetFileHash Files="$(MicrosoftTestingPlatformMSBuildTaskFolder)Microsoft.Testing.Platform.MSBuild.dll"
+                 Condition=" '$(GenerateSelfRegisteredExtensions)' == 'true' And '@(_TestingPlatformMSBuildTaskFileWithHash)' == '' ">
       <Output TaskParameter="Items" ItemName="_TestingPlatformMSBuildTaskFileWithHash" />
     </GetFileHash>
   </Target>
@@ -128,7 +136,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateTestingPlatformEntryPointFileInputCache" DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint;_GetTestingPlatformMSBuildTaskFileHash">
+  <Target Name="_GenerateTestingPlatformEntryPointFileInputCache" DependsOnTargets="_CalculateGenerateTestingPlatformEntryPoint;_GetTestingPlatformMSBuildTaskFileHashForEntryPoint">
     <PropertyGroup>
       <!-- Cache file to check -->
       <_GenerateTestingPlatformEntryPointInputsCachFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).gentestingplatformentrypointinputcache.cache</_GenerateTestingPlatformEntryPointInputsCachFilePath>
@@ -222,7 +230,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_GenerateSelfRegisteredExtensionsFileInputCache" DependsOnTargets="_CalculateGenerateSelfRegisteredExtensions;_GetTestingPlatformMSBuildTaskFileHash">
+  <Target Name="_GenerateSelfRegisteredExtensionsFileInputCache" DependsOnTargets="_CalculateGenerateSelfRegisteredExtensions;_GetTestingPlatformMSBuildTaskFileHashForSelfRegisteredExtensions">
     <PropertyGroup>
       <!-- Cache file to check -->
       <_GenerateSelfRegisteredExtensionsInputsCachFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).genautoregisteredextensionsinputcache.cache</_GenerateSelfRegisteredExtensionsInputsCachFilePath>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -180,6 +180,25 @@ module MicrosoftTestingPlatformEntryPoint =
         Assert.IsEmpty(binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformSelfRegisteredExtensions"));
         AssertTargetSkippedAsUpToDate(binLog, "_GenerateTestingPlatformEntryPoint");
         AssertTargetSkippedAsUpToDate(binLog, "_GenerateSelfRegisteredExtensions");
+
+        Directory.Delete(Path.Combine(testAsset.TargetAssetPath, "obj"), recursive: true);
+        string selfRegistrationOnlyProperties = $"{taskFolderProperty} -p:GenerateTestingPlatformEntryPoint=false -p:OutputType=Library";
+        await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {selfRegistrationOnlyProperties} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+
+        await using (FileStream stream = new(copiedTaskAssembly, FileMode.Append, FileAccess.Write, FileShare.None))
+        {
+            stream.WriteByte(0);
+        }
+
+        buildResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {selfRegistrationOnlyProperties} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+        binLog = SL.Serialization.Read(buildResult.BinlogPath!);
+
+        Assert.IsEmpty(binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformEntryPointTask"));
+        Assert.HasCount(1, binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformSelfRegisteredExtensions"));
     }
 
     private static void AssertTargetSkippedAsUpToDate(SL.Build binLog, string targetName)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.GenerateEntryPoint.cs
@@ -127,6 +127,71 @@ module MicrosoftTestingPlatformEntryPoint =
         |> Async.AwaitTask
         |> Async.RunSynchronously'", "Fsc");
 
+    [TestMethod]
+    public async Task GeneratedSourcesAreRegeneratedWhenMSBuildTaskChanges()
+    {
+        string sourceCode = CSharpSourceCode
+            .PatchCodeWithReplace("$TargetFrameworks$", TargetFrameworks.NetCurrent)
+            .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion);
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(nameof(GeneratedSourcesAreRegeneratedWhenMSBuildTaskChanges), sourceCode);
+
+        DotnetMuxerResult buildResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+        SL.Build binLog = SL.Serialization.Read(buildResult.BinlogPath!);
+        string taskAssembly = binLog.FindChildrenRecursive<SL.Task>()
+            .Single(t => t.Name == "TestingPlatformEntryPointTask")
+            .FromAssembly;
+
+        using TempDirectory taskDirectory = new();
+        taskDirectory.CopyDirectory(Path.GetDirectoryName(taskAssembly)!, taskDirectory.Path);
+        string copiedTaskAssembly = Path.Combine(taskDirectory.Path, Path.GetFileName(taskAssembly));
+        File.SetAttributes(copiedTaskAssembly, FileAttributes.Normal);
+        string taskFolderProperty = $"-p:MicrosoftTestingPlatformMSBuildTaskFolder={taskDirectory.Path}{Path.DirectorySeparatorChar}";
+
+        Directory.Delete(Path.Combine(testAsset.TargetAssetPath, "obj"), recursive: true);
+        buildResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {taskFolderProperty} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+        binLog = SL.Serialization.Read(buildResult.BinlogPath!);
+
+        Assert.HasCount(1, binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformEntryPointTask"));
+        Assert.HasCount(1, binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformSelfRegisteredExtensions"));
+
+        await using (FileStream stream = new(copiedTaskAssembly, FileMode.Append, FileAccess.Write, FileShare.None))
+        {
+            stream.WriteByte(0);
+        }
+
+        buildResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {taskFolderProperty} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+        binLog = SL.Serialization.Read(buildResult.BinlogPath!);
+
+        Assert.HasCount(1, binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformEntryPointTask"));
+        Assert.HasCount(1, binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformSelfRegisteredExtensions"));
+
+        buildResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Debug} {taskFolderProperty} {testAsset.TargetAssetPath} -v:n -nr:false",
+            cancellationToken: TestContext.CancellationToken);
+        binLog = SL.Serialization.Read(buildResult.BinlogPath!);
+
+        Assert.IsEmpty(binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformEntryPointTask"));
+        Assert.IsEmpty(binLog.FindChildrenRecursive<SL.Task>().Where(t => t.Name == "TestingPlatformSelfRegisteredExtensions"));
+        AssertTargetSkippedAsUpToDate(binLog, "_GenerateTestingPlatformEntryPoint");
+        AssertTargetSkippedAsUpToDate(binLog, "_GenerateSelfRegisteredExtensions");
+    }
+
+    private static void AssertTargetSkippedAsUpToDate(SL.Build binLog, string targetName)
+    {
+        SL.Target target = binLog.FindChildrenRecursive<SL.Target>().Single(t => t.Name == targetName && t.Children.Count > 0);
+        Assert.HasCount(
+            1,
+            target.FindChildrenRecursive<SL.Message>().Where(m => m.Text.Contains(
+                $"Skipping target \"{targetName}\" because all output files are up-to-date with respect to the input files.",
+                StringComparison.OrdinalIgnoreCase)));
+    }
+
     private async Task GenerateAndVerifyLanguageSpecificEntryPointAsync(string assetName, string sourceCode, string languageFileExtension, string tfm,
         BuildConfiguration compilationMode, Verb verb, string expectedEntryPoint, string cscProcessName)
     {


### PR DESCRIPTION
Fixes #10056.

## Summary
- include the `Microsoft.Testing.Platform.MSBuild.dll` content hash in entry-point and self-registered-extension cache keys
- avoid hashing when neither source-generation feature is enabled
- add acceptance coverage that replaces the task assembly in place, verifies both sources regenerate, and verifies the next unchanged build remains incremental

## Validation
- repository build and package validation
- `GeneratedSourcesAreRegeneratedWhenMSBuildTaskChanges`
- existing C# entry-point cache matrix (12 cases; one parallel collision passed in isolation)
- three independent review rounds, including MSBuild-specific review