### PR TITLE
[perf-improver] Replace Array.IndexOf state checks with direct type patterns

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/TestResultCapture.cs
@@ -4,7 +4,6 @@
 using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Messages;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
@@ -57,8 +56,6 @@ internal static class TestResultCapture
 #pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
             CancelledTestNodeStateProperty => ("other", "cancelled"),
 #pragma warning restore CS0618, MTP0001
-            _ when Array.IndexOf(TestNodePropertiesCategories.WellKnownTestNodeTestRunOutcomeFailedProperties, state.GetType()) >= 0
-                => ("failed", null),
             _ => throw ApplicationStateGuard.Unreachable(),
         };
 

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Messages;
 
 namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
 
@@ -152,7 +151,9 @@ internal static class TrxTestResultExtractor
             SkippedTestNodeStateProperty => TrxTestOutcome.Skipped,
             PassedTestNodeStateProperty => TrxTestOutcome.Passed,
             TimeoutTestNodeStateProperty => TrxTestOutcome.Timeout,
-            _ when Array.IndexOf(TestNodePropertiesCategories.WellKnownTestNodeTestRunOutcomeFailedProperties, state.GetType()) >= 0 => TrxTestOutcome.Failed,
+#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
+            CancelledTestNodeStateProperty or ErrorTestNodeStateProperty or FailedTestNodeStateProperty => TrxTestOutcome.Failed,
+#pragma warning restore CS0618, MTP0001
             _ => throw ApplicationStateGuard.Unreachable(),
         };
 }

--- a/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/TestResultCaptureHelper.cs
@@ -4,7 +4,6 @@
 using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.Messages;
 
 namespace Microsoft.Testing.Extensions;
 
@@ -103,8 +102,9 @@ internal static class TestResultCaptureHelper
             TimeoutTestNodeStateProperty => "timedOut",
             ErrorTestNodeStateProperty => "errored",
             FailedTestNodeStateProperty => "failed",
-            _ when Array.IndexOf(TestNodePropertiesCategories.WellKnownTestNodeTestRunOutcomeFailedProperties, state.GetType()) >= 0
-                => "failed",
+#pragma warning disable CS0618, MTP0001 // CancelledTestNodeStateProperty is obsolete
+            CancelledTestNodeStateProperty => "failed",
+#pragma warning restore CS0618, MTP0001
             _ => throw ApplicationStateGuard.Unreachable(),
         };
 


### PR DESCRIPTION
## Summary

- replace per-result `Array.IndexOf` scans with direct state type patterns
- remove the unreachable CTRF failed-state fallback
- remove imports that are no longer needed

Closes #10088

## Testing

- targeted build of `Microsoft.Testing.Extensions.UnitTests` across supported target frameworks
- 26 affected net8.0 extension tests passed