### PR TITLE
Split ANSI terminal test progress frame

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Append.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Append.cs
@@ -72,7 +72,7 @@ internal sealed partial class AnsiTerminalTestProgressFrame
 
         terminal.Append(' ');
         charsTaken++;
-        AnsiTerminalTextLayoutHelper.AppendToWidth(terminal, progress.AssemblyName, nonReservedWidth, ref charsTaken);
+        AppendToWidth(terminal, progress.AssemblyName, nonReservedWidth, ref charsTaken);
 
         if (charsTaken < nonReservedWidth && (progress.TargetFramework != null || progress.Architecture != null))
         {
@@ -132,7 +132,7 @@ internal sealed partial class AnsiTerminalTestProgressFrame
         terminal.Append("  ");
         charsTaken += 2;
 
-        AnsiTerminalTextLayoutHelper.AppendToWidth(terminal, detail.Text, nonReservedWidth, ref charsTaken);
+        AppendToWidth(terminal, detail.Text, nonReservedWidth, ref charsTaken);
 
         terminal.SetCursorHorizontal(Width - durationString.Length);
         terminal.Append(durationString);
@@ -144,7 +144,7 @@ internal sealed partial class AnsiTerminalTestProgressFrame
         int availableWidth = Math.Max(0, Width - 1);
         if (availableWidth > 0)
         {
-            AnsiTerminalTextLayoutHelper.AppendProgressMessageToWidth(terminal, message.Text, availableWidth);
+            AppendProgressMessageToWidth(terminal, message.Text, availableWidth);
         }
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Append.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Append.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+internal sealed partial class AnsiTerminalTestProgressFrame
+{
+    public void AppendTestWorkerProgress(TestProgressState progress, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    {
+        string durationString = HumanReadableDurationFormatter.Render(progress.Stopwatch.Elapsed);
+
+        currentLine.RenderedDurationLength = durationString.Length;
+
+        int nonReservedWidth = Width - (durationString.Length + 2);
+
+        int discovered = progress.DiscoveredTests;
+        int passed = progress.PassedTests;
+        int failed = progress.FailedTests;
+        int skipped = progress.SkippedTests;
+        int charsTaken = 0;
+
+        if (!progress.IsDiscovery)
+        {
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkGreen);
+            terminal.Append('✓');
+            charsTaken++;
+            string passedText = passed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(passedText);
+            charsTaken += passedText.Length;
+            terminal.ResetColor();
+
+            terminal.Append('/');
+            charsTaken++;
+
+            terminal.SetColor(TerminalColor.DarkRed);
+            terminal.Append('x');
+            charsTaken++;
+            string failedText = failed.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(failedText);
+            charsTaken += failedText.Length;
+            terminal.ResetColor();
+
+            terminal.Append('/');
+            charsTaken++;
+
+            terminal.SetColor(TerminalColor.DarkYellow);
+            terminal.Append('↓');
+            charsTaken++;
+            string skippedText = skipped.ToString(CultureInfo.CurrentCulture);
+            terminal.Append(skippedText);
+            charsTaken += skippedText.Length;
+            terminal.ResetColor();
+            terminal.Append(']');
+            charsTaken++;
+        }
+        else
+        {
+            string discoveredText = discovered.ToString(CultureInfo.CurrentCulture);
+            terminal.Append('[');
+            charsTaken++;
+            terminal.SetColor(TerminalColor.DarkMagenta);
+            terminal.Append('+');
+            charsTaken++;
+            terminal.Append(discoveredText);
+            charsTaken += discoveredText.Length;
+            terminal.ResetColor();
+            terminal.Append(']');
+            charsTaken++;
+        }
+
+        terminal.Append(' ');
+        charsTaken++;
+        AnsiTerminalTextLayoutHelper.AppendToWidth(terminal, progress.AssemblyName, nonReservedWidth, ref charsTaken);
+
+        if (charsTaken < nonReservedWidth && (progress.TargetFramework != null || progress.Architecture != null))
+        {
+            int lengthNeeded = 0;
+
+            lengthNeeded++; // for '('
+            if (progress.TargetFramework != null)
+            {
+                lengthNeeded += progress.TargetFramework.Length;
+                if (progress.Architecture != null)
+                {
+                    lengthNeeded++; // for '|'
+                }
+            }
+
+            if (progress.Architecture != null)
+            {
+                lengthNeeded += progress.Architecture.Length;
+            }
+
+            lengthNeeded++; // for ')'
+
+            if ((charsTaken + lengthNeeded) < nonReservedWidth)
+            {
+                terminal.Append(" (");
+                if (progress.TargetFramework != null)
+                {
+                    terminal.Append(progress.TargetFramework);
+                    if (progress.Architecture != null)
+                    {
+                        terminal.Append('|');
+                    }
+                }
+
+                if (progress.Architecture != null)
+                {
+                    terminal.Append(progress.Architecture);
+                }
+
+                terminal.Append(')');
+            }
+        }
+
+        terminal.SetCursorHorizontal(Width - durationString.Length);
+        terminal.Append(durationString);
+    }
+
+    public void AppendTestWorkerDetail(TestDetailState detail, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    {
+        string durationString = HumanReadableDurationFormatter.Render(detail.Stopwatch?.Elapsed);
+
+        currentLine.RenderedDurationLength = durationString.Length;
+
+        int nonReservedWidth = Width - (durationString.Length + 2);
+        int charsTaken = 0;
+
+        terminal.Append("  ");
+        charsTaken += 2;
+
+        AnsiTerminalTextLayoutHelper.AppendToWidth(terminal, detail.Text, nonReservedWidth, ref charsTaken);
+
+        terminal.SetCursorHorizontal(Width - durationString.Length);
+        terminal.Append(durationString);
+    }
+
+    private void AppendProgressMessage(TerminalProgressMessageState message, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    {
+        currentLine.RenderedDurationLength = 0;
+        int availableWidth = Math.Max(0, Width - 1);
+        if (availableWidth > 0)
+        {
+            AnsiTerminalTextLayoutHelper.AppendProgressMessageToWidth(terminal, message.Text, availableWidth);
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Render.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.Render.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+internal sealed partial class AnsiTerminalTestProgressFrame
+{
+    /// <summary>
+    /// Render VT100 string to update from current to next frame.
+    /// </summary>
+    public void Render(
+        AnsiTerminalTestProgressFrame previousFrame,
+        TestProgressState?[] progress,
+        TerminalProgressMessageState[] messages,
+        AnsiTerminal terminal)
+    {
+        // Clear everything if Terminal width or height have changed.
+        if (Width != previousFrame.Width || Height != previousFrame.Height)
+        {
+            terminal.EraseProgress();
+        }
+
+        // At the end of the terminal we're going to print the live progress.
+        // We re-render this progress by moving the cursor to the beginning of the previous progress
+        // and then overwriting the lines that have changed.
+        // The assumption we do here is that:
+        // - Each rendered line is a single line, i.e. a single detail cannot span multiple lines.
+        // - Each rendered detail can be tracked via a unique ID and version, so that we can
+        //   quickly determine if the detail has changed since the last render.
+
+        // Don't go up if we did not render any lines in previous frame or we already cleared them.
+        if (previousFrame.RenderedLinesCount > 0)
+        {
+            // Move cursor back to 1st line of progress.
+            // + 2 because we output and empty line right below.
+            terminal.MoveCursorUp(previousFrame.RenderedLinesCount + 2);
+        }
+
+        // When there is nothing to render, don't write empty lines, e.g. when we start the test run, and then we kick off build
+        // in dotnet test, there is a long pause where we have no assemblies and no test results (yet).
+        if (progress.Length > 0 || messages.Length > 0)
+        {
+            terminal.AppendLine();
+        }
+
+        int i;
+        List<object> progresses = GenerateLinesToRender(progress, messages);
+
+        for (i = 0; i < progresses.Count; i++)
+        {
+            object item = progresses[i];
+
+            if (previousFrame.RenderedLinesCount > i)
+            {
+                if (item is TestProgressState progressItem)
+                {
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(progressItem.Id, progressItem.Version);
+
+                    // We have a line that was rendered previously, compare it and decide how to render.
+                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
+                    if (previouslyRenderedLine.ProgressId == progressItem.Id && previouslyRenderedLine.ProgressVersion == progressItem.Version)
+                    {
+                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
+                        string durationString = HumanReadableDurationFormatter.Render(progressItem.Stopwatch.Elapsed);
+
+                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
+                        {
+                            // Duration is the same length: rewrite just the duration cell.
+                            // Use pre-computed escape sequences to avoid per-tick string allocations.
+                            int durLen = durationString.Length;
+                            terminal.Append(SetCursorHorizontalMaxColumn);
+                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
+                            terminal.Append(durationString);
+                            currentLine.RenderedDurationLength = durLen;
+                        }
+                        else
+                        {
+                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
+                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
+                            terminal.Append(AnsiCodes.CsiEraseInLine);
+                            AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                        }
+                    }
+                    else
+                    {
+                        // These lines are different or the line was updated. Render the whole line.
+                        terminal.Append(AnsiCodes.CsiEraseInLine);
+                        AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                    }
+                }
+                else if (item is TestDetailState detailItem)
+                {
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(detailItem.Id, detailItem.Version);
+
+                    // We have a line that was rendered previously, compare it and decide how to render.
+                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
+                    if (previouslyRenderedLine.ProgressId == detailItem.Id && previouslyRenderedLine.ProgressVersion == detailItem.Version)
+                    {
+                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
+                        string durationString = HumanReadableDurationFormatter.Render(detailItem.Stopwatch?.Elapsed);
+
+                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
+                        {
+                            // Duration is the same length: rewrite just the duration cell.
+                            // Use pre-computed escape sequences to avoid per-tick string allocations.
+                            int durLen = durationString.Length;
+                            terminal.Append(SetCursorHorizontalMaxColumn);
+                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
+                            terminal.Append(durationString);
+                            currentLine.RenderedDurationLength = durLen;
+                        }
+                        else
+                        {
+                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
+                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
+                            terminal.Append(AnsiCodes.CsiEraseInLine);
+                            AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                        }
+                    }
+                    else
+                    {
+                        // These lines are different or the line was updated. Render the whole line.
+                        terminal.Append(AnsiCodes.CsiEraseInLine);
+                        AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                    }
+                }
+                else if (item is TerminalProgressMessageState messageItem)
+                {
+                    RenderedProgressItem messageLine = GetOrAllocateNextSlot();
+                    messageLine.Reset(messageItem.Id, messageItem.Version);
+
+                    RenderedProgressItem previousMessageLine = previousFrame._renderedLines[i];
+                    if (previousMessageLine.ProgressId != messageItem.Id
+                        || previousMessageLine.ProgressVersion != messageItem.Version)
+                    {
+                        terminal.Append(AnsiCodes.CsiEraseInLine);
+                        AppendProgressMessage(messageItem, messageLine, terminal);
+                    }
+                }
+            }
+            else
+            {
+                // We are rendering more lines than we rendered in previous frame
+                if (item is TestProgressState progressItem)
+                {
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(progressItem.Id, progressItem.Version);
+                    AppendTestWorkerProgress(progressItem, currentLine, terminal);
+                }
+                else if (item is TestDetailState detailItem)
+                {
+                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
+                    currentLine.Reset(detailItem.Id, detailItem.Version);
+                    AppendTestWorkerDetail(detailItem, currentLine, terminal);
+                }
+                else if (item is TerminalProgressMessageState messageItem)
+                {
+                    RenderedProgressItem messageLine = GetOrAllocateNextSlot();
+                    messageLine.Reset(messageItem.Id, messageItem.Version);
+                    AppendProgressMessage(messageItem, messageLine, terminal);
+                }
+            }
+
+            // This makes the progress not stick to the last line on the command line, which is
+            // not what I would prefer. But also if someone writes to console, the message will
+            // start at the beginning of the new line. Not after the progress bar that is kept on screen.
+            terminal.AppendLine();
+        }
+
+        // We rendered more lines in previous frame. Clear them.
+        if (i < previousFrame.RenderedLinesCount)
+        {
+            terminal.Append(AnsiCodes.CsiEraseInDisplay);
+        }
+    }
+
+    private List<object> GenerateLinesToRender(TestProgressState?[] progress, TerminalProgressMessageState[] messages)
+    {
+        // Note: We want to render the list of active tests, but this can easily fill up the full screen.
+        // As such, we should balance the number of active tests shown per project.
+        // We do this by distributing the remaining lines for each projects.
+
+        // Collect non-null progress items without LINQ OfType allocation.
+        int itemCount = 0;
+        for (int j = 0; j < progress.Length; j++)
+        {
+            if (progress[j] is not null)
+            {
+                itemCount++;
+            }
+        }
+
+        // Grow cached working buffers when more capacity is needed; never shrink to avoid churn.
+        if (_progressItemsBuffer.Length < itemCount)
+        {
+            _progressItemsBuffer = new TestProgressState[itemCount];
+            _sortedIndicesBuffer = new int[itemCount];
+            _detailItemsBuffer = new List<TestDetailState>?[itemCount];
+        }
+
+        int idx = 0;
+        for (int j = 0; j < progress.Length; j++)
+        {
+            if (progress[j] is not null)
+            {
+                _progressItemsBuffer[idx++] = progress[j]!;
+            }
+        }
+
+        int linesToDistribute = (int)(Height * 0.7) - 1 - itemCount - messages.Length;
+
+        // Sort indices by detail count ascending to distribute lines fairly,
+        // without LINQ Enumerable.Range + OrderBy allocation.
+        for (int j = 0; j < itemCount; j++)
+        {
+            _sortedIndicesBuffer[j] = j;
+        }
+
+        // _progressCountComparer is a cached instance — no per-tick allocation.
+        _progressCountComparer.Buffer = _progressItemsBuffer;
+        Array.Sort(_sortedIndicesBuffer, 0, itemCount, _progressCountComparer);
+
+        // Only populate detail buffers when there is a positive line budget per item.
+        // GetRunningTasks(0) would compute itemsToTake = -1 and throw inside RemoveRange,
+        // and there's no point asking for details we cannot display anyway.
+        int linesPerItem = itemCount > 0 ? linesToDistribute / itemCount : 0;
+        if (linesPerItem > 0)
+        {
+            for (int j = 0; j < itemCount; j++)
+            {
+                int sortedItemIndex = _sortedIndicesBuffer[j];
+                _detailItemsBuffer[sortedItemIndex] = _progressItemsBuffer[sortedItemIndex].TestNodeResultsState?.GetRunningTasks(linesPerItem);
+            }
+        }
+
+        _linesToRenderBuffer.AddRange(messages);
+
+        for (int progressI = 0; progressI < itemCount; progressI++)
+        {
+            _linesToRenderBuffer.Add(_progressItemsBuffer[progressI]);
+            if (_detailItemsBuffer[progressI] is { } details)
+            {
+                _linesToRenderBuffer.AddRange(details);
+                _detailItemsBuffer[progressI] = null; // release to avoid holding stale GC roots
+            }
+
+            // Release the progress item reference too so completed workers can be collected
+            // even when this frame instance is kept alive across ticks.
+            _progressItemsBuffer[progressI] = null!;
+        }
+
+        return _linesToRenderBuffer;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.TextLayout.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.TextLayout.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-
 namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 
-[Embedded]
-internal static class AnsiTerminalTextLayoutHelper
+internal sealed partial class AnsiTerminalTestProgressFrame
 {
-    internal static void AppendProgressMessageToWidth(AnsiTerminal terminal, string text, int availableWidth)
+    private static void AppendProgressMessageToWidth(AnsiTerminal terminal, string text, int availableWidth)
     {
         List<TextElement> elements = [];
         int totalWidth = 0;
@@ -77,7 +74,7 @@ internal static class AnsiTerminalTextLayoutHelper
         }
     }
 
-    internal static void AppendToWidth(AnsiTerminal terminal, string text, int width, ref int charsTaken)
+    private static void AppendToWidth(AnsiTerminal terminal, string text, int width, ref int charsTaken)
     {
         if (charsTaken + text.Length < width)
         {

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTestProgressFrame.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
 /// Captures <see cref="TestProgressState"/> that was rendered to screen, so we can only partially update the screen on next update.
 /// </summary>
 [Embedded]
-internal sealed class AnsiTerminalTestProgressFrame
+internal sealed partial class AnsiTerminalTestProgressFrame
 {
     private const int MaxColumn = 250;
 
@@ -17,21 +17,6 @@ internal sealed class AnsiTerminalTestProgressFrame
     // Re-computing them via AnsiCodes methods on every render tick allocates a new string each time.
     private static readonly string SetCursorHorizontalMaxColumn = AnsiCodes.SetCursorHorizontal(MaxColumn);
     private static readonly string[] MoveCursorBackwardCache = CreateMoveCursorBackwardCache();
-
-    private static string[] CreateMoveCursorBackwardCache()
-    {
-        // Duration strings are at most 16 chars ("(1d 23h 59m 59s)" with parens).
-        // A cache of 17 slots (indices 0-16) covers every realistic case with zero allocation.
-        const int cacheSize = 17;
-        string[] cache = new string[cacheSize];
-        cache[0] = string.Empty;
-        for (int i = 1; i < cacheSize; i++)
-        {
-            cache[i] = AnsiCodes.MoveCursorBackward(i);
-        }
-
-        return cache;
-    }
 
     // Reusable working buffers for GenerateLinesToRender, cached across render ticks on the same frame
     // object to eliminate 4+ per-tick heap allocations (3 arrays + 1 List, plus the sort comparer).
@@ -46,17 +31,17 @@ internal sealed class AnsiTerminalTestProgressFrame
     // shrunk so slots from previous (higher-watermark) ticks remain available for reuse.
     private RenderedProgressItem[] _renderedLines = [];
 
-    public int Width { get; private set; }
-
-    public int Height { get; private set; }
-
-    public int RenderedLinesCount { get; private set; }
-
     public AnsiTerminalTestProgressFrame(int width, int height)
     {
         Width = Math.Min(width, MaxColumn);
         Height = height;
     }
+
+    public int Width { get; private set; }
+
+    public int Height { get; private set; }
+
+    public int RenderedLinesCount { get; private set; }
 
     /// <summary>
     /// Resets this frame for reuse as the next render target, avoiding a heap allocation per render tick.
@@ -68,6 +53,8 @@ internal sealed class AnsiTerminalTestProgressFrame
         RenderedLinesCount = 0;
         _linesToRenderBuffer.Clear();
     }
+
+    public void Clear() => RenderedLinesCount = 0;
 
     /// <summary>
     /// Returns the next available <see cref="RenderedProgressItem"/> slot, growing the pool on demand.
@@ -91,568 +78,20 @@ internal sealed class AnsiTerminalTestProgressFrame
         return _renderedLines[idx];
     }
 
-    public void AppendTestWorkerProgress(TestProgressState progress, RenderedProgressItem currentLine, AnsiTerminal terminal)
+    private static string[] CreateMoveCursorBackwardCache()
     {
-        string durationString = HumanReadableDurationFormatter.Render(progress.Stopwatch.Elapsed);
-
-        currentLine.RenderedDurationLength = durationString.Length;
-
-        int nonReservedWidth = Width - (durationString.Length + 2);
-
-        int discovered = progress.DiscoveredTests;
-        int passed = progress.PassedTests;
-        int failed = progress.FailedTests;
-        int skipped = progress.SkippedTests;
-        int charsTaken = 0;
-
-        if (!progress.IsDiscovery)
+        // Duration strings are at most 16 chars ("(1d 23h 59m 59s)" with parens).
+        // A cache of 17 slots (indices 0-16) covers every realistic case with zero allocation.
+        const int cacheSize = 17;
+        string[] cache = new string[cacheSize];
+        cache[0] = string.Empty;
+        for (int i = 1; i < cacheSize; i++)
         {
-            terminal.Append('[');
-            charsTaken++;
-            terminal.SetColor(TerminalColor.DarkGreen);
-            terminal.Append('✓');
-            charsTaken++;
-            string passedText = passed.ToString(CultureInfo.CurrentCulture);
-            terminal.Append(passedText);
-            charsTaken += passedText.Length;
-            terminal.ResetColor();
-
-            terminal.Append('/');
-            charsTaken++;
-
-            terminal.SetColor(TerminalColor.DarkRed);
-            terminal.Append('x');
-            charsTaken++;
-            string failedText = failed.ToString(CultureInfo.CurrentCulture);
-            terminal.Append(failedText);
-            charsTaken += failedText.Length;
-            terminal.ResetColor();
-
-            terminal.Append('/');
-            charsTaken++;
-
-            terminal.SetColor(TerminalColor.DarkYellow);
-            terminal.Append('↓');
-            charsTaken++;
-            string skippedText = skipped.ToString(CultureInfo.CurrentCulture);
-            terminal.Append(skippedText);
-            charsTaken += skippedText.Length;
-            terminal.ResetColor();
-            terminal.Append(']');
-            charsTaken++;
-        }
-        else
-        {
-            string discoveredText = discovered.ToString(CultureInfo.CurrentCulture);
-            terminal.Append('[');
-            charsTaken++;
-            terminal.SetColor(TerminalColor.DarkMagenta);
-            terminal.Append('+');
-            charsTaken++;
-            terminal.Append(discoveredText);
-            charsTaken += discoveredText.Length;
-            terminal.ResetColor();
-            terminal.Append(']');
-            charsTaken++;
+            cache[i] = AnsiCodes.MoveCursorBackward(i);
         }
 
-        terminal.Append(' ');
-        charsTaken++;
-        AppendToWidth(terminal, progress.AssemblyName, nonReservedWidth, ref charsTaken);
-
-        if (charsTaken < nonReservedWidth && (progress.TargetFramework != null || progress.Architecture != null))
-        {
-            int lengthNeeded = 0;
-
-            lengthNeeded++; // for '('
-            if (progress.TargetFramework != null)
-            {
-                lengthNeeded += progress.TargetFramework.Length;
-                if (progress.Architecture != null)
-                {
-                    lengthNeeded++; // for '|'
-                }
-            }
-
-            if (progress.Architecture != null)
-            {
-                lengthNeeded += progress.Architecture.Length;
-            }
-
-            lengthNeeded++; // for ')'
-
-            if ((charsTaken + lengthNeeded) < nonReservedWidth)
-            {
-                terminal.Append(" (");
-                if (progress.TargetFramework != null)
-                {
-                    terminal.Append(progress.TargetFramework);
-                    if (progress.Architecture != null)
-                    {
-                        terminal.Append('|');
-                    }
-                }
-
-                if (progress.Architecture != null)
-                {
-                    terminal.Append(progress.Architecture);
-                }
-
-                terminal.Append(')');
-            }
-        }
-
-        terminal.SetCursorHorizontal(Width - durationString.Length);
-        terminal.Append(durationString);
+        return cache;
     }
-
-    public void AppendTestWorkerDetail(TestDetailState detail, RenderedProgressItem currentLine, AnsiTerminal terminal)
-    {
-        string durationString = HumanReadableDurationFormatter.Render(detail.Stopwatch?.Elapsed);
-
-        currentLine.RenderedDurationLength = durationString.Length;
-
-        int nonReservedWidth = Width - (durationString.Length + 2);
-        int charsTaken = 0;
-
-        terminal.Append("  ");
-        charsTaken += 2;
-
-        AppendToWidth(terminal, detail.Text, nonReservedWidth, ref charsTaken);
-
-        terminal.SetCursorHorizontal(Width - durationString.Length);
-        terminal.Append(durationString);
-    }
-
-    private void AppendProgressMessage(TerminalProgressMessageState message, RenderedProgressItem currentLine, AnsiTerminal terminal)
-    {
-        currentLine.RenderedDurationLength = 0;
-        int availableWidth = Math.Max(0, Width - 1);
-        if (availableWidth > 0)
-        {
-            AppendProgressMessageToWidth(terminal, message.Text, availableWidth);
-        }
-    }
-
-    private static void AppendProgressMessageToWidth(AnsiTerminal terminal, string text, int availableWidth)
-    {
-        List<TextElement> elements = [];
-        int totalWidth = 0;
-        bool textWasNormalized = false;
-        TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(text);
-        while (enumerator.MoveNext())
-        {
-            string originalElement = enumerator.GetTextElement();
-            TextElement element = CreateTextElement(originalElement);
-            textWasNormalized |= !ReferenceEquals(originalElement, element.Text);
-            if (IsRegionalIndicator(element.Text)
-                && elements.Count > 0
-                && IsRegionalIndicator(elements[^1].Text))
-            {
-                TextElement previousElement = elements[^1];
-                elements[^1] = new TextElement(previousElement.Text + element.Text, Width: 2);
-                totalWidth += 2 - previousElement.Width;
-            }
-            else
-            {
-                elements.Add(element);
-                totalWidth += element.Width;
-            }
-        }
-
-        if (totalWidth <= availableWidth)
-        {
-            if (textWasNormalized)
-            {
-                foreach (TextElement element in elements)
-                {
-                    terminal.Append(element.Text);
-                }
-            }
-            else
-            {
-                terminal.Append(text);
-            }
-
-            return;
-        }
-
-        if (availableWidth < 3)
-        {
-            AppendPrefixToWidth(terminal, elements, availableWidth);
-            return;
-        }
-
-        terminal.Append("...");
-        int remainingWidth = availableWidth - 3;
-        int firstElementToAppend = elements.Count;
-        for (int i = elements.Count - 1; i >= 0; i--)
-        {
-            if (elements[i].Width > remainingWidth)
-            {
-                break;
-            }
-
-            remainingWidth -= elements[i].Width;
-            firstElementToAppend = i;
-        }
-
-        for (int i = firstElementToAppend; i < elements.Count; i++)
-        {
-            terminal.Append(elements[i].Text);
-        }
-    }
-
-    private static void AppendPrefixToWidth(AnsiTerminal terminal, List<TextElement> elements, int availableWidth)
-    {
-        foreach (TextElement element in elements)
-        {
-            if (element.Width > availableWidth)
-            {
-                break;
-            }
-
-            terminal.Append(element.Text);
-            availableWidth -= element.Width;
-        }
-    }
-
-    private static TextElement CreateTextElement(string textElement)
-    {
-        int width = 0;
-        bool hasEmojiPresentationSelector = false;
-        StringBuilder? normalizedText = null;
-        for (int i = 0; i < textElement.Length;)
-        {
-            int codePoint;
-            int codeUnitCount;
-            bool isMalformedSurrogate = char.IsSurrogate(textElement[i])
-                && !char.IsSurrogatePair(textElement, i);
-            if (isMalformedSurrogate)
-            {
-                normalizedText ??= new StringBuilder(textElement.Length).Append(textElement, 0, i);
-                normalizedText.Append('\uFFFD');
-                codePoint = 0xFFFD;
-                codeUnitCount = 1;
-            }
-            else
-            {
-                codePoint = char.ConvertToUtf32(textElement, i);
-                codeUnitCount = char.IsSurrogatePair(textElement, i) ? 2 : 1;
-                normalizedText?.Append(textElement, i, codeUnitCount);
-            }
-
-            hasEmojiPresentationSelector |= codePoint == 0xFE0F;
-            UnicodeCategory category = isMalformedSurrogate
-                ? UnicodeCategory.OtherSymbol
-                : CharUnicodeInfo.GetUnicodeCategory(textElement, i);
-            if (category is not (UnicodeCategory.NonSpacingMark or UnicodeCategory.EnclosingMark or UnicodeCategory.Format))
-            {
-                width = Math.Max(width, IsWideCodePoint(codePoint) ? 2 : 1);
-            }
-
-            i += codeUnitCount;
-        }
-
-        return new TextElement(
-            normalizedText?.ToString() ?? textElement,
-            hasEmojiPresentationSelector ? Math.Max(width, 2) : width);
-    }
-
-    private static bool IsWideCodePoint(int codePoint)
-        => codePoint is >= 0x1100
-            and (<= 0x115F
-                or 0x2329
-                or 0x232A
-                or (>= 0x2E80 and <= 0xA4CF and not 0x303F)
-                or (>= 0xAC00 and <= 0xD7A3)
-                or (>= 0xF900 and <= 0xFAFF)
-                or (>= 0xFE10 and <= 0xFE19)
-                or (>= 0xFE30 and <= 0xFE6F)
-                or (>= 0xFF00 and <= 0xFF60)
-                or (>= 0xFFE0 and <= 0xFFE6)
-                or (>= 0x1F1E6 and <= 0x1F1FF)
-                or (>= 0x1F300 and <= 0x1FAFF)
-                or (>= 0x20000 and <= 0x3FFFD));
-
-    private static bool IsRegionalIndicator(string textElement)
-        => textElement.Length == 2
-            && char.IsSurrogatePair(textElement, 0)
-            && char.ConvertToUtf32(textElement, 0) is >= 0x1F1E6 and <= 0x1F1FF;
-
-    private readonly record struct TextElement(string Text, int Width);
-
-    private static void AppendToWidth(AnsiTerminal terminal, string text, int width, ref int charsTaken)
-    {
-        if (charsTaken + text.Length < width)
-        {
-            terminal.Append(text);
-            charsTaken += text.Length;
-        }
-        else
-        {
-            terminal.Append("...");
-            charsTaken += 3;
-            if (charsTaken < width)
-            {
-                int charsToTake = width - charsTaken;
-                string cutText = text[^charsToTake..];
-                terminal.Append(cutText);
-                charsTaken += charsToTake;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Render VT100 string to update from current to next frame.
-    /// </summary>
-    public void Render(
-        AnsiTerminalTestProgressFrame previousFrame,
-        TestProgressState?[] progress,
-        TerminalProgressMessageState[] messages,
-        AnsiTerminal terminal)
-    {
-        // Clear everything if Terminal width or height have changed.
-        if (Width != previousFrame.Width || Height != previousFrame.Height)
-        {
-            terminal.EraseProgress();
-        }
-
-        // At the end of the terminal we're going to print the live progress.
-        // We re-render this progress by moving the cursor to the beginning of the previous progress
-        // and then overwriting the lines that have changed.
-        // The assumption we do here is that:
-        // - Each rendered line is a single line, i.e. a single detail cannot span multiple lines.
-        // - Each rendered detail can be tracked via a unique ID and version, so that we can
-        //   quickly determine if the detail has changed since the last render.
-
-        // Don't go up if we did not render any lines in previous frame or we already cleared them.
-        if (previousFrame.RenderedLinesCount > 0)
-        {
-            // Move cursor back to 1st line of progress.
-            // + 2 because we output and empty line right below.
-            terminal.MoveCursorUp(previousFrame.RenderedLinesCount + 2);
-        }
-
-        // When there is nothing to render, don't write empty lines, e.g. when we start the test run, and then we kick off build
-        // in dotnet test, there is a long pause where we have no assemblies and no test results (yet).
-        if (progress.Length > 0 || messages.Length > 0)
-        {
-            terminal.AppendLine();
-        }
-
-        int i;
-        List<object> progresses = GenerateLinesToRender(progress, messages);
-
-        for (i = 0; i < progresses.Count; i++)
-        {
-            object item = progresses[i];
-
-            if (previousFrame.RenderedLinesCount > i)
-            {
-                if (item is TestProgressState progressItem)
-                {
-                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
-                    currentLine.Reset(progressItem.Id, progressItem.Version);
-
-                    // We have a line that was rendered previously, compare it and decide how to render.
-                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
-                    if (previouslyRenderedLine.ProgressId == progressItem.Id && previouslyRenderedLine.ProgressVersion == progressItem.Version)
-                    {
-                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
-                        string durationString = HumanReadableDurationFormatter.Render(progressItem.Stopwatch.Elapsed);
-
-                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
-                        {
-                            // Duration is the same length: rewrite just the duration cell.
-                            // Use pre-computed escape sequences to avoid per-tick string allocations.
-                            int durLen = durationString.Length;
-                            terminal.Append(SetCursorHorizontalMaxColumn);
-                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
-                            terminal.Append(durationString);
-                            currentLine.RenderedDurationLength = durLen;
-                        }
-                        else
-                        {
-                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
-                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
-                            terminal.Append(AnsiCodes.CsiEraseInLine);
-                            AppendTestWorkerProgress(progressItem, currentLine, terminal);
-                        }
-                    }
-                    else
-                    {
-                        // These lines are different or the line was updated. Render the whole line.
-                        terminal.Append(AnsiCodes.CsiEraseInLine);
-                        AppendTestWorkerProgress(progressItem, currentLine, terminal);
-                    }
-                }
-                else if (item is TestDetailState detailItem)
-                {
-                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
-                    currentLine.Reset(detailItem.Id, detailItem.Version);
-
-                    // We have a line that was rendered previously, compare it and decide how to render.
-                    RenderedProgressItem previouslyRenderedLine = previousFrame._renderedLines[i];
-                    if (previouslyRenderedLine.ProgressId == detailItem.Id && previouslyRenderedLine.ProgressVersion == detailItem.Version)
-                    {
-                        // This is the same progress item and it was not updated since we rendered it, only update the timestamp if possible to avoid flicker.
-                        string durationString = HumanReadableDurationFormatter.Render(detailItem.Stopwatch?.Elapsed);
-
-                        if (previouslyRenderedLine.RenderedDurationLength == durationString.Length)
-                        {
-                            // Duration is the same length: rewrite just the duration cell.
-                            // Use pre-computed escape sequences to avoid per-tick string allocations.
-                            int durLen = durationString.Length;
-                            terminal.Append(SetCursorHorizontalMaxColumn);
-                            terminal.Append(durLen < MoveCursorBackwardCache.Length ? MoveCursorBackwardCache[durLen] : AnsiCodes.MoveCursorBackward(durLen));
-                            terminal.Append(durationString);
-                            currentLine.RenderedDurationLength = durLen;
-                        }
-                        else
-                        {
-                            // Duration is not the same length (it is longer because time moves only forward), we need to re-render the whole line
-                            // to avoid writing the duration over the last portion of text: my.dll (1s) -> my.d (1m 1s)
-                            terminal.Append(AnsiCodes.CsiEraseInLine);
-                            AppendTestWorkerDetail(detailItem, currentLine, terminal);
-                        }
-                    }
-                    else
-                    {
-                        // These lines are different or the line was updated. Render the whole line.
-                        terminal.Append(AnsiCodes.CsiEraseInLine);
-                        AppendTestWorkerDetail(detailItem, currentLine, terminal);
-                    }
-                }
-                else if (item is TerminalProgressMessageState messageItem)
-                {
-                    RenderedProgressItem messageLine = GetOrAllocateNextSlot();
-                    messageLine.Reset(messageItem.Id, messageItem.Version);
-
-                    RenderedProgressItem previousMessageLine = previousFrame._renderedLines[i];
-                    if (previousMessageLine.ProgressId != messageItem.Id
-                        || previousMessageLine.ProgressVersion != messageItem.Version)
-                    {
-                        terminal.Append(AnsiCodes.CsiEraseInLine);
-                        AppendProgressMessage(messageItem, messageLine, terminal);
-                    }
-                }
-            }
-            else
-            {
-                // We are rendering more lines than we rendered in previous frame
-                if (item is TestProgressState progressItem)
-                {
-                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
-                    currentLine.Reset(progressItem.Id, progressItem.Version);
-                    AppendTestWorkerProgress(progressItem, currentLine, terminal);
-                }
-                else if (item is TestDetailState detailItem)
-                {
-                    RenderedProgressItem currentLine = GetOrAllocateNextSlot();
-                    currentLine.Reset(detailItem.Id, detailItem.Version);
-                    AppendTestWorkerDetail(detailItem, currentLine, terminal);
-                }
-                else if (item is TerminalProgressMessageState messageItem)
-                {
-                    RenderedProgressItem messageLine = GetOrAllocateNextSlot();
-                    messageLine.Reset(messageItem.Id, messageItem.Version);
-                    AppendProgressMessage(messageItem, messageLine, terminal);
-                }
-            }
-
-            // This makes the progress not stick to the last line on the command line, which is
-            // not what I would prefer. But also if someone writes to console, the message will
-            // start at the beginning of the new line. Not after the progress bar that is kept on screen.
-            terminal.AppendLine();
-        }
-
-        // We rendered more lines in previous frame. Clear them.
-        if (i < previousFrame.RenderedLinesCount)
-        {
-            terminal.Append(AnsiCodes.CsiEraseInDisplay);
-        }
-    }
-
-    private List<object> GenerateLinesToRender(TestProgressState?[] progress, TerminalProgressMessageState[] messages)
-    {
-        // Note: We want to render the list of active tests, but this can easily fill up the full screen.
-        // As such, we should balance the number of active tests shown per project.
-        // We do this by distributing the remaining lines for each projects.
-
-        // Collect non-null progress items without LINQ OfType allocation.
-        int itemCount = 0;
-        for (int j = 0; j < progress.Length; j++)
-        {
-            if (progress[j] is not null)
-            {
-                itemCount++;
-            }
-        }
-
-        // Grow cached working buffers when more capacity is needed; never shrink to avoid churn.
-        if (_progressItemsBuffer.Length < itemCount)
-        {
-            _progressItemsBuffer = new TestProgressState[itemCount];
-            _sortedIndicesBuffer = new int[itemCount];
-            _detailItemsBuffer = new List<TestDetailState>?[itemCount];
-        }
-
-        int idx = 0;
-        for (int j = 0; j < progress.Length; j++)
-        {
-            if (progress[j] is not null)
-            {
-                _progressItemsBuffer[idx++] = progress[j]!;
-            }
-        }
-
-        int linesToDistribute = (int)(Height * 0.7) - 1 - itemCount - messages.Length;
-
-        // Sort indices by detail count ascending to distribute lines fairly,
-        // without LINQ Enumerable.Range + OrderBy allocation.
-        for (int j = 0; j < itemCount; j++)
-        {
-            _sortedIndicesBuffer[j] = j;
-        }
-
-        // _progressCountComparer is a cached instance — no per-tick allocation.
-        _progressCountComparer.Buffer = _progressItemsBuffer;
-        Array.Sort(_sortedIndicesBuffer, 0, itemCount, _progressCountComparer);
-
-        // Only populate detail buffers when there is a positive line budget per item.
-        // GetRunningTasks(0) would compute itemsToTake = -1 and throw inside RemoveRange,
-        // and there's no point asking for details we cannot display anyway.
-        int linesPerItem = itemCount > 0 ? linesToDistribute / itemCount : 0;
-        if (linesPerItem > 0)
-        {
-            for (int j = 0; j < itemCount; j++)
-            {
-                int sortedItemIndex = _sortedIndicesBuffer[j];
-                _detailItemsBuffer[sortedItemIndex] = _progressItemsBuffer[sortedItemIndex].TestNodeResultsState?.GetRunningTasks(linesPerItem);
-            }
-        }
-
-        _linesToRenderBuffer.AddRange(messages);
-
-        for (int progressI = 0; progressI < itemCount; progressI++)
-        {
-            _linesToRenderBuffer.Add(_progressItemsBuffer[progressI]);
-            if (_detailItemsBuffer[progressI] is { } details)
-            {
-                _linesToRenderBuffer.AddRange(details);
-                _detailItemsBuffer[progressI] = null; // release to avoid holding stale GC roots
-            }
-
-            // Release the progress item reference too so completed workers can be collected
-            // even when this frame instance is kept alive across ticks.
-            _progressItemsBuffer[progressI] = null!;
-        }
-
-        return _linesToRenderBuffer;
-    }
-
-    public void Clear() => RenderedLinesCount = 0;
 
     /// <summary>
     /// Reusable comparer for sorting progress-item indices by running-task count.
@@ -669,6 +108,12 @@ internal sealed class AnsiTerminalTestProgressFrame
 
     internal sealed class RenderedProgressItem
     {
+        public long ProgressId { get; private set; }
+
+        public long ProgressVersion { get; private set; }
+
+        public int RenderedDurationLength { get; set; }
+
         /// <summary>Resets this instance for reuse with new identity and version values.</summary>
         internal void Reset(long id, long version)
         {
@@ -676,11 +121,5 @@ internal sealed class AnsiTerminalTestProgressFrame
             ProgressVersion = version;
             RenderedDurationLength = 0;
         }
-
-        public long ProgressId { get; private set; }
-
-        public long ProgressVersion { get; private set; }
-
-        public int RenderedDurationLength { get; set; }
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTextLayoutHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminalTextLayoutHelper.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+[Embedded]
+internal static class AnsiTerminalTextLayoutHelper
+{
+    internal static void AppendProgressMessageToWidth(AnsiTerminal terminal, string text, int availableWidth)
+    {
+        List<TextElement> elements = [];
+        int totalWidth = 0;
+        bool textWasNormalized = false;
+        TextElementEnumerator enumerator = StringInfo.GetTextElementEnumerator(text);
+        while (enumerator.MoveNext())
+        {
+            string originalElement = enumerator.GetTextElement();
+            TextElement element = CreateTextElement(originalElement);
+            textWasNormalized |= !ReferenceEquals(originalElement, element.Text);
+            if (IsRegionalIndicator(element.Text)
+                && elements.Count > 0
+                && IsRegionalIndicator(elements[^1].Text))
+            {
+                TextElement previousElement = elements[^1];
+                elements[^1] = new TextElement(previousElement.Text + element.Text, Width: 2);
+                totalWidth += 2 - previousElement.Width;
+            }
+            else
+            {
+                elements.Add(element);
+                totalWidth += element.Width;
+            }
+        }
+
+        if (totalWidth <= availableWidth)
+        {
+            if (textWasNormalized)
+            {
+                foreach (TextElement element in elements)
+                {
+                    terminal.Append(element.Text);
+                }
+            }
+            else
+            {
+                terminal.Append(text);
+            }
+
+            return;
+        }
+
+        if (availableWidth < 3)
+        {
+            AppendPrefixToWidth(terminal, elements, availableWidth);
+            return;
+        }
+
+        terminal.Append("...");
+        int remainingWidth = availableWidth - 3;
+        int firstElementToAppend = elements.Count;
+        for (int i = elements.Count - 1; i >= 0; i--)
+        {
+            if (elements[i].Width > remainingWidth)
+            {
+                break;
+            }
+
+            remainingWidth -= elements[i].Width;
+            firstElementToAppend = i;
+        }
+
+        for (int i = firstElementToAppend; i < elements.Count; i++)
+        {
+            terminal.Append(elements[i].Text);
+        }
+    }
+
+    internal static void AppendToWidth(AnsiTerminal terminal, string text, int width, ref int charsTaken)
+    {
+        if (charsTaken + text.Length < width)
+        {
+            terminal.Append(text);
+            charsTaken += text.Length;
+        }
+        else
+        {
+            terminal.Append("...");
+            charsTaken += 3;
+            if (charsTaken < width)
+            {
+                int charsToTake = width - charsTaken;
+                string cutText = text[^charsToTake..];
+                terminal.Append(cutText);
+                charsTaken += charsToTake;
+            }
+        }
+    }
+
+    private static void AppendPrefixToWidth(AnsiTerminal terminal, List<TextElement> elements, int availableWidth)
+    {
+        foreach (TextElement element in elements)
+        {
+            if (element.Width > availableWidth)
+            {
+                break;
+            }
+
+            terminal.Append(element.Text);
+            availableWidth -= element.Width;
+        }
+    }
+
+    private static TextElement CreateTextElement(string textElement)
+    {
+        int width = 0;
+        bool hasEmojiPresentationSelector = false;
+        StringBuilder? normalizedText = null;
+        for (int i = 0; i < textElement.Length;)
+        {
+            int codePoint;
+            int codeUnitCount;
+            bool isMalformedSurrogate = char.IsSurrogate(textElement[i])
+                && !char.IsSurrogatePair(textElement, i);
+            if (isMalformedSurrogate)
+            {
+                normalizedText ??= new StringBuilder(textElement.Length).Append(textElement, 0, i);
+                normalizedText.Append('\uFFFD');
+                codePoint = 0xFFFD;
+                codeUnitCount = 1;
+            }
+            else
+            {
+                codePoint = char.ConvertToUtf32(textElement, i);
+                codeUnitCount = char.IsSurrogatePair(textElement, i) ? 2 : 1;
+                normalizedText?.Append(textElement, i, codeUnitCount);
+            }
+
+            hasEmojiPresentationSelector |= codePoint == 0xFE0F;
+            UnicodeCategory category = isMalformedSurrogate
+                ? UnicodeCategory.OtherSymbol
+                : CharUnicodeInfo.GetUnicodeCategory(textElement, i);
+            if (category is not (UnicodeCategory.NonSpacingMark or UnicodeCategory.EnclosingMark or UnicodeCategory.Format))
+            {
+                width = Math.Max(width, IsWideCodePoint(codePoint) ? 2 : 1);
+            }
+
+            i += codeUnitCount;
+        }
+
+        return new TextElement(
+            normalizedText?.ToString() ?? textElement,
+            hasEmojiPresentationSelector ? Math.Max(width, 2) : width);
+    }
+
+    private static bool IsWideCodePoint(int codePoint)
+        => codePoint is >= 0x1100
+            and (<= 0x115F
+                or 0x2329
+                or 0x232A
+                or (>= 0x2E80 and <= 0xA4CF and not 0x303F)
+                or (>= 0xAC00 and <= 0xD7A3)
+                or (>= 0xF900 and <= 0xFAFF)
+                or (>= 0xFE10 and <= 0xFE19)
+                or (>= 0xFE30 and <= 0xFE6F)
+                or (>= 0xFF00 and <= 0xFF60)
+                or (>= 0xFFE0 and <= 0xFFE6)
+                or (>= 0x1F1E6 and <= 0x1F1FF)
+                or (>= 0x1F300 and <= 0x1FAFF)
+                or (>= 0x20000 and <= 0x3FFFD));
+
+    private static bool IsRegionalIndicator(string textElement)
+        => textElement.Length == 2
+            && char.IsSurrogatePair(textElement, 0)
+            && char.ConvertToUtf32(textElement, 0) is >= 0x1F1E6 and <= 0x1F1FF;
+
+    private readonly record struct TextElement(string Text, int Width);
+}


### PR DESCRIPTION
## Summary

- split frame lifecycle and pooled state from progress row formatting
- isolate Unicode-aware terminal text layout in an embedded helper
- move VT100 diff rendering into a focused partial class
- keep every resulting source file under 300 lines

## Testing

- built `Microsoft.Testing.Platform.UnitTests` for `net8.0`
- ran all 139 `TerminalTestReporterTests`

Closes #10092