### PR TITLE
[code-simplifier] Simplify TestContext implementation

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TraceTextWriter.cs
@@ -25,7 +25,7 @@ internal sealed class TraceTextWriter : TextWriter
     public override void Write(char value)
     {
         TestOutputCaptureMode mode = _modeProvider();
-        if (mode != TestOutputCaptureMode.None && TestContext.Current as TestContextImplementation is { } testContext)
+        if (mode != TestOutputCaptureMode.None && TestContext.Current is TestContextImplementation testContext)
         {
             testContext.TraceBuilder.Append(value);
             if (mode == TestOutputCaptureMode.Live)
@@ -38,7 +38,7 @@ internal sealed class TraceTextWriter : TextWriter
     public override void Write(string? value)
     {
         TestOutputCaptureMode mode = _modeProvider();
-        if (mode != TestOutputCaptureMode.None && TestContext.Current as TestContextImplementation is { } testContext)
+        if (mode != TestOutputCaptureMode.None && TestContext.Current is TestContextImplementation testContext)
         {
             testContext.TraceBuilder.Append(value);
             if (mode == TestOutputCaptureMode.Live)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -316,15 +316,7 @@ internal sealed class TestContextImplementation : TestContext, ITestContext, IDi
     /// <param name="propertyValue">The property value.</param>
     /// <returns>True if found.</returns>
     public bool TryGetPropertyValue(string propertyName, out object? propertyValue)
-    {
-        if (_properties == null)
-        {
-            propertyValue = null;
-            return false;
-        }
-
-        return _properties.TryGetValue(propertyName, out propertyValue);
-    }
+        => _properties.TryGetValue(propertyName, out propertyValue);
 
     /// <summary>
     /// Adds the parameter name/value pair to property bag.


### PR DESCRIPTION
## Summary

- remove the unreachable null guard from `TestContextImplementation.TryGetPropertyValue`
- use direct type-pattern matching in `TraceTextWriter`, consistent with `ConsoleRouter`
- make the simplified property lookup expression-bodied per repository analyzer rules

## Testing

- `MSTestAdapter.PlatformServices.UnitTests` passed on `net462`, `net48`, `net8.0`, `net9.0`, and `net8.0-windows10.0.18362.0`

Fixes #10087