### PR TITLE
Prototype crash-resilient TRX writes

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -24,3 +24,107 @@ Microsoft.Testing.Extensions.MergeOutputFileHelper
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.BuildCaseFoldedProbePath(string! directory, string! probeFileName) -> string!
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath) -> void
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Flush() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Length.get -> long
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Position.get -> long
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Read(byte[]! buffer, int offset, int count) -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Seek(long offset, System.IO.SeekOrigin origin) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.SetLength(long length) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile.Write(byte[]! buffer, int offset, int count) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.CreateTemporarySiblingPath(string! destinationPath) -> string!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.Delete(string! path) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.Exists(string! path) -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.Open(string! path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) -> Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.ReplaceTemporarySibling(string! temporaryPath, string! destinationPath) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations.SupportsAtomicReplace.get -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.CreateTemporarySiblingPath(string! destinationPath) -> string!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.Delete(string! path) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.Exists(string! path) -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.Open(string! path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) -> Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.ReplaceTemporarySibling(string! temporaryPath, string! destinationPath) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.SupportsAtomicReplace.get -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeFileOperations.TrxPrototypeFileOperations() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.AppendCompleted(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult! result, System.Guid executionId, int? runningSlot = null) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.ClaimRunning(string! uid, string! displayName, System.Guid executionId, System.DateTimeOffset startTime) -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.Compact(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion! completion) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.Complete(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion! completion) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.Initialize() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.TrxIncrementalWriterPrototype(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations! operations, string! path, System.Guid runId, string! runName, string! machineName, string! testModule, string! frameworkUid, string! frameworkVersion, System.DateTimeOffset startTime, int definitionPadBytes = 65536, int entryPadBytes = 32768, int summaryPadBytes = 32768, int counterWidth = 10, int runningSlotCount = 4, int runningSlotByteCapacity = 512, Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxSnapshotPublisherPrototype? snapshotPublisher = null) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxIncrementalWriterPrototype.UpdateFinishTime(System.DateTimeOffset finishTime) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.AttachmentWarnings.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.AttachmentWarnings.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.CollectorAttachmentHrefs.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.CollectorAttachmentHrefs.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.CrashText.get -> string!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.CrashText.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.ExitCode.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.ExitCode.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.FinishTime.get -> System.DateTimeOffset
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.FinishTime.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.IsTestHostCrashed.get -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.IsTestHostCrashed.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion.TrxPrototypeCompletion() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderCompact(System.Guid runId, string! runName, System.DateTimeOffset startTime, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult!>! results, System.Collections.Generic.IReadOnlyList<System.Guid>! executionIds, Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion! completion) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderCompletedResult(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult! testResult, System.Guid executionId, System.DateTimeOffset fallbackTime) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderDefinition(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult! testResult, System.Guid executionId) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderRunningSlot(string! uid, string! displayName, System.Guid executionId, System.DateTimeOffset startTime, int byteCapacity) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderSummaryAdditions(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion! completion) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.TrxPrototypeXmlRenderer(string! machineName, string! testModule, string! frameworkUid, string! frameworkVersion) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.WriteJournalReplayedRecord(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile! destination, Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult! result, System.Guid executionId, System.DateTimeOffset fallbackTime) -> void
+static Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.GetTestId(string! uid) -> string!
+static Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderEntry(string! uid, System.Guid executionId) -> byte[]!
+static Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeXmlRenderer.RenderInitial(System.Guid runId, string! runName, System.DateTimeOffset startTime, int definitionPadBytes, int entryPadBytes, int summaryPadBytes, int counterWidth, int runningSlotCount, int runningSlotByteCapacity) -> byte[]!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxSnapshotPublisherPrototype
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxSnapshotPublisherPrototype.Publish(string! destinationPath, System.Action<Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFile!>! writeCompleteDocument) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxSnapshotPublisherPrototype.TrxSnapshotPublisherPrototype(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations! operations) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.DisplayName.get -> string!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.DisplayName.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.ExecutionId.get -> System.Guid
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.ExecutionId.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.StartTime.get -> System.DateTimeOffset
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.StartTime.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.TrxPrototypeRunningTest() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.Uid.get -> string!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest.Uid.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.AppendedRecordCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.AppendedRecordCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentDefinitionIdCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentDefinitionIdCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentRecordBufferBytes.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentRecordBufferBytes.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentReplayRecordCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.CurrentReplayRecordCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.MaxEncodedRecordBytes.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.MaxEncodedRecordBytes.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.MaxRenderedFragmentBytes.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.MaxRenderedFragmentBytes.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakDefinitionIdCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakDefinitionIdCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakLogicalBufferBytes.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakLogicalBufferBytes.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakRecordBufferBytes.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakRecordBufferBytes.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakReplayRecordCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PeakReplayRecordCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PublishedDefinitionCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PublishedDefinitionCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PublishedRecordCount.get -> int
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.PublishedRecordCount.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.RetainsResultCollection.get -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.RetainsResultCollection.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.RetainsXDocument.get -> bool
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.RetainsXDocument.init -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics.TrxJournalSnapshotDiagnostics() -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotPrototype
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotPrototype.Append(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxTestResult! result, System.Guid executionId) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotPrototype.Diagnostics.get -> Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotDiagnostics!
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotPrototype.PublishSnapshot(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeCompletion! completion, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxPrototypeRunningTest!>? runningTests = null) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.TrxJournalSnapshotPrototype.TrxJournalSnapshotPrototype(Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming.ITrxPrototypeFileOperations! operations, string! journalPath, string! destinationPath, System.Guid runId, string! runName, string! machineName, string! testModule, string! frameworkUid, string! frameworkVersion, System.DateTimeOffset startTime) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/ITrxPrototypeFileOperations.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/ITrxPrototypeFileOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/ITrxPrototypeFileOperations.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/ITrxPrototypeFileOperations.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal interface ITrxPrototypeFileOperations
+{
+    bool SupportsAtomicReplace { get; }
+
+    ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share);
+
+    string CreateTemporarySiblingPath(string destinationPath);
+
+    void ReplaceTemporarySibling(string temporaryPath, string destinationPath);
+
+    bool Exists(string path);
+
+    void Delete(string path);
+}
+
+internal interface ITrxPrototypeFile : IDisposable
+{
+    long Length { get; }
+
+    long Position { get; }
+
+    int Read(byte[] buffer, int offset, int count);
+
+    void Seek(long offset, SeekOrigin origin);
+
+    void Write(byte[] buffer, int offset, int count);
+
+    void Flush();
+
+    void SetLength(long length);
+}

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxIncrementalWriterPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxIncrementalWriterPrototype.cs
@@ -1,0 +1,809 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform;
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal sealed class TrxIncrementalWriterPrototype
+{
+    private const string ResultsClosers = "</Results></TestRun>";
+    private const int OutcomeCellWidth = 10;
+
+    private static readonly UTF8Encoding Utf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly string[] MutableCounterNames =
+        ["total", "executed", "passed", "failed", "timeout", "notExecuted", "inProgress"];
+
+    private readonly ITrxPrototypeFileOperations _operations;
+    private readonly string _path;
+    private readonly Guid _runId;
+    private readonly string _runName;
+    private readonly DateTimeOffset _startTime;
+    private readonly int _summaryPadBytes;
+    private readonly int _counterWidth;
+    private readonly int _runningSlotCount;
+    private readonly int _runningSlotByteCapacity;
+    private readonly TrxPrototypeXmlRenderer _renderer;
+    private readonly TrxSnapshotPublisherPrototype? _snapshotPublisher;
+#pragma warning disable IDE0028 // Collection expressions cannot preserve the ordinal test-id comparer.
+    private readonly Dictionary<string, string> _definitionNames = new(StringComparer.OrdinalIgnoreCase);
+#pragma warning restore IDE0028
+    private readonly List<TrxTestResult> _completedResults = [];
+    private readonly List<Guid> _completedExecutionIds = [];
+    private readonly RunningClaim?[] _runningClaims;
+    private readonly Dictionary<Guid, int> _runningSlotsByExecutionId = [];
+#pragma warning disable IDE0028 // Collection expressions cannot preserve the ordinal counter-name comparer.
+    private readonly Dictionary<string, long> _counterOffsets = new(StringComparer.Ordinal);
+#pragma warning restore IDE0028
+
+    private int _definitionPadBytes;
+    private int _entryPadBytes;
+    private long _definitionWriteOffset;
+    private long _entryWriteOffset;
+    private long _summaryWriteOffset;
+    private long _resultTailOffset;
+    private long _finishTimeOffset;
+    private long _outcomeCellOffset;
+    private int _definitionBytesRemaining;
+    private int _entryBytesRemaining;
+    private int _summaryBytesRemaining;
+    private long _runningSlotsOffset;
+    private int _passed;
+    private int _failed;
+    private int _skipped;
+    private int _timeout;
+    private DateTimeOffset _finishTime;
+    private bool _initialized;
+    private bool _completed;
+
+    public TrxIncrementalWriterPrototype(
+        ITrxPrototypeFileOperations operations,
+        string path,
+        Guid runId,
+        string runName,
+        string machineName,
+        string testModule,
+        string frameworkUid,
+        string frameworkVersion,
+        DateTimeOffset startTime,
+        int definitionPadBytes = 65_536,
+        int entryPadBytes = 32_768,
+        int summaryPadBytes = 32_768,
+        int counterWidth = 10,
+        int runningSlotCount = 4,
+        int runningSlotByteCapacity = 512,
+        TrxSnapshotPublisherPrototype? snapshotPublisher = null)
+    {
+        _operations = operations ?? throw new ArgumentNullException(nameof(operations));
+        ThrowIfNullOrEmpty(path, nameof(path));
+        ThrowIfNullOrEmpty(runName, nameof(runName));
+        ThrowIfNullOrEmpty(machineName, nameof(machineName));
+        ThrowIfNullOrEmpty(testModule, nameof(testModule));
+        ThrowIfNullOrEmpty(frameworkUid, nameof(frameworkUid));
+        ThrowIfNullOrEmpty(frameworkVersion, nameof(frameworkVersion));
+        if (definitionPadBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(definitionPadBytes));
+        }
+
+        if (entryPadBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(entryPadBytes));
+        }
+
+        if (summaryPadBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(summaryPadBytes));
+        }
+
+        if (counterWidth is < 1 or > 10)
+        {
+            throw new ArgumentOutOfRangeException(nameof(counterWidth));
+        }
+
+        if (runningSlotCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(runningSlotCount));
+        }
+
+        if (runningSlotByteCapacity < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(runningSlotByteCapacity));
+        }
+
+        _path = path;
+        _runId = runId;
+        _runName = runName;
+        _startTime = startTime;
+        _finishTime = startTime;
+        _definitionPadBytes = definitionPadBytes;
+        _entryPadBytes = entryPadBytes;
+        _summaryPadBytes = summaryPadBytes;
+        _counterWidth = counterWidth;
+        _runningSlotCount = runningSlotCount;
+        _runningSlotByteCapacity = runningSlotByteCapacity;
+        _renderer = new TrxPrototypeXmlRenderer(machineName, testModule, frameworkUid, frameworkVersion);
+        _snapshotPublisher = snapshotPublisher;
+        _runningClaims = new RunningClaim?[runningSlotCount];
+    }
+
+    public void Initialize()
+    {
+        if (_initialized)
+        {
+            throw new InvalidOperationException("The TRX prototype is already initialized.");
+        }
+
+        byte[] bytes = TrxPrototypeXmlRenderer.RenderInitial(
+            _runId,
+            _runName,
+            _startTime,
+            _definitionPadBytes,
+            _entryPadBytes,
+            _summaryPadBytes,
+            _counterWidth,
+            _runningSlotCount,
+            _runningSlotByteCapacity);
+        if (_snapshotPublisher is null)
+        {
+            using ITrxPrototypeFile file = _operations.Open(
+                _path,
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.Read | FileShare.Delete);
+            file.Write(bytes, 0, bytes.Length);
+            file.Flush();
+        }
+        else
+        {
+            _snapshotPublisher.Publish(
+                _path,
+                file => file.Write(bytes, 0, bytes.Length));
+        }
+
+        CalculateLayout(bytes);
+        _initialized = true;
+    }
+
+    public int ClaimRunning(string uid, string displayName, Guid executionId, DateTimeOffset startTime)
+    {
+        EnsureMutable();
+        ThrowIfNullOrEmpty(uid, nameof(uid));
+        if (displayName is null)
+        {
+            throw new ArgumentNullException(nameof(displayName));
+        }
+
+        if (_runningSlotsByExecutionId.ContainsKey(executionId))
+        {
+            throw new InvalidOperationException($"Execution '{executionId}' is already running.");
+        }
+
+        int slot = Array.FindIndex(_runningClaims, claim => claim is null);
+        if (slot < 0)
+        {
+            throw new InvalidOperationException(
+                $"All {_runningSlotCount} running-test slots are occupied; execution '{executionId}' was not recorded.");
+        }
+
+        byte[] slotBytes = _renderer.RenderRunningSlot(
+            uid,
+            displayName,
+            executionId,
+            startTime,
+            _runningSlotByteCapacity);
+        WriteFixedRegion(GetRunningSlotOffset(slot), slotBytes);
+
+        _runningClaims[slot] = new RunningClaim(uid, displayName, executionId, startTime);
+        _runningSlotsByExecutionId.Add(executionId, slot);
+        WriteCounter("inProgress", _runningSlotsByExecutionId.Count);
+        return slot;
+    }
+
+    public void AppendCompleted(TrxTestResult result, Guid executionId, int? runningSlot = null)
+    {
+        EnsureMutable();
+        if (result is null)
+        {
+            throw new ArgumentNullException(nameof(result));
+        }
+
+        RunningClaim? claim = null;
+        if (runningSlot is int slot)
+        {
+            if ((uint)slot >= (uint)_runningClaims.Length || _runningClaims[slot] is not { } existing)
+            {
+                throw new InvalidOperationException($"Running slot {slot} is not claimed.");
+            }
+
+            if (existing.ExecutionId != executionId)
+            {
+                throw new InvalidOperationException(
+                    $"Running slot {slot} belongs to execution '{existing.ExecutionId}', not '{executionId}'.");
+            }
+
+            if (!string.Equals(
+                    TrxPrototypeXmlRenderer.GetTestId(existing.Uid),
+                    TrxPrototypeXmlRenderer.GetTestId(result.Uid),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Running slot {slot} belongs to test '{existing.Uid}', not '{result.Uid}'.");
+            }
+
+            claim = existing;
+        }
+        else if (_runningSlotsByExecutionId.ContainsKey(executionId))
+        {
+            throw new InvalidOperationException(
+                $"Execution '{executionId}' has a running claim; its slot must be supplied when completing it.");
+        }
+
+        string testId = TrxPrototypeXmlRenderer.GetTestId(result.Uid);
+        string definitionName = result.TrxTestDefinitionName ?? result.DisplayName;
+        bool addDefinition = !_definitionNames.TryGetValue(testId, out string? existingDefinitionName);
+        if (!addDefinition
+            && result.TrxTestDefinitionName is not null
+            && !string.Equals(existingDefinitionName, definitionName, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Received two different test definition names ('{existingDefinitionName}' and '{definitionName}') for test id '{testId}'.");
+        }
+
+        byte[] resultBytes = _renderer.RenderCompletedResult(result, executionId, _startTime);
+        byte[] entryBytes = TrxPrototypeXmlRenderer.RenderEntry(result.Uid, executionId);
+        byte[]? definitionBytes = addDefinition ? _renderer.RenderDefinition(result, executionId) : null;
+        EnsureCounterCapacity();
+        if (_snapshotPublisher is not null
+            && ((definitionBytes?.Length ?? 0) > _definitionBytesRemaining
+                || entryBytes.Length > _entryBytesRemaining))
+        {
+            ReflowAndAppend(
+                result,
+                executionId,
+                runningSlot,
+                definitionName,
+                addDefinition,
+                definitionBytes?.Length ?? 0,
+                entryBytes.Length);
+            return;
+        }
+
+        EnsureCapacity("definition", definitionBytes?.Length ?? 0, _definitionBytesRemaining);
+        EnsureCapacity("entry", entryBytes.Length, _entryBytesRemaining);
+
+        if (definitionBytes is not null)
+        {
+            WriteFixedRegion(_definitionWriteOffset, definitionBytes);
+            _definitionWriteOffset += definitionBytes.Length;
+            _definitionBytesRemaining -= definitionBytes.Length;
+        }
+
+        WriteFixedRegion(_entryWriteOffset, entryBytes);
+        _entryWriteOffset += entryBytes.Length;
+        _entryBytesRemaining -= entryBytes.Length;
+        AppendResultAtTail(resultBytes);
+
+        if (runningSlot is int claimedSlot)
+        {
+            WriteFixedRegion(GetRunningSlotOffset(claimedSlot), CreateWhitespace(_runningSlotByteCapacity));
+            _runningClaims[claimedSlot] = null;
+            _ = _runningSlotsByExecutionId.Remove(executionId);
+        }
+
+        if (addDefinition)
+        {
+            _definitionNames.Add(testId, definitionName);
+        }
+
+        _completedResults.Add(result);
+        _completedExecutionIds.Add(executionId);
+        AddOutcome(result.Outcome);
+        WriteMutableCounters();
+        _ = claim;
+    }
+
+    public void UpdateFinishTime(DateTimeOffset finishTime)
+    {
+        EnsureMutable();
+        byte[] bytes = Utf8.GetBytes(finishTime.ToString("O", CultureInfo.InvariantCulture));
+        if (bytes.Length != Utf8.GetByteCount(_startTime.ToString("O", CultureInfo.InvariantCulture)))
+        {
+            throw new InvalidOperationException("The finish timestamp does not fit the fixed timestamp cell.");
+        }
+
+        WriteFixedRegion(_finishTimeOffset, bytes);
+        _finishTime = finishTime;
+    }
+
+    public void Complete(TrxPrototypeCompletion completion)
+    {
+        EnsureMutable();
+        if (completion is null)
+        {
+            throw new ArgumentNullException(nameof(completion));
+        }
+
+        if (_runningSlotsByExecutionId.Count != 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot complete while {_runningSlotsByExecutionId.Count} running-test slots remain claimed.");
+        }
+
+        byte[] summaryAdditions = _renderer.RenderSummaryAdditions(completion);
+        EnsureCapacity("summary", summaryAdditions.Length, _summaryBytesRemaining);
+        string outcome = IsFailedCompletion(completion) ? "Failed" : "Completed";
+        byte[] outcomeCell = CreateOutcomeCell(outcome);
+        byte[] finishTime = Utf8.GetBytes(completion.FinishTime.ToString("O", CultureInfo.InvariantCulture));
+        if (finishTime.Length != Utf8.GetByteCount(_startTime.ToString("O", CultureInfo.InvariantCulture)))
+        {
+            throw new InvalidOperationException("The completion timestamp does not fit the fixed timestamp cell.");
+        }
+
+        WriteFixedRegion(_finishTimeOffset, finishTime);
+        if (summaryAdditions.Length > 0)
+        {
+            WriteFixedRegion(_summaryWriteOffset, summaryAdditions);
+            _summaryWriteOffset += summaryAdditions.Length;
+            _summaryBytesRemaining -= summaryAdditions.Length;
+        }
+
+        WriteFixedRegion(_outcomeCellOffset, outcomeCell);
+        _finishTime = completion.FinishTime;
+        _completed = true;
+    }
+
+    public void Compact(TrxPrototypeCompletion completion)
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("The TRX prototype is not initialized.");
+        }
+
+        if (completion is null)
+        {
+            throw new ArgumentNullException(nameof(completion));
+        }
+
+        byte[] bytes = _renderer.RenderCompact(
+            _runId,
+            _runName,
+            _startTime,
+            _completedResults,
+            _completedExecutionIds,
+            completion);
+        if (_snapshotPublisher is null)
+        {
+            using ITrxPrototypeFile file = _operations.Open(
+                _path,
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.Read | FileShare.Delete);
+            file.Write(bytes, 0, bytes.Length);
+            file.Flush();
+        }
+        else
+        {
+            _snapshotPublisher.Publish(
+                _path,
+                file => file.Write(bytes, 0, bytes.Length));
+        }
+    }
+
+    private void CalculateLayout(byte[] document)
+    {
+        _counterOffsets.Clear();
+        _definitionWriteOffset = FindAfter(document, "<TestDefinitions>");
+        _definitionBytesRemaining = _definitionPadBytes;
+        _entryWriteOffset = FindAfter(document, "<TestEntries>");
+        _entryBytesRemaining = _entryPadBytes;
+        _runningSlotsOffset = FindAfter(document, "<Results>");
+        _resultTailOffset = Find(document, "</Results>");
+        _finishTimeOffset = FindAfter(document, "finish=\"");
+        _outcomeCellOffset = FindAfter(document, "<ResultSummary outcome=\"");
+
+        long countersStart = Find(document, "<Counters ");
+        long countersEnd = Find(document, "/>", countersStart) + 2;
+        _summaryWriteOffset = countersEnd;
+        _summaryBytesRemaining = _summaryPadBytes;
+        foreach (string counterName in MutableCounterNames)
+        {
+            _counterOffsets.Add(counterName, FindAfter(document, $"{counterName}=\"", countersStart));
+        }
+    }
+
+    private void ReflowAndAppend(
+        TrxTestResult result,
+        Guid executionId,
+        int? runningSlot,
+        string definitionName,
+        bool addDefinition,
+        int definitionByteCount,
+        int entryByteCount)
+    {
+        int usedDefinitionBytes = _definitionPadBytes - _definitionBytesRemaining;
+        int usedEntryBytes = _entryPadBytes - _entryBytesRemaining;
+        int definitionCapacity = GrowCapacity(
+            _definitionPadBytes,
+            checked(usedDefinitionBytes + definitionByteCount));
+        int entryCapacity = GrowCapacity(
+            _entryPadBytes,
+            checked(usedEntryBytes + entryByteCount));
+
+        List<TrxTestResult> results = [.. _completedResults, result];
+        List<Guid> executionIds = [.. _completedExecutionIds, executionId];
+        byte[] replacement = BuildPaddedDocument(
+            results,
+            executionIds,
+            definitionCapacity,
+            entryCapacity,
+            runningSlot,
+            out int replacementDefinitionBytes,
+            out int replacementEntryBytes);
+
+        _snapshotPublisher!.Publish(
+            _path,
+            file => file.Write(replacement, 0, replacement.Length));
+
+        _definitionPadBytes = definitionCapacity;
+        _entryPadBytes = entryCapacity;
+        CalculateLayout(replacement);
+        _definitionWriteOffset += replacementDefinitionBytes;
+        _definitionBytesRemaining -= replacementDefinitionBytes;
+        _entryWriteOffset += replacementEntryBytes;
+        _entryBytesRemaining -= replacementEntryBytes;
+
+        if (runningSlot is int claimedSlot)
+        {
+            _runningClaims[claimedSlot] = null;
+            _ = _runningSlotsByExecutionId.Remove(executionId);
+        }
+
+        if (addDefinition)
+        {
+            _definitionNames.Add(TrxPrototypeXmlRenderer.GetTestId(result.Uid), definitionName);
+        }
+
+        _completedResults.Add(result);
+        _completedExecutionIds.Add(executionId);
+        AddOutcome(result.Outcome);
+    }
+
+    private byte[] BuildPaddedDocument(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        int definitionCapacity,
+        int entryCapacity,
+        int? releasedRunningSlot,
+        out int definitionBytesUsed,
+        out int entryBytesUsed)
+    {
+        byte[] initial = TrxPrototypeXmlRenderer.RenderInitial(
+            _runId,
+            _runName,
+            _startTime,
+            definitionCapacity,
+            entryCapacity,
+            _summaryPadBytes,
+            _counterWidth,
+            _runningSlotCount,
+            _runningSlotByteCapacity);
+        long definitionOffset = FindAfter(initial, "<TestDefinitions>");
+        long entryOffset = FindAfter(initial, "<TestEntries>");
+        long runningOffset = FindAfter(initial, "<Results>");
+        long resultTailOffset = Find(initial, "</Results>");
+
+        definitionBytesUsed = 0;
+        entryBytesUsed = 0;
+        var definitionIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        List<byte[]> resultFragments = [];
+        int passed = 0;
+        int failed = 0;
+        int skipped = 0;
+        int timeout = 0;
+        for (int i = 0; i < results.Count; i++)
+        {
+            TrxTestResult completedResult = results[i];
+            Guid completedExecutionId = executionIds[i];
+            string testId = TrxPrototypeXmlRenderer.GetTestId(completedResult.Uid);
+            if (definitionIds.Add(testId))
+            {
+                byte[] definition = _renderer.RenderDefinition(completedResult, completedExecutionId);
+                CopyToFixedRegion(initial, definitionOffset + definitionBytesUsed, definition);
+                definitionBytesUsed += definition.Length;
+            }
+
+            byte[] entry = TrxPrototypeXmlRenderer.RenderEntry(completedResult.Uid, completedExecutionId);
+            CopyToFixedRegion(initial, entryOffset + entryBytesUsed, entry);
+            entryBytesUsed += entry.Length;
+            resultFragments.Add(_renderer.RenderCompletedResult(completedResult, completedExecutionId, _startTime));
+
+            switch (completedResult.Outcome)
+            {
+                case TrxTestOutcome.Passed:
+                    passed++;
+                    break;
+                case TrxTestOutcome.Failed:
+                    failed++;
+                    break;
+                case TrxTestOutcome.Skipped:
+                    skipped++;
+                    break;
+                case TrxTestOutcome.Timeout:
+                    timeout++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(results));
+            }
+        }
+
+        for (int slot = 0; slot < _runningClaims.Length; slot++)
+        {
+            if (slot == releasedRunningSlot || _runningClaims[slot] is not { } claim)
+            {
+                continue;
+            }
+
+            byte[] running = _renderer.RenderRunningSlot(
+                claim.Uid,
+                claim.DisplayName,
+                claim.ExecutionId,
+                claim.StartTime,
+                _runningSlotByteCapacity);
+            CopyToFixedRegion(initial, runningOffset + ((long)slot * _runningSlotByteCapacity), running);
+        }
+
+        WritePaddedCounter(initial, "total", passed + failed + skipped + timeout);
+        WritePaddedCounter(initial, "executed", passed + failed);
+        WritePaddedCounter(initial, "passed", passed);
+        WritePaddedCounter(initial, "failed", failed);
+        WritePaddedCounter(initial, "timeout", timeout);
+        WritePaddedCounter(initial, "notExecuted", skipped);
+        WritePaddedCounter(
+            initial,
+            "inProgress",
+            _runningSlotsByExecutionId.Count - (releasedRunningSlot.HasValue ? 1 : 0));
+        CopyToFixedRegion(
+            initial,
+            FindAfter(initial, "finish=\""),
+            Utf8.GetBytes(_finishTime.ToString("O", CultureInfo.InvariantCulture)));
+
+        int resultBytes = resultFragments.Sum(fragment => fragment.Length);
+        byte[] document = new byte[checked(initial.Length + resultBytes)];
+        Array.Copy(initial, 0, document, 0, resultTailOffset);
+        int destinationOffset = checked((int)resultTailOffset);
+        foreach (byte[] fragment in resultFragments)
+        {
+            Array.Copy(fragment, 0, document, destinationOffset, fragment.Length);
+            destinationOffset += fragment.Length;
+        }
+
+        Array.Copy(
+            initial,
+            resultTailOffset,
+            document,
+            destinationOffset,
+            initial.LongLength - resultTailOffset);
+        return document;
+    }
+
+    private void WritePaddedCounter(byte[] document, string name, int value)
+        => CopyToFixedRegion(
+            document,
+            FindAfter(document, $"{name}=\""),
+            Utf8.GetBytes(value.ToString($"D{_counterWidth}", CultureInfo.InvariantCulture)));
+
+    private static void CopyToFixedRegion(byte[] destination, long offset, byte[] source)
+    {
+        if (offset < 0 || offset > destination.LongLength - source.LongLength)
+        {
+            throw new InvalidOperationException("The rendered prototype fragment does not fit its fixed region.");
+        }
+
+        Array.Copy(source, 0, destination, offset, source.LongLength);
+    }
+
+    private static int GrowCapacity(int currentCapacity, int requiredCapacity)
+    {
+        if (requiredCapacity <= currentCapacity)
+        {
+            return currentCapacity;
+        }
+
+        int capacity = Math.Max(currentCapacity, 256);
+        while (capacity < requiredCapacity)
+        {
+            capacity = checked(capacity * 2);
+        }
+
+        return capacity;
+    }
+
+    private void AppendResultAtTail(byte[] resultBytes)
+    {
+        byte[] closers = Utf8.GetBytes(ResultsClosers);
+        byte[] bytes = new byte[resultBytes.Length + closers.Length];
+        Array.Copy(resultBytes, bytes, resultBytes.Length);
+        Array.Copy(closers, 0, bytes, resultBytes.Length, closers.Length);
+
+        using ITrxPrototypeFile file = _operations.Open(
+            _path,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read | FileShare.Delete);
+        file.Seek(_resultTailOffset, SeekOrigin.Begin);
+        file.Write(bytes, 0, bytes.Length);
+        file.SetLength(_resultTailOffset + bytes.Length);
+        file.Flush();
+        _resultTailOffset += resultBytes.Length;
+    }
+
+    private void WriteMutableCounters()
+    {
+        WriteCounter("total", _passed + _failed + _skipped + _timeout);
+        WriteCounter("executed", _passed + _failed);
+        WriteCounter("passed", _passed);
+        WriteCounter("failed", _failed);
+        WriteCounter("timeout", _timeout);
+        WriteCounter("notExecuted", _skipped);
+        WriteCounter("inProgress", _runningSlotsByExecutionId.Count);
+    }
+
+    private void WriteCounter(string name, int value)
+    {
+        byte[] bytes = Utf8.GetBytes(value.ToString($"D{_counterWidth}", CultureInfo.InvariantCulture));
+        if (bytes.Length != _counterWidth)
+        {
+            throw new InvalidOperationException(
+                $"Counter '{name}' value {value} does not fit the fixed width {_counterWidth}.");
+        }
+
+        WriteFixedRegion(_counterOffsets[name], bytes);
+    }
+
+    private void WriteFixedRegion(long offset, byte[] bytes)
+    {
+        using ITrxPrototypeFile file = _operations.Open(
+            _path,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read | FileShare.Delete);
+        file.Seek(offset, SeekOrigin.Begin);
+        file.Write(bytes, 0, bytes.Length);
+        file.Flush();
+    }
+
+    private long GetRunningSlotOffset(int slot)
+        => _runningSlotsOffset + ((long)slot * _runningSlotByteCapacity);
+
+    private void AddOutcome(TrxTestOutcome outcome)
+    {
+        switch (outcome)
+        {
+            case TrxTestOutcome.Passed:
+                _passed++;
+                break;
+            case TrxTestOutcome.Failed:
+                _failed++;
+                break;
+            case TrxTestOutcome.Skipped:
+                _skipped++;
+                break;
+            case TrxTestOutcome.Timeout:
+                _timeout++;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(outcome));
+        }
+    }
+
+    private void EnsureCounterCapacity()
+    {
+        int maximumValue = _counterWidth == 10
+            ? int.MaxValue
+            : (int)Math.Pow(10, _counterWidth) - 1;
+        if (_completedResults.Count == maximumValue)
+        {
+            throw new InvalidOperationException(
+                $"Another completed result would exceed the fixed counter width {_counterWidth}.");
+        }
+    }
+
+    private bool IsFailedCompletion(TrxPrototypeCompletion completion)
+        => completion.IsTestHostCrashed
+            || completion.ExitCode != 0
+            || _failed > 0
+            || _timeout > 0;
+
+    private void EnsureMutable()
+    {
+        if (!_initialized)
+        {
+            throw new InvalidOperationException("The TRX prototype is not initialized.");
+        }
+
+        if (_completed)
+        {
+            throw new InvalidOperationException("The TRX prototype is already complete.");
+        }
+    }
+
+    private static void EnsureCapacity(string region, int requestedBytes, int remainingBytes)
+    {
+        if (requestedBytes > remainingBytes)
+        {
+            throw new InvalidOperationException(
+                $"The {region} fragment requires {requestedBytes} UTF-8 bytes, but only {remainingBytes} bytes remain in its pad.");
+        }
+    }
+
+    private static byte[] CreateOutcomeCell(string outcome)
+    {
+        string cell = outcome == "Completed" ? "Completed\"" : "Failed\"   ";
+        byte[] bytes = Utf8.GetBytes(cell);
+        return bytes.Length == OutcomeCellWidth
+            ? bytes
+            : throw new InvalidOperationException("The result outcome does not fit the fixed outcome cell.");
+    }
+
+    private static byte[] CreateWhitespace(int count)
+    {
+        byte[] bytes = new byte[count];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = (byte)' ';
+        }
+
+        return bytes;
+    }
+
+    private static void ThrowIfNullOrEmpty(string value, string parameterName)
+    {
+        if (RoslynString.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException("The value cannot be null or empty.", parameterName);
+        }
+    }
+
+    private static long FindAfter(byte[] bytes, string marker, long start = 0)
+        => Find(bytes, marker, start) + Utf8.GetByteCount(marker);
+
+    private static long Find(byte[] bytes, string marker, long start = 0)
+    {
+        byte[] markerBytes = Utf8.GetBytes(marker);
+        for (long i = start; i <= bytes.LongLength - markerBytes.Length; i++)
+        {
+            bool matches = true;
+            for (int j = 0; j < markerBytes.Length; j++)
+            {
+                if (bytes[i + j] != markerBytes[j])
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException($"The rendered prototype document does not contain marker '{marker}'.");
+    }
+
+    private sealed class RunningClaim(
+        string uid,
+        string displayName,
+        Guid executionId,
+        DateTimeOffset startTime)
+    {
+        public string Uid { get; } = uid;
+
+        public string DisplayName { get; } = displayName;
+
+        public Guid ExecutionId { get; } = executionId;
+
+        public DateTimeOffset StartTime { get; } = startTime;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxIncrementalWriterPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxIncrementalWriterPrototype.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
@@ -361,24 +361,27 @@ internal sealed class TrxJournalSnapshotPrototype
     private byte[] RenderPrefix(DateTimeOffset finishTime)
     {
         XNamespace ns = NamespaceUri;
-        string root = new XElement(
-            ns + "TestRun",
-            new XAttribute("id", _runId),
-            new XAttribute("name", Sanitize(_runName))).ToString(SaveOptions.DisableFormatting);
-        root = root.Substring(0, root.LastIndexOf("/>", StringComparison.Ordinal)) + ">";
-        string times = new XElement(
-            "Times",
-            new XAttribute("creation", FormatTimestamp(_startTime)),
-            new XAttribute("queuing", FormatTimestamp(_startTime)),
-            new XAttribute("start", FormatTimestamp(_startTime)),
-            new XAttribute("finish", FormatTimestamp(finishTime))).ToString(SaveOptions.DisableFormatting);
-        string settings = new XElement(
-            "TestSettings",
-            new XAttribute("name", "default"),
-            new XAttribute("id", Guid.Empty),
+        string root = SerializeElement(
             new XElement(
-                "Deployment",
-                new XAttribute("runDeploymentRoot", Sanitize(_runName)))).ToString(SaveOptions.DisableFormatting);
+                ns + "TestRun",
+                new XAttribute("id", _runId),
+                new XAttribute("name", Sanitize(_runName))));
+        root = root.Substring(0, root.LastIndexOf("/>", StringComparison.Ordinal)) + ">";
+        string times = SerializeElement(
+            new XElement(
+                "Times",
+                new XAttribute("creation", FormatTimestamp(_startTime)),
+                new XAttribute("queuing", FormatTimestamp(_startTime)),
+                new XAttribute("start", FormatTimestamp(_startTime)),
+                new XAttribute("finish", FormatTimestamp(finishTime))));
+        string settings = SerializeElement(
+            new XElement(
+                "TestSettings",
+                new XAttribute("name", "default"),
+                new XAttribute("id", Guid.Empty),
+                new XElement(
+                    "Deployment",
+                    new XAttribute("runDeploymentRoot", Sanitize(_runName)))));
         return Utf8.GetBytes(string.Concat(
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
             root,
@@ -395,16 +398,17 @@ internal sealed class TrxJournalSnapshotPrototype
             || counts.Timeout > 0
                 ? "Failed"
                 : "Completed";
-        string testLists = new XElement(
-            "TestLists",
+        string testLists = SerializeElement(
             new XElement(
-                "TestList",
-                new XAttribute("name", "Results Not in a List"),
-                new XAttribute("id", UncategorizedTestListId)),
-            new XElement(
-                "TestList",
-                new XAttribute("name", "All Loaded Results"),
-                new XAttribute("id", "19431567-8539-422a-85D7-44EE4E166BDA"))).ToString(SaveOptions.DisableFormatting);
+                "TestLists",
+                new XElement(
+                    "TestList",
+                    new XAttribute("name", "Results Not in a List"),
+                    new XAttribute("id", UncategorizedTestListId)),
+                new XElement(
+                    "TestList",
+                    new XAttribute("name", "All Loaded Results"),
+                    new XAttribute("id", "19431567-8539-422a-85D7-44EE4E166BDA"))));
         return Utf8.GetBytes(string.Concat(
             "</TestEntries>",
             testLists,
@@ -418,14 +422,15 @@ internal sealed class TrxJournalSnapshotPrototype
 
     private byte[] RenderRunningTest(TrxPrototypeRunningTest running)
         => Utf8.GetBytes(
-            new XElement(
-                "UnitTestResult",
-                new XAttribute("executionId", running.ExecutionId),
-                new XAttribute("testId", TrxPrototypeXmlRenderer.GetTestId(running.Uid)),
-                new XAttribute("testName", Sanitize(running.DisplayName)),
-                new XAttribute("computerName", Sanitize(_machineName)),
-                new XAttribute("startTime", FormatTimestamp(running.StartTime)),
-                new XAttribute("outcome", "InProgress")).ToString(SaveOptions.DisableFormatting));
+            SerializeElement(
+                new XElement(
+                    "UnitTestResult",
+                    new XAttribute("executionId", running.ExecutionId),
+                    new XAttribute("testId", TrxPrototypeXmlRenderer.GetTestId(running.Uid)),
+                    new XAttribute("testName", Sanitize(running.DisplayName)),
+                    new XAttribute("computerName", Sanitize(_machineName)),
+                    new XAttribute("startTime", FormatTimestamp(running.StartTime)),
+                    new XAttribute("outcome", "InProgress"))));
 
     private static string RenderCounters(SnapshotCounts counts)
         => string.Concat(
@@ -520,6 +525,23 @@ internal sealed class TrxJournalSnapshotPrototype
                     nameof(runningTests));
             }
         }
+    }
+
+    private static string SerializeElement(XElement element)
+    {
+        XmlWriterSettings settings = new()
+        {
+            OmitXmlDeclaration = true,
+            Indent = false,
+            NewLineHandling = NewLineHandling.Entitize,
+        };
+        StringBuilder builder = new();
+        using (var writer = XmlWriter.Create(builder, settings))
+        {
+            element.WriteTo(writer);
+        }
+
+        return builder.ToString();
     }
 
     private static string Sanitize(string value)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxJournalSnapshotPrototype.cs
@@ -1,0 +1,682 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform;
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal sealed class TrxPrototypeRunningTest
+{
+    public required string Uid { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public required Guid ExecutionId { get; init; }
+
+    public required DateTimeOffset StartTime { get; init; }
+}
+
+internal sealed class TrxJournalSnapshotDiagnostics
+{
+    public int AppendedRecordCount { get; init; }
+
+    public int PublishedRecordCount { get; init; }
+
+    public int PublishedDefinitionCount { get; init; }
+
+    public int MaxEncodedRecordBytes { get; init; }
+
+    public int MaxRenderedFragmentBytes { get; init; }
+
+    public int PeakLogicalBufferBytes { get; init; }
+
+    public int CurrentReplayRecordCount { get; init; }
+
+    public int PeakReplayRecordCount { get; init; }
+
+    public int CurrentRecordBufferBytes { get; init; }
+
+    public int PeakRecordBufferBytes { get; init; }
+
+    public int CurrentDefinitionIdCount { get; init; }
+
+    public int PeakDefinitionIdCount { get; init; }
+
+    public bool RetainsResultCollection { get; init; }
+
+    public bool RetainsXDocument { get; init; }
+}
+
+internal sealed class TrxJournalSnapshotPrototype
+{
+    private const int MaximumPayloadLength = 64 * 1024 * 1024;
+    private const int ExecutionIdByteCount = 16;
+    private const string NamespaceUri = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+    private const string UncategorizedTestListId = "8C84FA94-04C1-424b-9868-57A2D4851A1D";
+
+    private static readonly UTF8Encoding Utf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    private readonly ITrxPrototypeFileOperations _operations;
+    private readonly TrxSnapshotPublisherPrototype _publisher;
+    private readonly string _journalPath;
+    private readonly string _destinationPath;
+    private readonly Guid _runId;
+    private readonly string _runName;
+    private readonly string _machineName;
+    private readonly DateTimeOffset _startTime;
+    private readonly TrxPrototypeXmlRenderer _renderer;
+    private int _appendedRecordCount;
+    private int _maxEncodedRecordBytes;
+    private bool _journalTailValidated;
+
+    public TrxJournalSnapshotPrototype(
+        ITrxPrototypeFileOperations operations,
+        string journalPath,
+        string destinationPath,
+        Guid runId,
+        string runName,
+        string machineName,
+        string testModule,
+        string frameworkUid,
+        string frameworkVersion,
+        DateTimeOffset startTime)
+    {
+        _operations = operations ?? throw new ArgumentNullException(nameof(operations));
+        ThrowIfNullOrEmpty(journalPath, nameof(journalPath));
+        ThrowIfNullOrEmpty(destinationPath, nameof(destinationPath));
+        ThrowIfNullOrEmpty(runName, nameof(runName));
+        ThrowIfNullOrEmpty(machineName, nameof(machineName));
+        ThrowIfNullOrEmpty(testModule, nameof(testModule));
+        ThrowIfNullOrEmpty(frameworkUid, nameof(frameworkUid));
+        ThrowIfNullOrEmpty(frameworkVersion, nameof(frameworkVersion));
+        if (string.Equals(
+                Path.GetFullPath(journalPath),
+                Path.GetFullPath(destinationPath),
+                Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+        {
+            throw new ArgumentException("The journal and snapshot paths must be different.", nameof(destinationPath));
+        }
+
+        _journalPath = journalPath;
+        _destinationPath = destinationPath;
+        _runId = runId;
+        _runName = runName;
+        _machineName = machineName;
+        _startTime = startTime;
+        _renderer = new TrxPrototypeXmlRenderer(machineName, testModule, frameworkUid, frameworkVersion);
+        _publisher = new TrxSnapshotPublisherPrototype(operations);
+    }
+
+    public TrxJournalSnapshotDiagnostics Diagnostics { get; private set; } = new();
+
+    public void Append(TrxTestResult result, Guid executionId)
+    {
+        if (result is null)
+        {
+            throw new ArgumentNullException(nameof(result));
+        }
+
+        byte[] encoded = EncodeRecord(result, executionId);
+        EnsureJournalTailIsValid();
+        using (ITrxPrototypeFile journal = _operations.Open(
+                   _journalPath,
+                   FileMode.Append,
+                   FileAccess.Write,
+                   FileShare.Read | FileShare.Delete))
+        {
+            journal.Write(encoded, 0, encoded.Length);
+            journal.Flush();
+        }
+
+        _appendedRecordCount++;
+        _maxEncodedRecordBytes = Math.Max(_maxEncodedRecordBytes, encoded.Length);
+        Diagnostics = new TrxJournalSnapshotDiagnostics
+        {
+            AppendedRecordCount = _appendedRecordCount,
+            MaxEncodedRecordBytes = _maxEncodedRecordBytes,
+            PeakLogicalBufferBytes = _maxEncodedRecordBytes,
+            CurrentReplayRecordCount = 0,
+            PeakReplayRecordCount = 0,
+            CurrentRecordBufferBytes = 0,
+            PeakRecordBufferBytes = 0,
+            CurrentDefinitionIdCount = 0,
+            PeakDefinitionIdCount = 0,
+            RetainsResultCollection = false,
+            RetainsXDocument = false,
+        };
+    }
+
+    public void PublishSnapshot(
+        TrxPrototypeCompletion completion,
+        IReadOnlyList<TrxPrototypeRunningTest>? runningTests = null)
+    {
+        if (completion is null)
+        {
+            throw new ArgumentNullException(nameof(completion));
+        }
+
+        runningTests ??= [];
+        ValidateRunningTests(runningTests);
+
+        var metrics = new SnapshotMetrics(_appendedRecordCount, _maxEncodedRecordBytes);
+        _publisher.Publish(
+            _destinationPath,
+            destination => WriteSnapshot(destination, completion, runningTests, metrics));
+        _maxEncodedRecordBytes = Math.Max(_maxEncodedRecordBytes, metrics.MaxEncodedRecordBytes);
+        Diagnostics = metrics.ToDiagnostics();
+    }
+
+    private void EnsureJournalTailIsValid()
+    {
+        if (_journalTailValidated)
+        {
+            return;
+        }
+
+        if (!_operations.Exists(_journalPath))
+        {
+            _journalTailValidated = true;
+            return;
+        }
+
+        var metrics = new SnapshotMetrics(_appendedRecordCount, _maxEncodedRecordBytes);
+        using ITrxPrototypeFile journal = _operations.Open(
+            _journalPath,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read | FileShare.Delete);
+        long validLength = 0;
+        while (TryReadRecord(journal, metrics, out _))
+        {
+            validLength = journal.Position;
+        }
+
+        if (validLength < journal.Length)
+        {
+            journal.SetLength(validLength);
+            journal.Flush();
+        }
+
+        _journalTailValidated = true;
+    }
+
+    private void WriteSnapshot(
+        ITrxPrototypeFile destination,
+        TrxPrototypeCompletion completion,
+        IReadOnlyList<TrxPrototypeRunningTest> runningTests,
+        SnapshotMetrics metrics)
+    {
+        WriteFragment(destination, RenderPrefix(completion.FinishTime), currentRecordBytes: 0, metrics);
+
+        var counts = new SnapshotCounts { InProgress = runningTests.Count };
+        Replay(
+            record =>
+            {
+                byte[] fragment = _renderer.RenderCompletedResult(record.Result, record.ExecutionId, _startTime);
+                WriteFragment(destination, fragment, record.EncodedByteCount, metrics);
+                counts.Add(record.Result.Outcome);
+                metrics.PublishedRecordCount++;
+            },
+            metrics);
+
+        foreach (TrxPrototypeRunningTest running in runningTests)
+        {
+            WriteFragment(destination, RenderRunningTest(running), currentRecordBytes: 0, metrics);
+        }
+
+        WriteFragment(destination, Utf8.GetBytes("</Results><TestDefinitions>"), currentRecordBytes: 0, metrics);
+
+#pragma warning disable IDE0028 // Collection expressions cannot preserve the ordinal test-id comparer.
+        var definitionIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+#pragma warning restore IDE0028
+        try
+        {
+            Replay(
+                record =>
+                {
+                    string testId = TrxPrototypeXmlRenderer.GetTestId(record.Result.Uid);
+                    if (definitionIds.Add(testId))
+                    {
+                        metrics.SetCurrentDefinitionIdCount(definitionIds.Count);
+                        byte[] fragment = _renderer.RenderDefinition(record.Result, record.ExecutionId);
+                        WriteFragment(destination, fragment, record.EncodedByteCount, metrics);
+                        metrics.PublishedDefinitionCount++;
+                    }
+                },
+                metrics);
+        }
+        finally
+        {
+            definitionIds.Clear();
+            metrics.SetCurrentDefinitionIdCount(0);
+        }
+
+        WriteFragment(destination, Utf8.GetBytes("</TestDefinitions><TestEntries>"), currentRecordBytes: 0, metrics);
+        Replay(
+            record =>
+            {
+                byte[] fragment = TrxPrototypeXmlRenderer.RenderEntry(record.Result.Uid, record.ExecutionId);
+                WriteFragment(destination, fragment, record.EncodedByteCount, metrics);
+            },
+            metrics);
+
+        WriteFragment(destination, RenderSuffix(completion, counts), currentRecordBytes: 0, metrics);
+    }
+
+    private void Replay(Action<JournalRecord> visit, SnapshotMetrics metrics)
+    {
+        if (!_operations.Exists(_journalPath))
+        {
+            return;
+        }
+
+        using ITrxPrototypeFile journal = _operations.Open(
+            _journalPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite | FileShare.Delete);
+        while (TryReadRecord(journal, metrics, out JournalRecord? record))
+        {
+            metrics.MaxEncodedRecordBytes = Math.Max(metrics.MaxEncodedRecordBytes, record!.EncodedByteCount);
+            metrics.BeginReplayRecord();
+            try
+            {
+                visit(record);
+            }
+            finally
+            {
+                metrics.EndReplayRecord();
+            }
+        }
+    }
+
+    private static bool TryReadRecord(
+        ITrxPrototypeFile journal,
+        SnapshotMetrics metrics,
+        out JournalRecord? record)
+    {
+        record = null;
+        byte[] lengthBytes = new byte[sizeof(int)];
+        metrics.SetCurrentRecordBufferBytes(lengthBytes.Length);
+        try
+        {
+            int lengthBytesRead = ReadExactly(journal, lengthBytes, 0, lengthBytes.Length);
+            if (lengthBytesRead < lengthBytes.Length)
+            {
+                return false;
+            }
+
+            int payloadLength = BitConverter.ToInt32(lengthBytes, 0);
+            if (payloadLength is <= 0 or > MaximumPayloadLength)
+            {
+                return false;
+            }
+
+            int remainingLength = checked(payloadLength + ExecutionIdByteCount);
+            byte[] remainder = new byte[remainingLength];
+            metrics.SetCurrentRecordBufferBytes(checked(lengthBytes.Length + remainder.Length));
+            if (ReadExactly(journal, remainder, 0, remainder.Length) < remainder.Length)
+            {
+                return false;
+            }
+
+            byte[] serializedResult = new byte[checked(sizeof(int) + payloadLength)];
+            metrics.SetCurrentRecordBufferBytes(
+                checked(lengthBytes.Length + remainder.Length + serializedResult.Length));
+            Array.Copy(lengthBytes, serializedResult, lengthBytes.Length);
+            Array.Copy(remainder, 0, serializedResult, lengthBytes.Length, payloadLength);
+            TrxTestResult? result;
+            try
+            {
+                using var stream = new MemoryStream(serializedResult, writable: false);
+                using IEnumerator<TrxTestResult> records = TrxTestResultSerializer.ReadAll(stream).GetEnumerator();
+                if (!records.MoveNext())
+                {
+                    return false;
+                }
+
+                result = records.Current;
+            }
+            catch (Exception ex) when (ex is EndOfStreamException or IOException or FormatException)
+            {
+                return false;
+            }
+
+            byte[] executionIdBytes = new byte[ExecutionIdByteCount];
+            metrics.SetCurrentRecordBufferBytes(
+                checked(lengthBytes.Length + remainder.Length + serializedResult.Length + executionIdBytes.Length));
+            Array.Copy(remainder, payloadLength, executionIdBytes, 0, executionIdBytes.Length);
+            record = new JournalRecord(
+                result,
+                new Guid(executionIdBytes),
+                checked(serializedResult.Length + ExecutionIdByteCount));
+            return true;
+        }
+        finally
+        {
+            metrics.SetCurrentRecordBufferBytes(0);
+        }
+    }
+
+    private byte[] RenderPrefix(DateTimeOffset finishTime)
+    {
+        XNamespace ns = NamespaceUri;
+        string root = new XElement(
+            ns + "TestRun",
+            new XAttribute("id", _runId),
+            new XAttribute("name", Sanitize(_runName))).ToString(SaveOptions.DisableFormatting);
+        root = root.Substring(0, root.LastIndexOf("/>", StringComparison.Ordinal)) + ">";
+        string times = new XElement(
+            "Times",
+            new XAttribute("creation", FormatTimestamp(_startTime)),
+            new XAttribute("queuing", FormatTimestamp(_startTime)),
+            new XAttribute("start", FormatTimestamp(_startTime)),
+            new XAttribute("finish", FormatTimestamp(finishTime))).ToString(SaveOptions.DisableFormatting);
+        string settings = new XElement(
+            "TestSettings",
+            new XAttribute("name", "default"),
+            new XAttribute("id", Guid.Empty),
+            new XElement(
+                "Deployment",
+                new XAttribute("runDeploymentRoot", Sanitize(_runName)))).ToString(SaveOptions.DisableFormatting);
+        return Utf8.GetBytes(string.Concat(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            root,
+            times,
+            settings,
+            "<Results>"));
+    }
+
+    private byte[] RenderSuffix(TrxPrototypeCompletion completion, SnapshotCounts counts)
+    {
+        string outcome = completion.IsTestHostCrashed
+            || completion.ExitCode != 0
+            || counts.Failed > 0
+            || counts.Timeout > 0
+                ? "Failed"
+                : "Completed";
+        string testLists = new XElement(
+            "TestLists",
+            new XElement(
+                "TestList",
+                new XAttribute("name", "Results Not in a List"),
+                new XAttribute("id", UncategorizedTestListId)),
+            new XElement(
+                "TestList",
+                new XAttribute("name", "All Loaded Results"),
+                new XAttribute("id", "19431567-8539-422a-85D7-44EE4E166BDA"))).ToString(SaveOptions.DisableFormatting);
+        return Utf8.GetBytes(string.Concat(
+            "</TestEntries>",
+            testLists,
+            "<ResultSummary outcome=\"",
+            outcome,
+            "\">",
+            RenderCounters(counts),
+            Utf8.GetString(_renderer.RenderSummaryAdditions(completion)),
+            "</ResultSummary></TestRun>"));
+    }
+
+    private byte[] RenderRunningTest(TrxPrototypeRunningTest running)
+        => Utf8.GetBytes(
+            new XElement(
+                "UnitTestResult",
+                new XAttribute("executionId", running.ExecutionId),
+                new XAttribute("testId", TrxPrototypeXmlRenderer.GetTestId(running.Uid)),
+                new XAttribute("testName", Sanitize(running.DisplayName)),
+                new XAttribute("computerName", Sanitize(_machineName)),
+                new XAttribute("startTime", FormatTimestamp(running.StartTime)),
+                new XAttribute("outcome", "InProgress")).ToString(SaveOptions.DisableFormatting));
+
+    private static string RenderCounters(SnapshotCounts counts)
+        => string.Concat(
+            "<Counters total=\"", Format(counts.Total),
+            "\" executed=\"", Format(counts.Executed),
+            "\" passed=\"", Format(counts.Passed),
+            "\" failed=\"", Format(counts.Failed),
+            "\" error=\"0\" timeout=\"", Format(counts.Timeout),
+            "\" aborted=\"0\" inconclusive=\"0\" passedButRunAborted=\"0\" notRunnable=\"0\" notExecuted=\"",
+            Format(counts.Skipped),
+            "\" disconnected=\"0\" warning=\"0\" completed=\"0\" inProgress=\"",
+            Format(counts.InProgress),
+            "\" pending=\"0\"/>");
+
+    private static string Format(int value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static string FormatTimestamp(DateTimeOffset value)
+        => value.ToString("O", CultureInfo.InvariantCulture);
+
+    private static byte[] EncodeRecord(TrxTestResult result, Guid executionId)
+    {
+        using var stream = new MemoryStream(capacity: 256);
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            TrxTestResultSerializer.Write(writer, result);
+        }
+
+        if (stream.Length > MaximumPayloadLength + sizeof(int))
+        {
+            throw new InvalidOperationException(
+                $"The encoded TRX journal record is {stream.Length} bytes, exceeding the supported maximum.");
+        }
+
+        byte[] resultBytes = stream.ToArray();
+        byte[] executionIdBytes = executionId.ToByteArray();
+        byte[] encoded = new byte[checked(resultBytes.Length + executionIdBytes.Length)];
+        Array.Copy(resultBytes, encoded, resultBytes.Length);
+        Array.Copy(executionIdBytes, 0, encoded, resultBytes.Length, executionIdBytes.Length);
+        return encoded;
+    }
+
+    private static int ReadExactly(ITrxPrototypeFile file, byte[] buffer, int offset, int count)
+    {
+        int total = 0;
+        while (total < count)
+        {
+            int read = file.Read(buffer, offset + total, count - total);
+            if (read == 0)
+            {
+                break;
+            }
+
+            total += read;
+        }
+
+        return total;
+    }
+
+    private static void WriteFragment(
+        ITrxPrototypeFile destination,
+        byte[] fragment,
+        int currentRecordBytes,
+        SnapshotMetrics metrics)
+    {
+        destination.Write(fragment, 0, fragment.Length);
+        metrics.MaxRenderedFragmentBytes = Math.Max(metrics.MaxRenderedFragmentBytes, fragment.Length);
+        metrics.PeakLogicalBufferBytes = Math.Max(
+            metrics.PeakLogicalBufferBytes,
+            checked(currentRecordBytes + fragment.Length));
+    }
+
+    private static void ValidateRunningTests(IReadOnlyList<TrxPrototypeRunningTest> runningTests)
+    {
+        var executionIds = new HashSet<Guid>();
+        foreach (TrxPrototypeRunningTest running in runningTests)
+        {
+            if (running is null)
+            {
+                throw new ArgumentException("Running breadcrumbs cannot contain null.", nameof(runningTests));
+            }
+
+            ThrowIfNullOrEmpty(running.Uid, nameof(runningTests));
+            if (running.DisplayName is null)
+            {
+                throw new ArgumentException("A running breadcrumb display name cannot be null.", nameof(runningTests));
+            }
+
+            if (!executionIds.Add(running.ExecutionId))
+            {
+                throw new ArgumentException(
+                    $"Running execution '{running.ExecutionId}' occurs more than once.",
+                    nameof(runningTests));
+            }
+        }
+    }
+
+    private static string Sanitize(string value)
+    {
+        StringBuilder? builder = null;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char current = value[i];
+            bool valid = current is '\t' or '\n' or '\r'
+                or (>= '\x20' and <= '\uD7FF')
+                or (>= '\uE000' and <= '\uFFFD');
+            bool surrogatePair = char.IsHighSurrogate(current)
+                && i + 1 < value.Length
+                && char.IsLowSurrogate(value[i + 1]);
+            if (valid || surrogatePair)
+            {
+                if (builder is not null)
+                {
+                    _ = builder.Append(current);
+                    if (surrogatePair)
+                    {
+                        _ = builder.Append(value[++i]);
+                    }
+                }
+                else if (surrogatePair)
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            builder ??= new StringBuilder(value, 0, i, value.Length + (value.Length / 2));
+            _ = builder.Append(@"\u").Append(((ushort)current).ToString("x4", CultureInfo.InvariantCulture));
+        }
+
+        return builder?.ToString() ?? value;
+    }
+
+    private static void ThrowIfNullOrEmpty(string value, string parameterName)
+    {
+        if (RoslynString.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException("The value cannot be null or empty.", parameterName);
+        }
+    }
+
+    private sealed class SnapshotCounts
+    {
+        public int Passed { get; private set; }
+
+        public int Failed { get; private set; }
+
+        public int Skipped { get; private set; }
+
+        public int Timeout { get; private set; }
+
+        public int InProgress { get; init; }
+
+        public int Total => Passed + Failed + Skipped + Timeout;
+
+        public int Executed => Passed + Failed;
+
+        public void Add(TrxTestOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case TrxTestOutcome.Passed:
+                    Passed++;
+                    break;
+                case TrxTestOutcome.Failed:
+                    Failed++;
+                    break;
+                case TrxTestOutcome.Skipped:
+                    Skipped++;
+                    break;
+                case TrxTestOutcome.Timeout:
+                    Timeout++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outcome));
+            }
+        }
+    }
+
+    private sealed class SnapshotMetrics(int appendedRecordCount, int maxEncodedRecordBytes)
+    {
+        public int AppendedRecordCount { get; } = appendedRecordCount;
+
+        public int PublishedRecordCount { get; set; }
+
+        public int PublishedDefinitionCount { get; set; }
+
+        public int MaxEncodedRecordBytes { get; set; } = maxEncodedRecordBytes;
+
+        public int MaxRenderedFragmentBytes { get; set; }
+
+        public int PeakLogicalBufferBytes { get; set; } = maxEncodedRecordBytes;
+
+        public int CurrentReplayRecordCount { get; private set; }
+
+        public int PeakReplayRecordCount { get; private set; }
+
+        public int CurrentRecordBufferBytes { get; private set; }
+
+        public int PeakRecordBufferBytes { get; private set; }
+
+        public int CurrentDefinitionIdCount { get; private set; }
+
+        public int PeakDefinitionIdCount { get; private set; }
+
+        public void BeginReplayRecord()
+        {
+            CurrentReplayRecordCount++;
+            PeakReplayRecordCount = Math.Max(PeakReplayRecordCount, CurrentReplayRecordCount);
+        }
+
+        public void EndReplayRecord() => CurrentReplayRecordCount--;
+
+        public void SetCurrentRecordBufferBytes(int value)
+        {
+            CurrentRecordBufferBytes = value;
+            PeakRecordBufferBytes = Math.Max(PeakRecordBufferBytes, value);
+        }
+
+        public void SetCurrentDefinitionIdCount(int value)
+        {
+            CurrentDefinitionIdCount = value;
+            PeakDefinitionIdCount = Math.Max(PeakDefinitionIdCount, value);
+        }
+
+        public TrxJournalSnapshotDiagnostics ToDiagnostics()
+            => new()
+            {
+                AppendedRecordCount = AppendedRecordCount,
+                PublishedRecordCount = PublishedRecordCount,
+                PublishedDefinitionCount = PublishedDefinitionCount,
+                MaxEncodedRecordBytes = MaxEncodedRecordBytes,
+                MaxRenderedFragmentBytes = MaxRenderedFragmentBytes,
+                PeakLogicalBufferBytes = PeakLogicalBufferBytes,
+                CurrentReplayRecordCount = CurrentReplayRecordCount,
+                PeakReplayRecordCount = PeakReplayRecordCount,
+                CurrentRecordBufferBytes = CurrentRecordBufferBytes,
+                PeakRecordBufferBytes = PeakRecordBufferBytes,
+                CurrentDefinitionIdCount = CurrentDefinitionIdCount,
+                PeakDefinitionIdCount = PeakDefinitionIdCount,
+                RetainsResultCollection = false,
+                RetainsXDocument = false,
+            };
+    }
+
+    private sealed class JournalRecord(TrxTestResult result, Guid executionId, int encodedByteCount)
+    {
+        public TrxTestResult Result { get; } = result;
+
+        public Guid ExecutionId { get; } = executionId;
+
+        public int EncodedByteCount { get; } = encodedByteCount;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeFileOperations.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeFileOperations.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal sealed class TrxPrototypeFileOperations : ITrxPrototypeFileOperations
+{
+#if NETCOREAPP
+    public bool SupportsAtomicReplace => true;
+#else
+    public bool SupportsAtomicReplace => false;
+#endif
+
+    public ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+        => new TrxPrototypeFile(path, mode, access, share);
+
+    public string CreateTemporarySiblingPath(string destinationPath)
+    {
+        string fullDestinationPath = Path.GetFullPath(destinationPath);
+        string directory = Path.GetDirectoryName(fullDestinationPath)!;
+        string fileName = Path.GetFileName(fullDestinationPath);
+        return Path.Combine(directory, $"{fileName}.{Guid.NewGuid():N}.tmp");
+    }
+
+    public void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+#if NETCOREAPP
+    {
+        if (File.Exists(destinationPath))
+        {
+            File.Replace(temporaryPath, destinationPath, destinationBackupFileName: null);
+        }
+        else
+        {
+            File.Move(temporaryPath, destinationPath);
+        }
+    }
+#else
+        => throw new PlatformNotSupportedException(
+            "Atomic overwrite replacement is unavailable on this runtime. The TRX prototype will not delete the destination before moving a temporary file.");
+#endif
+
+    public bool Exists(string path) => File.Exists(path);
+
+    public void Delete(string path) => File.Delete(path);
+
+    private sealed class TrxPrototypeFile : ITrxPrototypeFile
+    {
+        private readonly FileStream _stream;
+
+        public TrxPrototypeFile(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            _stream = new FileStream(path, mode, access, share);
+        }
+
+        public long Length => _stream.Length;
+
+        public long Position => _stream.Position;
+
+        public int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+
+        public void Seek(long offset, SeekOrigin origin) => _ = _stream.Seek(offset, origin);
+
+        public void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
+
+        public void Flush() => _stream.Flush();
+
+        public void SetLength(long length) => _stream.SetLength(length);
+
+        public void Dispose() => _stream.Dispose();
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeFileOperations.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeFileOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
@@ -569,10 +569,11 @@ internal sealed class TrxPrototypeXmlRenderer
 
     private static string CreateRootStart(Guid runId, string runName)
     {
-        string serialized = new XElement(
-            XNamespace.Get(NamespaceUri) + "TestRun",
-            new XAttribute("id", runId),
-            new XAttribute("name", Sanitize(runName))).ToString(SaveOptions.DisableFormatting);
+        string serialized = SerializeElement(
+            new XElement(
+                XNamespace.Get(NamespaceUri) + "TestRun",
+                new XAttribute("id", runId),
+                new XAttribute("name", Sanitize(runName))));
         int emptyElementMarker = serialized.LastIndexOf("/>", StringComparison.Ordinal);
         return serialized.Substring(0, emptyElementMarker) + ">";
     }
@@ -601,7 +602,21 @@ internal sealed class TrxPrototypeXmlRenderer
                     new XAttribute("id", "19431567-8539-422a-85D7-44EE4E166BDA"))));
 
     private static string SerializeElement(XElement element)
-        => element.ToString(SaveOptions.DisableFormatting);
+    {
+        var builder = new StringBuilder();
+        var settings = new XmlWriterSettings
+        {
+            ConformanceLevel = ConformanceLevel.Fragment,
+            NewLineHandling = NewLineHandling.Entitize,
+            OmitXmlDeclaration = true,
+        };
+        using (var writer = XmlWriter.Create(builder, settings))
+        {
+            element.WriteTo(writer);
+        }
+
+        return builder.ToString();
+    }
 
     private static string ToXmlOutcome(TrxTestOutcome outcome)
         => outcome switch

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxPrototypeXmlRenderer.cs
@@ -1,0 +1,693 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform;
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal sealed class TrxPrototypeCompletion
+{
+    public required DateTimeOffset FinishTime { get; init; }
+
+    public bool IsTestHostCrashed { get; init; }
+
+    public int ExitCode { get; init; }
+
+    public string CrashText { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> AttachmentWarnings { get; init; } = [];
+
+    public IReadOnlyList<string> CollectorAttachmentHrefs { get; init; } = [];
+}
+
+internal sealed class TrxPrototypeXmlRenderer
+{
+    private const string NamespaceUri = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+    private const string UnitTestTypeGuid = "13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B";
+    private const string UncategorizedTestListId = "8C84FA94-04C1-424b-9868-57A2D4851A1D";
+
+    private static readonly UTF8Encoding Utf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    private readonly string _machineName;
+    private readonly string _testModule;
+    private readonly string _frameworkUid;
+    private readonly string _frameworkVersion;
+
+    public TrxPrototypeXmlRenderer(
+        string machineName,
+        string testModule,
+        string frameworkUid,
+        string frameworkVersion)
+    {
+        _machineName = machineName;
+        _testModule = testModule;
+        _frameworkUid = frameworkUid;
+        _frameworkVersion = frameworkVersion;
+    }
+
+    public static byte[] RenderInitial(
+        Guid runId,
+        string runName,
+        DateTimeOffset startTime,
+        int definitionPadBytes,
+        int entryPadBytes,
+        int summaryPadBytes,
+        int counterWidth,
+        int runningSlotCount,
+        int runningSlotByteCapacity)
+    {
+        string rootStart = CreateRootStart(runId, runName);
+        string times = SerializeElement(
+            new XElement(
+                "Times",
+                new XAttribute("creation", FormatTimestamp(startTime)),
+                new XAttribute("queuing", FormatTimestamp(startTime)),
+                new XAttribute("start", FormatTimestamp(startTime)),
+                new XAttribute("finish", FormatTimestamp(startTime))));
+        string testSettings = CreateTestSettings(runName);
+        string counters = RenderCounters(new TrxPrototypeCounts(), counterWidth);
+
+        string document = string.Concat(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            rootStart,
+            times,
+            testSettings,
+            "<TestDefinitions>",
+            new string(' ', definitionPadBytes),
+            "</TestDefinitions>",
+            "<TestEntries>",
+            new string(' ', entryPadBytes),
+            "</TestEntries>",
+            CreateTestLists(),
+            "<ResultSummary outcome=\"Failed\"   >",
+            counters,
+            new string(' ', summaryPadBytes),
+            "</ResultSummary>",
+            "<Results>",
+            new string(' ', checked(runningSlotCount * runningSlotByteCapacity)),
+            "</Results></TestRun>");
+
+        return Utf8.GetBytes(document);
+    }
+
+    public byte[] RenderCompletedResult(TrxTestResult testResult, Guid executionId, DateTimeOffset fallbackTime)
+    {
+        string testId = GetTestId(testResult.Uid);
+        string displayName = Sanitize(testResult.DisplayName);
+        string executionIdText = executionId.ToString();
+        var unitTestResult = new XElement(
+            "UnitTestResult",
+            new XAttribute("executionId", executionIdText),
+            new XAttribute("testId", testId),
+            new XAttribute("testName", displayName),
+            new XAttribute("computerName", Sanitize(_machineName)),
+            new XAttribute(
+                "duration",
+                testResult.Duration?.ToString("hh\\:mm\\:ss\\.fffffff", CultureInfo.InvariantCulture)
+                    ?? "00:00:00"),
+            new XAttribute("startTime", FormatTimestamp(testResult.StartTime?.ToUniversalTime() ?? fallbackTime)),
+            new XAttribute("endTime", FormatTimestamp(testResult.EndTime?.ToUniversalTime() ?? fallbackTime)),
+            new XAttribute("testType", UnitTestTypeGuid),
+            new XAttribute("outcome", ToXmlOutcome(testResult.Outcome)),
+            new XAttribute("testListId", UncategorizedTestListId),
+            new XAttribute("relativeResultsDirectory", executionIdText));
+
+        AddOutput(unitTestResult, testResult);
+        AddResultFiles(unitTestResult, testResult);
+        return Utf8.GetBytes(SerializeElement(unitTestResult));
+    }
+
+    public byte[] RenderDefinition(TrxTestResult testResult, Guid executionId)
+    {
+        string testId = GetTestId(testResult.Uid);
+        string displayName = Sanitize(testResult.DisplayName);
+        string definitionName = Sanitize(testResult.TrxTestDefinitionName ?? displayName);
+        var unitTest = new XElement(
+            "UnitTest",
+            new XAttribute("name", definitionName),
+            new XAttribute("storage", Sanitize(_testModule.ToLowerInvariant())),
+            new XAttribute("id", testId));
+
+        if (testResult.Categories is { Count: > 0 })
+        {
+            unitTest.Add(
+                new XElement(
+                    "TestCategory",
+                    testResult.Categories.Select(
+                        category => new XElement(
+                            "TestCategoryItem",
+                            new XAttribute("TestCategory", Sanitize(category))))));
+        }
+
+        unitTest.Add(new XElement("Execution", new XAttribute("id", executionId.ToString())));
+        AddDefinitionMetadata(unitTest, testResult.Metadata);
+
+        (string className, string methodName) = GetClassAndMethodName(testResult, displayName);
+        unitTest.Add(
+            new XElement(
+                "TestMethod",
+                new XAttribute("codeBase", Sanitize(_testModule)),
+                new XAttribute("adapterTypeName", Sanitize($"executor://{_frameworkUid}/{_frameworkVersion}")),
+                new XAttribute("className", className),
+                new XAttribute("name", methodName)));
+
+        return Utf8.GetBytes(SerializeElement(unitTest));
+    }
+
+    public static byte[] RenderEntry(string uid, Guid executionId)
+        => Utf8.GetBytes(
+            SerializeElement(
+                new XElement(
+                    "TestEntry",
+                    new XAttribute("testId", GetTestId(uid)),
+                    new XAttribute("executionId", executionId.ToString()),
+                    new XAttribute("testListId", UncategorizedTestListId))));
+
+    public byte[] RenderRunningSlot(
+        string uid,
+        string displayName,
+        Guid executionId,
+        DateTimeOffset startTime,
+        int byteCapacity)
+    {
+        string sanitizedName = Sanitize(displayName);
+        byte[] unpadded = RenderRunningSlotCore(uid, sanitizedName, executionId, startTime);
+        if (unpadded.Length > byteCapacity)
+        {
+            string truncatedName = TruncateRunningName(
+                sanitizedName,
+                candidate => RenderRunningSlotCore(uid, candidate, executionId, startTime).Length,
+                byteCapacity);
+            unpadded = RenderRunningSlotCore(uid, truncatedName, executionId, startTime);
+        }
+
+        if (unpadded.Length > byteCapacity)
+        {
+            throw new InvalidOperationException(
+                $"The running-slot byte capacity {byteCapacity} is too small for the fixed XML attributes ({unpadded.Length} bytes required).");
+        }
+
+        byte[] padded = new byte[byteCapacity];
+        Array.Copy(unpadded, padded, unpadded.Length);
+        for (int i = unpadded.Length; i < padded.Length; i++)
+        {
+            padded[i] = (byte)' ';
+        }
+
+        return padded;
+    }
+
+    public byte[] RenderSummaryAdditions(TrxPrototypeCompletion completion)
+    {
+        var builder = new StringBuilder();
+        XElement? runInfos = null;
+        if (completion.IsTestHostCrashed)
+        {
+            AddRunInfo(ref runInfos, "Error", completion.CrashText, completion.FinishTime);
+        }
+        else if (completion.ExitCode != 0)
+        {
+            AddRunInfo(
+                ref runInfos,
+                "Error",
+                $"Exit code indicates failure: '{completion.ExitCode}'. Please refer to https://aka.ms/testingplatform/exitcodes for more information.",
+                completion.FinishTime);
+        }
+
+        foreach (string warning in completion.AttachmentWarnings)
+        {
+            AddRunInfo(ref runInfos, "Warning", warning, completion.FinishTime);
+        }
+
+        if (runInfos is not null)
+        {
+            _ = builder.Append(SerializeElement(runInfos));
+        }
+
+        if (completion.CollectorAttachmentHrefs.Count > 0)
+        {
+            var collectorDataEntries = new XElement(
+                "CollectorDataEntries",
+                new XElement(
+                    "Collector",
+                    new XAttribute("agentName", Sanitize(_machineName)),
+                    new XAttribute("uri", "datacollector://prototype/1.0"),
+                    new XAttribute("collectorDisplayName", "TRX prototype"),
+                    new XElement(
+                        "UriAttachments",
+                        completion.CollectorAttachmentHrefs.Select(
+                            href => new XElement(
+                                "UriAttachment",
+                                new XElement("A", new XAttribute("href", Sanitize(href))))))));
+            _ = builder.Append(SerializeElement(collectorDataEntries));
+        }
+
+        return Utf8.GetBytes(builder.ToString());
+    }
+
+    public byte[] RenderCompact(
+        Guid runId,
+        string runName,
+        DateTimeOffset startTime,
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        TrxPrototypeCompletion completion)
+    {
+        if (results.Count != executionIds.Count)
+        {
+            throw new ArgumentException("Every result must have exactly one execution id.", nameof(executionIds));
+        }
+
+        var counts = new TrxPrototypeCounts();
+        var resultBuilder = new StringBuilder();
+        var definitionBuilder = new StringBuilder();
+        var entryBuilder = new StringBuilder();
+        var definitions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < results.Count; i++)
+        {
+            TrxTestResult result = results[i];
+            Guid executionId = executionIds[i];
+            _ = resultBuilder.Append(Utf8.GetString(RenderCompletedResult(result, executionId, completion.FinishTime)));
+            string testId = GetTestId(result.Uid);
+            if (definitions.Add(testId))
+            {
+                _ = definitionBuilder.Append(Utf8.GetString(RenderDefinition(result, executionId)));
+            }
+
+            _ = entryBuilder.Append(Utf8.GetString(RenderEntry(result.Uid, executionId)));
+            counts.Add(result.Outcome);
+        }
+
+        string outcome = IsFailedCompletion(completion, counts) ? "Failed" : "Completed";
+        string summary = string.Concat(
+            "<ResultSummary outcome=\"",
+            outcome,
+            "\">",
+            RenderCounters(counts, counterWidth: 0),
+            Utf8.GetString(RenderSummaryAdditions(completion)),
+            "</ResultSummary>");
+
+        string document = string.Concat(
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
+            CreateRootStart(runId, runName),
+            SerializeElement(
+                new XElement(
+                    "Times",
+                    new XAttribute("creation", FormatTimestamp(startTime)),
+                    new XAttribute("queuing", FormatTimestamp(startTime)),
+                    new XAttribute("start", FormatTimestamp(startTime)),
+                    new XAttribute("finish", FormatTimestamp(completion.FinishTime)))),
+            CreateTestSettings(runName),
+            "<Results>",
+            resultBuilder,
+            "</Results><TestDefinitions>",
+            definitionBuilder,
+            "</TestDefinitions><TestEntries>",
+            entryBuilder,
+            "</TestEntries>",
+            CreateTestLists(),
+            summary,
+            "</TestRun>");
+        return Utf8.GetBytes(document);
+    }
+
+    public void WriteJournalReplayedRecord(
+        ITrxPrototypeFile destination,
+        TrxTestResult result,
+        Guid executionId,
+        DateTimeOffset fallbackTime)
+    {
+        byte[] bytes = RenderCompletedResult(result, executionId, fallbackTime);
+        destination.Write(bytes, 0, bytes.Length);
+    }
+
+    public static string GetTestId(string uid)
+    {
+        if (Guid.TryParse(uid, out Guid guid))
+        {
+            return guid.ToString();
+        }
+
+        byte[] hash = TestFx.Hashing.XxHash128.Hash(Encoding.Unicode.GetBytes(uid));
+        return new Guid(hash).ToString();
+    }
+
+    private static string RenderCounters(TrxPrototypeCounts counts, int counterWidth)
+    {
+        string Format(int value)
+            => counterWidth == 0
+                ? value.ToString(CultureInfo.InvariantCulture)
+                : value.ToString($"D{counterWidth}", CultureInfo.InvariantCulture);
+
+        return string.Concat(
+            "<Counters total=\"", Format(counts.Total),
+            "\" executed=\"", Format(counts.Executed),
+            "\" passed=\"", Format(counts.Passed),
+            "\" failed=\"", Format(counts.Failed),
+            "\" error=\"", Format(0),
+            "\" timeout=\"", Format(counts.Timeout),
+            "\" aborted=\"", Format(0),
+            "\" inconclusive=\"", Format(0),
+            "\" passedButRunAborted=\"", Format(0),
+            "\" notRunnable=\"", Format(0),
+            "\" notExecuted=\"", Format(counts.Skipped),
+            "\" disconnected=\"", Format(0),
+            "\" warning=\"", Format(0),
+            "\" completed=\"", Format(0),
+            "\" inProgress=\"", Format(counts.InProgress),
+            "\" pending=\"", Format(0),
+            "\"/>");
+    }
+
+    private static bool IsFailedCompletion(TrxPrototypeCompletion completion, TrxPrototypeCounts counts)
+        => completion.IsTestHostCrashed
+            || completion.ExitCode != 0
+            || counts.Failed > 0
+            || counts.Timeout > 0;
+
+    private byte[] RenderRunningSlotCore(
+        string uid,
+        string displayName,
+        Guid executionId,
+        DateTimeOffset startTime)
+        => Utf8.GetBytes(
+            SerializeElement(
+                new XElement(
+                    "UnitTestResult",
+                    new XAttribute("executionId", executionId.ToString()),
+                    new XAttribute("testId", GetTestId(uid)),
+                    new XAttribute("testName", displayName),
+                    new XAttribute("computerName", Sanitize(_machineName)),
+                    new XAttribute("startTime", FormatTimestamp(startTime)),
+                    new XAttribute("outcome", "InProgress"))));
+
+    private static string TruncateRunningName(string value, Func<string, int> getRenderedByteCount, int byteCapacity)
+    {
+        var builder = new StringBuilder();
+        int index = 0;
+        while (index < value.Length)
+        {
+            int scalarLength = char.IsHighSurrogate(value[index])
+                && index + 1 < value.Length
+                && char.IsLowSurrogate(value[index + 1])
+                    ? 2
+                    : 1;
+            _ = builder.Append(value, index, scalarLength);
+            if (getRenderedByteCount(builder.ToString()) > byteCapacity)
+            {
+                builder.Length -= scalarLength;
+                break;
+            }
+
+            index += scalarLength;
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AddOutput(XElement unitTestResult, TrxTestResult testResult)
+    {
+        var output = new XElement("Output");
+        StringBuilder? stdOut = null;
+        StringBuilder? stdErr = null;
+        StringBuilder? debugTrace = null;
+        foreach (TrxStreamMessage message in testResult.Messages ?? [])
+        {
+            switch (message.Kind)
+            {
+                case TrxStreamMessageKind.StandardOutput:
+                    stdOut?.Append(Environment.NewLine);
+                    _ = (stdOut ??= new StringBuilder()).Append(message.Message);
+                    break;
+                case TrxStreamMessageKind.StandardError:
+                    stdErr?.Append(Environment.NewLine);
+                    _ = (stdErr ??= new StringBuilder()).Append(message.Message);
+                    break;
+                case TrxStreamMessageKind.DebugOrTrace:
+                    debugTrace?.Append(Environment.NewLine);
+                    _ = (debugTrace ??= new StringBuilder()).Append(message.Message);
+                    break;
+            }
+        }
+
+        if (stdOut is not null)
+        {
+            output.Add(new XElement("StdOut", Sanitize(stdOut.ToString())));
+        }
+
+        if (stdErr is not null)
+        {
+            output.Add(new XElement("StdErr", Sanitize(stdErr.ToString())));
+        }
+
+        if (debugTrace is not null)
+        {
+            output.Add(new XElement("DebugTrace", Sanitize(debugTrace.ToString())));
+        }
+
+        if (testResult.ExceptionMessage is not null || testResult.ExceptionStackTrace is not null)
+        {
+            var errorInfo = new XElement("ErrorInfo");
+            if (testResult.ExceptionMessage is not null)
+            {
+                errorInfo.Add(new XElement("Message", Sanitize(testResult.ExceptionMessage)));
+            }
+
+            if (testResult.ExceptionStackTrace is not null)
+            {
+                errorInfo.Add(new XElement("StackTrace", Sanitize(testResult.ExceptionStackTrace)));
+            }
+
+            output.Add(errorInfo);
+        }
+
+        if (output.HasElements)
+        {
+            unitTestResult.Add(output);
+        }
+    }
+
+    private static void AddResultFiles(XElement unitTestResult, TrxTestResult testResult)
+    {
+        if (testResult.FileArtifacts is not { Count: > 0 })
+        {
+            return;
+        }
+
+        var resultFiles = new XElement("ResultFiles");
+        foreach (TrxTestFileArtifact artifact in testResult.FileArtifacts)
+        {
+            resultFiles.Add(
+                new XElement(
+                    "ResultFile",
+                    new XAttribute("path", Sanitize(artifact.FullPath))));
+        }
+
+        unitTestResult.Add(resultFiles);
+    }
+
+    private static void AddDefinitionMetadata(XElement unitTest, IReadOnlyList<TrxTestMetadata>? metadata)
+    {
+        XElement? owners = null;
+        XElement? description = null;
+        XElement? properties = null;
+        foreach (TrxTestMetadata item in metadata ?? [])
+        {
+            switch (item.Key)
+            {
+                case "Owner":
+                    owners ??= new XElement(
+                        "Owners",
+                        new XElement("Owner", new XAttribute("name", Sanitize(item.Value))));
+                    break;
+                case "Priority":
+                    if (int.TryParse(item.Value, out int priority) && priority != int.MaxValue)
+                    {
+                        unitTest.SetAttributeValue("priority", item.Value);
+                    }
+
+                    break;
+                case "Description":
+                    description ??= new XElement("Description", Sanitize(item.Value));
+                    break;
+                default:
+                    properties ??= new XElement("Properties");
+                    properties.Add(
+                        new XElement(
+                            "Property",
+                            new XElement("Key", Sanitize(item.Key)),
+                            new XElement("Value", Sanitize(item.Value))));
+                    break;
+            }
+        }
+
+        if (owners is not null)
+        {
+            unitTest.Add(owners);
+        }
+
+        if (description is not null)
+        {
+            unitTest.Add(description);
+        }
+
+        if (properties is not null)
+        {
+            unitTest.Add(properties);
+        }
+    }
+
+    private static (string ClassName, string MethodName) GetClassAndMethodName(
+        TrxTestResult testResult,
+        string displayName)
+    {
+        TrxTestMethodIdentifier? identifier = testResult.TestMethodIdentifier;
+        string className = testResult.TrxFullyQualifiedTypeName
+            ?? (identifier is null
+                ? string.Empty
+                : RoslynString.IsNullOrEmpty(identifier.Namespace)
+                    ? identifier.TypeName
+                    : $"{identifier.Namespace}.{identifier.TypeName}");
+        return (Sanitize(className), Sanitize(identifier?.MethodName ?? displayName));
+    }
+
+    private void AddRunInfo(
+        ref XElement? runInfos,
+        string outcome,
+        string text,
+        DateTimeOffset timestamp)
+    {
+        runInfos ??= new XElement("RunInfos");
+        runInfos.Add(
+            new XElement(
+                "RunInfo",
+                new XAttribute("computerName", Sanitize(_machineName)),
+                new XAttribute("outcome", outcome),
+                new XAttribute("timestamp", FormatTimestamp(timestamp)),
+                new XElement("Text", Sanitize(text))));
+    }
+
+    private static string CreateRootStart(Guid runId, string runName)
+    {
+        string serialized = new XElement(
+            XNamespace.Get(NamespaceUri) + "TestRun",
+            new XAttribute("id", runId),
+            new XAttribute("name", Sanitize(runName))).ToString(SaveOptions.DisableFormatting);
+        int emptyElementMarker = serialized.LastIndexOf("/>", StringComparison.Ordinal);
+        return serialized.Substring(0, emptyElementMarker) + ">";
+    }
+
+    private static string CreateTestSettings(string runName)
+        => SerializeElement(
+            new XElement(
+                "TestSettings",
+                new XAttribute("name", "default"),
+                new XAttribute("id", Guid.Empty),
+                new XElement(
+                    "Deployment",
+                    new XAttribute("runDeploymentRoot", Sanitize(runName)))));
+
+    private static string CreateTestLists()
+        => SerializeElement(
+            new XElement(
+                "TestLists",
+                new XElement(
+                    "TestList",
+                    new XAttribute("name", "Results Not in a List"),
+                    new XAttribute("id", UncategorizedTestListId)),
+                new XElement(
+                    "TestList",
+                    new XAttribute("name", "All Loaded Results"),
+                    new XAttribute("id", "19431567-8539-422a-85D7-44EE4E166BDA"))));
+
+    private static string SerializeElement(XElement element)
+        => element.ToString(SaveOptions.DisableFormatting);
+
+    private static string ToXmlOutcome(TrxTestOutcome outcome)
+        => outcome switch
+        {
+            TrxTestOutcome.Skipped => "NotExecuted",
+            TrxTestOutcome.Passed => "Passed",
+            TrxTestOutcome.Failed or TrxTestOutcome.Timeout => "Failed",
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome)),
+        };
+
+    private static string FormatTimestamp(DateTimeOffset value)
+        => value.ToString("O", CultureInfo.InvariantCulture);
+
+    private static string Sanitize(string value)
+    {
+        StringBuilder? builder = null;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char current = value[i];
+            bool isValidChar = current is '\t' or '\n' or '\r'
+                or (>= '\x20' and <= '\uD7FF')
+                or (>= '\uE000' and <= '\uFFFD');
+            bool isValidSurrogatePair = char.IsHighSurrogate(current)
+                && i + 1 < value.Length
+                && char.IsLowSurrogate(value[i + 1]);
+
+            if (isValidChar || isValidSurrogatePair)
+            {
+                if (builder is not null)
+                {
+                    _ = builder.Append(current);
+                    if (isValidSurrogatePair)
+                    {
+                        _ = builder.Append(value[++i]);
+                    }
+                }
+                else if (isValidSurrogatePair)
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            builder ??= new StringBuilder(value, 0, i, value.Length + (value.Length / 2));
+            _ = builder.Append(@"\u").Append(((ushort)current).ToString("x4", CultureInfo.InvariantCulture));
+        }
+
+        return builder?.ToString() ?? value;
+    }
+
+    private sealed class TrxPrototypeCounts
+    {
+        public int Passed { get; private set; }
+
+        public int Failed { get; private set; }
+
+        public int Skipped { get; private set; }
+
+        public int Timeout { get; private set; }
+
+        public int InProgress { get; set; }
+
+        public int Total => Passed + Failed + Skipped + Timeout;
+
+        public int Executed => Passed + Failed;
+
+        public void Add(TrxTestOutcome outcome)
+        {
+            switch (outcome)
+            {
+                case TrxTestOutcome.Passed:
+                    Passed++;
+                    break;
+                case TrxTestOutcome.Failed:
+                    Failed++;
+                    break;
+                case TrxTestOutcome.Skipped:
+                    Skipped++;
+                    break;
+                case TrxTestOutcome.Timeout:
+                    Timeout++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outcome));
+            }
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxSnapshotPublisherPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxSnapshotPublisherPrototype.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxSnapshotPublisherPrototype.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/Prototype/TrxSnapshotPublisherPrototype.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform;
+
+namespace Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+internal sealed class TrxSnapshotPublisherPrototype
+{
+    private readonly ITrxPrototypeFileOperations _operations;
+
+    public TrxSnapshotPublisherPrototype(ITrxPrototypeFileOperations operations)
+    {
+        _operations = operations ?? throw new ArgumentNullException(nameof(operations));
+    }
+
+    public void Publish(string destinationPath, Action<ITrxPrototypeFile> writeCompleteDocument)
+    {
+        if (RoslynString.IsNullOrEmpty(destinationPath))
+        {
+            throw new ArgumentException("The destination path cannot be null or empty.", nameof(destinationPath));
+        }
+
+        if (writeCompleteDocument is null)
+        {
+            throw new ArgumentNullException(nameof(writeCompleteDocument));
+        }
+
+        if (!_operations.SupportsAtomicReplace)
+        {
+            throw new PlatformNotSupportedException(
+                "Atomic overwrite replacement is unavailable on this runtime. The TRX prototype will not delete the destination before moving a temporary file.");
+        }
+
+        string temporaryPath = _operations.CreateTemporarySiblingPath(destinationPath);
+        ValidateTemporarySibling(destinationPath, temporaryPath);
+
+        try
+        {
+            using (ITrxPrototypeFile temporary = _operations.Open(
+                       temporaryPath,
+                       FileMode.CreateNew,
+                       FileAccess.ReadWrite,
+                       FileShare.Read | FileShare.Delete))
+            {
+                writeCompleteDocument(temporary);
+                temporary.Flush();
+            }
+
+            _operations.ReplaceTemporarySibling(temporaryPath, destinationPath);
+        }
+        catch
+        {
+            try
+            {
+                if (_operations.Exists(temporaryPath))
+                {
+                    _operations.Delete(temporaryPath);
+                }
+            }
+            catch
+            {
+                // Abrupt termination, permissions, or sharing can also prevent best-effort temp cleanup.
+                // The destination is deliberately never a cleanup target.
+            }
+
+            throw;
+        }
+    }
+
+    private static void ValidateTemporarySibling(string destinationPath, string temporaryPath)
+    {
+        if (RoslynString.IsNullOrEmpty(temporaryPath))
+        {
+            throw new InvalidOperationException("The temporary sibling path cannot be null or empty.");
+        }
+
+        string fullDestinationPath = Path.GetFullPath(destinationPath);
+        string fullTemporaryPath = Path.GetFullPath(temporaryPath);
+        StringComparison pathComparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        if (string.Equals(fullDestinationPath, fullTemporaryPath, pathComparison)
+            || !string.Equals(
+                Path.GetDirectoryName(fullDestinationPath),
+                Path.GetDirectoryName(fullTemporaryPath),
+                pathComparison))
+        {
+            throw new InvalidOperationException(
+                $"The temporary path '{temporaryPath}' must be a distinct sibling of destination '{destinationPath}' so replacement stays on one filesystem.");
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
@@ -1,0 +1,1094 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+namespace Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+internal enum TrxDocumentClassification
+{
+    Malformed,
+    ParseableInconsistent,
+    Repairable,
+    Truthful,
+}
+
+internal enum TrxSchemaStatus
+{
+    NotChecked,
+    Valid,
+    Invalid,
+}
+
+internal sealed class TrxExpectedResult
+{
+    public required string TestId { get; init; }
+
+    public required string ExecutionId { get; init; }
+
+    public required string TestName { get; init; }
+
+    public required TrxTestOutcome Outcome { get; init; }
+
+    public required string Duration { get; init; }
+
+    public required DateTimeOffset StartTime { get; init; }
+
+    public required DateTimeOffset EndTime { get; init; }
+
+    public required string ComputerName { get; init; }
+
+    public required string TestTypeId { get; init; }
+
+    public required string TestListId { get; init; }
+
+    public required string RelativeResultsDirectory { get; init; }
+
+    public required TrxExpectedDefinition Definition { get; init; }
+}
+
+internal sealed class TrxExpectedDefinition
+{
+    public required string Name { get; init; }
+
+    public required string Storage { get; init; }
+
+    public required string ClassName { get; init; }
+
+    public required string MethodName { get; init; }
+
+    public required string CodeBase { get; init; }
+
+    public required string AdapterTypeName { get; init; }
+
+    public string? Priority { get; init; }
+
+    public string? Owner { get; init; }
+
+    public string? Description { get; init; }
+
+    public IReadOnlyList<string> Categories { get; init; } = [];
+
+    public IReadOnlyList<TrxExpectedProperty> Properties { get; init; } = [];
+}
+
+internal sealed class TrxExpectedProperty
+{
+    public required string Key { get; init; }
+
+    public required string Value { get; init; }
+}
+
+internal sealed class TrxExpectedRunningTest
+{
+    public required string TestId { get; init; }
+
+    public required string ExecutionId { get; init; }
+
+    public required string TestName { get; init; }
+
+    public required string ComputerName { get; init; }
+
+    public required DateTimeOffset StartTime { get; init; }
+}
+
+internal sealed class TrxDocumentExpectation
+{
+    public required Guid RunId { get; init; }
+
+    public required string RunName { get; init; }
+
+    public required DateTimeOffset StartTime { get; init; }
+
+    public required DateTimeOffset FinishTime { get; init; }
+
+    public required string SummaryOutcome { get; init; }
+
+    public required IReadOnlyList<TrxExpectedResult> CompletedResults { get; init; }
+
+    public IReadOnlyList<TrxExpectedRunningTest> RunningTests { get; init; } = [];
+
+    public IReadOnlyDictionary<string, int>? Counters { get; init; }
+
+    public IReadOnlyList<string> RootChildOrder { get; init; } =
+        ["Times", "TestSettings", "Results", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary"];
+
+    public IReadOnlyList<string> SummaryChildOrder { get; init; } =
+        ["Counters", "RunInfos", "CollectorDataEntries"];
+
+    public string UncategorizedTestListId { get; init; } = "8C84FA94-04C1-424b-9868-57A2D4851A1D";
+
+    public string AllLoadedResultsTestListId { get; init; } = "19431567-8539-422a-85D7-44EE4E166BDA";
+}
+
+internal static class TrxExpectedResultFactory
+{
+    internal const string UnitTestTypeId = "13CDC9D9-DDB5-4fa4-A97D-D965CCFC6D4B";
+    internal const string UncategorizedTestListId = "8C84FA94-04C1-424b-9868-57A2D4851A1D";
+
+    public static TrxExpectedResult Create(
+        TrxTestResult result,
+        Guid executionId,
+        string computerName,
+        string testModule,
+        string frameworkUid,
+        string frameworkVersion,
+        DateTimeOffset fallbackTime)
+    {
+        string executionIdText = executionId.ToString();
+        string displayName = Sanitize(result.DisplayName);
+        TrxTestMethodIdentifier? identifier = result.TestMethodIdentifier;
+        string className = result.TrxFullyQualifiedTypeName
+            ?? (identifier is null
+                ? string.Empty
+                : string.IsNullOrEmpty(identifier.Namespace)
+                    ? identifier.TypeName
+                    : $"{identifier.Namespace}.{identifier.TypeName}");
+        string? owner = null;
+        string? description = null;
+        string? priority = null;
+        List<TrxExpectedProperty> properties = [];
+        foreach (TrxTestMetadata metadata in result.Metadata ?? [])
+        {
+            switch (metadata.Key)
+            {
+                case "Owner":
+                    owner ??= Sanitize(metadata.Value);
+                    break;
+                case "Description":
+                    description ??= Sanitize(metadata.Value);
+                    break;
+                case "Priority":
+                    if (int.TryParse(metadata.Value, out int priorityValue) && priorityValue != int.MaxValue)
+                    {
+                        priority = metadata.Value;
+                    }
+
+                    break;
+                default:
+                    properties.Add(
+                        new TrxExpectedProperty
+                        {
+                            Key = Sanitize(metadata.Key),
+                            Value = Sanitize(metadata.Value),
+                        });
+                    break;
+            }
+        }
+
+        return new TrxExpectedResult
+        {
+            TestId = Guid.Parse(result.Uid).ToString(),
+            ExecutionId = executionIdText,
+            TestName = displayName,
+            Outcome = result.Outcome,
+            Duration = result.Duration?.ToString("hh\\:mm\\:ss\\.fffffff", CultureInfo.InvariantCulture)
+                ?? "00:00:00",
+            StartTime = result.StartTime?.ToUniversalTime() ?? fallbackTime,
+            EndTime = result.EndTime?.ToUniversalTime() ?? fallbackTime,
+            ComputerName = Sanitize(computerName),
+            TestTypeId = UnitTestTypeId,
+            TestListId = UncategorizedTestListId,
+            RelativeResultsDirectory = executionIdText,
+            Definition = new TrxExpectedDefinition
+            {
+                Name = Sanitize(result.TrxTestDefinitionName ?? displayName),
+                Storage = Sanitize(testModule.ToLowerInvariant()),
+                ClassName = Sanitize(className),
+                MethodName = Sanitize(identifier?.MethodName ?? displayName),
+                CodeBase = Sanitize(testModule),
+                AdapterTypeName = Sanitize($"executor://{frameworkUid}/{frameworkVersion}"),
+                Priority = priority,
+                Owner = owner,
+                Description = description,
+                Categories = [.. (result.Categories ?? []).Select(Sanitize)],
+                Properties = properties,
+            },
+        };
+    }
+
+    private static string Sanitize(string value)
+    {
+        value = value.Replace("\r\n", "\n").Replace('\r', '\n');
+        StringBuilder? builder = null;
+        for (int i = 0; i < value.Length; i++)
+        {
+            char current = value[i];
+            bool valid = current is '\t' or '\n' or '\r'
+                or (>= '\x20' and <= '\uD7FF')
+                or (>= '\uE000' and <= '\uFFFD');
+            bool surrogatePair = char.IsHighSurrogate(current)
+                && i + 1 < value.Length
+                && char.IsLowSurrogate(value[i + 1]);
+            if (valid || surrogatePair)
+            {
+                if (builder is not null)
+                {
+                    _ = builder.Append(current);
+                    if (surrogatePair)
+                    {
+                        _ = builder.Append(value[++i]);
+                    }
+                }
+                else if (surrogatePair)
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            builder ??= new StringBuilder(value, 0, i, value.Length + (value.Length / 2));
+            _ = builder.Append(@"\u").Append(((ushort)current).ToString("x4", CultureInfo.InvariantCulture));
+        }
+
+        return builder?.ToString() ?? value;
+    }
+}
+
+internal sealed class TrxDocumentObservationContext
+{
+    public int? OperationIndex { get; init; }
+
+    public string? OperationKind { get; init; }
+
+    public int? CommittedByteCount { get; init; }
+
+    public long? PreviousTargetLength { get; init; }
+
+    public int PublishedEventSequenceNumber { get; init; }
+
+    public int LatestEventSequenceNumber { get; init; }
+}
+
+internal sealed class TrxSchemaValidationResult
+{
+    private TrxSchemaValidationResult(TrxSchemaStatus status, string? error)
+    {
+        Status = status;
+        Error = error;
+    }
+
+    public TrxSchemaStatus Status { get; }
+
+    public string? Error { get; }
+
+    public static TrxSchemaValidationResult NotChecked() => new(TrxSchemaStatus.NotChecked, null);
+
+    public static TrxSchemaValidationResult Valid() => new(TrxSchemaStatus.Valid, null);
+
+    public static TrxSchemaValidationResult Invalid(string error) => new(TrxSchemaStatus.Invalid, error);
+}
+
+internal sealed class TrxDocumentObservation
+{
+    public required TrxDocumentClassification Classification { get; init; }
+
+    public required TrxSchemaStatus SchemaStatus { get; init; }
+
+    public required IReadOnlyList<string> Errors { get; init; }
+
+    public required int TargetLength { get; init; }
+
+    public required int? RecoveryLength { get; init; }
+
+    public required int PublishedEventSequenceNumber { get; init; }
+
+    public required int Staleness { get; init; }
+
+    public required string ByteWindow { get; init; }
+
+    public required string Diagnostic { get; init; }
+}
+
+internal static class TrxDocumentClassifier
+{
+    internal static readonly XNamespace TeamTest2010Namespace = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+
+    private static readonly string[] DefinitionChildOrder =
+        ["TestCategory", "Execution", "Owners", "Description", "Properties", "TestMethod"];
+
+    public static TrxDocumentObservation Classify(
+        byte[] targetBytes,
+        TrxDocumentExpectation expectation,
+        TrxDocumentObservationContext? context = null,
+        byte[]? completeRecoveryBytes = null,
+        Func<XDocument, TrxSchemaValidationResult>? schemaValidator = null)
+    {
+        context ??= new TrxDocumentObservationContext();
+        ClassificationResult target = ClassifyDocument(targetBytes, expectation, schemaValidator);
+        TrxDocumentClassification classification = target.Classification;
+
+        if ((classification is TrxDocumentClassification.Malformed or TrxDocumentClassification.ParseableInconsistent)
+            && completeRecoveryBytes is not null)
+        {
+            ClassificationResult recovery = ClassifyDocument(
+                completeRecoveryBytes,
+                expectation,
+                schemaValidator);
+
+            if (recovery.Classification == TrxDocumentClassification.Truthful)
+            {
+                classification = TrxDocumentClassification.Repairable;
+            }
+        }
+
+        int staleness = context.LatestEventSequenceNumber - context.PublishedEventSequenceNumber;
+        var errors = target.Errors.ToList();
+        if (staleness < 0)
+        {
+            errors.Add(
+                $"Published event sequence {context.PublishedEventSequenceNumber} is newer than latest event sequence {context.LatestEventSequenceNumber}.");
+            if (classification == TrxDocumentClassification.Truthful)
+            {
+                classification = TrxDocumentClassification.ParseableInconsistent;
+            }
+        }
+
+        string byteWindow = CreateByteWindow(targetBytes, context.CommittedByteCount);
+        string diagnostic = CreateDiagnostic(
+            classification,
+            target.SchemaStatus,
+            errors,
+            targetBytes.Length,
+            completeRecoveryBytes?.Length,
+            context,
+            staleness,
+            byteWindow);
+
+        return new TrxDocumentObservation
+        {
+            Classification = classification,
+            SchemaStatus = target.SchemaStatus,
+            Errors = errors,
+            TargetLength = targetBytes.Length,
+            RecoveryLength = completeRecoveryBytes?.Length,
+            PublishedEventSequenceNumber = context.PublishedEventSequenceNumber,
+            Staleness = staleness,
+            ByteWindow = byteWindow,
+            Diagnostic = diagnostic,
+        };
+    }
+
+    private static ClassificationResult ClassifyDocument(
+        byte[] bytes,
+        TrxDocumentExpectation expectation,
+        Func<XDocument, TrxSchemaValidationResult>? schemaValidator)
+    {
+        string text;
+        try
+        {
+            text = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetString(bytes);
+            if (text.Length > 0 && text[0] == '\uFEFF')
+            {
+                text = text.Substring(1);
+            }
+        }
+        catch (DecoderFallbackException ex)
+        {
+            return ClassificationResult.Malformed($"Strict UTF-8 decoding failed: {ex.Message}");
+        }
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(text, LoadOptions.PreserveWhitespace);
+        }
+        catch (XmlException ex)
+        {
+            return ClassificationResult.Malformed($"XML parsing failed at line {ex.LineNumber}, position {ex.LinePosition}: {ex.Message}");
+        }
+
+        TrxSchemaValidationResult schema = schemaValidator?.Invoke(document)
+            ?? TrxSchemaValidationResult.NotChecked();
+        List<string> errors = [];
+
+        ValidateDocument(document, expectation, errors);
+
+        return new ClassificationResult(
+            errors.Count == 0 ? TrxDocumentClassification.Truthful : TrxDocumentClassification.ParseableInconsistent,
+            schema.Status,
+            errors);
+    }
+
+    private static void ValidateDocument(XDocument document, TrxDocumentExpectation expectation, List<string> errors)
+    {
+        XElement? root = document.Root;
+        if (root is null)
+        {
+            errors.Add("The XML document has no root element.");
+            return;
+        }
+
+        if (root.Name != TeamTest2010Namespace + "TestRun")
+        {
+            errors.Add($"Root must be '{{{TeamTest2010Namespace}}}TestRun' but was '{root.Name}'.");
+        }
+
+        string? runIdText = AttributeValue(root, "id", errors);
+        if (!Guid.TryParse(runIdText, out Guid runId) || runId != expectation.RunId)
+        {
+            errors.Add($"TestRun/@id must be '{expectation.RunId}' but was '{runIdText}'.");
+        }
+
+        CompareAttribute(root, "name", expectation.RunName, errors);
+        ValidateExactOrder(root, expectation.RootChildOrder, "TestRun child order", errors);
+
+        XElement? times = RequiredChild(root, "Times", errors);
+        XElement? results = RequiredChild(root, "Results", errors);
+        XElement? definitions = RequiredChild(root, "TestDefinitions", errors);
+        XElement? entries = RequiredChild(root, "TestEntries", errors);
+        XElement? testLists = RequiredChild(root, "TestLists", errors);
+        XElement? summary = RequiredChild(root, "ResultSummary", errors);
+        _ = RequiredChild(root, "TestSettings", errors);
+
+        if (times is not null)
+        {
+            ValidateTimes(times, expectation, errors);
+        }
+
+        if (results is not null)
+        {
+            ValidateResults(results, expectation, errors);
+            ValidateWhitespaceOnlyStructuralText(results, errors);
+        }
+
+        if (definitions is not null)
+        {
+            ValidateWhitespaceOnlyStructuralText(definitions, errors);
+            foreach (XElement definition in definitions.Elements())
+            {
+                ValidateRelativeOrder(definition, DefinitionChildOrder, "UnitTest child order", errors);
+            }
+        }
+
+        if (entries is not null)
+        {
+            ValidateWhitespaceOnlyStructuralText(entries, errors);
+        }
+
+        if (testLists is not null)
+        {
+            ValidateTestLists(testLists, expectation, errors);
+        }
+
+        if (results is not null && definitions is not null && entries is not null)
+        {
+            ValidateDefinitionAndEntryLinks(results, definitions, entries, expectation, errors);
+        }
+
+        if (summary is not null)
+        {
+            CompareAttribute(summary, "outcome", expectation.SummaryOutcome, errors);
+            ValidateRelativeOrder(summary, expectation.SummaryChildOrder, "ResultSummary child order", errors);
+            ValidateCounters(summary, expectation, errors);
+        }
+    }
+
+    private static void ValidateTimes(XElement times, TrxDocumentExpectation expectation, List<string> errors)
+    {
+        DateTimeOffset? creation = ParseTimestamp(times, "creation", errors);
+        DateTimeOffset? queuing = ParseTimestamp(times, "queuing", errors);
+        DateTimeOffset? start = ParseTimestamp(times, "start", errors);
+        DateTimeOffset? finish = ParseTimestamp(times, "finish", errors);
+
+        CompareTimestamp("Times/@creation", creation, expectation.StartTime, errors);
+        CompareTimestamp("Times/@queuing", queuing, expectation.StartTime, errors);
+        CompareTimestamp("Times/@start", start, expectation.StartTime, errors);
+        CompareTimestamp("Times/@finish", finish, expectation.FinishTime, errors);
+
+        if (start is not null && finish is not null && finish.Value < start.Value)
+        {
+            errors.Add($"Times/@finish '{finish:O}' is earlier than Times/@start '{start:O}'.");
+        }
+    }
+
+    private static void ValidateResults(XElement results, TrxDocumentExpectation expectation, List<string> errors)
+    {
+        List<XElement> allResults = [.. results.Elements(TeamTest2010Namespace + "UnitTestResult")];
+        List<XElement> completed = [.. allResults.Where(result => result.Attribute("outcome")?.Value != "InProgress")];
+        List<XElement> running = [.. allResults.Where(result => result.Attribute("outcome")?.Value == "InProgress")];
+
+        if (completed.Count != expectation.CompletedResults.Count)
+        {
+            errors.Add($"Completed result count must be {expectation.CompletedResults.Count} but was {completed.Count}.");
+        }
+
+        int completedCount = Math.Min(completed.Count, expectation.CompletedResults.Count);
+        for (int i = 0; i < completedCount; i++)
+        {
+            XElement actual = completed[i];
+            TrxExpectedResult expected = expectation.CompletedResults[i];
+            CompareAttribute(actual, "testId", expected.TestId, errors, $"Result[{i}]");
+            CompareAttribute(actual, "executionId", expected.ExecutionId, errors, $"Result[{i}]");
+            CompareAttribute(actual, "testName", expected.TestName, errors, $"Result[{i}]");
+            CompareAttribute(actual, "outcome", ToXmlOutcome(expected.Outcome), errors, $"Result[{i}]");
+            CompareAttribute(actual, "duration", expected.Duration, errors, $"Result[{i}]");
+            CompareAttribute(actual, "computerName", expected.ComputerName, errors, $"Result[{i}]");
+            CompareGuidAttribute(actual, "testType", expected.TestTypeId, errors, $"Result[{i}]");
+            CompareGuidAttribute(actual, "testListId", expected.TestListId, errors, $"Result[{i}]");
+            CompareAttribute(
+                actual,
+                "relativeResultsDirectory",
+                expected.RelativeResultsDirectory,
+                errors,
+                $"Result[{i}]");
+
+            DateTimeOffset? resultStart = ParseAndCompareTimestamp(
+                actual,
+                "startTime",
+                expected.StartTime,
+                $"Result[{i}]/@startTime",
+                errors);
+            DateTimeOffset? resultEnd = ParseAndCompareTimestamp(
+                actual,
+                "endTime",
+                expected.EndTime,
+                $"Result[{i}]/@endTime",
+                errors);
+            if (resultStart is not null && resultEnd is not null && resultEnd.Value < resultStart.Value)
+            {
+                errors.Add($"Result[{i}]/@endTime '{resultEnd:O}' is earlier than @startTime '{resultStart:O}'.");
+            }
+
+            ValidateRelativeOrder(actual, ["Output", "ResultFiles"], $"Result[{i}] child order", errors);
+        }
+
+        if (running.Count != expectation.RunningTests.Count)
+        {
+            errors.Add($"Running result count must be {expectation.RunningTests.Count} but was {running.Count}.");
+        }
+
+        int runningCount = Math.Min(running.Count, expectation.RunningTests.Count);
+        for (int i = 0; i < runningCount; i++)
+        {
+            XElement actual = running[i];
+            TrxExpectedRunningTest expected = expectation.RunningTests[i];
+            CompareAttribute(actual, "testId", expected.TestId, errors, $"Running[{i}]");
+            CompareAttribute(actual, "executionId", expected.ExecutionId, errors, $"Running[{i}]");
+            CompareAttribute(actual, "testName", expected.TestName, errors, $"Running[{i}]");
+            CompareAttribute(actual, "computerName", expected.ComputerName, errors, $"Running[{i}]");
+            _ = ParseAndCompareTimestamp(
+                actual,
+                "startTime",
+                expected.StartTime,
+                $"Running[{i}]/@startTime",
+                errors);
+        }
+    }
+
+    private static void ValidateDefinitionAndEntryLinks(
+        XElement results,
+        XElement definitions,
+        XElement entries,
+        TrxDocumentExpectation expectation,
+        List<string> errors)
+    {
+        List<XElement> resultElements = [.. results.Elements(TeamTest2010Namespace + "UnitTestResult")
+            .Where(result => result.Attribute("outcome")?.Value != "InProgress")];
+        List<XElement> definitionElements = [.. definitions.Elements(TeamTest2010Namespace + "UnitTest")];
+        List<XElement> entryElements = [.. entries.Elements(TeamTest2010Namespace + "TestEntry")];
+
+        int expectedDefinitionCount = expectation.CompletedResults.Select(result => result.TestId).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        if (definitionElements.Count != expectedDefinitionCount)
+        {
+            errors.Add($"Definition count must be {expectedDefinitionCount} but was {definitionElements.Count}.");
+        }
+
+        if (entryElements.Count != expectation.CompletedResults.Count)
+        {
+            errors.Add($"Entry count must be {expectation.CompletedResults.Count} but was {entryElements.Count}.");
+        }
+
+        string[] expectedDefinitionIds =
+        [
+            .. expectation.CompletedResults
+                .Select(result => result.TestId)
+                .Distinct(StringComparer.OrdinalIgnoreCase),
+        ];
+        string[] actualDefinitionIds =
+        [
+            .. definitionElements.Select(definition => definition.Attribute("id")?.Value ?? "<missing>"),
+        ];
+        if (!actualDefinitionIds.SequenceEqual(expectedDefinitionIds, StringComparer.OrdinalIgnoreCase))
+        {
+            errors.Add(
+                $"Definition id order must be [{string.Join(", ", expectedDefinitionIds)}] but was [{string.Join(", ", actualDefinitionIds)}].");
+        }
+
+        foreach (IGrouping<string, XElement> duplicate in definitionElements
+                     .Where(element => element.Attribute("id") is not null)
+                     .GroupBy(element => element.Attribute("id")!.Value, StringComparer.OrdinalIgnoreCase)
+                     .Where(group => group.Count() != 1))
+        {
+            errors.Add($"Test id '{duplicate.Key}' has {duplicate.Count()} definitions; exactly one is required.");
+        }
+
+        for (int i = 0; i < resultElements.Count; i++)
+        {
+            XElement result = resultElements[i];
+            TrxExpectedResult? expected = i < expectation.CompletedResults.Count
+                ? expectation.CompletedResults[i]
+                : null;
+            string? testId = result.Attribute("testId")?.Value;
+            string? executionId = result.Attribute("executionId")?.Value;
+            if (testId is null || executionId is null)
+            {
+                continue;
+            }
+
+            int definitionCount = definitionElements.Count(definition =>
+                string.Equals(definition.Attribute("id")?.Value, testId, StringComparison.OrdinalIgnoreCase));
+            if (definitionCount != 1)
+            {
+                errors.Add($"Result[{i}] test id '{testId}' has {definitionCount} matching definitions; exactly one is required.");
+            }
+
+            int entryCount = entryElements.Count(entry =>
+                string.Equals(entry.Attribute("testId")?.Value, testId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(entry.Attribute("executionId")?.Value, executionId, StringComparison.OrdinalIgnoreCase));
+            if (entryCount != 1)
+            {
+                errors.Add($"Result[{i}] execution '{executionId}' has {entryCount} matching entries; exactly one is required.");
+            }
+
+            if (expected is not null && i < entryElements.Count)
+            {
+                XElement entry = entryElements[i];
+                CompareAttribute(entry, "testId", expected.TestId, errors, $"Entry[{i}]");
+                CompareAttribute(entry, "executionId", expected.ExecutionId, errors, $"Entry[{i}]");
+                CompareGuidAttribute(entry, "testListId", expected.TestListId, errors, $"Entry[{i}]");
+            }
+        }
+
+        foreach (IGrouping<string, TrxExpectedResult> expectedByTestId in expectation.CompletedResults.GroupBy(
+                     result => result.TestId,
+                     StringComparer.OrdinalIgnoreCase))
+        {
+            XElement? definition = definitionElements.SingleOrDefault(element =>
+                string.Equals(element.Attribute("id")?.Value, expectedByTestId.Key, StringComparison.OrdinalIgnoreCase));
+            string? definitionExecution = definition?.Element(TeamTest2010Namespace + "Execution")?.Attribute("id")?.Value;
+            string expectedFirstExecution = expectedByTestId.First().ExecutionId;
+            if (definition is not null
+                && !string.Equals(definitionExecution, expectedFirstExecution, StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(
+                    $"Definition '{expectedByTestId.Key}' execution must link to first execution '{expectedFirstExecution}' but was '{definitionExecution}'.");
+            }
+
+            if (definition is not null)
+            {
+                ValidateDefinition(definition, expectedByTestId.First(), errors);
+            }
+        }
+    }
+
+    private static void ValidateDefinition(
+        XElement definition,
+        TrxExpectedResult expectedResult,
+        List<string> errors)
+    {
+        TrxExpectedDefinition expected = expectedResult.Definition;
+        string location = $"Definition[{expectedResult.TestId}]";
+        CompareAttribute(definition, "name", expected.Name, errors, location);
+        CompareAttribute(definition, "storage", expected.Storage, errors, location);
+        CompareOptionalAttribute(definition, "priority", expected.Priority, errors, location);
+
+        string[] categories =
+        [
+            .. definition
+                .Element(TeamTest2010Namespace + "TestCategory")?
+                .Elements(TeamTest2010Namespace + "TestCategoryItem")
+                .Select(element => element.Attribute("TestCategory")?.Value ?? "<missing>")
+                ?? [],
+        ];
+        if (!categories.SequenceEqual(expected.Categories, StringComparer.Ordinal))
+        {
+            errors.Add(
+                $"{location} categories must be [{string.Join(", ", expected.Categories)}] but were [{string.Join(", ", categories)}].");
+        }
+
+        XElement? owners = definition.Element(TeamTest2010Namespace + "Owners");
+        string? owner = owners?.Element(TeamTest2010Namespace + "Owner")?.Attribute("name")?.Value;
+        CompareOptionalValue($"{location}/Owners/Owner/@name", owner, expected.Owner, errors);
+
+        string? description = definition.Element(TeamTest2010Namespace + "Description")?.Value;
+        CompareOptionalValue($"{location}/Description", description, expected.Description, errors);
+
+        TrxExpectedProperty[] properties =
+        [
+            .. definition
+                .Element(TeamTest2010Namespace + "Properties")?
+                .Elements(TeamTest2010Namespace + "Property")
+                .Select(
+                    property => new TrxExpectedProperty
+                    {
+                        Key = property.Element(TeamTest2010Namespace + "Key")?.Value ?? "<missing>",
+                        Value = property.Element(TeamTest2010Namespace + "Value")?.Value ?? "<missing>",
+                    })
+                ?? [],
+        ];
+        if (properties.Length != expected.Properties.Count
+            || properties.Where(
+                (property, index) => !string.Equals(property.Key, expected.Properties[index].Key, StringComparison.Ordinal)
+                    || !string.Equals(property.Value, expected.Properties[index].Value, StringComparison.Ordinal)).Any())
+        {
+            static string FormatProperties(IEnumerable<TrxExpectedProperty> values)
+                => string.Join(", ", values.Select(property => $"{property.Key}={property.Value}"));
+            errors.Add(
+                $"{location} properties must be [{FormatProperties(expected.Properties)}] but were [{FormatProperties(properties)}].");
+        }
+
+        XElement? method = RequiredChild(definition, "TestMethod", errors);
+        if (method is not null)
+        {
+            CompareAttribute(method, "codeBase", expected.CodeBase, errors, $"{location}/TestMethod");
+            CompareAttribute(method, "adapterTypeName", expected.AdapterTypeName, errors, $"{location}/TestMethod");
+            CompareAttribute(method, "className", expected.ClassName, errors, $"{location}/TestMethod");
+            CompareAttribute(method, "name", expected.MethodName, errors, $"{location}/TestMethod");
+        }
+    }
+
+    private static void ValidateTestLists(
+        XElement testLists,
+        TrxDocumentExpectation expectation,
+        List<string> errors)
+    {
+        XElement[] actual = [.. testLists.Elements(TeamTest2010Namespace + "TestList")];
+        (string Name, string Id)[] expected =
+        [
+            ("Results Not in a List", expectation.UncategorizedTestListId),
+            ("All Loaded Results", expectation.AllLoadedResultsTestListId),
+        ];
+        if (actual.Length != expected.Length)
+        {
+            errors.Add($"TestLists must contain {expected.Length} TestList elements but contained {actual.Length}.");
+        }
+
+        for (int i = 0; i < Math.Min(actual.Length, expected.Length); i++)
+        {
+            CompareAttribute(actual[i], "name", expected[i].Name, errors, $"TestList[{i}]");
+            CompareGuidAttribute(actual[i], "id", expected[i].Id, errors, $"TestList[{i}]");
+        }
+    }
+
+    private static void ValidateCounters(XElement summary, TrxDocumentExpectation expectation, List<string> errors)
+    {
+        XElement? counters = summary.Element(TeamTest2010Namespace + "Counters");
+        if (counters is null)
+        {
+            errors.Add("ResultSummary/Counters is missing.");
+            return;
+        }
+
+        IReadOnlyDictionary<string, int> expectedCounters = expectation.Counters ?? CalculateCounters(expectation);
+        foreach (KeyValuePair<string, int> expected in expectedCounters)
+        {
+            string? actualText = counters.Attribute(expected.Key)?.Value;
+            if (!int.TryParse(actualText, NumberStyles.None, CultureInfo.InvariantCulture, out int actual))
+            {
+                errors.Add($"Counters/@{expected.Key} must be an integer but was '{actualText}'.");
+            }
+            else if (actual != expected.Value)
+            {
+                errors.Add($"Counters/@{expected.Key} must be {expected.Value} but was {actual}.");
+            }
+        }
+    }
+
+    private static IReadOnlyDictionary<string, int> CalculateCounters(TrxDocumentExpectation expectation)
+    {
+        int passed = expectation.CompletedResults.Count(result => result.Outcome == TrxTestOutcome.Passed);
+        int failed = expectation.CompletedResults.Count(result => result.Outcome == TrxTestOutcome.Failed);
+        int skipped = expectation.CompletedResults.Count(result => result.Outcome == TrxTestOutcome.Skipped);
+        int timedout = expectation.CompletedResults.Count(result => result.Outcome == TrxTestOutcome.Timeout);
+
+        return new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["total"] = passed + failed + skipped + timedout,
+            ["executed"] = passed + failed,
+            ["passed"] = passed,
+            ["failed"] = failed,
+            ["error"] = 0,
+            ["timeout"] = timedout,
+            ["aborted"] = 0,
+            ["inconclusive"] = 0,
+            ["passedButRunAborted"] = 0,
+            ["notRunnable"] = 0,
+            ["notExecuted"] = skipped,
+            ["disconnected"] = 0,
+            ["warning"] = 0,
+            ["completed"] = 0,
+            ["inProgress"] = expectation.RunningTests.Count,
+            ["pending"] = 0,
+        };
+    }
+
+    private static DateTimeOffset? ParseTimestamp(XElement element, string attributeName, List<string> errors)
+    {
+        string? value = element.Attribute(attributeName)?.Value;
+        if (!DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset parsed))
+        {
+            errors.Add($"{element.Name.LocalName}/@{attributeName} must be a round-trip timestamp but was '{value}'.");
+            return null;
+        }
+
+        string roundTrip = parsed.ToString("O", CultureInfo.InvariantCulture);
+        if (!DateTimeOffset.TryParse(roundTrip, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out _))
+        {
+            errors.Add($"{element.Name.LocalName}/@{attributeName} did not survive round-trip formatting.");
+        }
+
+        return parsed;
+    }
+
+    private static DateTimeOffset? ParseAndCompareTimestamp(
+        XElement element,
+        string attributeName,
+        DateTimeOffset expected,
+        string location,
+        List<string> errors)
+    {
+        DateTimeOffset? actual = ParseTimestamp(element, attributeName, errors);
+        CompareTimestamp(location, actual, expected, errors);
+        string expectedText = expected.ToString("O", CultureInfo.InvariantCulture);
+        string? actualText = element.Attribute(attributeName)?.Value;
+        if (actual is not null && !string.Equals(actualText, expectedText, StringComparison.Ordinal))
+        {
+            errors.Add($"{location} text must be exactly '{expectedText}' but was '{actualText}'.");
+        }
+
+        return actual;
+    }
+
+    private static void CompareTimestamp(string location, DateTimeOffset? actual, DateTimeOffset expected, List<string> errors)
+    {
+        if (actual is not null && (actual.Value != expected || actual.Value.Offset != expected.Offset))
+        {
+            errors.Add($"{location} must be '{expected:O}' but was '{actual:O}'.");
+        }
+    }
+
+    private static XElement? RequiredChild(XElement parent, string localName, List<string> errors)
+    {
+        List<XElement> matches = [.. parent.Elements(TeamTest2010Namespace + localName)];
+        if (matches.Count != 1)
+        {
+            errors.Add($"{parent.Name.LocalName}/{localName} must occur exactly once but occurred {matches.Count} times.");
+            return matches.FirstOrDefault();
+        }
+
+        return matches[0];
+    }
+
+    private static string? AttributeValue(XElement element, string name, List<string> errors)
+    {
+        string? value = element.Attribute(name)?.Value;
+        if (value is null)
+        {
+            errors.Add($"{element.Name.LocalName}/@{name} is missing.");
+        }
+
+        return value;
+    }
+
+    private static void CompareAttribute(
+        XElement element,
+        string name,
+        string expected,
+        List<string> errors,
+        string? location = null)
+    {
+        string? actual = element.Attribute(name)?.Value;
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            errors.Add($"{location ?? element.Name.LocalName}/@{name} must be '{expected}' but was '{actual}'.");
+        }
+    }
+
+    private static void CompareGuidAttribute(
+        XElement element,
+        string name,
+        string expected,
+        List<string> errors,
+        string location)
+    {
+        string? actual = element.Attribute(name)?.Value;
+        if (!Guid.TryParse(actual, out Guid actualGuid)
+            || !Guid.TryParse(expected, out Guid expectedGuid)
+            || actualGuid != expectedGuid)
+        {
+            errors.Add($"{location}/@{name} must identify '{expected}' but was '{actual}'.");
+        }
+    }
+
+    private static void CompareOptionalAttribute(
+        XElement element,
+        string name,
+        string? expected,
+        List<string> errors,
+        string location)
+        => CompareOptionalValue($"{location}/@{name}", element.Attribute(name)?.Value, expected, errors);
+
+    private static void CompareOptionalValue(
+        string location,
+        string? actual,
+        string? expected,
+        List<string> errors)
+    {
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            errors.Add($"{location} must be '{expected ?? "<absent>"}' but was '{actual ?? "<absent>"}'.");
+        }
+    }
+
+    private static void ValidateExactOrder(
+        XElement parent,
+        IReadOnlyList<string> expected,
+        string location,
+        List<string> errors)
+    {
+        string[] actual = [.. parent.Elements().Select(element => element.Name.LocalName)];
+        if (!actual.SequenceEqual(expected, StringComparer.Ordinal))
+        {
+            errors.Add($"{location} must be [{string.Join(", ", expected)}] but was [{string.Join(", ", actual)}].");
+        }
+    }
+
+    private static void ValidateRelativeOrder(
+        XElement parent,
+        IReadOnlyList<string> allowedOrder,
+        string location,
+        List<string> errors)
+    {
+        int previousIndex = -1;
+        foreach (XElement child in parent.Elements())
+        {
+            int currentIndex = IndexOf(allowedOrder, child.Name.LocalName);
+            if (currentIndex < 0)
+            {
+                errors.Add($"{location} contains unexpected child '{child.Name.LocalName}'.");
+                continue;
+            }
+
+            if (currentIndex < previousIndex)
+            {
+                errors.Add($"{location} is invalid at '{child.Name.LocalName}'; expected relative order [{string.Join(", ", allowedOrder)}].");
+                return;
+            }
+
+            previousIndex = currentIndex;
+        }
+    }
+
+    private static int IndexOf(IReadOnlyList<string> values, string value)
+    {
+        for (int i = 0; i < values.Count; i++)
+        {
+            if (string.Equals(values[i], value, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static void ValidateWhitespaceOnlyStructuralText(XElement section, List<string> errors)
+    {
+        foreach (XText text in section.Nodes().OfType<XText>())
+        {
+            if (text.Value.Any(character => !char.IsWhiteSpace(character)))
+            {
+                errors.Add($"{section.Name.LocalName} contains non-whitespace pad text '{Bound(text.Value, 40)}'.");
+            }
+        }
+    }
+
+    private static string ToXmlOutcome(TrxTestOutcome outcome)
+        => outcome switch
+        {
+            TrxTestOutcome.Passed => "Passed",
+            TrxTestOutcome.Skipped => "NotExecuted",
+            TrxTestOutcome.Failed or TrxTestOutcome.Timeout => "Failed",
+            _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+        };
+
+    private static string CreateByteWindow(byte[] bytes, int? committedByteCount)
+    {
+        const int windowSize = 32;
+        int center = committedByteCount ?? bytes.Length;
+        center = Math.Max(0, Math.Min(center, bytes.Length));
+        int start = Math.Max(0, center - (windowSize / 2));
+        if (start + windowSize > bytes.Length)
+        {
+            start = Math.Max(0, bytes.Length - windowSize);
+        }
+
+        int count = Math.Min(windowSize, bytes.Length - start);
+        byte[] window = new byte[count];
+        Array.Copy(bytes, start, window, 0, count);
+        string hex = BitConverter.ToString(window).Replace("-", " ");
+        StringBuilder text = new(count);
+        foreach (byte value in window)
+        {
+            text.Append(value is >= 0x20 and <= 0x7E ? (char)value : '.');
+        }
+
+        return $"offset={start}; count={count}; hex={hex}; text={text}";
+    }
+
+    private static string CreateDiagnostic(
+        TrxDocumentClassification classification,
+        TrxSchemaStatus schemaStatus,
+        IReadOnlyList<string> errors,
+        int targetLength,
+        int? recoveryLength,
+        TrxDocumentObservationContext context,
+        int staleness,
+        string byteWindow)
+    {
+        string error = errors.Count == 0 ? "<none>" : Bound(string.Join(" | ", errors.Take(3)), 360);
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "classification={0}; schema={1}; operation={2}:{3}; cut={4}; previousLength={5}; targetLength={6}; recoveryLength={7}; eventSequence={8}; latestSequence={9}; staleness={10}; error={11}; window=[{12}]",
+            classification,
+            schemaStatus,
+            context.OperationIndex?.ToString(CultureInfo.InvariantCulture) ?? "<none>",
+            context.OperationKind ?? "<none>",
+            context.CommittedByteCount?.ToString(CultureInfo.InvariantCulture) ?? "<none>",
+            context.PreviousTargetLength?.ToString(CultureInfo.InvariantCulture) ?? "<none>",
+            targetLength,
+            recoveryLength?.ToString(CultureInfo.InvariantCulture) ?? "<none>",
+            context.PublishedEventSequenceNumber,
+            context.LatestEventSequenceNumber,
+            staleness,
+            error,
+            byteWindow);
+    }
+
+    private static string Bound(string value, int maximumLength)
+        => value.Length <= maximumLength ? value : value.Substring(0, maximumLength) + "…";
+
+    private sealed class ClassificationResult
+    {
+        public ClassificationResult(
+            TrxDocumentClassification classification,
+            TrxSchemaStatus schemaStatus,
+            IReadOnlyList<string> errors)
+        {
+            Classification = classification;
+            SchemaStatus = schemaStatus;
+            Errors = errors;
+        }
+
+        public TrxDocumentClassification Classification { get; }
+
+        public TrxSchemaStatus SchemaStatus { get; }
+
+        public IReadOnlyList<string> Errors { get; }
+
+        public static ClassificationResult Malformed(string error)
+            => new(TrxDocumentClassification.Malformed, TrxSchemaStatus.NotChecked, [error]);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxDocumentClassifier.cs
@@ -44,6 +44,16 @@ internal sealed class TrxExpectedResult
 
     public required string RelativeResultsDirectory { get; init; }
 
+    public string? StandardOutput { get; init; }
+
+    public string? StandardError { get; init; }
+
+    public string? DebugTrace { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public string? ErrorStackTrace { get; init; }
+
     public required TrxExpectedDefinition Definition { get; init; }
 }
 
@@ -133,10 +143,17 @@ internal static class TrxExpectedResultFactory
         string testModule,
         string frameworkUid,
         string frameworkVersion,
-        DateTimeOffset fallbackTime)
+        DateTimeOffset fallbackTime,
+        Func<string, string>? renderedTextTransform = null)
     {
+        string RenderText(string value)
+        {
+            string sanitized = Sanitize(value);
+            return renderedTextTransform?.Invoke(sanitized) ?? sanitized;
+        }
+
         string executionIdText = executionId.ToString();
-        string displayName = Sanitize(result.DisplayName);
+        string displayName = RenderText(result.DisplayName);
         TrxTestMethodIdentifier? identifier = result.TestMethodIdentifier;
         string className = result.TrxFullyQualifiedTypeName
             ?? (identifier is null
@@ -153,10 +170,10 @@ internal static class TrxExpectedResultFactory
             switch (metadata.Key)
             {
                 case "Owner":
-                    owner ??= Sanitize(metadata.Value);
+                    owner ??= RenderText(metadata.Value);
                     break;
                 case "Description":
-                    description ??= Sanitize(metadata.Value);
+                    description ??= RenderText(metadata.Value);
                     break;
                 case "Priority":
                     if (int.TryParse(metadata.Value, out int priorityValue) && priorityValue != int.MaxValue)
@@ -169,8 +186,8 @@ internal static class TrxExpectedResultFactory
                     properties.Add(
                         new TrxExpectedProperty
                         {
-                            Key = Sanitize(metadata.Key),
-                            Value = Sanitize(metadata.Value),
+                            Key = RenderText(metadata.Key),
+                            Value = RenderText(metadata.Value),
                         });
                     break;
             }
@@ -186,30 +203,43 @@ internal static class TrxExpectedResultFactory
                 ?? "00:00:00",
             StartTime = result.StartTime?.ToUniversalTime() ?? fallbackTime,
             EndTime = result.EndTime?.ToUniversalTime() ?? fallbackTime,
-            ComputerName = Sanitize(computerName),
+            ComputerName = RenderText(computerName),
             TestTypeId = UnitTestTypeId,
             TestListId = UncategorizedTestListId,
             RelativeResultsDirectory = executionIdText,
+            StandardOutput = CreateMessageText(result.Messages, TrxStreamMessageKind.StandardOutput, RenderText),
+            StandardError = CreateMessageText(result.Messages, TrxStreamMessageKind.StandardError, RenderText),
+            DebugTrace = CreateMessageText(result.Messages, TrxStreamMessageKind.DebugOrTrace, RenderText),
+            ErrorMessage = result.ExceptionMessage is null ? null : RenderText(result.ExceptionMessage),
+            ErrorStackTrace = result.ExceptionStackTrace is null ? null : RenderText(result.ExceptionStackTrace),
             Definition = new TrxExpectedDefinition
             {
-                Name = Sanitize(result.TrxTestDefinitionName ?? displayName),
-                Storage = Sanitize(testModule.ToLowerInvariant()),
-                ClassName = Sanitize(className),
-                MethodName = Sanitize(identifier?.MethodName ?? displayName),
-                CodeBase = Sanitize(testModule),
-                AdapterTypeName = Sanitize($"executor://{frameworkUid}/{frameworkVersion}"),
+                Name = RenderText(result.TrxTestDefinitionName ?? displayName),
+                Storage = RenderText(testModule.ToLowerInvariant()),
+                ClassName = RenderText(className),
+                MethodName = RenderText(identifier?.MethodName ?? displayName),
+                CodeBase = RenderText(testModule),
+                AdapterTypeName = RenderText($"executor://{frameworkUid}/{frameworkVersion}"),
                 Priority = priority,
                 Owner = owner,
                 Description = description,
-                Categories = [.. (result.Categories ?? []).Select(Sanitize)],
+                Categories = [.. (result.Categories ?? []).Select(RenderText)],
                 Properties = properties,
             },
         };
     }
 
+    private static string? CreateMessageText(
+        IReadOnlyList<TrxStreamMessage>? messages,
+        TrxStreamMessageKind kind,
+        Func<string, string> renderText)
+    {
+        string[] matching = [.. (messages ?? []).Where(message => message.Kind == kind).Select(message => message.Message ?? string.Empty)];
+        return matching.Length == 0 ? null : renderText(string.Join(Environment.NewLine, matching));
+    }
+
     private static string Sanitize(string value)
     {
-        value = value.Replace("\r\n", "\n").Replace('\r', '\n');
         StringBuilder? builder = null;
         for (int i = 0; i < value.Length; i++)
         {
@@ -551,6 +581,7 @@ internal static class TrxDocumentClassifier
                 errors.Add($"Result[{i}]/@endTime '{resultEnd:O}' is earlier than @startTime '{resultStart:O}'.");
             }
 
+            ValidateOutput(actual, expected, i, errors);
             ValidateRelativeOrder(actual, ["Output", "ResultFiles"], $"Result[{i}] child order", errors);
         }
 
@@ -575,6 +606,41 @@ internal static class TrxDocumentClassifier
                 $"Running[{i}]/@startTime",
                 errors);
         }
+    }
+
+    private static void ValidateOutput(
+        XElement result,
+        TrxExpectedResult expected,
+        int resultIndex,
+        List<string> errors)
+    {
+        XElement? output = result.Element(TeamTest2010Namespace + "Output");
+        string location = $"Result[{resultIndex}]/Output";
+        CompareOptionalValue(
+            $"{location}/StdOut",
+            output?.Element(TeamTest2010Namespace + "StdOut")?.Value,
+            expected.StandardOutput,
+            errors);
+        CompareOptionalValue(
+            $"{location}/StdErr",
+            output?.Element(TeamTest2010Namespace + "StdErr")?.Value,
+            expected.StandardError,
+            errors);
+        CompareOptionalValue(
+            $"{location}/DebugTrace",
+            output?.Element(TeamTest2010Namespace + "DebugTrace")?.Value,
+            expected.DebugTrace,
+            errors);
+        CompareOptionalValue(
+            $"{location}/ErrorInfo/Message",
+            output?.Element(TeamTest2010Namespace + "ErrorInfo")?.Element(TeamTest2010Namespace + "Message")?.Value,
+            expected.ErrorMessage,
+            errors);
+        CompareOptionalValue(
+            $"{location}/ErrorInfo/StackTrace",
+            output?.Element(TeamTest2010Namespace + "ErrorInfo")?.Element(TeamTest2010Namespace + "StackTrace")?.Value,
+            expected.ErrorStackTrace,
+            errors);
     }
 
     private static void ValidateDefinitionAndEntryLinks(

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxFaultInjectingFileOperations.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxFaultInjectingFileOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxFaultInjectingFileOperations.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxFaultInjectingFileOperations.cs
@@ -1,0 +1,865 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.ObjectModel;
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+namespace Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+internal enum TrxFileOperationKind
+{
+    Open,
+    Read,
+    Seek,
+    Write,
+    Flush,
+    SetLength,
+    Replace,
+    Delete,
+}
+
+internal enum TrxReplacementModel
+{
+    Atomic,
+    DeleteThenMove,
+    Unsupported,
+}
+
+internal sealed class TrxTerminationPlan
+{
+    public TrxTerminationPlan(int operationIndex, int? committedByteCount = null)
+    {
+        if (operationIndex < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(operationIndex));
+        }
+
+        if (committedByteCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(committedByteCount));
+        }
+
+        OperationIndex = operationIndex;
+        CommittedByteCount = committedByteCount;
+    }
+
+    public int OperationIndex { get; }
+
+    public int? CommittedByteCount { get; }
+}
+
+internal sealed class TrxFileOperationRecord
+{
+    public required int OperationIndex { get; init; }
+
+    public required TrxFileOperationKind Kind { get; init; }
+
+    public required string Path { get; init; }
+
+    public long? PrePosition { get; init; }
+
+    public long? PostPosition { get; init; }
+
+    public required long PreLength { get; init; }
+
+    public required long PostLength { get; init; }
+
+    public int RequestedByteCount { get; init; }
+
+    public int CommittedByteCount { get; init; }
+
+    public FileMode? Mode { get; init; }
+
+    public FileAccess? Access { get; init; }
+
+    public FileShare? Share { get; init; }
+
+    public string? ReplacementSource { get; init; }
+
+    public string? ReplacementTarget { get; init; }
+
+    public required string ByteWindow { get; init; }
+
+    public override string ToString()
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "#{0:D3} {1} path='{2}' position={3}->{4} length={5}->{6} requested={7} committed={8} mode={9} access={10} share={11} replace='{12}'->'{13}' window=[{14}]",
+            OperationIndex,
+            Kind,
+            Path,
+            FormatNullable(PrePosition),
+            FormatNullable(PostPosition),
+            PreLength,
+            PostLength,
+            RequestedByteCount,
+            CommittedByteCount,
+            Mode?.ToString() ?? "-",
+            Access?.ToString() ?? "-",
+            Share?.ToString() ?? "-",
+            ReplacementSource ?? "-",
+            ReplacementTarget ?? "-",
+            ByteWindow);
+
+    private static string FormatNullable(long? value)
+        => value?.ToString(CultureInfo.InvariantCulture) ?? "-";
+}
+
+internal sealed class TrxVirtualFileSystemSnapshot
+{
+    private readonly IReadOnlyDictionary<string, byte[]> _files;
+
+    public TrxVirtualFileSystemSnapshot(
+        int operationIndex,
+        bool isProcessDead,
+        IEnumerable<KeyValuePair<string, byte[]>> files)
+    {
+        OperationIndex = operationIndex;
+        IsProcessDead = isProcessDead;
+
+        var copies = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (KeyValuePair<string, byte[]> file in files)
+        {
+            copies.Add(file.Key, (byte[])file.Value.Clone());
+        }
+
+        _files = new ReadOnlyDictionary<string, byte[]>(copies);
+    }
+
+    public int OperationIndex { get; }
+
+    public bool IsProcessDead { get; }
+
+    public int FileCount => _files.Count;
+
+    public IReadOnlyList<string> Paths => [.. _files.Keys];
+
+    public bool Contains(string path) => _files.ContainsKey(path);
+
+    public byte[] GetFileBytes(string path) => (byte[])_files[path].Clone();
+
+    public override string ToString()
+    {
+        StringBuilder builder = new();
+        _ = builder.Append("operation=")
+            .Append(OperationIndex.ToString(CultureInfo.InvariantCulture))
+            .Append("; dead=")
+            .Append(IsProcessDead)
+            .Append("; files=");
+        foreach (KeyValuePair<string, byte[]> file in _files)
+        {
+            _ = builder.Append('[')
+                .Append(file.Key)
+                .Append(':')
+                .Append(Convert.ToBase64String(file.Value))
+                .Append(']');
+        }
+
+        return builder.ToString();
+    }
+}
+
+internal sealed class TrxSimulatedProcessTerminationException : IOException
+{
+    public TrxSimulatedProcessTerminationException(int operationIndex)
+        : base($"The virtual TRX process terminated at semantic file operation {operationIndex}.")
+    {
+        OperationIndex = operationIndex;
+    }
+
+    public int OperationIndex { get; }
+}
+
+internal sealed class TrxFaultInjectingFileOperations : ITrxPrototypeFileOperations
+{
+    private const int DiagnosticWindowSize = 16;
+
+#pragma warning disable IDE0028 // Collection expressions cannot preserve the ordinal path comparer.
+    private readonly Dictionary<string, VirtualFileEntry> _files = new(StringComparer.Ordinal);
+#pragma warning restore IDE0028
+    private readonly List<VirtualFileHandle> _handles = [];
+    private readonly List<TrxFileOperationRecord> _operations = [];
+    private readonly List<TrxVirtualFileSystemSnapshot> _snapshots = [];
+    private readonly TrxReplacementModel _replacementModel;
+    private readonly Action<TrxFileOperationRecord, TrxVirtualFileSystemSnapshot>? _afterOperation;
+    private readonly bool _enforceShareSemantics;
+    private readonly bool _captureSnapshots;
+    private TrxTerminationPlan? _terminationPlan;
+    private bool _recordOperations;
+    private int _nextOperationIndex;
+    private int _nextTemporaryPath;
+
+    public TrxFaultInjectingFileOperations(
+        TrxReplacementModel replacementModel = TrxReplacementModel.Atomic,
+        TrxTerminationPlan? terminationPlan = null,
+        Action<TrxFileOperationRecord, TrxVirtualFileSystemSnapshot>? afterOperation = null,
+        bool enforceShareSemantics = true,
+        bool captureSnapshots = true,
+        bool recordOperations = true)
+    {
+        _replacementModel = replacementModel;
+        _terminationPlan = terminationPlan;
+        _afterOperation = afterOperation;
+        _enforceShareSemantics = enforceShareSemantics;
+        _captureSnapshots = captureSnapshots;
+        _recordOperations = recordOperations;
+    }
+
+    public bool SupportsAtomicReplace => _replacementModel == TrxReplacementModel.Atomic;
+
+    public bool IsProcessDead { get; private set; }
+
+    public IReadOnlyList<TrxFileOperationRecord> Operations => [.. _operations];
+
+    public IReadOnlyList<TrxVirtualFileSystemSnapshot> Snapshots => [.. _snapshots];
+
+    public void SeedFile(string path, byte[] bytes)
+    {
+        if (_nextOperationIndex != 0 || _handles.Count != 0)
+        {
+            throw new InvalidOperationException("Virtual files can only be seeded before semantic operations begin.");
+        }
+
+        _files[path] = new VirtualFileEntry(bytes);
+    }
+
+    public byte[] GetFileBytes(string path) => (byte[])_files[path].Bytes.Clone();
+
+    public TrxVirtualFileSystemSnapshot CaptureSnapshot()
+        => CreateSnapshot(_nextOperationIndex - 1);
+
+    public string FormatTrace() => string.Join(Environment.NewLine, _operations);
+
+    public void BeginFaultWindow(TrxTerminationPlan? terminationPlan)
+    {
+        EnsureProcessAlive();
+        if (_handles.Count != 0)
+        {
+            throw new InvalidOperationException("A fault window can only begin after every virtual file handle is closed.");
+        }
+
+        _operations.Clear();
+        _snapshots.Clear();
+        _nextOperationIndex = 0;
+        _terminationPlan = terminationPlan;
+        _recordOperations = true;
+    }
+
+    public ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+    {
+        EnsureProcessAlive();
+        ValidateOpenArguments(mode, access);
+
+        _files.TryGetValue(path, out VirtualFileEntry? entry);
+        if (mode == FileMode.CreateNew && entry is not null)
+        {
+            throw new IOException($"The virtual file '{path}' already exists.");
+        }
+
+        if ((mode == FileMode.Open || mode == FileMode.Truncate) && entry is null)
+        {
+            throw new FileNotFoundException($"The virtual file '{path}' does not exist.", path);
+        }
+
+        long preLength = entry?.Bytes.LongLength ?? 0;
+        if (entry is not null)
+        {
+            EnsureOpenShareIsCompatible(entry, access, share);
+        }
+
+        if (entry is null)
+        {
+            entry = new VirtualFileEntry([]);
+            _files.Add(path, entry);
+        }
+
+        if (mode is FileMode.Create or FileMode.Truncate)
+        {
+            entry.SetBytes([]);
+        }
+
+        long position = mode == FileMode.Append ? entry.Bytes.LongLength : 0;
+        var handle = new VirtualFileHandle(this, path, entry, access, share, position);
+        _handles.Add(handle);
+
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Open,
+            Path = path,
+            PreLength = preLength,
+            PostLength = entry.Bytes.LongLength,
+            PostPosition = position,
+            Mode = mode,
+            Access = access,
+            Share = share,
+            ByteWindow = CreateByteWindow(entry.Bytes, position),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+        return handle;
+    }
+
+    public string CreateTemporarySiblingPath(string destinationPath)
+    {
+        EnsureProcessAlive();
+        string? directory = Path.GetDirectoryName(destinationPath);
+        string fileName = Path.GetFileName(destinationPath);
+        string candidate;
+        do
+        {
+            _nextTemporaryPath++;
+            candidate = Path.Combine(
+                directory ?? string.Empty,
+                $"{fileName}.prototype-{_nextTemporaryPath:D4}.tmp");
+        }
+        while (_files.ContainsKey(candidate));
+
+        return candidate;
+    }
+
+    public void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+    {
+        EnsureProcessAlive();
+        if (_replacementModel == TrxReplacementModel.Unsupported)
+        {
+            throw new PlatformNotSupportedException("Atomic replacement is disabled in this virtual filesystem.");
+        }
+
+        if (_replacementModel == TrxReplacementModel.DeleteThenMove)
+        {
+            DeleteCore(destinationPath);
+            MoveTemporaryEntry(temporaryPath, destinationPath);
+            return;
+        }
+
+        AtomicReplace(temporaryPath, destinationPath);
+    }
+
+    public bool Exists(string path)
+    {
+        EnsureProcessAlive();
+        return _files.ContainsKey(path);
+    }
+
+    public void Delete(string path)
+    {
+        EnsureProcessAlive();
+        DeleteCore(path);
+    }
+
+    private void AtomicReplace(string temporaryPath, string destinationPath)
+    {
+        VirtualFileEntry source = GetRequiredEntry(temporaryPath);
+        _files.TryGetValue(destinationPath, out VirtualFileEntry? destination);
+        EnsureDeleteShareIsCompatible(source, temporaryPath);
+        if (destination is not null && !ReferenceEquals(source, destination))
+        {
+            EnsureDeleteShareIsCompatible(destination, destinationPath);
+        }
+
+        long preLength = destination?.Bytes.LongLength ?? 0;
+        _ = _files.Remove(temporaryPath);
+        _files[destinationPath] = source;
+
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Replace,
+            Path = destinationPath,
+            PreLength = preLength,
+            PostLength = source.Bytes.LongLength,
+            ReplacementSource = temporaryPath,
+            ReplacementTarget = destinationPath,
+            ByteWindow = CreateByteWindow(source.Bytes, source.Bytes.LongLength),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private void MoveTemporaryEntry(string temporaryPath, string destinationPath)
+    {
+        VirtualFileEntry source = GetRequiredEntry(temporaryPath);
+        EnsureDeleteShareIsCompatible(source, temporaryPath);
+
+        long preLength = _files.TryGetValue(destinationPath, out VirtualFileEntry? destination)
+            ? destination.Bytes.LongLength
+            : 0;
+        if (destination is not null)
+        {
+            EnsureDeleteShareIsCompatible(destination, destinationPath);
+        }
+
+        _ = _files.Remove(temporaryPath);
+        _files[destinationPath] = source;
+
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Replace,
+            Path = destinationPath,
+            PreLength = preLength,
+            PostLength = source.Bytes.LongLength,
+            ReplacementSource = temporaryPath,
+            ReplacementTarget = destinationPath,
+            ByteWindow = CreateByteWindow(source.Bytes, source.Bytes.LongLength),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private void DeleteCore(string path)
+    {
+        _files.TryGetValue(path, out VirtualFileEntry? entry);
+        long preLength = entry?.Bytes.LongLength ?? 0;
+        if (entry is not null)
+        {
+            EnsureDeleteShareIsCompatible(entry, path);
+            _ = _files.Remove(path);
+        }
+
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Delete,
+            Path = path,
+            PreLength = preLength,
+            PostLength = 0,
+            ByteWindow = CreateByteWindow([], 0),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private int Read(VirtualFileHandle handle, byte[] buffer, int offset, int count)
+    {
+        EnsureHandleUsable(handle);
+        EnsureReadable(handle);
+        ValidateBufferArguments(buffer, offset, count);
+
+        long prePosition = handle.Position;
+        long preLength = handle.Entry.Bytes.LongLength;
+        int available = (int)Math.Min(count, Math.Max(0, preLength - prePosition));
+        if (available > 0)
+        {
+            Array.Copy(handle.Entry.Bytes, prePosition, buffer, offset, available);
+            handle.Position += available;
+        }
+
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Read,
+            Path = handle.Path,
+            PrePosition = prePosition,
+            PostPosition = handle.Position,
+            PreLength = preLength,
+            PostLength = handle.Entry.Bytes.LongLength,
+            RequestedByteCount = count,
+            CommittedByteCount = available,
+            ByteWindow = CreateByteWindow(handle.Entry.Bytes, handle.Position),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+        return available;
+    }
+
+    private void Seek(VirtualFileHandle handle, long offset, SeekOrigin origin)
+    {
+        EnsureHandleUsable(handle);
+        long prePosition = handle.Position;
+        long preLength = handle.Entry.Bytes.LongLength;
+        long originPosition = origin switch
+        {
+            SeekOrigin.Begin => 0,
+            SeekOrigin.Current => handle.Position,
+            SeekOrigin.End => preLength,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+        long postPosition = checked(originPosition + offset);
+        if (postPosition < 0)
+        {
+            throw new IOException("An attempt was made to seek before the beginning of the virtual file.");
+        }
+
+        handle.Position = postPosition;
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Seek,
+            Path = handle.Path,
+            PrePosition = prePosition,
+            PostPosition = postPosition,
+            PreLength = preLength,
+            PostLength = preLength,
+            ByteWindow = CreateByteWindow(handle.Entry.Bytes, postPosition),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private void Write(VirtualFileHandle handle, byte[] buffer, int offset, int count)
+    {
+        EnsureHandleUsable(handle);
+        EnsureWritable(handle);
+        ValidateBufferArguments(buffer, offset, count);
+
+        int operationIndex = _nextOperationIndex;
+        int committedByteCount = GetCommittedWriteCount(operationIndex, count);
+        long prePosition = handle.Position;
+        long preLength = handle.Entry.Bytes.LongLength;
+        long requiredLength = checked(prePosition + committedByteCount);
+        if (requiredLength > int.MaxValue)
+        {
+            throw new IOException("The virtual file cannot exceed Int32.MaxValue bytes.");
+        }
+
+        if (requiredLength > preLength)
+        {
+            handle.Entry.Resize((int)requiredLength);
+        }
+
+        if (committedByteCount > 0)
+        {
+            Array.Copy(buffer, offset, handle.Entry.Bytes, prePosition, committedByteCount);
+            handle.Position += committedByteCount;
+        }
+
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Write,
+            Path = handle.Path,
+            PrePosition = prePosition,
+            PostPosition = handle.Position,
+            PreLength = preLength,
+            PostLength = handle.Entry.Bytes.LongLength,
+            RequestedByteCount = count,
+            CommittedByteCount = committedByteCount,
+            ByteWindow = CreateByteWindow(handle.Entry.Bytes, handle.Position),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private void Flush(VirtualFileHandle handle)
+    {
+        EnsureHandleUsable(handle);
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.Flush,
+            Path = handle.Path,
+            PrePosition = handle.Position,
+            PostPosition = handle.Position,
+            PreLength = handle.Entry.Bytes.LongLength,
+            PostLength = handle.Entry.Bytes.LongLength,
+            ByteWindow = CreateByteWindow(handle.Entry.Bytes, handle.Position),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private void SetLength(VirtualFileHandle handle, long length)
+    {
+        EnsureHandleUsable(handle);
+        EnsureWritable(handle);
+        if (length is < 0 or > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length));
+        }
+
+        long preLength = handle.Entry.Bytes.LongLength;
+        handle.Entry.Resize((int)length);
+        int operationIndex = _nextOperationIndex;
+        var record = new TrxFileOperationRecord
+        {
+            OperationIndex = operationIndex,
+            Kind = TrxFileOperationKind.SetLength,
+            Path = handle.Path,
+            PrePosition = handle.Position,
+            PostPosition = handle.Position,
+            PreLength = preLength,
+            PostLength = length,
+            ByteWindow = CreateByteWindow(handle.Entry.Bytes, handle.Position),
+        };
+        RecordAndFinish(record, ShouldTerminate(operationIndex));
+    }
+
+    private long GetLength(VirtualFileHandle handle)
+    {
+        EnsureHandleUsable(handle);
+        return handle.Entry.Bytes.LongLength;
+    }
+
+    private long GetPosition(VirtualFileHandle handle)
+    {
+        EnsureHandleUsable(handle);
+        return handle.Position;
+    }
+
+    private void DisposeHandle(VirtualFileHandle handle)
+    {
+        EnsureProcessAlive();
+        if (handle.IsDisposed)
+        {
+            return;
+        }
+
+        handle.IsDisposed = true;
+        _ = _handles.Remove(handle);
+    }
+
+    private int GetCommittedWriteCount(int operationIndex, int requestedByteCount)
+    {
+        int committedByteCount = _terminationPlan?.OperationIndex == operationIndex
+            && _terminationPlan.CommittedByteCount is { } plannedByteCount
+                ? plannedByteCount
+                : requestedByteCount;
+
+        return committedByteCount <= requestedByteCount
+            ? committedByteCount
+            : throw new InvalidOperationException(
+                $"The termination plan requests {committedByteCount} committed bytes for a {requestedByteCount}-byte write.");
+    }
+
+    private bool ShouldTerminate(int operationIndex)
+        => _terminationPlan?.OperationIndex == operationIndex;
+
+    private void RecordAndFinish(TrxFileOperationRecord record, bool terminate)
+    {
+        if (terminate)
+        {
+            IsProcessDead = true;
+        }
+
+        if (_recordOperations)
+        {
+            _operations.Add(record);
+        }
+
+        _nextOperationIndex++;
+        if (_recordOperations && (_captureSnapshots || _afterOperation is not null))
+        {
+            TrxVirtualFileSystemSnapshot snapshot = CreateSnapshot(record.OperationIndex);
+            if (_captureSnapshots)
+            {
+                _snapshots.Add(snapshot);
+            }
+
+            _afterOperation?.Invoke(record, snapshot);
+        }
+
+        if (terminate)
+        {
+            throw new TrxSimulatedProcessTerminationException(record.OperationIndex);
+        }
+    }
+
+    private TrxVirtualFileSystemSnapshot CreateSnapshot(int operationIndex)
+        => new(
+            operationIndex,
+            IsProcessDead,
+            _files.Select(file => new KeyValuePair<string, byte[]>(file.Key, file.Value.Bytes)));
+
+    private void EnsureProcessAlive()
+    {
+#pragma warning disable IDE0046 // Keep the dead-process guard explicit at this operation boundary.
+        if (IsProcessDead)
+        {
+            int operationIndex = _terminationPlan?.OperationIndex ?? _nextOperationIndex - 1;
+            throw new TrxSimulatedProcessTerminationException(operationIndex);
+        }
+#pragma warning restore IDE0046
+    }
+
+    private void EnsureHandleUsable(VirtualFileHandle handle)
+    {
+        EnsureProcessAlive();
+        if (handle.IsDisposed)
+        {
+            throw new ObjectDisposedException(nameof(ITrxPrototypeFile));
+        }
+    }
+
+    private static void EnsureReadable(VirtualFileHandle handle)
+    {
+        if ((handle.Access & FileAccess.Read) == 0)
+        {
+            throw new NotSupportedException("The virtual handle does not permit reading.");
+        }
+    }
+
+    private static void EnsureWritable(VirtualFileHandle handle)
+    {
+        if ((handle.Access & FileAccess.Write) == 0)
+        {
+            throw new NotSupportedException("The virtual handle does not permit writing.");
+        }
+    }
+
+    private void EnsureOpenShareIsCompatible(VirtualFileEntry entry, FileAccess access, FileShare share)
+    {
+        if (!_enforceShareSemantics)
+        {
+            return;
+        }
+
+        foreach (VirtualFileHandle existing in _handles.Where(handle => !handle.IsDisposed && ReferenceEquals(handle.Entry, entry)))
+        {
+            if (!ShareAllowsAccess(existing.Share, access) || !ShareAllowsAccess(share, existing.Access))
+            {
+                throw new IOException("The requested virtual file access conflicts with an existing handle's share mode.");
+            }
+        }
+    }
+
+    private void EnsureDeleteShareIsCompatible(VirtualFileEntry entry, string path)
+    {
+        if (!_enforceShareSemantics)
+        {
+            return;
+        }
+
+        if (_handles.Any(handle =>
+                !handle.IsDisposed
+                && ReferenceEquals(handle.Entry, entry)
+                && (handle.Share & FileShare.Delete) == 0))
+        {
+            throw new IOException($"The virtual file '{path}' is open without FileShare.Delete.");
+        }
+    }
+
+    private static bool ShareAllowsAccess(FileShare share, FileAccess access)
+        => ((access & FileAccess.Read) == 0 || (share & FileShare.Read) != 0)
+            && ((access & FileAccess.Write) == 0 || (share & FileShare.Write) != 0);
+
+    private static void ValidateOpenArguments(FileMode mode, FileAccess access)
+    {
+        if (mode == FileMode.Append && access != FileAccess.Write)
+        {
+            throw new ArgumentException("Append mode requires write-only access.", nameof(access));
+        }
+
+        if (mode is FileMode.Create or FileMode.CreateNew or FileMode.Truncate
+            && (access & FileAccess.Write) == 0)
+        {
+            throw new ArgumentException($"{mode} mode requires write access.", nameof(access));
+        }
+    }
+
+    private static void ValidateBufferArguments(byte[] buffer, int offset, int count)
+    {
+        if (buffer is null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (offset < 0 || count < 0 || offset > buffer.Length - count)
+        {
+            throw new ArgumentOutOfRangeException(
+                offset < 0 ? nameof(offset) : nameof(count),
+                "The offset and count must select a valid buffer range.");
+        }
+    }
+
+    private VirtualFileEntry GetRequiredEntry(string path)
+        => _files.TryGetValue(path, out VirtualFileEntry? entry)
+            ? entry
+            : throw new FileNotFoundException($"The virtual file '{path}' does not exist.", path);
+
+    private static string CreateByteWindow(byte[] bytes, long position)
+    {
+        int center = (int)Math.Min(Math.Max(position, 0), bytes.LongLength);
+        int start = Math.Max(0, center - (DiagnosticWindowSize / 2));
+        if (start + DiagnosticWindowSize > bytes.Length)
+        {
+            start = Math.Max(0, bytes.Length - DiagnosticWindowSize);
+        }
+
+        int count = Math.Min(DiagnosticWindowSize, bytes.Length - start);
+        byte[] window = new byte[count];
+        Array.Copy(bytes, start, window, 0, count);
+        string hex = BitConverter.ToString(window).Replace("-", " ");
+        string utf8 = Encoding.UTF8.GetString(window);
+        StringBuilder text = new(utf8.Length);
+        foreach (char value in utf8)
+        {
+            text.Append(char.IsControl(value) ? '.' : value);
+        }
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "offset={0}; count={1}; hex={2}; utf8={3}",
+            start,
+            count,
+            hex,
+            text);
+    }
+
+    private sealed class VirtualFileEntry
+    {
+        private byte[] _bytes;
+
+        public VirtualFileEntry(byte[] bytes)
+        {
+            _bytes = (byte[])bytes.Clone();
+        }
+
+        public byte[] Bytes => _bytes;
+
+        public void Resize(int length) => Array.Resize(ref _bytes, length);
+
+        public void SetBytes(byte[] bytes) => _bytes = bytes;
+    }
+
+    private sealed class VirtualFileHandle : ITrxPrototypeFile
+    {
+        private readonly TrxFaultInjectingFileOperations _owner;
+
+        public VirtualFileHandle(
+            TrxFaultInjectingFileOperations owner,
+            string path,
+            VirtualFileEntry entry,
+            FileAccess access,
+            FileShare share,
+            long position)
+        {
+            _owner = owner;
+            Path = path;
+            Entry = entry;
+            Access = access;
+            Share = share;
+            Position = position;
+        }
+
+        public string Path { get; }
+
+        public VirtualFileEntry Entry { get; }
+
+        public FileAccess Access { get; }
+
+        public FileShare Share { get; }
+
+        public long Position { get; set; }
+
+        public bool IsDisposed { get; set; }
+
+        long ITrxPrototypeFile.Length => _owner.GetLength(this);
+
+        long ITrxPrototypeFile.Position => _owner.GetPosition(this);
+
+        int ITrxPrototypeFile.Read(byte[] buffer, int offset, int count)
+            => _owner.Read(this, buffer, offset, count);
+
+        void ITrxPrototypeFile.Seek(long offset, SeekOrigin origin) => _owner.Seek(this, offset, origin);
+
+        void ITrxPrototypeFile.Write(byte[] buffer, int offset, int count)
+            => _owner.Write(this, buffer, offset, count);
+
+        void ITrxPrototypeFile.Flush() => _owner.Flush(this);
+
+        void ITrxPrototypeFile.SetLength(long length) => _owner.SetLength(this, length);
+
+        public void Dispose() => _owner.DisposeHandle(this);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeDiagnostics.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeDiagnostics.cs
@@ -1,0 +1,510 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+namespace Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+internal sealed class TrxPrototypeOperationTotals
+{
+    private readonly Dictionary<TrxFileOperationKind, int> _counts =
+        Enum.GetValues(typeof(TrxFileOperationKind))
+            .Cast<TrxFileOperationKind>()
+            .ToDictionary(kind => kind, _ => 0);
+
+    private readonly List<long> _replacementSizes = [];
+
+    public IReadOnlyDictionary<TrxFileOperationKind, int> Counts => _counts;
+
+    public long RequestedReadBytes { get; private set; }
+
+    public long CommittedReadBytes { get; private set; }
+
+    public long RequestedWriteBytes { get; private set; }
+
+    public long CommittedWriteBytes { get; private set; }
+
+    public int MaxWriteBytes { get; private set; }
+
+    public long MaxFileBytes { get; private set; }
+
+    public IReadOnlyList<long> ReplacementSizes => _replacementSizes;
+
+    public int TotalOperations => _counts.Values.Sum();
+
+    public int this[TrxFileOperationKind kind] => _counts[kind];
+
+    public void Record(
+        TrxFileOperationKind kind,
+        long fileLength,
+        int requestedBytes = 0,
+        int committedBytes = 0)
+    {
+        _counts[kind]++;
+        MaxFileBytes = Math.Max(MaxFileBytes, fileLength);
+        if (kind == TrxFileOperationKind.Read)
+        {
+            RequestedReadBytes += requestedBytes;
+            CommittedReadBytes += committedBytes;
+        }
+        else if (kind == TrxFileOperationKind.Write)
+        {
+            RequestedWriteBytes += requestedBytes;
+            CommittedWriteBytes += committedBytes;
+            MaxWriteBytes = Math.Max(MaxWriteBytes, requestedBytes);
+        }
+        else if (kind == TrxFileOperationKind.Replace)
+        {
+            _replacementSizes.Add(fileLength);
+        }
+    }
+}
+
+internal sealed class TrxPrototypeDiagnosticRun
+{
+    public required TrxPrototypeOperationTotals Operations { get; init; }
+
+    public required byte[] JournalBytes { get; init; }
+
+    public required byte[] SnapshotBytes { get; init; }
+
+    public required int ResultCount { get; init; }
+
+    public required int UniqueDefinitionCount { get; init; }
+
+    public required int RunningCount { get; init; }
+
+    public required int PassedCount { get; init; }
+
+    public required int FailedCount { get; init; }
+
+    public required int SkippedCount { get; init; }
+
+    public required int TimeoutCount { get; init; }
+
+    public required int PublishCount { get; init; }
+
+    public required int ReflowCount { get; init; }
+
+    public required int InitialDefinitionPadBytes { get; init; }
+
+    public required int InitialEntryPadBytes { get; init; }
+
+    public required int RemainingDefinitionPadBytes { get; init; }
+
+    public required int RemainingEntryPadBytes { get; init; }
+
+    public required int RemainingSummaryPadBytes { get; init; }
+
+    public required int PaddedSnapshotBytes { get; init; }
+
+    public required int CompactSnapshotBytes { get; init; }
+
+    public required int FixtureInputResultCount { get; init; }
+
+    public required TrxJournalSnapshotDiagnostics? JournalDiagnostics { get; init; }
+
+    public required IReadOnlyList<TrxTestResult> Results { get; init; }
+
+    public required IReadOnlyList<Guid> ExecutionIds { get; init; }
+
+    public required IReadOnlyList<TrxPrototypeRunningTest> RunningTests { get; init; }
+}
+
+internal static class TrxPrototypeDiagnostics
+{
+    internal const int ResultCount = 10_000;
+    internal const int UniqueDefinitionCount = 100;
+    internal const int PublicationCadence = 2_500;
+    internal const int InitialDefinitionPadBytes = 1_024;
+    internal const int InitialEntryPadBytes = 1_024;
+    internal const int SummaryPadBytes = 4_096;
+    internal const int RunningCount = 3;
+
+    private const string JournalPath = "diagnostics.trx.journal";
+
+    public static TrxPrototypeDiagnosticRun RunPadded()
+    {
+        IReadOnlyList<TrxTestResult> results = CreateResults();
+        IReadOnlyList<Guid> executionIds = CreateExecutionIds();
+        var operations = new TrxCountingFileOperations();
+        var publisher = new TrxSnapshotPublisherPrototype(operations);
+        var writer = new TrxIncrementalWriterPrototype(
+            operations,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime,
+            InitialDefinitionPadBytes,
+            InitialEntryPadBytes,
+            SummaryPadBytes,
+            counterWidth: 5,
+            runningSlotCount: 4,
+            runningSlotByteCapacity: 384,
+            publisher);
+        writer.Initialize();
+        for (int i = 0; i < results.Count; i++)
+        {
+            writer.AppendCompleted(results[i], executionIds[i]);
+        }
+
+        TrxPrototypeCompletion completion = CreateCompletion();
+        writer.Complete(completion);
+        byte[] padded = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        (int definitionWhitespace, int entryWhitespace, int summaryWhitespace) = CountStructuralWhitespace(padded);
+        writer.Compact(completion);
+        byte[] compact = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        OutcomeCounts counts = CountOutcomes(results);
+        int publishCount = operations.Totals[TrxFileOperationKind.Replace];
+        return new TrxPrototypeDiagnosticRun
+        {
+            Operations = operations.Totals,
+            JournalBytes = [],
+            SnapshotBytes = compact,
+            ResultCount = results.Count,
+            UniqueDefinitionCount = UniqueDefinitionCount,
+            RunningCount = 0,
+            PassedCount = counts.Passed,
+            FailedCount = counts.Failed,
+            SkippedCount = counts.Skipped,
+            TimeoutCount = counts.Timeout,
+            PublishCount = publishCount,
+            ReflowCount = publishCount - 2,
+            InitialDefinitionPadBytes = InitialDefinitionPadBytes,
+            InitialEntryPadBytes = InitialEntryPadBytes,
+            RemainingDefinitionPadBytes = definitionWhitespace,
+            RemainingEntryPadBytes = entryWhitespace,
+            RemainingSummaryPadBytes = summaryWhitespace,
+            PaddedSnapshotBytes = padded.Length,
+            CompactSnapshotBytes = compact.Length,
+            FixtureInputResultCount = results.Count,
+            JournalDiagnostics = null,
+            Results = results,
+            ExecutionIds = executionIds,
+            RunningTests = [],
+        };
+    }
+
+    public static TrxPrototypeDiagnosticRun RunJournal()
+    {
+        IReadOnlyList<TrxTestResult> results = CreateResults();
+        IReadOnlyList<Guid> executionIds = CreateExecutionIds();
+        IReadOnlyList<TrxPrototypeRunningTest> running = CreateRunningTests();
+        var operations = new TrxCountingFileOperations();
+        var journal = new TrxJournalSnapshotPrototype(
+            operations,
+            JournalPath,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime);
+        int publishCount = 0;
+        for (int i = 0; i < results.Count; i++)
+        {
+            journal.Append(results[i], executionIds[i]);
+            if ((i + 1) % PublicationCadence == 0)
+            {
+                journal.PublishSnapshot(
+                    CreateCompletion(),
+                    i + 1 == ResultCount ? running : []);
+                publishCount++;
+            }
+        }
+
+        byte[] journalBytes = operations.GetFileBytes(JournalPath);
+        byte[] snapshot = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        OutcomeCounts counts = CountOutcomes(results);
+        return new TrxPrototypeDiagnosticRun
+        {
+            Operations = operations.Totals,
+            JournalBytes = journalBytes,
+            SnapshotBytes = snapshot,
+            ResultCount = results.Count,
+            UniqueDefinitionCount = UniqueDefinitionCount,
+            RunningCount = running.Count,
+            PassedCount = counts.Passed,
+            FailedCount = counts.Failed,
+            SkippedCount = counts.Skipped,
+            TimeoutCount = counts.Timeout,
+            PublishCount = publishCount,
+            ReflowCount = 0,
+            InitialDefinitionPadBytes = 0,
+            InitialEntryPadBytes = 0,
+            RemainingDefinitionPadBytes = 0,
+            RemainingEntryPadBytes = 0,
+            RemainingSummaryPadBytes = 0,
+            PaddedSnapshotBytes = 0,
+            CompactSnapshotBytes = snapshot.Length,
+            FixtureInputResultCount = results.Count,
+            JournalDiagnostics = journal.Diagnostics,
+            Results = results,
+            ExecutionIds = executionIds,
+            RunningTests = running,
+        };
+    }
+
+    public static IReadOnlyList<TrxTestResult> CreateResults()
+    {
+        var results = new TrxTestResult[ResultCount];
+        for (int i = 0; i < results.Length; i++)
+        {
+            int definition = i % UniqueDefinitionCount;
+            IReadOnlyList<TrxTestMetadata>? metadata = i == 0
+                ?
+                [
+                    new TrxTestMetadata
+                    {
+                        Key = "Description",
+                        Value = "diagnostic é漢😀 <&> " + new string('m', 700),
+                    },
+                    new TrxTestMetadata { Key = "Owner", Value = "phase5-owner" },
+                ]
+                : null;
+            IReadOnlyList<TrxStreamMessage>? messages = i % 777 == 0
+                ?
+                [
+                    new TrxStreamMessage
+                    {
+                        Kind = TrxStreamMessageKind.StandardOutput,
+                        Message = $"output-{i:D5}-é漢😀<&>-" + new string('o', 1_024),
+                    },
+                ]
+                : null;
+            results[i] = TrxPhase3EvidenceMatrix.CreateResult(
+                700 + definition,
+                $"diagnostic[{i:D5}]",
+                (TrxTestOutcome)((i % 4) + 1),
+                $"Diagnostic.Definition.{definition:D3}",
+                metadata,
+                categories: definition % 2 == 0 ? ["even", "phase5"] : ["odd"],
+                messages);
+        }
+
+        return results;
+    }
+
+    public static IReadOnlyList<Guid> CreateExecutionIds()
+    {
+        var executionIds = new Guid[ResultCount];
+        for (int i = 0; i < executionIds.Length; i++)
+        {
+            executionIds[i] = TrxPhase3EvidenceMatrix.ExecutionId(10_000 + i);
+        }
+
+        return executionIds;
+    }
+
+    public static IReadOnlyList<TrxPrototypeRunningTest> CreateRunningTests()
+        =>
+        [
+            new TrxPrototypeRunningTest
+            {
+                Uid = TrxPhase3EvidenceMatrix.TestId(901),
+                DisplayName = "running[0] é漢😀 <&>",
+                ExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(30_001),
+                StartTime = TrxPhase3EvidenceMatrix.StartTime.AddMinutes(1),
+            },
+            new TrxPrototypeRunningTest
+            {
+                Uid = TrxPhase3EvidenceMatrix.TestId(902),
+                DisplayName = "running[1] e\u0301 مرحبا",
+                ExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(30_002),
+                StartTime = TrxPhase3EvidenceMatrix.StartTime.AddMinutes(2),
+            },
+            new TrxPrototypeRunningTest
+            {
+                Uid = TrxPhase3EvidenceMatrix.TestId(903),
+                DisplayName = "running[2] >500 " + new string('r', 520),
+                ExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(30_003),
+                StartTime = TrxPhase3EvidenceMatrix.StartTime.AddMinutes(3),
+            },
+        ];
+
+    private static TrxPrototypeCompletion CreateCompletion()
+        => new()
+        {
+            FinishTime = TrxPhase3EvidenceMatrix.FinishTime,
+            ExitCode = 1,
+            AttachmentWarnings = ["diagnostic attachment warning é漢😀 <&>"],
+            CollectorAttachmentHrefs = ["diagnostic/collector-é漢😀<&>.bin"],
+        };
+
+    private static OutcomeCounts CountOutcomes(IReadOnlyList<TrxTestResult> results)
+        => new(
+            results.Count(result => result.Outcome == TrxTestOutcome.Passed),
+            results.Count(result => result.Outcome == TrxTestOutcome.Failed),
+            results.Count(result => result.Outcome == TrxTestOutcome.Skipped),
+            results.Count(result => result.Outcome == TrxTestOutcome.Timeout));
+
+    private static (int Definition, int Entry, int Summary) CountStructuralWhitespace(byte[] bytes)
+    {
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(bytes);
+        XNamespace ns = TrxDocumentClassifier.TeamTest2010Namespace;
+        static int Count(XElement element)
+            => Encoding.UTF8.GetByteCount(string.Concat(element.Nodes().OfType<XText>().Select(text => text.Value)));
+
+        return (
+            Count(document.Root!.Element(ns + "TestDefinitions")!),
+            Count(document.Root!.Element(ns + "TestEntries")!),
+            Count(document.Root!.Element(ns + "ResultSummary")!));
+    }
+
+    private sealed class OutcomeCounts(int passed, int failed, int skipped, int timeout)
+    {
+        public int Passed { get; } = passed;
+
+        public int Failed { get; } = failed;
+
+        public int Skipped { get; } = skipped;
+
+        public int Timeout { get; } = timeout;
+    }
+}
+
+internal sealed class TrxCountingFileOperations : ITrxPrototypeFileOperations
+{
+#pragma warning disable IDE0028 // Collection expressions cannot preserve the ordinal path comparer.
+    private readonly Dictionary<string, MemoryStream> _files = new(StringComparer.Ordinal);
+#pragma warning restore IDE0028
+    private int _temporaryPath;
+
+    public bool SupportsAtomicReplace => true;
+
+    public TrxPrototypeOperationTotals Totals { get; } = new();
+
+    public ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+    {
+        _files.TryGetValue(path, out MemoryStream? stream);
+        if (mode == FileMode.CreateNew && stream is not null)
+        {
+            throw new IOException($"File '{path}' already exists.");
+        }
+
+        if ((mode == FileMode.Open || mode == FileMode.Truncate) && stream is null)
+        {
+            throw new FileNotFoundException($"File '{path}' does not exist.", path);
+        }
+
+        if (stream is null)
+        {
+            stream = new MemoryStream();
+            _files.Add(path, stream);
+        }
+
+        if (mode is FileMode.Create or FileMode.Truncate)
+        {
+            stream.SetLength(0);
+        }
+
+        long position = mode == FileMode.Append ? stream.Length : 0;
+        Totals.Record(TrxFileOperationKind.Open, stream.Length);
+        return new CountingFile(this, stream, position, access);
+    }
+
+    public string CreateTemporarySiblingPath(string destinationPath)
+    {
+        _temporaryPath++;
+        return $"{destinationPath}.diagnostic-{_temporaryPath:D4}.tmp";
+    }
+
+    public void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+    {
+        MemoryStream temporary = _files[temporaryPath];
+        _ = _files.Remove(temporaryPath);
+        _files[destinationPath] = temporary;
+        Totals.Record(TrxFileOperationKind.Replace, temporary.Length);
+    }
+
+    public bool Exists(string path) => _files.ContainsKey(path);
+
+    public void Delete(string path)
+    {
+        long length = _files.TryGetValue(path, out MemoryStream? stream) ? stream.Length : 0;
+        _ = _files.Remove(path);
+        Totals.Record(TrxFileOperationKind.Delete, length);
+    }
+
+    public byte[] GetFileBytes(string path) => _files[path].ToArray();
+
+    private sealed class CountingFile(
+        TrxCountingFileOperations owner,
+        MemoryStream stream,
+        long position,
+        FileAccess access)
+        : ITrxPrototypeFile
+    {
+        private long CurrentPosition { get; set; } = position;
+
+        public long Length => stream.Length;
+
+        public long Position => CurrentPosition;
+
+        public int Read(byte[] buffer, int offset, int count)
+        {
+            EnsureReadable();
+            stream.Position = CurrentPosition;
+            int read = stream.Read(buffer, offset, count);
+            CurrentPosition += read;
+            owner.Totals.Record(TrxFileOperationKind.Read, stream.Length, count, read);
+            return read;
+        }
+
+        public void Seek(long offset, SeekOrigin origin)
+        {
+            CurrentPosition = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => checked(CurrentPosition + offset),
+                SeekOrigin.End => checked(stream.Length + offset),
+                _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+            };
+            owner.Totals.Record(TrxFileOperationKind.Seek, stream.Length);
+        }
+
+        public void Write(byte[] buffer, int offset, int count)
+        {
+            EnsureWritable();
+            stream.Position = CurrentPosition;
+            stream.Write(buffer, offset, count);
+            CurrentPosition += count;
+            owner.Totals.Record(TrxFileOperationKind.Write, stream.Length, count, count);
+        }
+
+        public void Flush() => owner.Totals.Record(TrxFileOperationKind.Flush, stream.Length);
+
+        public void SetLength(long length)
+        {
+            EnsureWritable();
+            stream.SetLength(length);
+            owner.Totals.Record(TrxFileOperationKind.SetLength, stream.Length);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private void EnsureReadable()
+        {
+            if (access == FileAccess.Write)
+            {
+                throw new NotSupportedException("The diagnostic handle is write-only.");
+            }
+        }
+
+        private void EnsureWritable()
+        {
+            if (access == FileAccess.Read)
+            {
+                throw new NotSupportedException("The diagnostic handle is read-only.");
+            }
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
@@ -279,6 +279,7 @@ internal static class TrxPrototypeScenarioFactory
         {
             Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
             Indent = true,
+            NewLineHandling = NewLineHandling.Entitize,
             OmitXmlDeclaration = false,
         };
         using (var writer = XmlWriter.Create(stream, settings))
@@ -315,7 +316,8 @@ internal static class TrxPrototypeScenarioFactory
                 TestModule,
                 FrameworkUid,
                 FrameworkVersion,
-                FinishTime);
+                FinishTime,
+                NormalizeTrxReportEngineLineEndings);
         }
 
         return new TrxPrototypeScenario
@@ -333,6 +335,9 @@ internal static class TrxPrototypeScenarioFactory
             },
         };
     }
+
+    private static string NormalizeTrxReportEngineLineEndings(string value)
+        => value.Replace("\r\n", "\n").Replace('\r', '\n');
 
     private static TrxTestResult CreateResult(
         string uid,

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
@@ -1,0 +1,415 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+internal sealed class TrxPrototypeScenario
+{
+    public required IReadOnlyList<TrxTestResult> Results { get; init; }
+
+    public required TrxDocumentExpectation Expectation { get; init; }
+}
+
+internal sealed class TrxScenarioRenderOptions
+{
+    public bool IsTestHostCrashed { get; init; }
+
+    public string TestHostCrashInfo { get; init; } = string.Empty;
+
+    public int ExitCode { get; init; }
+
+    public bool IncludeExtensionArtifact { get; init; }
+
+    public IReadOnlyList<string> FailingArtifactFileNames { get; init; } = [];
+}
+
+internal sealed class TrxRenderedScenario
+{
+    public required XDocument Document { get; init; }
+
+    public required byte[] Bytes { get; init; }
+
+    public required TrxDocumentExpectation Expectation { get; init; }
+}
+
+internal static class TrxPrototypeScenarioFactory
+{
+    public const string MachineName = "scenario-machine";
+    public const string UserName = "scenario-user";
+    public const string TestModule = "Scenario.Tests.dll";
+    public const string GoodResultArtifactName = "scenario-result.txt";
+    public const string BadResultArtifactName = "scenario-bad-result.txt";
+    public const string ExtensionArtifactName = "scenario-collector.bin";
+    public const string FrameworkUid = "scenario-framework";
+    public const string FrameworkVersion = "1.0.0";
+
+    public static readonly Guid RunId = new("10000000-0000-0000-0000-000000000001");
+    public static readonly Guid TestSettingsId = new("10000000-0000-0000-0000-000000000002");
+    public static readonly DateTimeOffset StartTime = new(2026, 7, 20, 10, 0, 0, TimeSpan.Zero);
+    public static readonly DateTimeOffset FinishTime = new(2026, 7, 20, 10, 5, 0, TimeSpan.Zero);
+    public static readonly string RunName = $"{UserName}@{MachineName} 2026-07-20 10:05:00.0000000";
+
+    private static readonly string[] TestIds =
+    [
+        "20000000-0000-0000-0000-000000000001",
+        "20000000-0000-0000-0000-000000000002",
+        "20000000-0000-0000-0000-000000000003",
+        "20000000-0000-0000-0000-000000000004",
+        "20000000-0000-0000-0000-000000000001",
+    ];
+
+    private static readonly string[] ExecutionIds =
+    [
+        "30000000-0000-0000-0000-000000000001",
+        "30000000-0000-0000-0000-000000000002",
+        "30000000-0000-0000-0000-000000000003",
+        "30000000-0000-0000-0000-000000000004",
+        "30000000-0000-0000-0000-000000000005",
+    ];
+
+    public static TrxPrototypeScenario CreateMixedResultsScenario()
+    {
+        TrxTestResult[] results =
+        [
+            CreateResult(
+                TestIds[0],
+                "Scenario.Pass[1]",
+                "Scenario.Pass",
+                TrxTestOutcome.Passed,
+                StartTime.AddSeconds(1),
+                StartTime.AddSeconds(2)),
+            CreateResult(
+                TestIds[1],
+                "Scenario.Failure",
+                "Scenario.Failure",
+                TrxTestOutcome.Failed,
+                StartTime.AddSeconds(3),
+                StartTime.AddSeconds(5)),
+            CreateResult(
+                TestIds[2],
+                "Scenario.Skipped",
+                "Scenario.Skipped",
+                TrxTestOutcome.Skipped,
+                StartTime.AddSeconds(6),
+                StartTime.AddSeconds(6)),
+            CreateResult(
+                TestIds[3],
+                "Scenario.Timeout",
+                "Scenario.Timeout",
+                TrxTestOutcome.Timeout,
+                StartTime.AddSeconds(7),
+                StartTime.AddSeconds(17)),
+            CreateResult(
+                TestIds[4],
+                "Scenario.Pass[2]",
+                "Scenario.Pass",
+                TrxTestOutcome.Passed,
+                StartTime.AddSeconds(18),
+                StartTime.AddSeconds(20)),
+        ];
+
+        return CreateScenario(results, ExecutionIds, summaryOutcome: "Failed");
+    }
+
+    public static TrxPrototypeScenario CreateUnicodeMetadataScenario()
+    {
+        string longDescription =
+            "Description é漢😀 e\u0301 مرحبا <xml>&\"'\r\n "
+            + new string('x', 560);
+        TrxTestResult result = new()
+        {
+            Uid = "20000000-0000-0000-0000-000000000005",
+            DisplayName = "Unicode é漢😀 e\u0301 مرحبا <test>",
+            Outcome = TrxTestOutcome.Passed,
+            StartTime = StartTime.AddSeconds(1),
+            EndTime = StartTime.AddSeconds(3),
+            Duration = TimeSpan.FromSeconds(2),
+            TrxTestDefinitionName = "Unicode.Metadata.Definition",
+            TrxFullyQualifiedTypeName = "Scenario.UnicodeMetadataTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Scenario",
+                TypeName = "UnicodeMetadataTests",
+                MethodName = "UnicodeMetadata",
+            },
+            ExceptionMessage = "exception é漢😀 <&> control:\u0001",
+            ExceptionStackTrace = "stack e\u0301 مرحبا\r\nline",
+            Messages =
+            [
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = "stdout é漢😀 <&>\r\n control:\u0001" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = "stdout second e\u0301 مرحبا" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardError, Message = "stderr 漢" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.DebugOrTrace, Message = "debug 😀" },
+            ],
+            Categories = ["fast", "unicode-漢"],
+            Metadata =
+            [
+                new TrxTestMetadata { Key = "Owner", Value = "Zoë <owner>" },
+                new TrxTestMetadata { Key = "Description", Value = longDescription },
+                new TrxTestMetadata { Key = "Priority", Value = "7" },
+                new TrxTestMetadata { Key = "Custom<&>", Value = "value é漢😀 " + new string('v', 520) },
+            ],
+            FileArtifacts =
+            [
+                new TrxTestFileArtifact { FullPath = GoodResultArtifactName },
+                new TrxTestFileArtifact { FullPath = BadResultArtifactName },
+            ],
+        };
+
+        return CreateScenario(
+            [result],
+            ["30000000-0000-0000-0000-000000000006"],
+            summaryOutcome: "Completed");
+    }
+
+    public static async Task<TrxRenderedScenario> RenderAsync(
+        TrxPrototypeScenario scenario,
+        TrxScenarioRenderOptions? options = null)
+    {
+        options ??= new TrxScenarioRenderOptions();
+        string temporaryDirectory = Path.Combine(Path.GetTempPath(), $"trx-phase-zero-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(temporaryDirectory);
+
+        try
+        {
+            Mock<IFileSystem> fileSystem = new();
+            CapturingFileStream stream = new();
+            List<(string Source, string Destination)> copiedFiles = [];
+            _ = fileSystem.Setup(system => system.ExistFile(It.IsAny<string>())).Returns(false);
+            _ = fileSystem.Setup(system => system.NewFileStream(It.IsAny<string>(), FileMode.Create)).Returns(stream);
+            _ = fileSystem
+                .Setup(system => system.CopyFile(It.IsAny<string>(), It.IsAny<string>()))
+                .Callback<string, string, bool>((source, destination, _) =>
+                {
+                    if (options.FailingArtifactFileNames.Contains(Path.GetFileName(source), StringComparer.Ordinal))
+                    {
+                        throw new UnauthorizedAccessException("Deterministic phase-zero copy failure.");
+                    }
+
+                    copiedFiles.Add((source, destination));
+                });
+
+            Mock<ITestApplicationModuleInfo> module = new();
+            _ = module.Setup(info => info.GetCurrentTestApplicationFullPath()).Returns(TestModule);
+
+            Mock<IEnvironment> environment = new();
+            _ = environment.SetupGet(value => value.MachineName).Returns(MachineName);
+            _ = environment.SetupGet(value => value.ProcessId).Returns(4242);
+            _ = environment
+                .Setup(value => value.GetEnvironmentVariable("TESTINGPLATFORM_TRX_TESTRUN_ID"))
+                .Returns(RunId.ToString());
+            _ = environment.Setup(value => value.GetEnvironmentVariable("UserName")).Returns(UserName);
+
+            Mock<ICommandLineOptions> commandLine = new();
+            Mock<IConfiguration> configuration = new();
+            _ = configuration.SetupGet(value => value[It.IsAny<string>()]).Returns(temporaryDirectory);
+
+            Mock<IClock> clock = new();
+            _ = clock.SetupGet(value => value.UtcNow).Returns(FinishTime);
+
+            Mock<ITestFramework> testFramework = new();
+            _ = testFramework.SetupGet(value => value.Uid).Returns(FrameworkUid);
+            _ = testFramework.SetupGet(value => value.Version).Returns(FrameworkVersion);
+            _ = testFramework.SetupGet(value => value.DisplayName).Returns("Scenario framework");
+
+            Dictionary<IExtension, List<SessionFileArtifact>> extensionArtifacts = [];
+            if (options.IncludeExtensionArtifact)
+            {
+                extensionArtifacts.Add(
+                    new TestExtension(),
+                    [new SessionFileArtifact(new SessionUid("phase-zero"), new FileInfo(ExtensionArtifactName), "collector")]);
+            }
+
+            TrxReportEngine engine = new(
+                fileSystem.Object,
+                module.Object,
+                environment.Object,
+                commandLine.Object,
+                configuration.Object,
+                clock.Object,
+                extensionArtifacts,
+                testFramework.Object,
+                StartTime,
+#if NETCOREAPP
+                options.ExitCode,
+                CancellationToken.None);
+#else
+                options.ExitCode);
+#endif
+
+            _ = await engine.GenerateReportAsync(
+                scenario.Results,
+                options.TestHostCrashInfo,
+                options.IsTestHostCrashed);
+
+            byte[] renderedBytes = stream.ToArray();
+            XDocument rendered = LoadStrict(renderedBytes);
+            NormalizeGeneratedIds(rendered, scenario.Expectation);
+            byte[] normalizedBytes = SaveUtf8(rendered);
+            return new TrxRenderedScenario
+            {
+                Document = LoadStrict(normalizedBytes),
+                Bytes = normalizedBytes,
+                Expectation = scenario.Expectation,
+            };
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    public static byte[] SaveUtf8(XDocument document)
+    {
+        using MemoryStream stream = new();
+        XmlWriterSettings settings = new()
+        {
+            Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
+            Indent = true,
+            OmitXmlDeclaration = false,
+        };
+        using (var writer = XmlWriter.Create(stream, settings))
+        {
+            document.Save(writer);
+        }
+
+        return stream.ToArray();
+    }
+
+    public static XDocument LoadStrict(byte[] bytes)
+    {
+        string text = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true).GetString(bytes);
+        if (text.Length > 0 && text[0] == '\uFEFF')
+        {
+            text = text.Substring(1);
+        }
+
+        return XDocument.Parse(text, LoadOptions.PreserveWhitespace);
+    }
+
+    private static TrxPrototypeScenario CreateScenario(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<string> executionIds,
+        string summaryOutcome)
+    {
+        var expected = new TrxExpectedResult[results.Count];
+        for (int i = 0; i < results.Count; i++)
+        {
+            expected[i] = TrxExpectedResultFactory.Create(
+                results[i],
+                Guid.Parse(executionIds[i]),
+                MachineName,
+                TestModule,
+                FrameworkUid,
+                FrameworkVersion,
+                FinishTime);
+        }
+
+        return new TrxPrototypeScenario
+        {
+            Results = results,
+            Expectation = new TrxDocumentExpectation
+            {
+                RunId = RunId,
+                RunName = RunName,
+                StartTime = StartTime,
+                FinishTime = FinishTime,
+                SummaryOutcome = summaryOutcome,
+                CompletedResults = expected,
+                SummaryChildOrder = ["Counters", "CollectorDataEntries", "RunInfos"],
+            },
+        };
+    }
+
+    private static TrxTestResult CreateResult(
+        string uid,
+        string displayName,
+        string definitionName,
+        TrxTestOutcome outcome,
+        DateTimeOffset start,
+        DateTimeOffset end)
+        => new()
+        {
+            Uid = uid,
+            DisplayName = displayName,
+            Outcome = outcome,
+            StartTime = start,
+            EndTime = end,
+            Duration = end - start,
+            TrxTestDefinitionName = definitionName,
+            TrxFullyQualifiedTypeName = "Scenario.ContractTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Scenario",
+                TypeName = "ContractTests",
+                MethodName = definitionName,
+            },
+        };
+
+    private static void NormalizeGeneratedIds(XDocument document, TrxDocumentExpectation expectation)
+    {
+        XNamespace ns = TrxDocumentClassifier.TeamTest2010Namespace;
+        XElement root = document.Root!;
+        XElement? testSettings = root.Element(ns + "TestSettings");
+        testSettings?.SetAttributeValue("id", TestSettingsId);
+
+        List<XElement> results = [.. root.Element(ns + "Results")!.Elements(ns + "UnitTestResult")];
+        Dictionary<string, string> replacements = [];
+        for (int i = 0; i < Math.Min(results.Count, expectation.CompletedResults.Count); i++)
+        {
+            string actual = results[i].Attribute("executionId")!.Value;
+            string expected = expectation.CompletedResults[i].ExecutionId;
+            replacements[actual] = expected;
+            results[i].SetAttributeValue("executionId", expected);
+            results[i].SetAttributeValue("relativeResultsDirectory", expected);
+        }
+
+        foreach (XAttribute executionId in document
+                     .Descendants()
+                     .Attributes("executionId")
+                     .Where(attribute => replacements.ContainsKey(attribute.Value)))
+        {
+            executionId.Value = replacements[executionId.Value];
+        }
+
+        foreach (XAttribute definitionExecutionId in document
+                     .Descendants(ns + "Execution")
+                     .Attributes("id")
+                     .Where(attribute => replacements.ContainsKey(attribute.Value)))
+        {
+            definitionExecutionId.Value = replacements[definitionExecutionId.Value];
+        }
+    }
+
+    private sealed class CapturingFileStream : IFileStream
+    {
+        private readonly MemoryStream _stream = new();
+
+        Stream IFileStream.Stream => _stream;
+
+        string IFileStream.Name => string.Empty;
+
+        public byte[] ToArray() => _stream.ToArray();
+
+        public void Dispose()
+        {
+        }
+
+#if NETCOREAPP
+        public ValueTask DisposeAsync() => default;
+#endif
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/Helpers/TrxPrototypeScenarioFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCompatibilityEvidenceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCompatibilityEvidenceTests.cs
@@ -1,0 +1,278 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxCompatibilityEvidenceTests
+{
+    private const string JournalPath = "compatibility.trx.journal";
+
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+
+    [TestMethod]
+    public async Task PrototypeOrder_CurrentCanonicalAndIssueLayout_AreReportedSeparately()
+    {
+        TrxRenderedScenario current = await TrxPrototypeScenarioFactory.RenderAsync(
+            TrxPrototypeScenarioFactory.CreateMixedResultsScenario());
+        string[] currentOrder = [.. current.Document.Root!.Elements().Select(element => element.Name.LocalName)];
+
+        byte[] issueBytes = TrxPrototypeXmlRenderer.RenderInitial(
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes: 256,
+            entryPadBytes: 128,
+            summaryPadBytes: 128,
+            counterWidth: 3,
+            runningSlotCount: 1,
+            runningSlotByteCapacity: 320);
+        string[] issueOrder =
+        [
+            .. TrxPrototypeScenarioFactory.LoadStrict(issueBytes).Root!
+                .Elements()
+                .Select(element => element.Name.LocalName),
+        ];
+
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            601,
+            "streaming canonical",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(601);
+        byte[] journalBytes = PublishJournal([result], [executionId], []);
+        string[] journalOrder =
+        [
+            .. TrxPrototypeScenarioFactory.LoadStrict(journalBytes).Root!
+                .Elements()
+                .Select(element => element.Name.LocalName),
+        ];
+
+        Assert.AreSequenceEqual(
+            ["Times", "TestSettings", "Results", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary"],
+            currentOrder);
+        Assert.AreSequenceEqual(currentOrder, journalOrder);
+        Assert.AreSequenceEqual(TrxPhase3EvidenceMatrix.PrototypeRootOrder, issueOrder);
+        Assert.IsFalse(currentOrder.SequenceEqual(issueOrder, StringComparer.Ordinal));
+    }
+
+    [TestMethod]
+    public void InProgress_WellFormednessSemanticMeaningAndSchemaStatus_AreSeparate()
+    {
+        TrxPrototypeRunningTest running = new()
+        {
+            Uid = TrxPhase3EvidenceMatrix.TestId(602),
+            DisplayName = "running compatibility probe",
+            ExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(602),
+            StartTime = TrxPhase3EvidenceMatrix.StartTime,
+        };
+        byte[] bytes = PublishJournal([], [], [running]);
+        TrxDocumentExpectation expectation = CreateExpectation(
+            [],
+            [],
+            [
+                new TrxExpectedRunningTest
+                {
+                    TestId = Guid.Parse(running.Uid).ToString(),
+                    ExecutionId = running.ExecutionId.ToString(),
+                    TestName = running.DisplayName,
+                    ComputerName = TrxPhase3EvidenceMatrix.MachineName,
+                    StartTime = running.StartTime,
+                },
+            ]);
+
+        XDocument parsed = TrxPrototypeScenarioFactory.LoadStrict(bytes);
+        TrxDocumentObservation semantic = TrxDocumentClassifier.Classify(bytes, expectation);
+        var evidence = CompatibilityEvidence.CreateWithoutExternalProbes(semantic);
+
+        Assert.IsNotNull(parsed.Root);
+        Assert.AreEqual(TrxDocumentClassification.Truthful, evidence.SemanticClassification);
+        Assert.AreEqual(TrxSchemaStatus.NotChecked, evidence.SchemaStatus);
+        Assert.AreEqual(ExternalCompatibilityStatus.NotChecked, evidence.VisualStudio);
+        Assert.AreEqual(ExternalCompatibilityStatus.NotChecked, evidence.AzureDevOps);
+        Assert.AreEqual(ExternalCompatibilityStatus.NotChecked, evidence.ThirdPartyReaders);
+    }
+
+    [TestMethod]
+    public async Task SummaryAndDefinitionChildOrder_MatchesCurrentCanonicalRenderer()
+    {
+        TrxPrototypeScenario scenario = TrxPrototypeScenarioFactory.CreateUnicodeMetadataScenario();
+        TrxRenderedScenario current = await TrxPrototypeScenarioFactory.RenderAsync(
+            scenario,
+            new TrxScenarioRenderOptions
+            {
+                IsTestHostCrashed = true,
+                TestHostCrashInfo = "compatibility crash",
+                IncludeExtensionArtifact = true,
+                FailingArtifactFileNames = [TrxPrototypeScenarioFactory.BadResultArtifactName],
+            });
+        TrxTestResult result = scenario.Results[0];
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(603);
+        byte[] journalBytes = PublishJournal(
+            [result],
+            [executionId],
+            [],
+            new TrxPrototypeCompletion
+            {
+                FinishTime = TrxPrototypeScenarioFactory.FinishTime,
+                IsTestHostCrashed = true,
+                CrashText = "compatibility crash",
+                AttachmentWarnings = ["compatibility warning"],
+                CollectorAttachmentHrefs = [TrxPrototypeScenarioFactory.ExtensionArtifactName],
+            });
+        XDocument journal = TrxPrototypeScenarioFactory.LoadStrict(journalBytes);
+
+        AssertRelativeOrder(
+            current.Document.Root!.Element(Ns + "ResultSummary")!,
+            ["Counters", "RunInfos", "CollectorDataEntries"]);
+        AssertRelativeOrder(
+            journal.Root!.Element(Ns + "ResultSummary")!,
+            ["Counters", "RunInfos", "CollectorDataEntries"]);
+        AssertRelativeOrder(
+            current.Document.Root!.Element(Ns + "TestDefinitions")!.Element(Ns + "UnitTest")!,
+            ["TestCategory", "Execution", "Owners", "Description", "Properties", "TestMethod"]);
+        AssertRelativeOrder(
+            journal.Root!.Element(Ns + "TestDefinitions")!.Element(Ns + "UnitTest")!,
+            ["TestCategory", "Execution", "Owners", "Description", "Properties", "TestMethod"]);
+    }
+
+    [TestMethod]
+    public void NoApprovedSchema_DoesNotProduceAFalseSchemaSuccess()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            604,
+            "no schema claim",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(604);
+        byte[] bytes = PublishJournal([result], [executionId], []);
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            bytes,
+            CreateExpectation([result], [executionId]));
+        var evidence = CompatibilityEvidence.CreateWithoutExternalProbes(observation);
+
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification);
+        Assert.AreEqual(TrxSchemaStatus.NotChecked, observation.SchemaStatus);
+        Assert.DoesNotContain("schema=Valid", observation.Diagnostic);
+        Assert.AreEqual("No approved TRX XSD is checked in.", evidence.SchemaBlocker);
+        Assert.AreEqual(
+            "Requires versioned execution in Visual Studio, Azure DevOps, and named third-party readers.",
+            evidence.ExternalConsumerBlocker);
+    }
+
+    private static byte[] PublishJournal(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        IReadOnlyList<TrxPrototypeRunningTest> running,
+        TrxPrototypeCompletion? completion = null)
+    {
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        var journal = new TrxJournalSnapshotPrototype(
+            operations,
+            JournalPath,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime);
+        for (int i = 0; i < results.Count; i++)
+        {
+            journal.Append(results[i], executionIds[i]);
+        }
+
+        journal.PublishSnapshot(
+            completion
+                ?? new TrxPrototypeCompletion
+                {
+                    FinishTime = TrxPhase3EvidenceMatrix.StartTime,
+                    ExitCode = 1,
+                },
+            running);
+        return operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+    }
+
+    private static TrxDocumentExpectation CreateExpectation(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        IReadOnlyList<TrxExpectedRunningTest>? running = null)
+    {
+        TrxDocumentExpectation padded = TrxPhase3EvidenceMatrix.CreateExpectation(
+            results,
+            executionIds,
+            running,
+            finishTime: TrxPhase3EvidenceMatrix.StartTime);
+        return new TrxDocumentExpectation
+        {
+            RunId = padded.RunId,
+            RunName = padded.RunName,
+            StartTime = padded.StartTime,
+            FinishTime = padded.FinishTime,
+            SummaryOutcome = padded.SummaryOutcome,
+            CompletedResults = padded.CompletedResults,
+            RunningTests = padded.RunningTests,
+            Counters = padded.Counters,
+        };
+    }
+
+    private static void AssertRelativeOrder(XElement parent, IReadOnlyList<string> allowedOrder)
+    {
+        int previous = -1;
+        foreach (XElement child in parent.Elements())
+        {
+            int current = -1;
+            for (int i = 0; i < allowedOrder.Count; i++)
+            {
+                if (string.Equals(allowedOrder[i], child.Name.LocalName, StringComparison.Ordinal))
+                {
+                    current = i;
+                    break;
+                }
+            }
+
+            Assert.IsGreaterThanOrEqualTo(0, current, child.Name.LocalName);
+            Assert.IsGreaterThanOrEqualTo(previous, current, child.Name.LocalName);
+            previous = current;
+        }
+    }
+
+    private enum ExternalCompatibilityStatus
+    {
+        NotChecked,
+        Compatible,
+        Incompatible,
+    }
+
+    private sealed class CompatibilityEvidence
+    {
+        public required TrxDocumentClassification SemanticClassification { get; init; }
+
+        public required TrxSchemaStatus SchemaStatus { get; init; }
+
+        public required ExternalCompatibilityStatus VisualStudio { get; init; }
+
+        public required ExternalCompatibilityStatus AzureDevOps { get; init; }
+
+        public required ExternalCompatibilityStatus ThirdPartyReaders { get; init; }
+
+        public required string SchemaBlocker { get; init; }
+
+        public required string ExternalConsumerBlocker { get; init; }
+
+        public static CompatibilityEvidence CreateWithoutExternalProbes(TrxDocumentObservation observation)
+            => new()
+            {
+                SemanticClassification = observation.Classification,
+                SchemaStatus = observation.SchemaStatus,
+                VisualStudio = ExternalCompatibilityStatus.NotChecked,
+                AzureDevOps = ExternalCompatibilityStatus.NotChecked,
+                ThirdPartyReaders = ExternalCompatibilityStatus.NotChecked,
+                SchemaBlocker = "No approved TRX XSD is checked in.",
+                ExternalConsumerBlocker =
+                    "Requires versioned execution in Visual Studio, Azure DevOps, and named third-party readers.",
+            };
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxConcurrentReaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxConcurrentReaderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxConcurrentReaderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxConcurrentReaderTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxConcurrentReaderTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void VirtualReader_AfterEveryPrimitive_ReopensAndClassifiesPublishedTarget()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            61,
+            "barrier-reader",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(61);
+        TrxDocumentExpectation before = TrxPhase3EvidenceMatrix.CreateExpectation([], []);
+        TrxDocumentExpectation after = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+        bool observe = false;
+        List<TrxDocumentObservation> observations = [];
+        var operations = new TrxFaultInjectingFileOperations(
+            afterOperation: (_, snapshot) =>
+            {
+                if (observe)
+                {
+                    byte[] reopened = snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+                    observations.Add(ClassifyAgainstEither(reopened, before, after));
+                }
+            });
+        TrxIncrementalWriterPrototype writer = TrxPhase3EvidenceMatrix.CreateWriter(operations);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+        observe = true;
+
+        writer.AppendCompleted(result, executionId);
+
+        Assert.HasCount(operations.Operations.Count, observations);
+        Assert.IsTrue(observations.All(
+            observation => observation.Classification is TrxDocumentClassification.Truthful
+                or TrxDocumentClassification.ParseableInconsistent));
+        Assert.Contains(
+            observation => observation.Classification == TrxDocumentClassification.Truthful,
+            observations);
+        Assert.Contains(
+            observation => observation.Classification == TrxDocumentClassification.ParseableInconsistent,
+            observations);
+        Assert.AreEqual(
+            TrxDocumentClassification.Truthful,
+            observations[observations.Count - 1].Classification,
+            observations[observations.Count - 1].Diagnostic);
+    }
+
+    [TestMethod]
+    public void MultipleVirtualReaders_AtSameBarrier_ObserveIdenticalBytes()
+    {
+        const int readerCount = 4;
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            62,
+            "multiple-readers",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(62);
+        bool observe = false;
+        int barrierCount = 0;
+        var operations = new TrxFaultInjectingFileOperations(
+            afterOperation: (_, snapshot) =>
+            {
+                if (!observe)
+                {
+                    return;
+                }
+
+                barrierCount++;
+                string?[] copies = new string?[readerCount];
+                using var ready = new CountdownEvent(readerCount);
+                using var start = new ManualResetEventSlim(initialState: false);
+                var readers = new Thread[readerCount];
+                for (int i = 0; i < readers.Length; i++)
+                {
+                    int readerIndex = i;
+                    readers[i] = new Thread(
+                        () =>
+                        {
+                            ready.Signal();
+                            start.Wait(TestContext.CancellationToken);
+                            copies[readerIndex] = Convert.ToBase64String(
+                                snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+                        });
+                    readers[i].Start();
+                }
+
+                ready.Wait(TestContext.CancellationToken);
+                start.Set();
+                foreach (Thread reader in readers)
+                {
+                    reader.Join();
+                }
+
+                Assert.IsNotNull(copies[0]);
+                for (int i = 1; i < copies.Length; i++)
+                {
+                    Assert.AreEqual(copies[0], copies[i], $"Barrier {barrierCount}, reader {i}");
+                }
+            });
+        TrxIncrementalWriterPrototype writer = TrxPhase3EvidenceMatrix.CreateWriter(operations);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+        observe = true;
+
+        writer.AppendCompleted(result, executionId);
+
+        Assert.AreEqual(operations.Operations.Count, barrierCount);
+        Assert.IsGreaterThan(0, barrierCount);
+    }
+
+    [TestMethod]
+    public void Reader_BeforeAndAfterReplace_SeesOnlyWholeOldOrWholeNewSnapshot()
+    {
+        TrxDocumentExpectation oldExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([], []);
+        byte[] oldBytes = RenderInitial();
+
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            63,
+            "replacement-new",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(63);
+        TrxDocumentExpectation newExpectation =
+            TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+        var newOperations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype newWriter = TrxPhase3EvidenceMatrix.CreateWriter(newOperations);
+        newWriter.Initialize();
+        newWriter.AppendCompleted(result, executionId);
+        byte[] newBytes = newOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+
+        const string temporaryPath = "results.trx.prototype-0001.tmp";
+        byte[]? atReplacement = null;
+        var replaceOperations = new TrxFaultInjectingFileOperations(
+            afterOperation: (operation, snapshot) =>
+            {
+                if (operation.Kind == TrxFileOperationKind.Replace)
+                {
+                    atReplacement = snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+                }
+            });
+        replaceOperations.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, oldBytes);
+        replaceOperations.SeedFile(temporaryPath, newBytes);
+        byte[] beforeReplacement = replaceOperations.CaptureSnapshot()
+            .GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+
+        replaceOperations.ReplaceTemporarySibling(temporaryPath, TrxPhase3EvidenceMatrix.TargetPath);
+
+        Assert.IsNotNull(atReplacement);
+        Assert.AreSequenceEqual(oldBytes, beforeReplacement);
+        Assert.AreSequenceEqual(newBytes, atReplacement);
+        Assert.AreEqual(
+            TrxDocumentClassification.Truthful,
+            TrxDocumentClassifier.Classify(beforeReplacement, oldExpectation).Classification);
+        Assert.AreEqual(
+            TrxDocumentClassification.Truthful,
+            TrxDocumentClassifier.Classify(atReplacement, newExpectation).Classification);
+        Assert.IsFalse(replaceOperations.CaptureSnapshot().Contains(temporaryPath));
+    }
+
+    [TestMethod]
+    public void Reader_DuringPaddedMutation_CapturesExpectedIntermediateCounterexample()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            64,
+            "partial-reader <&> é漢😀",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(64);
+        TrxDocumentExpectation before = TrxPhase3EvidenceMatrix.CreateExpectation([], []);
+        TrxDocumentExpectation after = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+
+        var traceOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false, recordOperations: false);
+        TrxIncrementalWriterPrototype traceWriter = TrxPhase3EvidenceMatrix.CreateWriter(traceOperations);
+        traceWriter.Initialize();
+        traceOperations.BeginFaultWindow(terminationPlan: null);
+        traceWriter.AppendCompleted(result, executionId);
+        TrxFileOperationRecord definitionWrite = traceOperations.Operations.First(
+            operation => operation.Kind == TrxFileOperationKind.Write
+                && operation.RequestedByteCount > 100);
+
+        TrxDocumentObservation? observed = null;
+        bool observe = false;
+        var faultOperations = new TrxFaultInjectingFileOperations(
+            afterOperation: (operation, snapshot) =>
+            {
+                if (observe && operation.OperationIndex == definitionWrite.OperationIndex)
+                {
+                    observed = ClassifyAgainstEither(
+                        snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+                        before,
+                        after);
+                }
+            },
+            captureSnapshots: false,
+            recordOperations: false);
+        TrxIncrementalWriterPrototype faultWriter = TrxPhase3EvidenceMatrix.CreateWriter(faultOperations);
+        faultWriter.Initialize();
+        faultOperations.BeginFaultWindow(
+            new TrxTerminationPlan(definitionWrite.OperationIndex, committedByteCount: 1));
+        observe = true;
+
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => faultWriter.AppendCompleted(result, executionId));
+
+        Assert.IsNotNull(observed);
+        Assert.AreEqual(TrxDocumentClassification.Malformed, observed.Classification, observed.Diagnostic);
+        Assert.IsTrue(faultOperations.IsProcessDead);
+        Assert.HasCount(definitionWrite.OperationIndex + 1, faultOperations.Operations);
+    }
+
+    private static TrxDocumentObservation ClassifyAgainstEither(
+        byte[] bytes,
+        TrxDocumentExpectation before,
+        TrxDocumentExpectation after)
+    {
+        TrxDocumentObservation prior = TrxDocumentClassifier.Classify(bytes, before);
+        if (prior.Classification == TrxDocumentClassification.Truthful)
+        {
+            return prior;
+        }
+
+        TrxDocumentObservation current = TrxDocumentClassifier.Classify(bytes, after);
+        return current.Classification == TrxDocumentClassification.Truthful
+            ? current
+            : prior.Classification == TrxDocumentClassification.ParseableInconsistent
+                ? prior
+                : current.Classification == TrxDocumentClassification.ParseableInconsistent
+                    ? current
+                    : prior;
+    }
+
+    private static byte[] RenderInitial()
+        => TrxPrototypeXmlRenderer.RenderInitial(
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes: 4_096,
+            entryPadBytes: 2_048,
+            summaryPadBytes: 2_048,
+            counterWidth: TrxPhase3EvidenceMatrix.CounterWidth,
+            runningSlotCount: 2,
+            runningSlotByteCapacity: 320);
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCrashConsistencyContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCrashConsistencyContractTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.UnitTests.Helpers;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCrashConsistencyContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxCrashConsistencyContractTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxCrashConsistencyContractTests
+{
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+
+    [TestMethod]
+    public async Task CurrentRenderer_DeterministicMixedResults_IsSemanticallyTruthful()
+    {
+        TrxRenderedScenario rendered = await TrxPrototypeScenarioFactory.RenderAsync(
+            TrxPrototypeScenarioFactory.CreateMixedResultsScenario());
+
+        TrxDocumentObservationContext context = new()
+        {
+            PublishedEventSequenceNumber = 5,
+            LatestEventSequenceNumber = 5,
+        };
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            rendered.Bytes,
+            rendered.Expectation,
+            context);
+
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+        Assert.AreEqual(TrxSchemaStatus.NotChecked, observation.SchemaStatus);
+        Assert.AreEqual(0, observation.Staleness);
+
+        XElement root = rendered.Document.Root!;
+        XElement results = root.Element(Ns + "Results")!;
+        XElement definitions = root.Element(Ns + "TestDefinitions")!;
+        XElement entries = root.Element(Ns + "TestEntries")!;
+        XElement counters = root.Element(Ns + "ResultSummary")!.Element(Ns + "Counters")!;
+
+        Assert.AreSequenceEqual(
+            ["Scenario.Pass[1]", "Scenario.Failure", "Scenario.Skipped", "Scenario.Timeout", "Scenario.Pass[2]"],
+            results.Elements(Ns + "UnitTestResult").Select(element => element.Attribute("testName")!.Value).ToArray());
+        Assert.AreSequenceEqual(
+            ["Passed", "Failed", "NotExecuted", "Failed", "Passed"],
+            results.Elements(Ns + "UnitTestResult").Select(element => element.Attribute("outcome")!.Value).ToArray());
+        Assert.HasCount(4, definitions.Elements(Ns + "UnitTest"));
+        Assert.HasCount(5, entries.Elements(Ns + "TestEntry"));
+        Assert.AreEqual("5", counters.Attribute("total")!.Value);
+        Assert.AreEqual("3", counters.Attribute("executed")!.Value);
+        Assert.AreEqual("2", counters.Attribute("passed")!.Value);
+        Assert.AreEqual("1", counters.Attribute("failed")!.Value);
+        Assert.AreEqual("1", counters.Attribute("timeout")!.Value);
+        Assert.AreEqual("1", counters.Attribute("notExecuted")!.Value);
+
+        foreach (TrxExpectedResult expected in rendered.Expectation.CompletedResults)
+        {
+            XElement result = results.Elements(Ns + "UnitTestResult")
+                .Single(element => element.Attribute("executionId")!.Value == expected.ExecutionId);
+            Assert.AreEqual(expected.TestId, result.Attribute("testId")!.Value);
+            Assert.AreEqual(expected.TestName, result.Attribute("testName")!.Value);
+            Assert.AreEqual(expected.ComputerName, result.Attribute("computerName")!.Value);
+            Assert.AreEqual(expected.Duration, result.Attribute("duration")!.Value);
+            Assert.AreEqual(
+                expected.StartTime.ToString("O", CultureInfo.InvariantCulture),
+                result.Attribute("startTime")!.Value);
+            Assert.AreEqual(
+                expected.EndTime.ToString("O", CultureInfo.InvariantCulture),
+                result.Attribute("endTime")!.Value);
+            Assert.AreEqual(expected.TestTypeId, result.Attribute("testType")!.Value);
+            Assert.AreEqual(expected.TestListId, result.Attribute("testListId")!.Value);
+            Assert.AreEqual(expected.RelativeResultsDirectory, result.Attribute("relativeResultsDirectory")!.Value);
+            Assert.HasCount(
+                1,
+                entries.Elements(Ns + "TestEntry").Where(entry =>
+                    entry.Attribute("testId")!.Value == expected.TestId
+                    && entry.Attribute("executionId")!.Value == expected.ExecutionId
+                    && entry.Attribute("testListId")!.Value == expected.TestListId));
+
+            XElement definition = definitions.Elements(Ns + "UnitTest")
+                .Single(element => element.Attribute("id")!.Value == expected.TestId);
+            Assert.AreEqual(expected.Definition.Name, definition.Attribute("name")!.Value);
+            Assert.AreEqual(expected.Definition.Storage, definition.Attribute("storage")!.Value);
+            XElement method = definition.Element(Ns + "TestMethod")!;
+            Assert.AreEqual(expected.Definition.ClassName, method.Attribute("className")!.Value);
+            Assert.AreEqual(expected.Definition.MethodName, method.Attribute("name")!.Value);
+            Assert.AreEqual(expected.Definition.CodeBase, method.Attribute("codeBase")!.Value);
+            Assert.AreEqual(expected.Definition.AdapterTypeName, method.Attribute("adapterTypeName")!.Value);
+        }
+    }
+
+    [TestMethod]
+    public async Task CurrentRenderer_CurrentChildOrder_IsCaptured()
+    {
+        TrxPrototypeScenario scenario = TrxPrototypeScenarioFactory.CreateUnicodeMetadataScenario();
+        TrxRenderedScenario rendered = await TrxPrototypeScenarioFactory.RenderAsync(
+            scenario,
+            new TrxScenarioRenderOptions
+            {
+                IncludeExtensionArtifact = true,
+                FailingArtifactFileNames = [TrxPrototypeScenarioFactory.BadResultArtifactName],
+            });
+
+        XElement root = rendered.Document.Root!;
+        Assert.AreSequenceEqual(
+            ["Times", "TestSettings", "Results", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary"],
+            root.Elements().Select(element => element.Name.LocalName).ToArray());
+
+        XElement result = root.Element(Ns + "Results")!.Element(Ns + "UnitTestResult")!;
+        Assert.AreSequenceEqual(
+            ["Output", "ResultFiles"],
+            result.Elements().Select(element => element.Name.LocalName).ToArray());
+
+        XElement definition = root.Element(Ns + "TestDefinitions")!.Element(Ns + "UnitTest")!;
+        Assert.AreSequenceEqual(
+            ["TestCategory", "Execution", "Owners", "Description", "Properties", "TestMethod"],
+            definition.Elements().Select(element => element.Name.LocalName).ToArray());
+
+        XElement summary = root.Element(Ns + "ResultSummary")!;
+        Assert.AreSequenceEqual(
+            ["Counters", "CollectorDataEntries", "RunInfos"],
+            summary.Elements().Select(element => element.Name.LocalName).ToArray());
+
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            rendered.Bytes,
+            rendered.Expectation,
+            new TrxDocumentObservationContext
+            {
+                PublishedEventSequenceNumber = 1,
+                LatestEventSequenceNumber = 1,
+            });
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+    }
+
+    [TestMethod]
+    public async Task CurrentRenderer_UnicodeMetadataLargeOutputAndAttachments_RemainsTruthful()
+    {
+        TrxPrototypeScenario scenario = TrxPrototypeScenarioFactory.CreateUnicodeMetadataScenario();
+        TrxRenderedScenario rendered = await TrxPrototypeScenarioFactory.RenderAsync(
+            scenario,
+            new TrxScenarioRenderOptions
+            {
+                FailingArtifactFileNames = [TrxPrototypeScenarioFactory.BadResultArtifactName],
+            });
+
+        XElement root = rendered.Document.Root!;
+        XElement result = root.Element(Ns + "Results")!.Element(Ns + "UnitTestResult")!;
+        XElement output = result.Element(Ns + "Output")!;
+        XElement definition = root.Element(Ns + "TestDefinitions")!.Element(Ns + "UnitTest")!;
+        XElement properties = definition.Element(Ns + "Properties")!;
+
+        Assert.AreEqual("Unicode é漢😀 e\u0301 مرحبا <test>", result.Attribute("testName")!.Value);
+        Assert.AreEqual(
+            "stdout é漢😀 <&>\n control:\\u0001\nstdout second e\u0301 مرحبا",
+            output.Element(Ns + "StdOut")!.Value);
+        Assert.AreEqual("stderr 漢", output.Element(Ns + "StdErr")!.Value);
+        Assert.AreEqual("debug 😀", output.Element(Ns + "DebugTrace")!.Value);
+        Assert.AreEqual("exception é漢😀 <&> control:\\u0001", output.Descendants(Ns + "Message").Single().Value);
+        Assert.AreEqual("stack e\u0301 مرحبا\nline", output.Descendants(Ns + "StackTrace").Single().Value);
+
+        Assert.AreEqual("7", definition.Attribute("priority")!.Value);
+        Assert.AreEqual("Zoë <owner>", definition.Element(Ns + "Owners")!.Element(Ns + "Owner")!.Attribute("name")!.Value);
+        string description = definition.Element(Ns + "Description")!.Value;
+        Assert.IsGreaterThan(500, Encoding.UTF8.GetByteCount(description));
+        Assert.Contains("é漢😀", description);
+        Assert.AreSequenceEqual(
+            ["fast", "unicode-漢"],
+            definition.Descendants(Ns + "TestCategoryItem").Select(element => element.Attribute("TestCategory")!.Value).ToArray());
+
+        XElement customProperty = properties.Elements(Ns + "Property")
+            .Single(element => element.Element(Ns + "Key")!.Value == "Custom<&>");
+        Assert.IsGreaterThan(500, Encoding.UTF8.GetByteCount(customProperty.Element(Ns + "Value")!.Value));
+        XElement resultFile = result.Element(Ns + "ResultFiles")!.Element(Ns + "ResultFile")!;
+        Assert.AreEqual(
+            Path.Combine(TrxPrototypeScenarioFactory.MachineName, TrxPrototypeScenarioFactory.GoodResultArtifactName),
+            resultFile.Attribute("path")!.Value);
+
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            rendered.Bytes,
+            rendered.Expectation,
+            new TrxDocumentObservationContext
+            {
+                PublishedEventSequenceNumber = 1,
+                LatestEventSequenceNumber = 1,
+            });
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+    }
+
+    [TestMethod]
+    public async Task CurrentRenderer_CrashInfoAndAttachmentWarnings_PreserveSummarySemantics()
+    {
+        TrxRenderedScenario rendered = await TrxPrototypeScenarioFactory.RenderAsync(
+            TrxPrototypeScenarioFactory.CreateUnicodeMetadataScenario(),
+            new TrxScenarioRenderOptions
+            {
+                IsTestHostCrashed = true,
+                TestHostCrashInfo = "test host crashed after deterministic event 1",
+                IncludeExtensionArtifact = true,
+                FailingArtifactFileNames = [TrxPrototypeScenarioFactory.BadResultArtifactName],
+            });
+
+        XElement summary = rendered.Document.Root!.Element(Ns + "ResultSummary")!;
+        XElement counters = summary.Element(Ns + "Counters")!;
+        List<XElement> runInfos = [.. summary.Element(Ns + "RunInfos")!.Elements(Ns + "RunInfo")];
+        XElement collector = summary.Element(Ns + "CollectorDataEntries")!.Element(Ns + "Collector")!;
+
+        Assert.AreEqual("Failed", summary.Attribute("outcome")!.Value);
+        Assert.AreEqual("1", counters.Attribute("total")!.Value);
+        Assert.AreEqual("1", counters.Attribute("passed")!.Value);
+        Assert.HasCount(2, runInfos);
+        Assert.AreSequenceEqual(
+            ["Error", "Warning"],
+            runInfos.Select(info => info.Attribute("outcome")!.Value).ToArray());
+        Assert.AreEqual("test host crashed after deterministic event 1", runInfos[0].Element(Ns + "Text")!.Value);
+        Assert.Contains("Unable to copy attachment", runInfos[1].Element(Ns + "Text")!.Value);
+        Assert.Contains(TrxPrototypeScenarioFactory.BadResultArtifactName, runInfos[1].Element(Ns + "Text")!.Value);
+        Assert.Contains("UnauthorizedAccessException", runInfos[1].Element(Ns + "Text")!.Value);
+        Assert.AreEqual("datacollector://Uid/Version", collector.Attribute("uri")!.Value);
+        Assert.AreEqual(
+            Path.Combine(TrxPrototypeScenarioFactory.MachineName, TrxPrototypeScenarioFactory.ExtensionArtifactName),
+            collector.Descendants(Ns + "A").Single().Attribute("href")!.Value);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.UnitTests.Helpers;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
@@ -1,0 +1,340 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxDocumentClassifierTests
+{
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+
+    [TestMethod]
+    public async Task Classify_InvalidUtf8OrTornXml_ReturnsMalformed()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+        byte[] invalidUtf8 = [0x3C, 0x54, 0x65, 0x73, 0x74, 0xFF];
+        byte[] tornXml = rendered.Bytes.Take(rendered.Bytes.Length - 17).ToArray();
+
+        TrxDocumentObservation invalidUtf8Observation = TrxDocumentClassifier.Classify(invalidUtf8, rendered.Expectation);
+        TrxDocumentObservation tornXmlObservation = TrxDocumentClassifier.Classify(tornXml, rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.Malformed, invalidUtf8Observation.Classification);
+        Assert.Contains("Strict UTF-8 decoding failed", invalidUtf8Observation.Errors.Single());
+        Assert.AreEqual(TrxDocumentClassification.Malformed, tornXmlObservation.Classification);
+        Assert.Contains("XML parsing failed", tornXmlObservation.Errors.Single());
+    }
+
+    [TestMethod]
+    public async Task Classify_ParseableWrongCountersOutcomeOrTimestamp_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        XDocument wrongCounters = Clone(rendered.Document);
+        wrongCounters.Root!.Element(Ns + "ResultSummary")!.Element(Ns + "Counters")!.SetAttributeValue("passed", "99");
+        TrxDocumentObservation countersObservation = Classify(wrongCounters, rendered.Expectation);
+
+        XDocument wrongOutcome = Clone(rendered.Document);
+        wrongOutcome.Root!.Element(Ns + "ResultSummary")!.SetAttributeValue("outcome", "Completed");
+        TrxDocumentObservation outcomeObservation = Classify(wrongOutcome, rendered.Expectation);
+
+        XDocument wrongTimestamp = Clone(rendered.Document);
+        wrongTimestamp.Root!.Element(Ns + "Times")!.SetAttributeValue("finish", "not-a-timestamp");
+        TrxDocumentObservation timestampObservation = Classify(wrongTimestamp, rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, countersObservation.Classification);
+        Assert.Contains(error => error.Contains("Counters/@passed must be 2 but was 99", StringComparison.Ordinal), countersObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, outcomeObservation.Classification);
+        Assert.Contains(error => error.Contains("ResultSummary/@outcome must be 'Failed'", StringComparison.Ordinal), outcomeObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, timestampObservation.Classification);
+        Assert.Contains(error => error.Contains("Times/@finish must be a round-trip timestamp", StringComparison.Ordinal), timestampObservation.Errors);
+    }
+
+    [TestMethod]
+    public async Task Classify_SemanticallyWrongCompletedResultAttributes_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+        (string Name, Action<XElement> Mutate, string Error)[] mutations =
+        [
+            ("duration", result => result.SetAttributeValue("duration", "00:00:42.0000000"), "Result[0]/@duration"),
+            ("startTime", result => result.SetAttributeValue("startTime", "2026-07-20T10:00:09.0000000+00:00"), "Result[0]/@startTime"),
+            ("endTime", result => result.SetAttributeValue("endTime", "2026-07-20T10:00:10.0000000+00:00"), "Result[0]/@endTime"),
+            ("computerName", result => result.SetAttributeValue("computerName", "other-machine"), "Result[0]/@computerName"),
+            ("testType", result => result.SetAttributeValue("testType", Guid.Empty), "Result[0]/@testType"),
+            ("testListId", result => result.SetAttributeValue("testListId", Guid.Empty), "Result[0]/@testListId"),
+            ("relativeResultsDirectory", result => result.SetAttributeValue("relativeResultsDirectory", "plausible-but-wrong"), "Result[0]/@relativeResultsDirectory"),
+        ];
+
+        foreach ((string name, Action<XElement> mutate, string error) in mutations)
+        {
+            XDocument mutated = Clone(rendered.Document);
+            mutate(mutated.Root!.Element(Ns + "Results")!.Elements(Ns + "UnitTestResult").First());
+
+            TrxDocumentObservation observation = Classify(mutated, rendered.Expectation);
+
+            Assert.AreEqual(
+                TrxDocumentClassification.ParseableInconsistent,
+                observation.Classification,
+                $"{name}: {observation.Diagnostic}");
+            Assert.Contains(
+                candidate => candidate.Contains(error, StringComparison.Ordinal),
+                observation.Errors,
+                name);
+        }
+    }
+
+    [TestMethod]
+    public async Task Classify_SemanticallyWrongDefinitionIdentity_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+        (string Name, Action<XElement> Mutate, string Error)[] mutations =
+        [
+            ("definition name", definition => definition.SetAttributeValue("name", "Wrong.Definition"), "/@name"),
+            ("storage", definition => definition.SetAttributeValue("storage", "wrong.tests.dll"), "/@storage"),
+            ("class", definition => definition.Element(Ns + "TestMethod")!.SetAttributeValue("className", "Wrong.Class"), "TestMethod/@className"),
+            ("method", definition => definition.Element(Ns + "TestMethod")!.SetAttributeValue("name", "WrongMethod"), "TestMethod/@name"),
+            ("code base", definition => definition.Element(Ns + "TestMethod")!.SetAttributeValue("codeBase", "Wrong.dll"), "TestMethod/@codeBase"),
+            ("adapter", definition => definition.Element(Ns + "TestMethod")!.SetAttributeValue("adapterTypeName", "executor://wrong/0"), "TestMethod/@adapterTypeName"),
+        ];
+
+        foreach ((string name, Action<XElement> mutate, string error) in mutations)
+        {
+            XDocument mutated = Clone(rendered.Document);
+            mutate(mutated.Root!.Element(Ns + "TestDefinitions")!.Elements(Ns + "UnitTest").First());
+
+            TrxDocumentObservation observation = Classify(mutated, rendered.Expectation);
+
+            Assert.AreEqual(
+                TrxDocumentClassification.ParseableInconsistent,
+                observation.Classification,
+                $"{name}: {observation.Diagnostic}");
+            Assert.Contains(
+                candidate => candidate.Contains(error, StringComparison.Ordinal),
+                observation.Errors,
+                name);
+        }
+    }
+
+    [TestMethod]
+    public async Task Classify_SemanticallyWrongDefinitionMetadata_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await TrxPrototypeScenarioFactory.RenderAsync(
+            TrxPrototypeScenarioFactory.CreateUnicodeMetadataScenario());
+        (string Name, Action<XElement> Mutate, string Error)[] mutations =
+        [
+            ("priority", definition => definition.SetAttributeValue("priority", "8"), "/@priority"),
+            ("owner", definition => definition.Element(Ns + "Owners")!.Element(Ns + "Owner")!.SetAttributeValue("name", "Wrong Owner"), "Owners/Owner/@name"),
+            ("description", definition => definition.Element(Ns + "Description")!.Value = "Wrong description", "/Description"),
+            ("category", definition => definition.Descendants(Ns + "TestCategoryItem").First().SetAttributeValue("TestCategory", "wrong-category"), "categories must be"),
+            ("property key", definition => definition.Descendants(Ns + "Property").First().Element(Ns + "Key")!.Value = "WrongKey", "properties must be"),
+            ("property value", definition => definition.Descendants(Ns + "Property").First().Element(Ns + "Value")!.Value = "WrongValue", "properties must be"),
+        ];
+
+        foreach ((string name, Action<XElement> mutate, string error) in mutations)
+        {
+            XDocument mutated = Clone(rendered.Document);
+            mutate(mutated.Root!.Element(Ns + "TestDefinitions")!.Element(Ns + "UnitTest")!);
+
+            TrxDocumentObservation observation = Classify(mutated, rendered.Expectation);
+
+            Assert.AreEqual(
+                TrxDocumentClassification.ParseableInconsistent,
+                observation.Classification,
+                $"{name}: {observation.Diagnostic}");
+            Assert.Contains(
+                candidate => candidate.Contains(error, StringComparison.Ordinal),
+                observation.Errors,
+                name);
+        }
+    }
+
+    [TestMethod]
+    public async Task Classify_SemanticallyWrongEntryOrDeclaredTestList_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        XDocument wrongEntryList = Clone(rendered.Document);
+        wrongEntryList.Root!.Element(Ns + "TestEntries")!.Elements(Ns + "TestEntry").First()
+            .SetAttributeValue("testListId", Guid.Empty);
+        TrxDocumentObservation entryObservation = Classify(wrongEntryList, rendered.Expectation);
+
+        XDocument wrongDeclaredList = Clone(rendered.Document);
+        wrongDeclaredList.Root!.Element(Ns + "TestLists")!.Elements(Ns + "TestList").First()
+            .SetAttributeValue("id", Guid.Empty);
+        TrxDocumentObservation listObservation = Classify(wrongDeclaredList, rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, entryObservation.Classification);
+        Assert.Contains(
+            error => error.Contains("Entry[0]/@testListId", StringComparison.Ordinal),
+            entryObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, listObservation.Classification);
+        Assert.Contains(
+            error => error.Contains("TestList[0]/@id", StringComparison.Ordinal),
+            listObservation.Errors);
+    }
+
+    [TestMethod]
+    public async Task Classify_TornTargetWithCompleteJournalPrefix_ReturnsRepairable()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+        byte[] tornTarget = rendered.Bytes.Take(rendered.Bytes.Length / 2).ToArray();
+
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            tornTarget,
+            rendered.Expectation,
+            new TrxDocumentObservationContext
+            {
+                PublishedEventSequenceNumber = 5,
+                LatestEventSequenceNumber = 5,
+            },
+            completeRecoveryBytes: rendered.Bytes);
+
+        Assert.AreEqual(TrxDocumentClassification.Repairable, observation.Classification, observation.Diagnostic);
+        Assert.AreEqual(tornTarget.Length, observation.TargetLength);
+        Assert.AreEqual(rendered.Bytes.Length, observation.RecoveryLength);
+        Assert.Contains("XML parsing failed", observation.Errors.Single());
+    }
+
+    [TestMethod]
+    public async Task Classify_ConsistentCurrentOrPriorSnapshot_ReturnsTruthfulAndReportsStaleness()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        TrxDocumentObservation current = TrxDocumentClassifier.Classify(
+            rendered.Bytes,
+            rendered.Expectation,
+            new TrxDocumentObservationContext
+            {
+                PublishedEventSequenceNumber = 5,
+                LatestEventSequenceNumber = 5,
+            });
+        TrxDocumentObservation prior = TrxDocumentClassifier.Classify(
+            rendered.Bytes,
+            rendered.Expectation,
+            new TrxDocumentObservationContext
+            {
+                PublishedEventSequenceNumber = 5,
+                LatestEventSequenceNumber = 8,
+            });
+
+        Assert.AreEqual(TrxDocumentClassification.Truthful, current.Classification, current.Diagnostic);
+        Assert.AreEqual(0, current.Staleness);
+        Assert.AreEqual(TrxDocumentClassification.Truthful, prior.Classification, prior.Diagnostic);
+        Assert.AreEqual(3, prior.Staleness);
+        Assert.AreEqual(5, prior.PublishedEventSequenceNumber);
+    }
+
+    [TestMethod]
+    public async Task Classify_MissingDefinitionEntryOrExecutionLink_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        XDocument missingDefinition = Clone(rendered.Document);
+        missingDefinition.Root!.Element(Ns + "TestDefinitions")!.Elements(Ns + "UnitTest").First().Remove();
+        TrxDocumentObservation definitionObservation = Classify(missingDefinition, rendered.Expectation);
+
+        XDocument missingEntry = Clone(rendered.Document);
+        missingEntry.Root!.Element(Ns + "TestEntries")!.Elements(Ns + "TestEntry").First().Remove();
+        TrxDocumentObservation entryObservation = Classify(missingEntry, rendered.Expectation);
+
+        XDocument wrongLink = Clone(rendered.Document);
+        wrongLink.Root!.Element(Ns + "TestEntries")!.Elements(Ns + "TestEntry").First()
+            .SetAttributeValue("executionId", "ffffffff-ffff-ffff-ffff-ffffffffffff");
+        TrxDocumentObservation linkObservation = Classify(wrongLink, rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, definitionObservation.Classification);
+        Assert.Contains(error => error.Contains("Definition count must be 4 but was 3", StringComparison.Ordinal), definitionObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, entryObservation.Classification);
+        Assert.Contains(error => error.Contains("Entry count must be 5 but was 4", StringComparison.Ordinal), entryObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, linkObservation.Classification);
+        Assert.Contains(error => error.Contains("matching entries; exactly one is required", StringComparison.Ordinal), linkObservation.Errors);
+    }
+
+    [TestMethod]
+    public async Task Classify_RunningSetAndOrderingMismatch_ReturnsParseableInconsistent()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        XDocument runningMismatch = Clone(rendered.Document);
+        runningMismatch.Root!.Element(Ns + "Results")!.Elements(Ns + "UnitTestResult").First()
+            .SetAttributeValue("outcome", "InProgress");
+        TrxDocumentObservation runningObservation = Classify(runningMismatch, rendered.Expectation);
+
+        XDocument orderMismatch = Clone(rendered.Document);
+        XElement results = orderMismatch.Root!.Element(Ns + "Results")!;
+        XElement first = results.Elements(Ns + "UnitTestResult").First();
+        first.Remove();
+        results.Add(first);
+        TrxDocumentObservation orderObservation = Classify(orderMismatch, rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, runningObservation.Classification);
+        Assert.Contains(error => error.Contains("Running result count must be 0 but was 1", StringComparison.Ordinal), runningObservation.Errors);
+        Assert.AreEqual(TrxDocumentClassification.ParseableInconsistent, orderObservation.Classification);
+        Assert.Contains(error => error.Contains("Result[0]/@testId", StringComparison.Ordinal), orderObservation.Errors);
+    }
+
+    [TestMethod]
+    public async Task Classify_WithoutApprovedSchema_ReportsNotCheckedAndNeverClaimsSchemaValidity()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+
+        TrxDocumentObservation truthful = TrxDocumentClassifier.Classify(rendered.Bytes, rendered.Expectation);
+        TrxDocumentObservation malformed = TrxDocumentClassifier.Classify([0xFF], rendered.Expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.Truthful, truthful.Classification, truthful.Diagnostic);
+        Assert.AreEqual(TrxSchemaStatus.NotChecked, truthful.SchemaStatus);
+        Assert.DoesNotContain("schema=Valid", truthful.Diagnostic);
+        Assert.AreEqual(TrxSchemaStatus.NotChecked, malformed.SchemaStatus);
+    }
+
+    [TestMethod]
+    public async Task Diagnostics_IncludeOperationCutLengthsErrorAndBoundedByteWindow()
+    {
+        TrxRenderedScenario rendered = await RenderMixedAsync();
+        byte[] torn = rendered.Bytes.Take(73).ToArray();
+        TrxDocumentObservationContext context = new()
+        {
+            OperationIndex = 7,
+            OperationKind = "Write",
+            CommittedByteCount = 23,
+            PreviousTargetLength = 4096,
+            PublishedEventSequenceNumber = 2,
+            LatestEventSequenceNumber = 5,
+        };
+
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(
+            torn,
+            rendered.Expectation,
+            context,
+            completeRecoveryBytes: rendered.Bytes);
+
+        Assert.AreEqual(TrxDocumentClassification.Repairable, observation.Classification);
+        Assert.Contains("operation=7:Write", observation.Diagnostic);
+        Assert.Contains("cut=23", observation.Diagnostic);
+        Assert.Contains("previousLength=4096", observation.Diagnostic);
+        Assert.Contains($"targetLength={torn.Length}", observation.Diagnostic);
+        Assert.Contains($"recoveryLength={rendered.Bytes.Length}", observation.Diagnostic);
+        Assert.Contains("eventSequence=2", observation.Diagnostic);
+        Assert.Contains("staleness=3", observation.Diagnostic);
+        Assert.Contains("XML parsing failed", observation.Diagnostic);
+        Assert.IsLessThanOrEqualTo(32, ParseWindowCount(observation.ByteWindow));
+        Assert.IsLessThan(900, observation.Diagnostic.Length);
+    }
+
+    private static async Task<TrxRenderedScenario> RenderMixedAsync()
+        => await TrxPrototypeScenarioFactory.RenderAsync(TrxPrototypeScenarioFactory.CreateMixedResultsScenario());
+
+    private static XDocument Clone(XDocument document) => new(document);
+
+    private static TrxDocumentObservation Classify(XDocument document, TrxDocumentExpectation expectation)
+        => TrxDocumentClassifier.Classify(TrxPrototypeScenarioFactory.SaveUtf8(document), expectation);
+
+    private static int ParseWindowCount(string byteWindow)
+    {
+        const string marker = "count=";
+        int start = byteWindow.IndexOf(marker, StringComparison.Ordinal) + marker.Length;
+        int end = byteWindow.IndexOf(';', start);
+        return int.Parse(byteWindow.Substring(start, end - start), CultureInfo.InvariantCulture);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxDocumentClassifierTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
@@ -146,6 +147,78 @@ public sealed class TrxDocumentClassifierTests
                 candidate => candidate.Contains(error, StringComparison.Ordinal),
                 observation.Errors,
                 name);
+        }
+    }
+
+    [TestMethod]
+    public void Classify_PrototypeRenderersPreserveCrLfAndRejectLfOnlyMutations()
+    {
+        TrxTestResult result = CreateLineEndingResult();
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(901);
+        const string runName = "line-ending run first\r\nline-ending run second";
+        TrxPrototypeCompletion completion = new()
+        {
+            FinishTime = TrxPhase3EvidenceMatrix.FinishTime,
+            ExitCode = 1,
+        };
+        foreach ((string renderer, byte[] bytes) in RenderPrototypeDocuments(result, executionId, completion, runName))
+        {
+            TrxDocumentExpectation expectation = TrxPhase3EvidenceMatrix.CreateExpectation(
+                [result],
+                [executionId],
+                finishTime: completion.FinishTime,
+                rootChildOrder: ["Times", "TestSettings", "Results", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary"],
+                runName: runName);
+            TrxDocumentObservation truthful = TrxDocumentClassifier.Classify(bytes, expectation);
+            Assert.AreEqual(
+                TrxDocumentClassification.Truthful,
+                truthful.Classification,
+                $"{renderer}: {truthful.Diagnostic}");
+
+            XDocument document = TrxPrototypeScenarioFactory.LoadStrict(bytes);
+            AssertAttributeLineEndingMutationIsDetected(
+                renderer,
+                document,
+                expectation,
+                value => value.Root!.Attribute("name")!,
+                "run name",
+                "TestRun/@name");
+            AssertAttributeLineEndingMutationIsDetected(
+                renderer,
+                document,
+                expectation,
+                value => value.Descendants(Ns + "UnitTestResult").Single().Attribute("testName")!,
+                "test name",
+                "Result[0]/@testName");
+            (string Name, Func<XDocument, XElement> Select, string Error)[] fields =
+            [
+                ("stdout", value => value.Descendants(Ns + "StdOut").Single(), "/Output/StdOut"),
+                ("stderr", value => value.Descendants(Ns + "StdErr").Single(), "/Output/StdErr"),
+                ("debug trace", value => value.Descendants(Ns + "DebugTrace").Single(), "/Output/DebugTrace"),
+                ("error message", value => value.Descendants(Ns + "Message").Single(), "/ErrorInfo/Message"),
+                ("stack trace", value => value.Descendants(Ns + "StackTrace").Single(), "/ErrorInfo/StackTrace"),
+                ("description", value => value.Descendants(Ns + "Description").Single(), "/Description"),
+                ("custom metadata", value => value.Descendants(Ns + "Property").Single().Element(Ns + "Value")!, "properties must be"),
+            ];
+
+            foreach ((string name, Func<XDocument, XElement> select, string error) in fields)
+            {
+                XDocument mutated = Clone(document);
+                XElement field = select(mutated);
+                Assert.Contains("\r\n", field.Value, $"{renderer}: {name}");
+                field.Value = field.Value.Replace("\r\n", "\n");
+
+                TrxDocumentObservation observation = Classify(mutated, expectation);
+
+                Assert.AreEqual(
+                    TrxDocumentClassification.ParseableInconsistent,
+                    observation.Classification,
+                    $"{renderer}: {name}: {observation.Diagnostic}");
+                Assert.Contains(
+                    candidate => candidate.Contains(error, StringComparison.Ordinal),
+                    observation.Errors,
+                    $"{renderer}: {name}");
+            }
         }
     }
 
@@ -324,6 +397,116 @@ public sealed class TrxDocumentClassifierTests
 
     private static async Task<TrxRenderedScenario> RenderMixedAsync()
         => await TrxPrototypeScenarioFactory.RenderAsync(TrxPrototypeScenarioFactory.CreateMixedResultsScenario());
+
+    private static TrxTestResult CreateLineEndingResult()
+        => new()
+        {
+            Uid = TrxPhase3EvidenceMatrix.TestId(901),
+            DisplayName = "line-ending result first\r\nline-ending result second",
+            Outcome = TrxTestOutcome.Failed,
+            StartTime = TrxPhase3EvidenceMatrix.StartTime.AddSeconds(1),
+            EndTime = TrxPhase3EvidenceMatrix.StartTime.AddSeconds(2),
+            Duration = TimeSpan.FromSeconds(1),
+            TrxTestDefinitionName = "LineEnding.Definition",
+            TrxFullyQualifiedTypeName = "Phase3.LineEndingTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Phase3",
+                TypeName = "LineEndingTests",
+                MethodName = "PreservesCrLf",
+            },
+            ExceptionMessage = "message first\r\nmessage second",
+            ExceptionStackTrace = "stack first\r\nstack second",
+            Messages =
+            [
+                new TrxStreamMessage
+                {
+                    Kind = TrxStreamMessageKind.StandardOutput,
+                    Message = "stdout first\r\nstdout second",
+                },
+                new TrxStreamMessage
+                {
+                    Kind = TrxStreamMessageKind.StandardError,
+                    Message = "stderr first\r\nstderr second",
+                },
+                new TrxStreamMessage
+                {
+                    Kind = TrxStreamMessageKind.DebugOrTrace,
+                    Message = "debug first\r\ndebug second",
+                },
+            ],
+            Metadata =
+            [
+                new TrxTestMetadata { Key = "Description", Value = "description first\r\ndescription second" },
+                new TrxTestMetadata { Key = "Custom", Value = "metadata first\r\nmetadata second" },
+            ],
+        };
+
+    private static IReadOnlyList<(string Renderer, byte[] Bytes)> RenderPrototypeDocuments(
+        TrxTestResult result,
+        Guid executionId,
+        TrxPrototypeCompletion completion,
+        string runName)
+    {
+        var renderer = new TrxPrototypeXmlRenderer(
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion);
+        byte[] compact = renderer.RenderCompact(
+            TrxPhase3EvidenceMatrix.RunId,
+            runName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            [result],
+            [executionId],
+            completion);
+
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        var journal = new TrxJournalSnapshotPrototype(
+            operations,
+            TrxPhase3EvidenceMatrix.RecoveryPath,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            runName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime);
+        journal.Append(result, executionId);
+        journal.PublishSnapshot(completion);
+
+        return
+        [
+            ("compact renderer", compact),
+            ("journal snapshot renderer", operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath)),
+        ];
+    }
+
+    private static void AssertAttributeLineEndingMutationIsDetected(
+        string renderer,
+        XDocument document,
+        TrxDocumentExpectation expectation,
+        Func<XDocument, XAttribute> select,
+        string fieldName,
+        string expectedError)
+    {
+        XDocument mutated = Clone(document);
+        XAttribute field = select(mutated);
+        Assert.Contains("\r\n", field.Value, $"{renderer}: {fieldName}");
+        field.Value = field.Value.Replace("\r\n", "\n");
+
+        TrxDocumentObservation observation = Classify(mutated, expectation);
+
+        Assert.AreEqual(
+            TrxDocumentClassification.ParseableInconsistent,
+            observation.Classification,
+            $"{renderer}: {fieldName}: {observation.Diagnostic}");
+        Assert.Contains(
+            candidate => candidate.Contains(expectedError, StringComparison.Ordinal),
+            observation.Errors,
+            $"{renderer}: {fieldName}");
+    }
 
     private static XDocument Clone(XDocument document) => new(document);
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxFaultInjectingFileOperationsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxFaultInjectingFileOperationsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxFaultInjectingFileOperationsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxFaultInjectingFileOperationsTests.cs
@@ -1,0 +1,347 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxFaultInjectingFileOperationsTests
+{
+    private static readonly Encoding Utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    [TestMethod]
+    public void Open_Create_TruncatesExistingEntryAndRecordsPrePostLength()
+    {
+        TrxFaultInjectingFileOperations operations = new();
+        operations.SeedFile("results.trx", Utf8.GetBytes("prior"));
+
+        using ITrxPrototypeFile file = operations.Open(
+            "results.trx",
+            FileMode.Create,
+            FileAccess.ReadWrite,
+            FileShare.Read);
+
+        Assert.AreEqual(0, file.Length);
+        Assert.AreEqual(0, file.Position);
+        Assert.HasCount(1, operations.Operations);
+        TrxFileOperationRecord record = operations.Operations[0];
+        Assert.AreEqual(0, record.OperationIndex);
+        Assert.AreEqual(TrxFileOperationKind.Open, record.Kind);
+        Assert.AreEqual(5, record.PreLength);
+        Assert.AreEqual(0, record.PostLength);
+        Assert.AreEqual(FileMode.Create, record.Mode);
+        Assert.AreEqual(FileAccess.ReadWrite, record.Access);
+        Assert.AreEqual(FileShare.Read, record.Share);
+        Assert.HasCount(1, operations.Snapshots);
+        Assert.IsEmpty(operations.Snapshots[0].GetFileBytes("results.trx"));
+    }
+
+    [TestMethod]
+    public void SeekReadWriteFlushSetLength_RecordMonotonicOperations()
+    {
+        TrxFaultInjectingFileOperations operations = new();
+        operations.SeedFile("results.trx", Utf8.GetBytes("abcdef"));
+
+        using ITrxPrototypeFile file = operations.Open(
+            "results.trx",
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read);
+        file.Seek(2, SeekOrigin.Begin);
+        byte[] readBuffer = new byte[2];
+        int read = file.Read(readBuffer, 0, readBuffer.Length);
+        file.Seek(-1, SeekOrigin.Current);
+        byte[] writeBuffer = Utf8.GetBytes("_12_");
+        file.Write(writeBuffer, 1, 2);
+        file.Flush();
+        file.SetLength(4);
+
+        Assert.AreEqual(2, read);
+        Assert.AreEqual("cd", Utf8.GetString(readBuffer));
+        Assert.AreEqual("abc1", Utf8.GetString(operations.GetFileBytes("results.trx")));
+        Assert.AreSequenceEqual(
+            [
+                TrxFileOperationKind.Open,
+                TrxFileOperationKind.Seek,
+                TrxFileOperationKind.Read,
+                TrxFileOperationKind.Seek,
+                TrxFileOperationKind.Write,
+                TrxFileOperationKind.Flush,
+                TrxFileOperationKind.SetLength,
+            ],
+            operations.Operations.Select(record => record.Kind).ToArray());
+        Assert.AreSequenceEqual(
+            Enumerable.Range(0, 7).ToArray(),
+            operations.Operations.Select(record => record.OperationIndex).ToArray());
+        Assert.AreEqual(2, operations.Operations[2].RequestedByteCount);
+        Assert.AreEqual(2, operations.Operations[2].CommittedByteCount);
+        Assert.AreEqual(3, operations.Operations[4].PrePosition);
+        Assert.AreEqual(5, operations.Operations[4].PostPosition);
+        Assert.AreEqual(6, operations.Operations[6].PreLength);
+        Assert.AreEqual(4, operations.Operations[6].PostLength);
+    }
+
+    [TestMethod]
+    public void Write_TerminationAtEveryByte_CommitsExactlyRequestedPrefix()
+    {
+        byte[] original = Utf8.GetBytes("xxxxx");
+        byte[] payload = Utf8.GetBytes("ABCDE");
+
+        for (int committedByteCount = 0; committedByteCount <= payload.Length; committedByteCount++)
+        {
+            TrxFaultInjectingFileOperations operations = new(
+                terminationPlan: new TrxTerminationPlan(operationIndex: 1, committedByteCount));
+            operations.SeedFile("results.trx", original);
+            ITrxPrototypeFile file = operations.Open(
+                "results.trx",
+                FileMode.Open,
+                FileAccess.Write,
+                FileShare.Read);
+
+            TrxSimulatedProcessTerminationException exception =
+                Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+                    () => file.Write(payload, 0, payload.Length));
+
+            byte[] expected = (byte[])original.Clone();
+            Array.Copy(payload, expected, committedByteCount);
+            Assert.AreSequenceEqual(expected, operations.GetFileBytes("results.trx"), $"Cut {committedByteCount}");
+            Assert.AreEqual(1, exception.OperationIndex);
+            Assert.IsTrue(operations.IsProcessDead);
+            Assert.HasCount(2, operations.Operations);
+            Assert.AreEqual(payload.Length, operations.Operations[1].RequestedByteCount);
+            Assert.AreEqual(committedByteCount, operations.Operations[1].CommittedByteCount);
+            Assert.IsTrue(operations.Snapshots[1].IsProcessDead);
+        }
+    }
+
+    [TestMethod]
+    public void Termination_RejectsEveryLaterMutationIncludingFinallyCleanup()
+    {
+        TrxFaultInjectingFileOperations operations = new(
+            terminationPlan: new TrxTerminationPlan(operationIndex: 1, committedByteCount: 2));
+        operations.SeedFile("results.trx", Utf8.GetBytes("012345"));
+        operations.SeedFile("results.trx.tmp", Utf8.GetBytes("replacement"));
+        ITrxPrototypeFile file = operations.Open(
+            "results.trx",
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.ReadWrite | FileShare.Delete);
+
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => file.Write(Utf8.GetBytes("ABC"), 0, 3));
+        TrxVirtualFileSystemSnapshot frozen = operations.CaptureSnapshot();
+
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(() => file.Flush());
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(() => file.SetLength(0));
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(() => file.Dispose());
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(() => operations.Delete("results.trx"));
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => operations.ReplaceTemporarySibling("results.trx.tmp", "results.trx"));
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => operations.Open("other.trx", FileMode.Create, FileAccess.Write, FileShare.None));
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(() => operations.Exists("results.trx"));
+
+        Assert.HasCount(2, operations.Operations);
+        Assert.AreEqual(frozen.ToString(), operations.CaptureSnapshot().ToString());
+        Assert.AreEqual("AB2345", Utf8.GetString(operations.GetFileBytes("results.trx")));
+        Assert.AreEqual("replacement", Utf8.GetString(operations.GetFileBytes("results.trx.tmp")));
+    }
+
+    [TestMethod]
+    public void AtomicReplace_SwapsWholeEntryInOneOperation()
+    {
+        var barriers = new List<TrxVirtualFileSystemSnapshot>();
+        TrxFaultInjectingFileOperations operations = new(
+            afterOperation: (_, snapshot) => barriers.Add(snapshot));
+        operations.SeedFile("results.trx", Utf8.GetBytes("old"));
+        operations.SeedFile("results.trx.tmp", Utf8.GetBytes("complete-new"));
+
+        operations.ReplaceTemporarySibling("results.trx.tmp", "results.trx");
+
+        Assert.IsTrue(operations.SupportsAtomicReplace);
+        Assert.HasCount(1, operations.Operations);
+        Assert.AreEqual(TrxFileOperationKind.Replace, operations.Operations[0].Kind);
+        Assert.AreEqual("results.trx.tmp", operations.Operations[0].ReplacementSource);
+        Assert.AreEqual("results.trx", operations.Operations[0].ReplacementTarget);
+        Assert.AreEqual("complete-new", Utf8.GetString(operations.GetFileBytes("results.trx")));
+        Assert.IsFalse(operations.Exists("results.trx.tmp"));
+        Assert.HasCount(1, barriers);
+        Assert.IsTrue(barriers[0].Contains("results.trx"));
+        Assert.IsFalse(barriers[0].Contains("results.trx.tmp"));
+    }
+
+    [TestMethod]
+    public void DeleteThenMoveEmulation_ExposesTargetMissingWindow()
+    {
+        var targetPresenceAtBarriers = new List<bool>();
+        TrxFaultInjectingFileOperations operations = new(
+            TrxReplacementModel.DeleteThenMove,
+            afterOperation: (_, snapshot) => targetPresenceAtBarriers.Add(snapshot.Contains("results.trx")));
+        operations.SeedFile("results.trx", Utf8.GetBytes("old"));
+        operations.SeedFile("results.trx.tmp", Utf8.GetBytes("complete-new"));
+
+        operations.ReplaceTemporarySibling("results.trx.tmp", "results.trx");
+
+        Assert.IsFalse(operations.SupportsAtomicReplace);
+        Assert.AreSequenceEqual(
+            [TrxFileOperationKind.Delete, TrxFileOperationKind.Replace],
+            operations.Operations.Select(record => record.Kind).ToArray());
+        Assert.AreSequenceEqual([false, true], targetPresenceAtBarriers);
+        Assert.AreEqual("complete-new", Utf8.GetString(operations.GetFileBytes("results.trx")));
+    }
+
+    [TestMethod]
+    public void Barrier_AfterEveryPrimitive_ObservesFrozenPostOperationState()
+    {
+        var records = new List<TrxFileOperationRecord>();
+        var snapshots = new List<TrxVirtualFileSystemSnapshot>();
+        TrxFaultInjectingFileOperations operations = new(
+            afterOperation: (record, snapshot) =>
+            {
+                records.Add(record);
+                snapshots.Add(snapshot);
+            });
+        operations.SeedFile("results.trx", Utf8.GetBytes("abcd"));
+
+        using ITrxPrototypeFile file = operations.Open(
+            "results.trx",
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read);
+        file.Seek(1, SeekOrigin.Begin);
+        file.Write(Utf8.GetBytes("XY"), 0, 2);
+        file.Flush();
+        file.SetLength(2);
+
+        Assert.HasCount(5, records);
+        Assert.HasCount(5, snapshots);
+        for (int i = 0; i < records.Count; i++)
+        {
+            Assert.AreEqual(i, records[i].OperationIndex);
+            Assert.AreEqual(i, snapshots[i].OperationIndex);
+            Assert.IsFalse(snapshots[i].IsProcessDead);
+        }
+
+        Assert.AreEqual("abcd", Utf8.GetString(snapshots[1].GetFileBytes("results.trx")));
+        Assert.AreEqual("aXYd", Utf8.GetString(snapshots[2].GetFileBytes("results.trx")));
+        Assert.AreEqual("aX", Utf8.GetString(snapshots[4].GetFileBytes("results.trx")));
+        Assert.AreEqual(snapshots[4].ToString(), operations.CaptureSnapshot().ToString());
+    }
+
+    [TestMethod]
+    public void FreshRun_WithSamePlan_ProducesIdenticalTraceAndSnapshots()
+    {
+        TrxFaultInjectingFileOperations first = RunDeterministicFaultScenario();
+        TrxFaultInjectingFileOperations second = RunDeterministicFaultScenario();
+
+        Assert.IsTrue(first.IsProcessDead);
+        Assert.IsTrue(second.IsProcessDead);
+        Assert.AreEqual(first.FormatTrace(), second.FormatTrace());
+        Assert.AreSequenceEqual(
+            first.Snapshots.Select(snapshot => snapshot.ToString()).ToArray(),
+            second.Snapshots.Select(snapshot => snapshot.ToString()).ToArray());
+        Assert.AreSequenceEqual(first.GetFileBytes("results.trx"), second.GetFileBytes("results.trx"));
+    }
+
+    [TestMethod]
+    public void MultipleHandles_RespectConfiguredShareAndSnapshotRules()
+    {
+        TrxFaultInjectingFileOperations operations = new();
+        operations.SeedFile("results.trx", Utf8.GetBytes("old"));
+        TrxVirtualFileSystemSnapshot initial = operations.CaptureSnapshot();
+
+        using (ITrxPrototypeFile firstReader = operations.Open(
+                   "results.trx",
+                   FileMode.Open,
+                   FileAccess.Read,
+                   FileShare.Read | FileShare.Delete))
+        using (ITrxPrototypeFile secondReader = operations.Open(
+                   "results.trx",
+                   FileMode.Open,
+                   FileAccess.Read,
+                   FileShare.Read | FileShare.Delete))
+        {
+            _ = Assert.ThrowsExactly<IOException>(
+                () => operations.Open(
+                    "results.trx",
+                    FileMode.Open,
+                    FileAccess.Write,
+                    FileShare.ReadWrite | FileShare.Delete));
+
+            byte[] firstByte = new byte[1];
+            byte[] secondByte = new byte[1];
+            Assert.AreEqual(1, firstReader.Read(firstByte, 0, 1));
+            Assert.AreEqual(1, secondReader.Read(secondByte, 0, 1));
+            Assert.AreEqual((byte)'o', firstByte[0]);
+            Assert.AreEqual((byte)'o', secondByte[0]);
+        }
+
+        using (ITrxPrototypeFile writer = operations.Open(
+                   "results.trx",
+                   FileMode.Open,
+                   FileAccess.Write,
+                   FileShare.Read))
+        {
+            writer.Write(Utf8.GetBytes("N"), 0, 1);
+        }
+
+        Assert.AreEqual("old", Utf8.GetString(initial.GetFileBytes("results.trx")));
+        Assert.AreEqual("Nld", Utf8.GetString(operations.GetFileBytes("results.trx")));
+
+        TrxFaultInjectingFileOperations relaxed = new(enforceShareSemantics: false);
+        relaxed.SeedFile("relaxed.trx", Utf8.GetBytes("data"));
+        using ITrxPrototypeFile exclusiveReader = relaxed.Open(
+            "relaxed.trx",
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.None);
+        using ITrxPrototypeFile conflictingWriter = relaxed.Open(
+            "relaxed.trx",
+            FileMode.Open,
+            FileAccess.Write,
+            FileShare.None);
+        conflictingWriter.Write(Utf8.GetBytes("X"), 0, 1);
+        Assert.AreEqual("Xata", Utf8.GetString(relaxed.GetFileBytes("relaxed.trx")));
+    }
+
+    [TestMethod]
+    public void TraceDiagnostics_AreStableAndBounded()
+    {
+        TrxFaultInjectingFileOperations operations = new();
+        operations.SeedFile("trace.trx", Utf8.GetBytes("AéZ"));
+        using ITrxPrototypeFile file = operations.Open(
+            "trace.trx",
+            FileMode.Open,
+            FileAccess.Write,
+            FileShare.Read);
+        file.Write(Utf8.GetBytes("!"), 0, 1);
+
+        const string expectedWriteDiagnostic =
+            "#001 Write path='trace.trx' position=0->1 length=4->4 requested=1 committed=1 mode=- access=- share=- replace='-'->'-' window=[offset=0; count=4; hex=21 C3 A9 5A; utf8=!éZ]";
+        Assert.AreEqual(expectedWriteDiagnostic, operations.Operations[1].ToString());
+        Assert.Contains("mode=Open access=Write share=Read", operations.Operations[0].ToString());
+        Assert.IsLessThan(600, operations.FormatTrace().Length);
+        Assert.IsTrue(operations.Operations.All(record => record.ByteWindow.Contains("count=", StringComparison.Ordinal)));
+        Assert.IsTrue(operations.Operations.All(record => record.ByteWindow.Contains("hex=", StringComparison.Ordinal)));
+        Assert.IsTrue(operations.Operations.All(record => record.ByteWindow.Contains("utf8=", StringComparison.Ordinal)));
+    }
+
+    private static TrxFaultInjectingFileOperations RunDeterministicFaultScenario()
+    {
+        TrxFaultInjectingFileOperations operations = new(
+            terminationPlan: new TrxTerminationPlan(operationIndex: 3, committedByteCount: 1));
+        operations.SeedFile("results.trx", Utf8.GetBytes("old"));
+        ITrxPrototypeFile file = operations.Open(
+            "results.trx",
+            FileMode.Create,
+            FileAccess.ReadWrite,
+            FileShare.Read);
+        file.Write(Utf8.GetBytes("AB"), 0, 2);
+        file.Seek(0, SeekOrigin.Begin);
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => file.Write(Utf8.GetBytes("XY"), 0, 2));
+        return operations;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Security.Cryptography;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public sealed class TrxIncrementalWriterInterruptionTests
 {
+    private const string ExpectedFaultEvidenceDigest =
+        "45AE4708CD7B0FBC81D1D69273A3CE20F6C9FAD45E068A78CC49465F12192020";
+
+    private const string ExpectedBaselineEvidenceDigest =
+        "68A3FFB46711D86062DD42BED697489449E3B2A7B19CAFB57C6671B6FE221D23";
+
     private static readonly Lazy<TrxPhase3EvidenceReport> Evidence =
         new(TrxPhase3EvidenceMatrix.Create);
 
@@ -24,29 +30,29 @@ public sealed class TrxIncrementalWriterInterruptionTests
         TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "startup-existing");
         TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "startup-recoverable");
 
-        TrxPhase3EvidenceObservation truncated = report.Observations.Single(
+        TrxPhase3EvidenceObservation truncated = report.FaultObservations.Single(
             observation => observation.Scenario == "startup-existing"
-                && observation.Dimension == TrxPhase3EvidenceDimension.Operation
+                && observation.Dimension == TrxPhase3EvidenceDimension.OperationFault
                 && observation.OperationIndex == 0);
         Assert.AreEqual(TrxDocumentClassification.Malformed, truncated.Classification, truncated.Diagnostic);
         Assert.AreEqual(0, truncated.TargetLength);
 
         Assert.Contains(
             observation => observation.Scenario == "startup-absent"
-                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                 && observation.Cut == 0
                 && observation.Classification == TrxDocumentClassification.Malformed,
-            report.Observations);
+            report.FaultObservations);
         Assert.Contains(
             observation => observation.Scenario == "startup-absent"
-                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                 && observation.Cut == observation.RequestedBytes
                 && observation.Classification == TrxDocumentClassification.Truthful,
-            report.Observations);
+            report.FaultObservations);
         Assert.Contains(
             observation => observation.Scenario == "startup-recoverable"
                 && observation.Classification == TrxDocumentClassification.Repairable,
-            report.Observations);
+            report.FaultObservations);
     }
 
     [TestMethod]
@@ -62,12 +68,12 @@ public sealed class TrxIncrementalWriterInterruptionTests
         Assert.Contains(
             observation => observation.WriteRole == TrxPhase3WriteRole.ResultTail
                 && observation.Classification == TrxDocumentClassification.Malformed,
-            report.Observations);
+            report.FaultObservations);
         Assert.Contains(
             observation => observation.WriteRole == TrxPhase3WriteRole.ResultTail
                 && observation.Cut == observation.RequestedBytes
                 && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
-            report.Observations);
+            report.FaultObservations);
     }
 
     [TestMethod]
@@ -81,9 +87,9 @@ public sealed class TrxIncrementalWriterInterruptionTests
             "definition-small",
             TrxPhase3WriteRole.Definition);
 
-        TrxPhase3EvidenceObservation largeDefinition = report.Observations.First(
+        TrxPhase3EvidenceObservation largeDefinition = report.FaultObservations.First(
             observation => observation.Scenario == "definition-large-metadata"
-                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                 && observation.WriteRole == TrxPhase3WriteRole.Definition);
         Assert.IsGreaterThan(500, largeDefinition.RequestedBytes);
         TrxPhase3EvidenceMatrix.AssertSelectedLargeCuts(report, "definition-large-metadata", largeDefinition.OperationIndex);
@@ -115,7 +121,7 @@ public sealed class TrxIncrementalWriterInterruptionTests
         Assert.Contains(
             observation => observation.WriteRole == TrxPhase3WriteRole.Counter
                 && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
-            report.Observations);
+            report.FaultObservations);
     }
 
     [TestMethod]
@@ -129,11 +135,11 @@ public sealed class TrxIncrementalWriterInterruptionTests
         Assert.Contains(
             observation => observation.Scenario == "finish-timestamp"
                 && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
-            report.Observations);
+            report.FaultObservations);
         Assert.Contains(
             observation => observation.Scenario == "clean-outcome"
                 && observation.Classification == TrxDocumentClassification.Malformed,
-            report.Observations);
+            report.FaultObservations);
     }
 
     [TestMethod]
@@ -170,20 +176,20 @@ public sealed class TrxIncrementalWriterInterruptionTests
         foreach (TrxPhase3WriteRole role in requiredRoles)
         {
             Assert.Contains(
-                observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                observation => observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                         && observation.WriteRole == role
                         && observation.Cut == 0,
-                report.Observations,
+                report.FaultObservations,
                 $"No zero-byte frozen prefix was recorded for {role}.");
             Assert.Contains(
-                observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                observation => observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                         && observation.WriteRole == role
                         && observation.Cut == observation.RequestedBytes,
-                report.Observations,
+                report.FaultObservations,
                 $"No complete frozen prefix was recorded for {role}.");
         }
 
-        Assert.IsTrue(report.Observations.All(observation => observation.CleanupWasFrozen));
+        Assert.IsTrue(report.FaultObservations.All(observation => observation.CleanupWasFrozen));
     }
 
     [TestMethod]
@@ -191,9 +197,9 @@ public sealed class TrxIncrementalWriterInterruptionTests
     {
         TrxPhase3EvidenceReport report = Evidence.Value;
         TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "large-payload");
-        foreach (TrxPhase3EvidenceObservation write in report.Observations
+        foreach (TrxPhase3EvidenceObservation write in report.FaultObservations
                      .Where(observation => observation.Scenario == "large-payload"
-                         && observation.Dimension == TrxPhase3EvidenceDimension.Byte)
+                         && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault)
                      .GroupBy(observation => observation.OperationIndex)
                      .Select(group => group.First()))
         {
@@ -203,35 +209,55 @@ public sealed class TrxIncrementalWriterInterruptionTests
     }
 
     [TestMethod]
-    public void PaddedWriter_EvidenceDigest_IsStableAndContainsExpectedCounterexamples()
+    public void PaddedWriter_FaultAndBaselineEvidenceCountsAndDigests_AreStableAndDistinct()
     {
         TrxPhase3EvidenceReport report = Evidence.Value;
-
-        Assert.AreEqual(574, report.OperationCaseCount);
-        Assert.AreEqual(5_082, report.ByteCaseCount);
-        Assert.HasCount(5_698, report.Observations);
-        Assert.AreEqual(report.Observations.Count, report.ClassificationCounts.Values.Sum());
-        Assert.AreEqual(4_546, report.ClassificationCounts[TrxDocumentClassification.Malformed]);
-        Assert.AreEqual(719, report.ClassificationCounts[TrxDocumentClassification.ParseableInconsistent]);
-        Assert.AreEqual(22, report.ClassificationCounts[TrxDocumentClassification.Repairable]);
-        Assert.AreEqual(411, report.ClassificationCounts[TrxDocumentClassification.Truthful]);
-        Assert.AreEqual(
-            "A2F70EA25564B1EDA70F4804D7C452E7D286D955F21B262D67ABF0759FCDD62E",
-            report.Digest);
-        Assert.IsTrue(report.Observations.All(observation => observation.WriteRole != TrxPhase3WriteRole.Unknown));
-        Assert.IsTrue(report.Observations.All(observation => observation.Diagnostic.Contains("window=", StringComparison.Ordinal)));
-        Assert.IsTrue(report.Observations.All(observation => observation.Diagnostic.Contains("flushes=", StringComparison.Ordinal)));
-
         TestContext.WriteLine(report.Summary);
+
+        Assert.AreEqual(574, report.OperationFaultCount);
+        Assert.AreEqual(5_082, report.ByteCutFaultCount);
+        Assert.AreEqual(5_656, report.FaultObservationCount);
+        Assert.AreEqual(42, report.BaselineObservationCount);
+        Assert.AreEqual(5_698, report.CombinedObservationCount);
+        Assert.AreEqual(report.FaultObservationCount, report.FaultClassificationCounts.Values.Sum());
+        Assert.AreEqual(report.BaselineObservationCount, report.BaselineClassificationCounts.Values.Sum());
+        Assert.AreEqual(4_545, report.FaultClassificationCounts[TrxDocumentClassification.Malformed]);
+        Assert.AreEqual(719, report.FaultClassificationCounts[TrxDocumentClassification.ParseableInconsistent]);
+        Assert.AreEqual(22, report.FaultClassificationCounts[TrxDocumentClassification.Repairable]);
+        Assert.AreEqual(370, report.FaultClassificationCounts[TrxDocumentClassification.Truthful]);
+        Assert.AreEqual(0, report.BaselineClassificationCounts[TrxDocumentClassification.Malformed]);
+        Assert.AreEqual(0, report.BaselineClassificationCounts[TrxDocumentClassification.ParseableInconsistent]);
+        Assert.AreEqual(0, report.BaselineClassificationCounts[TrxDocumentClassification.Repairable]);
+        Assert.AreEqual(42, report.BaselineClassificationCounts[TrxDocumentClassification.Truthful]);
+        Assert.AreEqual(
+            21,
+            report.BaselineObservations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.BaselineBefore));
+        Assert.AreEqual(
+            21,
+            report.BaselineObservations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.BaselineAfter));
+        Assert.AreEqual(
+            ExpectedFaultEvidenceDigest,
+            report.FaultDigest,
+            report.Summary);
+        Assert.AreEqual(
+            ExpectedBaselineEvidenceDigest,
+            report.BaselineDigest,
+            report.Summary);
+        Assert.IsTrue(report.FaultObservations.All(observation => observation.WriteRole != TrxPhase3WriteRole.Unknown));
+        Assert.IsTrue(report.FaultObservations.All(observation => observation.Diagnostic.Contains("evidenceCategory=fault;", StringComparison.Ordinal)));
+        Assert.IsTrue(report.BaselineObservations.All(observation => observation.Diagnostic.Contains("evidenceCategory=baseline;", StringComparison.Ordinal)));
+        Assert.IsTrue(report.FaultObservations.All(observation => observation.Diagnostic.Contains("window=", StringComparison.Ordinal)));
+        Assert.IsTrue(report.FaultObservations.All(observation => observation.Diagnostic.Contains("flushes=", StringComparison.Ordinal)));
+        Assert.IsTrue(report.BaselineObservations.All(observation => observation.Classification == TrxDocumentClassification.Truthful));
     }
 }
 
 internal enum TrxPhase3EvidenceDimension
 {
-    BeforeFirst,
-    Operation,
-    Byte,
-    Successful,
+    BaselineBefore,
+    OperationFault,
+    ByteCutFault,
+    BaselineAfter,
 }
 
 internal enum TrxPhase3WriteRole
@@ -283,17 +309,29 @@ internal sealed class TrxPhase3EvidenceObservation
 
 internal sealed class TrxPhase3EvidenceReport
 {
-    public required IReadOnlyList<TrxPhase3EvidenceObservation> Observations { get; init; }
+    public required IReadOnlyList<TrxPhase3EvidenceObservation> FaultObservations { get; init; }
+
+    public required IReadOnlyList<TrxPhase3EvidenceObservation> BaselineObservations { get; init; }
 
     public required IReadOnlyDictionary<string, IReadOnlyList<TrxFileOperationRecord>> BaselineOperations { get; init; }
 
-    public required IReadOnlyDictionary<TrxDocumentClassification, int> ClassificationCounts { get; init; }
+    public required IReadOnlyDictionary<TrxDocumentClassification, int> FaultClassificationCounts { get; init; }
 
-    public required int OperationCaseCount { get; init; }
+    public required IReadOnlyDictionary<TrxDocumentClassification, int> BaselineClassificationCounts { get; init; }
 
-    public required int ByteCaseCount { get; init; }
+    public required int OperationFaultCount { get; init; }
 
-    public required string Digest { get; init; }
+    public required int ByteCutFaultCount { get; init; }
+
+    public int FaultObservationCount => FaultObservations.Count;
+
+    public int BaselineObservationCount => BaselineObservations.Count;
+
+    public int CombinedObservationCount => FaultObservationCount + BaselineObservationCount;
+
+    public required string FaultDigest { get; init; }
+
+    public required string BaselineDigest { get; init; }
 
     public required string Summary { get; init; }
 }
@@ -320,28 +358,32 @@ internal static class TrxPhase3EvidenceMatrix
     public static TrxPhase3EvidenceReport Create()
     {
         List<TrxPhase3Scenario> scenarios = CreateScenarios();
-        List<TrxPhase3EvidenceObservation> observations = [];
+        List<TrxPhase3EvidenceObservation> faultObservations = [];
+        List<TrxPhase3EvidenceObservation> baselineObservations = [];
         var baselineOperations = new Dictionary<string, IReadOnlyList<TrxFileOperationRecord>>(StringComparer.Ordinal);
 
         foreach (TrxPhase3Scenario scenario in scenarios)
         {
-            TrxPhase3Run baseline = Run(scenario, terminationPlan: null, captureSnapshots: true);
-            Assert.IsTrue(baseline.Completed);
+            TrxPhase3Run baselineBeforeFaultSweep = Run(scenario, terminationPlan: null, captureSnapshots: true);
+            Assert.IsTrue(baselineBeforeFaultSweep.Completed);
             Assert.AreEqual(
                 TrxDocumentClassification.Truthful,
-                ClassifyBest(scenario, baseline.TargetBytes, operation: null, cut: null).Classification,
+                ClassifyBest(scenario, baselineBeforeFaultSweep.TargetBytes, operation: null, cut: null).Classification,
                 scenario.Name);
-            baselineOperations.Add(scenario.Name, baseline.Operations);
+            baselineOperations.Add(scenario.Name, baselineBeforeFaultSweep.Operations);
 
-            observations.Add(CreateBeforeFirstObservation(scenario, baseline.PreActSnapshot));
-            for (int operationIndex = 0; operationIndex < baseline.Operations.Count; operationIndex++)
+            baselineObservations.Add(CreateCleanBaselineObservation(
+                scenario,
+                baselineBeforeFaultSweep,
+                TrxPhase3EvidenceDimension.BaselineBefore));
+            for (int operationIndex = 0; operationIndex < baselineBeforeFaultSweep.Operations.Count; operationIndex++)
             {
-                TrxFileOperationRecord operation = baseline.Operations[operationIndex];
-                observations.Add(RunFaultCase(
+                TrxFileOperationRecord operation = baselineBeforeFaultSweep.Operations[operationIndex];
+                faultObservations.Add(RunFaultCase(
                     scenario,
-                    baseline,
+                    baselineBeforeFaultSweep,
                     operation,
-                    TrxPhase3EvidenceDimension.Operation,
+                    TrxPhase3EvidenceDimension.OperationFault,
                     cut: null));
 
                 if (operation.Kind != TrxFileOperationKind.Write)
@@ -349,101 +391,97 @@ internal static class TrxPhase3EvidenceMatrix
                     continue;
                 }
 
-                TrxPhase3WriteRole role = InferWriteRole(scenario, baseline, operation);
+                TrxPhase3WriteRole role = InferWriteRole(scenario, baselineBeforeFaultSweep, operation);
                 IReadOnlyList<int> cuts = scenario.ExhaustiveRoles.Contains(role)
                     ? Enumerable.Range(0, operation.RequestedByteCount + 1).ToArray()
                     : scenario.SelectedRoles.Contains(role)
-                        ? CreateSelectedCuts(GetWrittenBytes(baseline, operation))
+                        ? CreateSelectedCuts(GetWrittenBytes(baselineBeforeFaultSweep, operation))
                         : [];
                 foreach (int cut in cuts)
                 {
-                    observations.Add(RunFaultCase(
+                    faultObservations.Add(RunFaultCase(
                         scenario,
-                        baseline,
+                        baselineBeforeFaultSweep,
                         operation,
-                        TrxPhase3EvidenceDimension.Byte,
+                        TrxPhase3EvidenceDimension.ByteCutFault,
                         cut));
                 }
             }
 
-            TrxDocumentObservation successful = ClassifyBest(
+            TrxPhase3Run baselineAfterFaultSweep = Run(scenario, terminationPlan: null, captureSnapshots: false);
+            Assert.IsTrue(baselineAfterFaultSweep.Completed);
+            Assert.AreSequenceEqual(
+                baselineBeforeFaultSweep.TargetBytes,
+                baselineAfterFaultSweep.TargetBytes,
+                scenario.Name);
+            baselineObservations.Add(CreateCleanBaselineObservation(
                 scenario,
-                baseline.TargetBytes,
-                operation: null,
-                cut: null);
-            observations.Add(new TrxPhase3EvidenceObservation
-            {
-                Scenario = scenario.Name,
-                Dimension = TrxPhase3EvidenceDimension.Successful,
-                OperationIndex = baseline.Operations.Count,
-                OperationKind = null,
-                WriteRole = TrxPhase3WriteRole.None,
-                Offset = 0,
-                RequestedBytes = 0,
-                Cut = null,
-                TargetLength = baseline.TargetBytes.Length,
-                FlushCount = baseline.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush),
-                TargetPresent = baseline.TargetPresent,
-                CleanupWasFrozen = true,
-                Classification = successful.Classification,
-                Diagnostic = CreateStableDiagnostic(
-                    scenario.Name,
-                    TrxPhase3EvidenceDimension.Successful,
-                    baseline.Operations.Count,
-                    null,
-                    TrxPhase3WriteRole.None,
-                    0,
-                    0,
-                    null,
-                    baseline.TargetPresent,
-                    baseline.TargetBytes,
-                    baseline.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush),
-                    successful.Classification),
-            });
+                baselineAfterFaultSweep,
+                TrxPhase3EvidenceDimension.BaselineAfter));
         }
 
-        IReadOnlyDictionary<TrxDocumentClassification, int> counts = Enum
+        IReadOnlyDictionary<TrxDocumentClassification, int> faultCounts =
+            CountClassifications(faultObservations);
+        IReadOnlyDictionary<TrxDocumentClassification, int> baselineCounts =
+            CountClassifications(baselineObservations);
+        int operationFaults = faultObservations.Count(
+            observation => observation.Dimension == TrxPhase3EvidenceDimension.OperationFault);
+        int byteCutFaults = faultObservations.Count(
+            observation => observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault);
+        string faultDigest = ComputeDigest(faultObservations.Select(observation => observation.Diagnostic));
+        string baselineDigest = ComputeDigest(baselineObservations.Select(observation => observation.Diagnostic));
+        string faultCountText = string.Join(
+            ",",
+            faultCounts.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
+        string baselineCountText = string.Join(
+            ",",
+            baselineCounts.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
+        string summary = string.Format(
+            CultureInfo.InvariantCulture,
+            "phase3 scenarios={0}; operationFaults={1}; byteCutFaults={2}; faultObservations={3}; baselineObservations={4}; combinedObservations={5}; faultClassifications=[{6}]; baselineClassifications=[{7}]; faultDigest={8}; baselineDigest={9}",
+            scenarios.Count,
+            operationFaults,
+            byteCutFaults,
+            faultObservations.Count,
+            baselineObservations.Count,
+            faultObservations.Count + baselineObservations.Count,
+            faultCountText,
+            baselineCountText,
+            faultDigest,
+            baselineDigest);
+
+        return new TrxPhase3EvidenceReport
+        {
+            FaultObservations = faultObservations,
+            BaselineObservations = baselineObservations,
+            BaselineOperations = baselineOperations,
+            FaultClassificationCounts = faultCounts,
+            BaselineClassificationCounts = baselineCounts,
+            OperationFaultCount = operationFaults,
+            ByteCutFaultCount = byteCutFaults,
+            FaultDigest = faultDigest,
+            BaselineDigest = baselineDigest,
+            Summary = summary,
+        };
+    }
+
+    private static IReadOnlyDictionary<TrxDocumentClassification, int> CountClassifications(
+        IReadOnlyList<TrxPhase3EvidenceObservation> observations)
+        => Enum
             .GetValues(typeof(TrxDocumentClassification))
             .Cast<TrxDocumentClassification>()
             .ToDictionary(
                 classification => classification,
                 classification => observations.Count(observation => observation.Classification == classification));
-        int operationCases = observations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.Operation);
-        int byteCases = observations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte);
-        string digest = ComputeDigest(observations.Select(observation => observation.Diagnostic));
-        string countText = string.Join(
-            ",",
-            counts.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
-        string summary = string.Format(
-            CultureInfo.InvariantCulture,
-            "phase3 scenarios={0}; operations={1}; byteCuts={2}; observations={3}; classifications=[{4}]; digest={5}",
-            scenarios.Count,
-            operationCases,
-            byteCases,
-            observations.Count,
-            countText,
-            digest);
-
-        return new TrxPhase3EvidenceReport
-        {
-            Observations = observations,
-            BaselineOperations = baselineOperations,
-            ClassificationCounts = counts,
-            OperationCaseCount = operationCases,
-            ByteCaseCount = byteCases,
-            Digest = digest,
-            Summary = summary,
-        };
-    }
 
     public static void AssertOperationCoverage(TrxPhase3EvidenceReport report, string scenario)
     {
         IReadOnlyList<TrxFileOperationRecord> baseline = report.BaselineOperations[scenario];
         TrxPhase3EvidenceObservation[] operationCases =
         [
-            .. report.Observations.Where(
+            .. report.FaultObservations.Where(
                 observation => observation.Scenario == scenario
-                    && observation.Dimension == TrxPhase3EvidenceDimension.Operation),
+                    && observation.Dimension == TrxPhase3EvidenceDimension.OperationFault),
         ];
         Assert.HasCount(baseline.Count, operationCases);
         Assert.AreSequenceEqual(
@@ -474,9 +512,9 @@ internal static class TrxPhase3EvidenceMatrix
     {
         IGrouping<int, TrxPhase3EvidenceObservation>[] writes =
         [
-            .. report.Observations
+            .. report.FaultObservations
                 .Where(observation => observation.Scenario == scenario
-                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                    && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                     && observation.WriteRole == role)
                 .GroupBy(observation => observation.OperationIndex),
         ];
@@ -498,18 +536,18 @@ internal static class TrxPhase3EvidenceMatrix
     {
         int[] cuts =
         [
-            .. report.Observations
+            .. report.FaultObservations
                 .Where(observation => observation.Scenario == scenario
                     && observation.OperationIndex == operationIndex
-                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte)
+                    && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault)
                 .Select(observation => observation.Cut!.Value)
                 .OrderBy(value => value),
         ];
         Assert.IsNotEmpty(cuts);
-        int requested = report.Observations.First(
+        int requested = report.FaultObservations.First(
             observation => observation.Scenario == scenario
                 && observation.OperationIndex == operationIndex
-                && observation.Dimension == TrxPhase3EvidenceDimension.Byte).RequestedBytes;
+                && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault).RequestedBytes;
         Assert.Contains(0, cuts);
         Assert.Contains(1, cuts);
         Assert.Contains(requested - 1, cuts);
@@ -533,9 +571,9 @@ internal static class TrxPhase3EvidenceMatrix
     {
         IGrouping<int, TrxPhase3EvidenceObservation>[] cells =
         [
-            .. report.Observations
+            .. report.FaultObservations
                 .Where(observation => observation.Scenario == scenario
-                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                    && observation.Dimension == TrxPhase3EvidenceDimension.ByteCutFault
                     && observation.WriteRole == TrxPhase3WriteRole.Counter)
                 .GroupBy(observation => observation.OperationIndex),
         ];
@@ -619,7 +657,9 @@ internal static class TrxPhase3EvidenceMatrix
         IReadOnlyList<Guid> executionIds,
         IReadOnlyList<TrxExpectedRunningTest>? running = null,
         DateTimeOffset? finishTime = null,
-        string summaryOutcome = "Failed")
+        string summaryOutcome = "Failed",
+        IReadOnlyList<string>? rootChildOrder = null,
+        string? runName = null)
     {
         var expected = new TrxExpectedResult[results.Count];
         for (int i = 0; i < results.Count; i++)
@@ -637,13 +677,13 @@ internal static class TrxPhase3EvidenceMatrix
         return new TrxDocumentExpectation
         {
             RunId = RunId,
-            RunName = RunName,
+            RunName = runName ?? RunName,
             StartTime = StartTime,
             FinishTime = finishTime ?? StartTime,
             SummaryOutcome = summaryOutcome,
             CompletedResults = expected,
             RunningTests = running ?? [],
-            RootChildOrder = PrototypeRootOrder,
+            RootChildOrder = rootChildOrder ?? PrototypeRootOrder,
         };
     }
 
@@ -1117,40 +1157,46 @@ internal static class TrxPhase3EvidenceMatrix
             frozen.Contains(TargetPath) ? frozen.GetFileBytes(TargetPath) : []);
     }
 
-    private static TrxPhase3EvidenceObservation CreateBeforeFirstObservation(
+    private static TrxPhase3EvidenceObservation CreateCleanBaselineObservation(
         TrxPhase3Scenario scenario,
-        TrxVirtualFileSystemSnapshot preAct)
+        TrxPhase3Run baseline,
+        TrxPhase3EvidenceDimension dimension)
     {
-        bool present = preAct.Contains(TargetPath);
-        byte[] bytes = present ? preAct.GetFileBytes(TargetPath) : [];
-        TrxDocumentObservation classification = ClassifyBest(scenario, bytes, operation: null, cut: null, useBeforeOnly: true);
+        Assert.IsTrue(
+            dimension is TrxPhase3EvidenceDimension.BaselineBefore or TrxPhase3EvidenceDimension.BaselineAfter);
+        TrxDocumentObservation classification =
+            ClassifyBest(scenario, baseline.TargetBytes, operation: null, cut: null);
+        int operationIndex = dimension == TrxPhase3EvidenceDimension.BaselineBefore
+            ? -1
+            : baseline.Operations.Count;
+        int flushCount = baseline.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush);
         return new TrxPhase3EvidenceObservation
         {
             Scenario = scenario.Name,
-            Dimension = TrxPhase3EvidenceDimension.BeforeFirst,
-            OperationIndex = -1,
+            Dimension = dimension,
+            OperationIndex = operationIndex,
             OperationKind = null,
             WriteRole = TrxPhase3WriteRole.None,
             Offset = 0,
             RequestedBytes = 0,
             Cut = null,
-            TargetLength = bytes.Length,
-            FlushCount = 0,
-            TargetPresent = present,
+            TargetLength = baseline.TargetBytes.Length,
+            FlushCount = flushCount,
+            TargetPresent = baseline.TargetPresent,
             CleanupWasFrozen = true,
             Classification = classification.Classification,
             Diagnostic = CreateStableDiagnostic(
                 scenario.Name,
-                TrxPhase3EvidenceDimension.BeforeFirst,
-                -1,
+                dimension,
+                operationIndex,
                 null,
                 TrxPhase3WriteRole.None,
                 0,
                 0,
                 null,
-                present,
-                bytes,
-                0,
+                baseline.TargetPresent,
+                baseline.TargetBytes,
+                flushCount,
                 classification.Classification),
         };
     }
@@ -1454,10 +1500,16 @@ internal static class TrxPhase3EvidenceMatrix
         byte[] targetBytes,
         int flushCount,
         TrxDocumentClassification classification)
-        => string.Format(
+    {
+        string evidenceCategory = dimension is TrxPhase3EvidenceDimension.OperationFault
+            or TrxPhase3EvidenceDimension.ByteCutFault
+                ? "fault"
+                : "baseline";
+        return string.Format(
             CultureInfo.InvariantCulture,
-            "scenario={0}; dimension={1}; operation={2:D3}:{3}; role={4}; offset={5}; requested={6}; cut={7}; targetPresent={8}; targetLength={9}; flushes={10}; classification={11}; window={12}",
+            "scenario={0}; evidenceCategory={1}; dimension={2}; operation={3:D3}:{4}; role={5}; offset={6}; requested={7}; cut={8}; targetPresent={9}; targetLength={10}; flushes={11}; classification={12}; window={13}",
             scenario,
+            evidenceCategory,
             dimension,
             operationIndex,
             operationKind?.ToString() ?? "-",
@@ -1470,6 +1522,7 @@ internal static class TrxPhase3EvidenceMatrix
             flushCount,
             classification,
             CreateHexWindow(targetBytes, offset + (cut ?? 0)));
+    }
 
     private static string CreateHexWindow(byte[] bytes, long center)
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterInterruptionTests.cs
@@ -1,0 +1,1592 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxIncrementalWriterInterruptionTests
+{
+    private static readonly Lazy<TrxPhase3EvidenceReport> Evidence =
+        new(TrxPhase3EvidenceMatrix.Create);
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void Initialize_EveryCreateWriteFlushAndByteCut_ClassifiesStartupStates()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "startup-absent");
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "startup-existing");
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "startup-recoverable");
+
+        TrxPhase3EvidenceObservation truncated = report.Observations.Single(
+            observation => observation.Scenario == "startup-existing"
+                && observation.Dimension == TrxPhase3EvidenceDimension.Operation
+                && observation.OperationIndex == 0);
+        Assert.AreEqual(TrxDocumentClassification.Malformed, truncated.Classification, truncated.Diagnostic);
+        Assert.AreEqual(0, truncated.TargetLength);
+
+        Assert.Contains(
+            observation => observation.Scenario == "startup-absent"
+                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.Cut == 0
+                && observation.Classification == TrxDocumentClassification.Malformed,
+            report.Observations);
+        Assert.Contains(
+            observation => observation.Scenario == "startup-absent"
+                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.Cut == observation.RequestedBytes
+                && observation.Classification == TrxDocumentClassification.Truthful,
+            report.Observations);
+        Assert.Contains(
+            observation => observation.Scenario == "startup-recoverable"
+                && observation.Classification == TrxDocumentClassification.Repairable,
+            report.Observations);
+    }
+
+    [TestMethod]
+    public void ResultTailAndClosers_EverySeekWriteFlushAndByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        foreach (string scenario in new[] { "tail-zero-prior", "tail-one-prior", "tail-many-prior" })
+        {
+            TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, scenario);
+            TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, scenario, TrxPhase3WriteRole.ResultTail);
+        }
+
+        Assert.Contains(
+            observation => observation.WriteRole == TrxPhase3WriteRole.ResultTail
+                && observation.Classification == TrxDocumentClassification.Malformed,
+            report.Observations);
+        Assert.Contains(
+            observation => observation.WriteRole == TrxPhase3WriteRole.ResultTail
+                && observation.Cut == observation.RequestedBytes
+                && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
+            report.Observations);
+    }
+
+    [TestMethod]
+    public void DefinitionPad_EveryStructuralByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "definition-small");
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "definition-large-metadata");
+        TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(
+            report,
+            "definition-small",
+            TrxPhase3WriteRole.Definition);
+
+        TrxPhase3EvidenceObservation largeDefinition = report.Observations.First(
+            observation => observation.Scenario == "definition-large-metadata"
+                && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                && observation.WriteRole == TrxPhase3WriteRole.Definition);
+        Assert.IsGreaterThan(500, largeDefinition.RequestedBytes);
+        TrxPhase3EvidenceMatrix.AssertSelectedLargeCuts(report, "definition-large-metadata", largeDefinition.OperationIndex);
+    }
+
+    [TestMethod]
+    public void EntryPad_EveryStructuralByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        foreach (string scenario in new[] { "entry-unique", "entry-repeated", "entry-exact-boundary" })
+        {
+            TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, scenario);
+            TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, scenario, TrxPhase3WriteRole.Entry);
+        }
+
+        TrxPhase3EvidenceMatrix.AssertEntryOverflowIsRejectedBeforeMutation();
+    }
+
+    [TestMethod]
+    public void FixedCounters_EveryCellTransitionAndByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        foreach (string scenario in new[] { "counter-0-to-1", "counter-9-to-10", "counter-99-to-100" })
+        {
+            TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, scenario);
+        }
+
+        TrxPhase3EvidenceMatrix.AssertEveryCounterCellWasCut(report, "counter-0-to-1");
+        Assert.Contains(
+            observation => observation.WriteRole == TrxPhase3WriteRole.Counter
+                && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
+            report.Observations);
+    }
+
+    [TestMethod]
+    public void FixedOutcomeAndTimestamp_EveryByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, "finish-timestamp", TrxPhase3WriteRole.Timestamp);
+        TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, "clean-outcome", TrxPhase3WriteRole.Outcome);
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "summary-crash-details");
+
+        Assert.Contains(
+            observation => observation.Scenario == "finish-timestamp"
+                && observation.Classification == TrxDocumentClassification.ParseableInconsistent,
+            report.Observations);
+        Assert.Contains(
+            observation => observation.Scenario == "clean-outcome"
+                && observation.Classification == TrxDocumentClassification.Malformed,
+            report.Observations);
+    }
+
+    [TestMethod]
+    public void RunningSlots_ClaimReleaseCompleteAndOverflow_EveryByteCut_ProducesStableEvidence()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        foreach (string scenario in new[] { "running-claim", "running-second-claim", "running-release" })
+        {
+            TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, scenario);
+        }
+
+        TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, "running-claim", TrxPhase3WriteRole.RunningSlot);
+        TrxPhase3EvidenceMatrix.AssertEveryByteWasCut(report, "running-release", TrxPhase3WriteRole.RunningSlotClear);
+        TrxPhase3EvidenceMatrix.AssertRunningValidationFailuresDoNotMutate();
+    }
+
+    [TestMethod]
+    public void ForcedPartialWrites_AllStructuralWrites_AreFrozenWithoutCleanupRepair()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        TrxPhase3WriteRole[] requiredRoles =
+        [
+            TrxPhase3WriteRole.StartupDocument,
+            TrxPhase3WriteRole.Definition,
+            TrxPhase3WriteRole.Entry,
+            TrxPhase3WriteRole.ResultTail,
+            TrxPhase3WriteRole.Counter,
+            TrxPhase3WriteRole.Timestamp,
+            TrxPhase3WriteRole.Outcome,
+            TrxPhase3WriteRole.RunningSlot,
+            TrxPhase3WriteRole.RunningSlotClear,
+        ];
+
+        foreach (TrxPhase3WriteRole role in requiredRoles)
+        {
+            Assert.Contains(
+                observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                        && observation.WriteRole == role
+                        && observation.Cut == 0,
+                report.Observations,
+                $"No zero-byte frozen prefix was recorded for {role}.");
+            Assert.Contains(
+                observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                        && observation.WriteRole == role
+                        && observation.Cut == observation.RequestedBytes,
+                report.Observations,
+                $"No complete frozen prefix was recorded for {role}.");
+        }
+
+        Assert.IsTrue(report.Observations.All(observation => observation.CleanupWasFrozen));
+    }
+
+    [TestMethod]
+    public void LargePayload_SelectedUtf8EntityTagAndSectorAdjacentCuts_AreClassified()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+        TrxPhase3EvidenceMatrix.AssertOperationCoverage(report, "large-payload");
+        foreach (TrxPhase3EvidenceObservation write in report.Observations
+                     .Where(observation => observation.Scenario == "large-payload"
+                         && observation.Dimension == TrxPhase3EvidenceDimension.Byte)
+                     .GroupBy(observation => observation.OperationIndex)
+                     .Select(group => group.First()))
+        {
+            Assert.IsGreaterThan(500, write.RequestedBytes);
+            TrxPhase3EvidenceMatrix.AssertSelectedLargeCuts(report, "large-payload", write.OperationIndex);
+        }
+    }
+
+    [TestMethod]
+    public void PaddedWriter_EvidenceDigest_IsStableAndContainsExpectedCounterexamples()
+    {
+        TrxPhase3EvidenceReport report = Evidence.Value;
+
+        Assert.AreEqual(574, report.OperationCaseCount);
+        Assert.AreEqual(5_082, report.ByteCaseCount);
+        Assert.HasCount(5_698, report.Observations);
+        Assert.AreEqual(report.Observations.Count, report.ClassificationCounts.Values.Sum());
+        Assert.AreEqual(4_546, report.ClassificationCounts[TrxDocumentClassification.Malformed]);
+        Assert.AreEqual(719, report.ClassificationCounts[TrxDocumentClassification.ParseableInconsistent]);
+        Assert.AreEqual(22, report.ClassificationCounts[TrxDocumentClassification.Repairable]);
+        Assert.AreEqual(411, report.ClassificationCounts[TrxDocumentClassification.Truthful]);
+        Assert.AreEqual(
+            "A2F70EA25564B1EDA70F4804D7C452E7D286D955F21B262D67ABF0759FCDD62E",
+            report.Digest);
+        Assert.IsTrue(report.Observations.All(observation => observation.WriteRole != TrxPhase3WriteRole.Unknown));
+        Assert.IsTrue(report.Observations.All(observation => observation.Diagnostic.Contains("window=", StringComparison.Ordinal)));
+        Assert.IsTrue(report.Observations.All(observation => observation.Diagnostic.Contains("flushes=", StringComparison.Ordinal)));
+
+        TestContext.WriteLine(report.Summary);
+    }
+}
+
+internal enum TrxPhase3EvidenceDimension
+{
+    BeforeFirst,
+    Operation,
+    Byte,
+    Successful,
+}
+
+internal enum TrxPhase3WriteRole
+{
+    None,
+    StartupDocument,
+    Definition,
+    Entry,
+    ResultTail,
+    Counter,
+    Timestamp,
+    Outcome,
+    RunningSlot,
+    RunningSlotClear,
+    Summary,
+    Unknown,
+}
+
+internal sealed class TrxPhase3EvidenceObservation
+{
+    public required string Scenario { get; init; }
+
+    public required TrxPhase3EvidenceDimension Dimension { get; init; }
+
+    public required int OperationIndex { get; init; }
+
+    public required TrxFileOperationKind? OperationKind { get; init; }
+
+    public required TrxPhase3WriteRole WriteRole { get; init; }
+
+    public required long Offset { get; init; }
+
+    public required int RequestedBytes { get; init; }
+
+    public required int? Cut { get; init; }
+
+    public required int TargetLength { get; init; }
+
+    public required int FlushCount { get; init; }
+
+    public required bool TargetPresent { get; init; }
+
+    public required bool CleanupWasFrozen { get; init; }
+
+    public required TrxDocumentClassification Classification { get; init; }
+
+    public required string Diagnostic { get; init; }
+}
+
+internal sealed class TrxPhase3EvidenceReport
+{
+    public required IReadOnlyList<TrxPhase3EvidenceObservation> Observations { get; init; }
+
+    public required IReadOnlyDictionary<string, IReadOnlyList<TrxFileOperationRecord>> BaselineOperations { get; init; }
+
+    public required IReadOnlyDictionary<TrxDocumentClassification, int> ClassificationCounts { get; init; }
+
+    public required int OperationCaseCount { get; init; }
+
+    public required int ByteCaseCount { get; init; }
+
+    public required string Digest { get; init; }
+
+    public required string Summary { get; init; }
+}
+
+internal static class TrxPhase3EvidenceMatrix
+{
+    internal const string TargetPath = "results.trx";
+    internal const string RecoveryPath = "results.trx.recovery";
+    internal const string MachineName = "phase3-machine";
+    internal const string TestModule = "Phase3.Tests.dll";
+    internal const string FrameworkUid = "phase3-framework";
+    internal const string FrameworkVersion = "1.0.0";
+    internal const string RunName = "phase3-user@phase3-machine 2026-07-20 10:00:00.0000000";
+    internal const int CounterWidth = 3;
+
+    internal static readonly Guid RunId = new("10000000-0000-0000-0000-000000000031");
+    internal static readonly DateTimeOffset StartTime = new(2026, 7, 20, 10, 0, 0, TimeSpan.Zero);
+    internal static readonly DateTimeOffset FinishTime = new(2026, 7, 20, 10, 5, 0, TimeSpan.Zero);
+    internal static readonly string[] PrototypeRootOrder =
+        ["Times", "TestSettings", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary", "Results"];
+
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    public static TrxPhase3EvidenceReport Create()
+    {
+        List<TrxPhase3Scenario> scenarios = CreateScenarios();
+        List<TrxPhase3EvidenceObservation> observations = [];
+        var baselineOperations = new Dictionary<string, IReadOnlyList<TrxFileOperationRecord>>(StringComparer.Ordinal);
+
+        foreach (TrxPhase3Scenario scenario in scenarios)
+        {
+            TrxPhase3Run baseline = Run(scenario, terminationPlan: null, captureSnapshots: true);
+            Assert.IsTrue(baseline.Completed);
+            Assert.AreEqual(
+                TrxDocumentClassification.Truthful,
+                ClassifyBest(scenario, baseline.TargetBytes, operation: null, cut: null).Classification,
+                scenario.Name);
+            baselineOperations.Add(scenario.Name, baseline.Operations);
+
+            observations.Add(CreateBeforeFirstObservation(scenario, baseline.PreActSnapshot));
+            for (int operationIndex = 0; operationIndex < baseline.Operations.Count; operationIndex++)
+            {
+                TrxFileOperationRecord operation = baseline.Operations[operationIndex];
+                observations.Add(RunFaultCase(
+                    scenario,
+                    baseline,
+                    operation,
+                    TrxPhase3EvidenceDimension.Operation,
+                    cut: null));
+
+                if (operation.Kind != TrxFileOperationKind.Write)
+                {
+                    continue;
+                }
+
+                TrxPhase3WriteRole role = InferWriteRole(scenario, baseline, operation);
+                IReadOnlyList<int> cuts = scenario.ExhaustiveRoles.Contains(role)
+                    ? Enumerable.Range(0, operation.RequestedByteCount + 1).ToArray()
+                    : scenario.SelectedRoles.Contains(role)
+                        ? CreateSelectedCuts(GetWrittenBytes(baseline, operation))
+                        : [];
+                foreach (int cut in cuts)
+                {
+                    observations.Add(RunFaultCase(
+                        scenario,
+                        baseline,
+                        operation,
+                        TrxPhase3EvidenceDimension.Byte,
+                        cut));
+                }
+            }
+
+            TrxDocumentObservation successful = ClassifyBest(
+                scenario,
+                baseline.TargetBytes,
+                operation: null,
+                cut: null);
+            observations.Add(new TrxPhase3EvidenceObservation
+            {
+                Scenario = scenario.Name,
+                Dimension = TrxPhase3EvidenceDimension.Successful,
+                OperationIndex = baseline.Operations.Count,
+                OperationKind = null,
+                WriteRole = TrxPhase3WriteRole.None,
+                Offset = 0,
+                RequestedBytes = 0,
+                Cut = null,
+                TargetLength = baseline.TargetBytes.Length,
+                FlushCount = baseline.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush),
+                TargetPresent = baseline.TargetPresent,
+                CleanupWasFrozen = true,
+                Classification = successful.Classification,
+                Diagnostic = CreateStableDiagnostic(
+                    scenario.Name,
+                    TrxPhase3EvidenceDimension.Successful,
+                    baseline.Operations.Count,
+                    null,
+                    TrxPhase3WriteRole.None,
+                    0,
+                    0,
+                    null,
+                    baseline.TargetPresent,
+                    baseline.TargetBytes,
+                    baseline.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush),
+                    successful.Classification),
+            });
+        }
+
+        IReadOnlyDictionary<TrxDocumentClassification, int> counts = Enum
+            .GetValues(typeof(TrxDocumentClassification))
+            .Cast<TrxDocumentClassification>()
+            .ToDictionary(
+                classification => classification,
+                classification => observations.Count(observation => observation.Classification == classification));
+        int operationCases = observations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.Operation);
+        int byteCases = observations.Count(observation => observation.Dimension == TrxPhase3EvidenceDimension.Byte);
+        string digest = ComputeDigest(observations.Select(observation => observation.Diagnostic));
+        string countText = string.Join(
+            ",",
+            counts.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
+        string summary = string.Format(
+            CultureInfo.InvariantCulture,
+            "phase3 scenarios={0}; operations={1}; byteCuts={2}; observations={3}; classifications=[{4}]; digest={5}",
+            scenarios.Count,
+            operationCases,
+            byteCases,
+            observations.Count,
+            countText,
+            digest);
+
+        return new TrxPhase3EvidenceReport
+        {
+            Observations = observations,
+            BaselineOperations = baselineOperations,
+            ClassificationCounts = counts,
+            OperationCaseCount = operationCases,
+            ByteCaseCount = byteCases,
+            Digest = digest,
+            Summary = summary,
+        };
+    }
+
+    public static void AssertOperationCoverage(TrxPhase3EvidenceReport report, string scenario)
+    {
+        IReadOnlyList<TrxFileOperationRecord> baseline = report.BaselineOperations[scenario];
+        TrxPhase3EvidenceObservation[] operationCases =
+        [
+            .. report.Observations.Where(
+                observation => observation.Scenario == scenario
+                    && observation.Dimension == TrxPhase3EvidenceDimension.Operation),
+        ];
+        Assert.HasCount(baseline.Count, operationCases);
+        Assert.AreSequenceEqual(
+            baseline.Select(operation => operation.OperationIndex).ToArray(),
+            operationCases.Select(observation => observation.OperationIndex).ToArray());
+
+        foreach (TrxFileOperationKind required in new[]
+                 {
+                     TrxFileOperationKind.Seek,
+                     TrxFileOperationKind.Write,
+                     TrxFileOperationKind.Flush,
+                 })
+        {
+            if (baseline.Any(operation => operation.Kind == required))
+            {
+                Assert.AreEqual(
+                    baseline.Count(operation => operation.Kind == required),
+                    operationCases.Count(observation => observation.OperationKind == required),
+                    $"{scenario}: {required}");
+            }
+        }
+    }
+
+    public static void AssertEveryByteWasCut(
+        TrxPhase3EvidenceReport report,
+        string scenario,
+        TrxPhase3WriteRole role)
+    {
+        IGrouping<int, TrxPhase3EvidenceObservation>[] writes =
+        [
+            .. report.Observations
+                .Where(observation => observation.Scenario == scenario
+                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                    && observation.WriteRole == role)
+                .GroupBy(observation => observation.OperationIndex),
+        ];
+        Assert.IsNotEmpty(writes, $"{scenario}: {role}");
+        foreach (IGrouping<int, TrxPhase3EvidenceObservation> write in writes)
+        {
+            int requested = write.First().RequestedBytes;
+            Assert.AreSequenceEqual(
+                Enumerable.Range(0, requested + 1).ToArray(),
+                write.Select(observation => observation.Cut!.Value).OrderBy(value => value).ToArray(),
+                $"{scenario}: operation {write.Key}, role {role}");
+        }
+    }
+
+    public static void AssertSelectedLargeCuts(
+        TrxPhase3EvidenceReport report,
+        string scenario,
+        int operationIndex)
+    {
+        int[] cuts =
+        [
+            .. report.Observations
+                .Where(observation => observation.Scenario == scenario
+                    && observation.OperationIndex == operationIndex
+                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte)
+                .Select(observation => observation.Cut!.Value)
+                .OrderBy(value => value),
+        ];
+        Assert.IsNotEmpty(cuts);
+        int requested = report.Observations.First(
+            observation => observation.Scenario == scenario
+                && observation.OperationIndex == operationIndex
+                && observation.Dimension == TrxPhase3EvidenceDimension.Byte).RequestedBytes;
+        Assert.Contains(0, cuts);
+        Assert.Contains(1, cuts);
+        Assert.Contains(requested - 1, cuts);
+        Assert.Contains(requested, cuts);
+        if (requested > 513)
+        {
+            Assert.Contains(511, cuts);
+            Assert.Contains(512, cuts);
+            Assert.Contains(513, cuts);
+        }
+
+        if (requested > 4_097)
+        {
+            Assert.Contains(4_095, cuts);
+            Assert.Contains(4_096, cuts);
+            Assert.Contains(4_097, cuts);
+        }
+    }
+
+    public static void AssertEveryCounterCellWasCut(TrxPhase3EvidenceReport report, string scenario)
+    {
+        IGrouping<int, TrxPhase3EvidenceObservation>[] cells =
+        [
+            .. report.Observations
+                .Where(observation => observation.Scenario == scenario
+                    && observation.Dimension == TrxPhase3EvidenceDimension.Byte
+                    && observation.WriteRole == TrxPhase3WriteRole.Counter)
+                .GroupBy(observation => observation.OperationIndex),
+        ];
+        Assert.HasCount(7, cells);
+        foreach (IGrouping<int, TrxPhase3EvidenceObservation> cell in cells)
+        {
+            Assert.AreSequenceEqual(
+                Enumerable.Range(0, CounterWidth + 1).ToArray(),
+                cell.Select(observation => observation.Cut!.Value).OrderBy(value => value).ToArray());
+        }
+    }
+
+    public static void AssertEntryOverflowIsRejectedBeforeMutation()
+    {
+        TrxTestResult result = CreateResult(41, "entry-overflow", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(41);
+        int entryBytes = TrxPrototypeXmlRenderer.RenderEntry(result.Uid, executionId).Length;
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false, recordOperations: false);
+        TrxIncrementalWriterPrototype writer = CreateWriter(
+            operations,
+            definitionPadBytes: 2_048,
+            entryPadBytes: entryBytes - 1);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+        byte[] before = operations.GetFileBytes(TargetPath);
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() => writer.AppendCompleted(result, executionId));
+
+        Assert.IsEmpty(operations.Operations);
+        Assert.AreSequenceEqual(before, operations.GetFileBytes(TargetPath));
+    }
+
+    public static void AssertRunningValidationFailuresDoNotMutate()
+    {
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false, recordOperations: false);
+        TrxIncrementalWriterPrototype writer = CreateWriter(operations, runningSlotCount: 1, runningSlotByteCapacity: 320);
+        writer.Initialize();
+        Guid runningExecution = ExecutionId(51);
+        int slot = writer.ClaimRunning(TestId(51), "running-one", runningExecution, StartTime);
+        operations.BeginFaultWindow(terminationPlan: null);
+        byte[] before = operations.GetFileBytes(TargetPath);
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => writer.ClaimRunning(TestId(52), "overflow", ExecutionId(52), StartTime));
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => writer.ClaimRunning(TestId(51), "duplicate", runningExecution, StartTime));
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => writer.AppendCompleted(CreateResult(52, "not-claimed", TrxTestOutcome.Passed), ExecutionId(52), slot));
+
+        Assert.IsEmpty(operations.Operations);
+        Assert.AreSequenceEqual(before, operations.GetFileBytes(TargetPath));
+    }
+
+    internal static TrxIncrementalWriterPrototype CreateWriter(
+        ITrxPrototypeFileOperations operations,
+        int definitionPadBytes = 4_096,
+        int entryPadBytes = 2_048,
+        int summaryPadBytes = 2_048,
+        int counterWidth = CounterWidth,
+        int runningSlotCount = 2,
+        int runningSlotByteCapacity = 320)
+        => new(
+            operations,
+            TargetPath,
+            RunId,
+            RunName,
+            MachineName,
+            TestModule,
+            FrameworkUid,
+            FrameworkVersion,
+            StartTime,
+            definitionPadBytes,
+            entryPadBytes,
+            summaryPadBytes,
+            counterWidth,
+            runningSlotCount,
+            runningSlotByteCapacity);
+
+    internal static TrxDocumentExpectation CreateExpectation(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        IReadOnlyList<TrxExpectedRunningTest>? running = null,
+        DateTimeOffset? finishTime = null,
+        string summaryOutcome = "Failed")
+    {
+        var expected = new TrxExpectedResult[results.Count];
+        for (int i = 0; i < results.Count; i++)
+        {
+            expected[i] = TrxExpectedResultFactory.Create(
+                results[i],
+                executionIds[i],
+                MachineName,
+                TestModule,
+                FrameworkUid,
+                FrameworkVersion,
+                finishTime ?? StartTime);
+        }
+
+        return new TrxDocumentExpectation
+        {
+            RunId = RunId,
+            RunName = RunName,
+            StartTime = StartTime,
+            FinishTime = finishTime ?? StartTime,
+            SummaryOutcome = summaryOutcome,
+            CompletedResults = expected,
+            RunningTests = running ?? [],
+            RootChildOrder = PrototypeRootOrder,
+        };
+    }
+
+    internal static TrxTestResult CreateResult(
+        int number,
+        string displayName,
+        TrxTestOutcome outcome,
+        string? definitionName = null,
+        IReadOnlyList<TrxTestMetadata>? metadata = null,
+        IReadOnlyList<string>? categories = null,
+        IReadOnlyList<TrxStreamMessage>? messages = null)
+        => new()
+        {
+            Uid = TestId(number),
+            DisplayName = displayName,
+            Outcome = outcome,
+            StartTime = StartTime.AddSeconds(number),
+            EndTime = StartTime.AddSeconds(number + 1),
+            Duration = TimeSpan.FromSeconds(1),
+            TrxTestDefinitionName = definitionName ?? displayName,
+            TrxFullyQualifiedTypeName = "Phase3.ContractTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Phase3",
+                TypeName = "ContractTests",
+                MethodName = definitionName ?? displayName,
+            },
+            Metadata = metadata,
+            Categories = categories,
+            Messages = messages,
+        };
+
+    internal static string TestId(int value) => $"20000000-0000-0000-0000-{value:D12}";
+
+    internal static Guid ExecutionId(int value) => new($"30000000-0000-0000-0000-{value:D12}");
+
+    private static List<TrxPhase3Scenario> CreateScenarios()
+    {
+        List<TrxPhase3Scenario> scenarios = [];
+        TrxDocumentExpectation empty = CreateExpectation([], []);
+        byte[] initialSmall = TrxPrototypeXmlRenderer.RenderInitial(
+            RunId,
+            RunName,
+            StartTime,
+            definitionPadBytes: 32,
+            entryPadBytes: 32,
+            summaryPadBytes: 32,
+            counterWidth: CounterWidth,
+            runningSlotCount: 0,
+            runningSlotByteCapacity: 1);
+        scenarios.Add(new TrxPhase3Scenario(
+            "startup-absent",
+            empty,
+            empty,
+            _ => { },
+            writer => writer.Initialize(),
+            definitionPadBytes: 32,
+            entryPadBytes: 32,
+            summaryPadBytes: 32,
+            runningSlotCount: 0,
+            runningSlotByteCapacity: 1,
+            exhaustiveRoles: [TrxPhase3WriteRole.StartupDocument]));
+        scenarios.Add(new TrxPhase3Scenario(
+            "startup-existing",
+            empty,
+            empty,
+            _ => { },
+            writer => writer.Initialize(),
+            definitionPadBytes: 32,
+            entryPadBytes: 32,
+            summaryPadBytes: 32,
+            runningSlotCount: 0,
+            runningSlotByteCapacity: 1,
+            seedTarget: initialSmall,
+            selectedRoles: [TrxPhase3WriteRole.StartupDocument]));
+        scenarios.Add(new TrxPhase3Scenario(
+            "startup-recoverable",
+            empty,
+            empty,
+            _ => { },
+            writer => writer.Initialize(),
+            definitionPadBytes: 32,
+            entryPadBytes: 32,
+            summaryPadBytes: 32,
+            runningSlotCount: 0,
+            runningSlotByteCapacity: 1,
+            seedTarget: initialSmall,
+            recoveryBytes: initialSmall,
+            selectedRoles: [TrxPhase3WriteRole.StartupDocument]));
+
+        AddTailScenario(scenarios, "tail-zero-prior", priorCount: 0, resultNumber: 1);
+        AddTailScenario(scenarios, "tail-one-prior", priorCount: 1, resultNumber: 2);
+        AddTailScenario(scenarios, "tail-many-prior", priorCount: 3, resultNumber: 4);
+
+        TrxTestResult smallDefinition = CreateResult(
+            11,
+            "definition <&> é漢😀",
+            TrxTestOutcome.Passed,
+            metadata: [new TrxTestMetadata { Key = "Owner", Value = "Zoë <owner>" }],
+            categories: ["fast", "unicode-漢"]);
+        AddAppendScenario(
+            scenarios,
+            "definition-small",
+            [],
+            [],
+            smallDefinition,
+            ExecutionId(11),
+            exhaustiveRoles: [TrxPhase3WriteRole.Definition]);
+
+        string largeMetadataValue = string.Concat("é漢😀<&>", new string('界', 260));
+        TrxTestResult largeDefinition = CreateResult(
+            12,
+            "large-definition",
+            TrxTestOutcome.Passed,
+            metadata:
+            [
+                new TrxTestMetadata { Key = "Owner", Value = "Zoë" },
+                new TrxTestMetadata { Key = "Description", Value = largeMetadataValue },
+                new TrxTestMetadata { Key = "Custom<&>", Value = largeMetadataValue },
+            ],
+            categories: ["large", "unicode-漢"]);
+        AddAppendScenario(
+            scenarios,
+            "definition-large-metadata",
+            [],
+            [],
+            largeDefinition,
+            ExecutionId(12),
+            definitionPadBytes: 4_096,
+            selectedRoles: [TrxPhase3WriteRole.Definition]);
+
+        AddAppendScenario(
+            scenarios,
+            "entry-unique",
+            [],
+            [],
+            CreateResult(13, "entry-unique", TrxTestOutcome.Passed),
+            ExecutionId(13),
+            exhaustiveRoles: [TrxPhase3WriteRole.Entry]);
+
+        TrxTestResult repeatedFirst = CreateResult(14, "repeat[1]", TrxTestOutcome.Passed, "Repeated.Definition");
+        TrxTestResult repeatedSecond = CreateResult(14, "repeat[2]", TrxTestOutcome.Passed, "Repeated.Definition");
+        AddAppendScenario(
+            scenarios,
+            "entry-repeated",
+            [repeatedFirst],
+            [ExecutionId(14)],
+            repeatedSecond,
+            ExecutionId(15),
+            exhaustiveRoles: [TrxPhase3WriteRole.Entry]);
+
+        TrxTestResult exactEntry = CreateResult(16, "entry-boundary", TrxTestOutcome.Passed);
+        int exactEntryBytes = TrxPrototypeXmlRenderer.RenderEntry(exactEntry.Uid, ExecutionId(16)).Length;
+        AddAppendScenario(
+            scenarios,
+            "entry-exact-boundary",
+            [],
+            [],
+            exactEntry,
+            ExecutionId(16),
+            entryPadBytes: exactEntryBytes,
+            exhaustiveRoles: [TrxPhase3WriteRole.Entry]);
+
+        AddCounterScenario(scenarios, "counter-0-to-1", priorCount: 0, exhaustive: true);
+        AddCounterScenario(scenarios, "counter-9-to-10", priorCount: 9, exhaustive: false);
+        AddCounterScenario(scenarios, "counter-99-to-100", priorCount: 99, exhaustive: false);
+
+        scenarios.Add(CreateTimestampScenario());
+        scenarios.Add(CreateOutcomeScenario());
+        scenarios.Add(CreateSummaryScenario());
+        scenarios.Add(CreateRunningClaimScenario("running-claim", hasPriorClaim: false));
+        scenarios.Add(CreateRunningClaimScenario("running-second-claim", hasPriorClaim: true));
+        scenarios.Add(CreateRunningReleaseScenario());
+        scenarios.Add(CreateLargePayloadScenario());
+        return scenarios;
+    }
+
+    private static void AddTailScenario(
+        List<TrxPhase3Scenario> scenarios,
+        string name,
+        int priorCount,
+        int resultNumber)
+    {
+        List<TrxTestResult> prior = [];
+        List<Guid> priorExecutions = [];
+        for (int i = 1; i <= priorCount; i++)
+        {
+            prior.Add(CreateResult(i, $"prior-{i}", TrxTestOutcome.Passed, $"Prior.{i}"));
+            priorExecutions.Add(ExecutionId(i));
+        }
+
+        TrxTestResult result = CreateResult(resultNumber, $"tail-{resultNumber}", TrxTestOutcome.Passed, $"Tail.{resultNumber}");
+        AddAppendScenario(
+            scenarios,
+            name,
+            prior,
+            priorExecutions,
+            result,
+            ExecutionId(100 + resultNumber),
+            exhaustiveRoles: [TrxPhase3WriteRole.ResultTail]);
+    }
+
+    private static void AddAppendScenario(
+        List<TrxPhase3Scenario> scenarios,
+        string name,
+        IReadOnlyList<TrxTestResult> prior,
+        IReadOnlyList<Guid> priorExecutions,
+        TrxTestResult result,
+        Guid executionId,
+        int definitionPadBytes = 4_096,
+        int entryPadBytes = 2_048,
+        IReadOnlyList<TrxPhase3WriteRole>? exhaustiveRoles = null,
+        IReadOnlyList<TrxPhase3WriteRole>? selectedRoles = null)
+    {
+        TrxTestResult[] afterResults = [.. prior, result];
+        Guid[] afterExecutions = [.. priorExecutions, executionId];
+        scenarios.Add(new TrxPhase3Scenario(
+            name,
+            CreateExpectation(prior, priorExecutions),
+            CreateExpectation(afterResults, afterExecutions),
+            writer =>
+            {
+                writer.Initialize();
+                for (int i = 0; i < prior.Count; i++)
+                {
+                    writer.AppendCompleted(prior[i], priorExecutions[i]);
+                }
+            },
+            writer => writer.AppendCompleted(result, executionId),
+            definitionPadBytes: definitionPadBytes,
+            entryPadBytes: entryPadBytes,
+            exhaustiveRoles: exhaustiveRoles,
+            selectedRoles: selectedRoles));
+    }
+
+    private static void AddCounterScenario(
+        List<TrxPhase3Scenario> scenarios,
+        string name,
+        int priorCount,
+        bool exhaustive)
+    {
+        List<TrxTestResult> prior = [];
+        List<Guid> priorExecutions = [];
+        for (int i = 1; i <= priorCount; i++)
+        {
+            prior.Add(CreateResult(21, $"counter[{i}]", TrxTestOutcome.Passed, "Counter.Definition"));
+            priorExecutions.Add(ExecutionId(200 + i));
+        }
+
+        TrxTestResult next = CreateResult(21, $"counter[{priorCount + 1}]", TrxTestOutcome.Passed, "Counter.Definition");
+        AddAppendScenario(
+            scenarios,
+            name,
+            prior,
+            priorExecutions,
+            next,
+            ExecutionId(200 + priorCount + 1),
+            definitionPadBytes: 1_024,
+            entryPadBytes: 24_000,
+            exhaustiveRoles: exhaustive ? [TrxPhase3WriteRole.Counter] : null,
+            selectedRoles: exhaustive ? null : [TrxPhase3WriteRole.Counter]);
+    }
+
+    private static TrxPhase3Scenario CreateTimestampScenario()
+    {
+        DateTimeOffset finish = new(2026, 7, 20, 15, 45, 30, TimeSpan.FromHours(-4));
+        return new TrxPhase3Scenario(
+            "finish-timestamp",
+            CreateExpectation([], []),
+            CreateExpectation([], [], finishTime: finish),
+            writer => writer.Initialize(),
+            writer => writer.UpdateFinishTime(finish),
+            exhaustiveRoles: [TrxPhase3WriteRole.Timestamp]);
+    }
+
+    private static TrxPhase3Scenario CreateOutcomeScenario()
+    {
+        TrxTestResult result = CreateResult(22, "clean-complete", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(22);
+        return new TrxPhase3Scenario(
+            "clean-outcome",
+            CreateExpectation([result], [executionId]),
+            CreateExpectation([result], [executionId], finishTime: FinishTime, summaryOutcome: "Completed"),
+            writer =>
+            {
+                writer.Initialize();
+                writer.AppendCompleted(result, executionId);
+            },
+            writer => writer.Complete(new TrxPrototypeCompletion { FinishTime = FinishTime }),
+            exhaustiveRoles: [TrxPhase3WriteRole.Timestamp, TrxPhase3WriteRole.Outcome]);
+    }
+
+    private static TrxPhase3Scenario CreateSummaryScenario()
+    {
+        TrxTestResult result = CreateResult(23, "crash-summary", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(23);
+        return new TrxPhase3Scenario(
+            "summary-crash-details",
+            CreateExpectation([result], [executionId]),
+            CreateExpectation([result], [executionId], finishTime: FinishTime),
+            writer =>
+            {
+                writer.Initialize();
+                writer.AppendCompleted(result, executionId);
+            },
+            writer => writer.Complete(
+                new TrxPrototypeCompletion
+                {
+                    FinishTime = FinishTime,
+                    IsTestHostCrashed = true,
+                    ExitCode = 17,
+                    CrashText = "host crashed <&> 😀",
+                    CollectorAttachmentHrefs = ["collector/first.bin", "collector/second.bin"],
+                    AttachmentWarnings = ["warning one", "warning two"],
+                }),
+            selectedRoles: [TrxPhase3WriteRole.Summary]);
+    }
+
+    private static TrxPhase3Scenario CreateRunningClaimScenario(string name, bool hasPriorClaim)
+    {
+        const int slotCapacity = 320;
+        Guid firstExecution = ExecutionId(31);
+        Guid secondExecution = ExecutionId(32);
+        string firstName = "first-running";
+        string longSecondName = string.Concat("prefix<&>é漢😀", new string('界', 80), "😀tail");
+        string renderedSecondName = ReadRunningName(
+            new TrxPrototypeXmlRenderer(MachineName, TestModule, FrameworkUid, FrameworkVersion)
+                .RenderRunningSlot(TestId(32), longSecondName, secondExecution, StartTime, slotCapacity));
+        TrxExpectedRunningTest first = CreateExpectedRunning(31, firstExecution, firstName);
+        TrxExpectedRunningTest second = CreateExpectedRunning(32, secondExecution, renderedSecondName);
+
+        return new TrxPhase3Scenario(
+            name,
+            CreateExpectation([], [], hasPriorClaim ? [first] : []),
+            CreateExpectation([], [], hasPriorClaim ? [first, second] : [second]),
+            writer =>
+            {
+                writer.Initialize();
+                if (hasPriorClaim)
+                {
+                    _ = writer.ClaimRunning(TestId(31), firstName, firstExecution, StartTime);
+                }
+            },
+            writer => _ = writer.ClaimRunning(TestId(32), longSecondName, secondExecution, StartTime),
+            runningSlotCount: 2,
+            runningSlotByteCapacity: slotCapacity,
+            exhaustiveRoles: [TrxPhase3WriteRole.RunningSlot]);
+    }
+
+    private static TrxPhase3Scenario CreateRunningReleaseScenario()
+    {
+        const int slotCapacity = 320;
+        TrxTestResult result = CreateResult(33, "release-running", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(33);
+        TrxExpectedRunningTest running = CreateExpectedRunning(33, executionId, result.DisplayName);
+        return new TrxPhase3Scenario(
+            "running-release",
+            CreateExpectation([], [], [running]),
+            CreateExpectation([result], [executionId]),
+            writer =>
+            {
+                writer.Initialize();
+                _ = writer.ClaimRunning(result.Uid, result.DisplayName, executionId, StartTime);
+            },
+            writer => writer.AppendCompleted(result, executionId, runningSlot: 0),
+            runningSlotCount: 1,
+            runningSlotByteCapacity: slotCapacity,
+            exhaustiveRoles: [TrxPhase3WriteRole.RunningSlotClear]);
+    }
+
+    private static TrxPhase3Scenario CreateLargePayloadScenario()
+    {
+        string payload = string.Concat(
+            "begin<&>é漢😀",
+            new string('x', 5_200),
+            "<middle>&amp;",
+            new string('y', 3_000),
+            "😀end");
+        string metadata = string.Concat("metadata<&>é漢😀", new string('界', 300));
+        TrxTestResult result = CreateResult(
+            34,
+            "large-payload",
+            TrxTestOutcome.Failed,
+            metadata:
+            [
+                new TrxTestMetadata { Key = "Description", Value = metadata },
+                new TrxTestMetadata { Key = "Custom<&>", Value = metadata },
+            ],
+            messages:
+            [
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = payload },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardError, Message = payload },
+            ]);
+        Guid executionId = ExecutionId(34);
+        return new TrxPhase3Scenario(
+            "large-payload",
+            CreateExpectation([], []),
+            CreateExpectation([result], [executionId]),
+            writer => writer.Initialize(),
+            writer => writer.AppendCompleted(result, executionId),
+            definitionPadBytes: 4_096,
+            selectedRoles: [TrxPhase3WriteRole.Definition, TrxPhase3WriteRole.ResultTail]);
+    }
+
+    private static TrxExpectedRunningTest CreateExpectedRunning(int number, Guid executionId, string displayName)
+        => new()
+        {
+            TestId = Guid.Parse(TestId(number)).ToString(),
+            ExecutionId = executionId.ToString(),
+            TestName = displayName,
+            ComputerName = MachineName,
+            StartTime = StartTime,
+        };
+
+    private static string ReadRunningName(byte[] slot)
+    {
+        string xml = StrictUtf8.GetString(slot).TrimEnd();
+        return XElement.Parse(xml).Attribute("testName")!.Value;
+    }
+
+    private static TrxPhase3Run Run(
+        TrxPhase3Scenario scenario,
+        TrxTerminationPlan? terminationPlan,
+        bool captureSnapshots)
+    {
+        var operations = new TrxFaultInjectingFileOperations(
+            terminationPlan: null,
+            captureSnapshots: captureSnapshots,
+            recordOperations: false);
+        if (scenario.SeedTarget is not null)
+        {
+            operations.SeedFile(TargetPath, scenario.SeedTarget);
+        }
+
+        if (scenario.RecoveryBytes is not null)
+        {
+            operations.SeedFile(RecoveryPath, scenario.RecoveryBytes);
+        }
+
+        TrxIncrementalWriterPrototype writer = CreateWriter(
+            operations,
+            scenario.DefinitionPadBytes,
+            scenario.EntryPadBytes,
+            scenario.SummaryPadBytes,
+            CounterWidth,
+            scenario.RunningSlotCount,
+            scenario.RunningSlotByteCapacity);
+        scenario.Setup(writer);
+        TrxVirtualFileSystemSnapshot preAct = operations.CaptureSnapshot();
+        operations.BeginFaultWindow(terminationPlan);
+        bool completed = false;
+        try
+        {
+            scenario.Act(writer);
+            completed = true;
+        }
+        catch (TrxSimulatedProcessTerminationException)
+        {
+            if (terminationPlan is null)
+            {
+                throw;
+            }
+        }
+
+        TrxVirtualFileSystemSnapshot frozen = operations.CaptureSnapshot();
+        return new TrxPhase3Run(
+            operations,
+            preAct,
+            frozen,
+            completed,
+            frozen.Contains(TargetPath) ? frozen.GetFileBytes(TargetPath) : []);
+    }
+
+    private static TrxPhase3EvidenceObservation CreateBeforeFirstObservation(
+        TrxPhase3Scenario scenario,
+        TrxVirtualFileSystemSnapshot preAct)
+    {
+        bool present = preAct.Contains(TargetPath);
+        byte[] bytes = present ? preAct.GetFileBytes(TargetPath) : [];
+        TrxDocumentObservation classification = ClassifyBest(scenario, bytes, operation: null, cut: null, useBeforeOnly: true);
+        return new TrxPhase3EvidenceObservation
+        {
+            Scenario = scenario.Name,
+            Dimension = TrxPhase3EvidenceDimension.BeforeFirst,
+            OperationIndex = -1,
+            OperationKind = null,
+            WriteRole = TrxPhase3WriteRole.None,
+            Offset = 0,
+            RequestedBytes = 0,
+            Cut = null,
+            TargetLength = bytes.Length,
+            FlushCount = 0,
+            TargetPresent = present,
+            CleanupWasFrozen = true,
+            Classification = classification.Classification,
+            Diagnostic = CreateStableDiagnostic(
+                scenario.Name,
+                TrxPhase3EvidenceDimension.BeforeFirst,
+                -1,
+                null,
+                TrxPhase3WriteRole.None,
+                0,
+                0,
+                null,
+                present,
+                bytes,
+                0,
+                classification.Classification),
+        };
+    }
+
+    private static TrxPhase3EvidenceObservation RunFaultCase(
+        TrxPhase3Scenario scenario,
+        TrxPhase3Run baseline,
+        TrxFileOperationRecord baselineOperation,
+        TrxPhase3EvidenceDimension dimension,
+        int? cut)
+    {
+        var plan = new TrxTerminationPlan(baselineOperation.OperationIndex, cut);
+        TrxPhase3Run fault = Run(scenario, plan, captureSnapshots: false);
+        Assert.IsFalse(fault.Completed);
+        Assert.IsTrue(fault.OperationsOwner.IsProcessDead);
+        Assert.HasCount(baselineOperation.OperationIndex + 1, fault.Operations);
+        TrxFileOperationRecord actualOperation = fault.Operations[fault.Operations.Count - 1];
+        Assert.AreEqual(baselineOperation.Kind, actualOperation.Kind);
+        Assert.AreEqual(baselineOperation.PrePosition, actualOperation.PrePosition);
+        Assert.AreEqual(baselineOperation.RequestedByteCount, actualOperation.RequestedByteCount);
+        Assert.AreEqual(
+            cut ?? baselineOperation.RequestedByteCount,
+            actualOperation.CommittedByteCount);
+
+        byte[] expectedBytes = CreateExpectedFrozenBytes(
+            baseline,
+            baselineOperation,
+            cut,
+            out bool expectedPresent);
+        Assert.AreEqual(expectedPresent, fault.TargetPresent);
+        Assert.AreSequenceEqual(expectedBytes, fault.TargetBytes);
+
+        int operationCount = fault.Operations.Count;
+        string beforeRejectedCleanup = fault.FrozenSnapshot.ToString();
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => fault.OperationsOwner.Delete(TargetPath));
+        bool cleanupFrozen = operationCount == fault.Operations.Count
+            && string.Equals(beforeRejectedCleanup, fault.OperationsOwner.CaptureSnapshot().ToString(), StringComparison.Ordinal);
+        Assert.IsTrue(cleanupFrozen);
+
+        TrxPhase3WriteRole role = baselineOperation.Kind == TrxFileOperationKind.Write
+            ? InferWriteRole(scenario, baseline, baselineOperation)
+            : TrxPhase3WriteRole.None;
+        TrxDocumentObservation classification = ClassifyBest(scenario, fault.TargetBytes, baselineOperation, cut);
+        int flushes = fault.Operations.Count(operation => operation.Kind == TrxFileOperationKind.Flush);
+        long offset = baselineOperation.PrePosition ?? 0;
+        string diagnostic = CreateStableDiagnostic(
+            scenario.Name,
+            dimension,
+            baselineOperation.OperationIndex,
+            baselineOperation.Kind,
+            role,
+            offset,
+            baselineOperation.RequestedByteCount,
+            cut,
+            fault.TargetPresent,
+            fault.TargetBytes,
+            flushes,
+            classification.Classification);
+        return new TrxPhase3EvidenceObservation
+        {
+            Scenario = scenario.Name,
+            Dimension = dimension,
+            OperationIndex = baselineOperation.OperationIndex,
+            OperationKind = baselineOperation.Kind,
+            WriteRole = role,
+            Offset = offset,
+            RequestedBytes = baselineOperation.RequestedByteCount,
+            Cut = cut,
+            TargetLength = fault.TargetBytes.Length,
+            FlushCount = flushes,
+            TargetPresent = fault.TargetPresent,
+            CleanupWasFrozen = cleanupFrozen,
+            Classification = classification.Classification,
+            Diagnostic = diagnostic,
+        };
+    }
+
+    private static byte[] CreateExpectedFrozenBytes(
+        TrxPhase3Run baseline,
+        TrxFileOperationRecord operation,
+        int? cut,
+        out bool targetPresent)
+    {
+        TrxVirtualFileSystemSnapshot before = operation.OperationIndex == 0
+            ? baseline.PreActSnapshot
+            : baseline.Snapshots[operation.OperationIndex - 1];
+        TrxVirtualFileSystemSnapshot after = baseline.Snapshots[operation.OperationIndex];
+        targetPresent = after.Contains(TargetPath);
+        if (!targetPresent)
+        {
+            return [];
+        }
+
+        if (operation.Kind != TrxFileOperationKind.Write || cut is null)
+        {
+            return after.GetFileBytes(TargetPath);
+        }
+
+        byte[] beforeBytes = before.Contains(TargetPath) ? before.GetFileBytes(TargetPath) : [];
+        byte[] afterBytes = after.GetFileBytes(TargetPath);
+        int committed = cut.Value;
+        long offset = operation.PrePosition!.Value;
+        long requiredLength = offset + committed;
+        if (requiredLength > beforeBytes.LongLength)
+        {
+            Array.Resize(ref beforeBytes, checked((int)requiredLength));
+        }
+
+        if (committed > 0)
+        {
+            Array.Copy(afterBytes, offset, beforeBytes, offset, committed);
+        }
+
+        return beforeBytes;
+    }
+
+    private static TrxDocumentObservation ClassifyBest(
+        TrxPhase3Scenario scenario,
+        byte[] bytes,
+        TrxFileOperationRecord? operation,
+        int? cut,
+        bool useBeforeOnly = false)
+    {
+        var beforeContext = new TrxDocumentObservationContext
+        {
+            OperationIndex = operation?.OperationIndex,
+            OperationKind = operation?.Kind.ToString(),
+            CommittedByteCount = cut,
+            PreviousTargetLength = operation?.PreLength,
+            PublishedEventSequenceNumber = 0,
+            LatestEventSequenceNumber = 1,
+        };
+        TrxDocumentObservation before = TrxDocumentClassifier.Classify(
+            bytes,
+            scenario.BeforeExpectation,
+            beforeContext,
+            scenario.RecoveryBytes);
+        if (useBeforeOnly || before.Classification == TrxDocumentClassification.Truthful)
+        {
+            return before;
+        }
+
+        var afterContext = new TrxDocumentObservationContext
+        {
+            OperationIndex = operation?.OperationIndex,
+            OperationKind = operation?.Kind.ToString(),
+            CommittedByteCount = cut,
+            PreviousTargetLength = operation?.PreLength,
+            PublishedEventSequenceNumber = 1,
+            LatestEventSequenceNumber = 1,
+        };
+        TrxDocumentObservation after = TrxDocumentClassifier.Classify(
+            bytes,
+            scenario.AfterExpectation,
+            afterContext,
+            scenario.RecoveryBytes);
+        return after.Classification == TrxDocumentClassification.Truthful
+            ? after
+            : before.Classification == TrxDocumentClassification.Repairable
+                ? before
+                : after.Classification == TrxDocumentClassification.Repairable
+                    ? after
+                    : before.Classification == TrxDocumentClassification.ParseableInconsistent
+                        ? before
+                        : after.Classification == TrxDocumentClassification.ParseableInconsistent ? after : before;
+    }
+
+    private static TrxPhase3WriteRole InferWriteRole(
+        TrxPhase3Scenario scenario,
+        TrxPhase3Run baseline,
+        TrxFileOperationRecord operation)
+    {
+        byte[] written = GetWrittenBytes(baseline, operation);
+        string text;
+        try
+        {
+            text = StrictUtf8.GetString(written);
+        }
+        catch (DecoderFallbackException)
+        {
+            return TrxPhase3WriteRole.Unknown;
+        }
+
+        return written switch
+        {
+            _ when scenario.Name.StartsWith("startup-", StringComparison.Ordinal)
+                => TrxPhase3WriteRole.StartupDocument,
+            _ when written.Length == CounterWidth
+                && written.All(value => value is >= (byte)'0' and <= (byte)'9')
+                => TrxPhase3WriteRole.Counter,
+            _ when written.Length == 10
+                && (text.StartsWith("Completed\"", StringComparison.Ordinal)
+                    || text.StartsWith("Failed\"", StringComparison.Ordinal))
+                => TrxPhase3WriteRole.Outcome,
+            _ when DateTimeOffset.TryParse(
+                text,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.RoundtripKind,
+                out _)
+                => TrxPhase3WriteRole.Timestamp,
+            _ when written.All(value => value == (byte)' ')
+                && written.Length == scenario.RunningSlotByteCapacity
+                => TrxPhase3WriteRole.RunningSlotClear,
+            _ when text.Contains("<UnitTestResult", StringComparison.Ordinal)
+                && text.Contains("outcome=\"InProgress\"", StringComparison.Ordinal)
+                && written.Length == scenario.RunningSlotByteCapacity
+                => TrxPhase3WriteRole.RunningSlot,
+            _ when text.Contains("</Results></TestRun>", StringComparison.Ordinal)
+                => TrxPhase3WriteRole.ResultTail,
+            _ when text.StartsWith("<UnitTest ", StringComparison.Ordinal)
+                => TrxPhase3WriteRole.Definition,
+            _ when text.StartsWith("<TestEntry ", StringComparison.Ordinal)
+                => TrxPhase3WriteRole.Entry,
+            _ when text.StartsWith("<CollectorDataEntries", StringComparison.Ordinal)
+                || text.StartsWith("<RunInfos", StringComparison.Ordinal)
+                => TrxPhase3WriteRole.Summary,
+            _ => TrxPhase3WriteRole.Unknown,
+        };
+    }
+
+    private static byte[] GetWrittenBytes(TrxPhase3Run baseline, TrxFileOperationRecord operation)
+    {
+        byte[] after = baseline.Snapshots[operation.OperationIndex].GetFileBytes(TargetPath);
+        byte[] written = new byte[operation.RequestedByteCount];
+        Array.Copy(after, operation.PrePosition!.Value, written, 0, written.Length);
+        return written;
+    }
+
+    private static IReadOnlyList<int> CreateSelectedCuts(byte[] bytes)
+    {
+        var cuts = new SortedSet<int>
+        {
+            0,
+            Math.Min(1, bytes.Length),
+            Math.Max(0, bytes.Length - 1),
+            bytes.Length,
+        };
+        AddNearby(cuts, bytes.Length, 512);
+        AddNearby(cuts, bytes.Length, 4_096);
+
+        List<int> utf8Boundaries = [];
+        List<int> delimiters = [];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            byte value = bytes[i];
+            if ((value & 0xC0) == 0xC0 || (i > 0 && (value & 0xC0) != 0x80 && (bytes[i - 1] & 0x80) != 0))
+            {
+                utf8Boundaries.Add(i);
+            }
+
+            if (value is (byte)'<' or (byte)'>' or (byte)'&' or (byte)';' or (byte)'"')
+            {
+                delimiters.Add(i);
+                delimiters.Add(i + 1);
+            }
+        }
+
+        AddFirstAndLast(cuts, utf8Boundaries, bytes.Length);
+        AddFirstAndLast(cuts, delimiters, bytes.Length);
+        return [.. cuts];
+    }
+
+    private static void AddNearby(SortedSet<int> cuts, int length, int boundary)
+    {
+        for (int delta = -1; delta <= 1; delta++)
+        {
+            int value = boundary + delta;
+            if (value >= 0 && value <= length)
+            {
+                _ = cuts.Add(value);
+            }
+        }
+    }
+
+    private static void AddFirstAndLast(SortedSet<int> cuts, IReadOnlyList<int> candidates, int length)
+    {
+        foreach (int value in candidates.Take(6).Concat(candidates.Skip(Math.Max(0, candidates.Count - 6))))
+        {
+            for (int delta = -1; delta <= 1; delta++)
+            {
+                int candidate = value + delta;
+                if (candidate >= 0 && candidate <= length)
+                {
+                    _ = cuts.Add(candidate);
+                }
+            }
+        }
+    }
+
+    private static string CreateStableDiagnostic(
+        string scenario,
+        TrxPhase3EvidenceDimension dimension,
+        int operationIndex,
+        TrxFileOperationKind? operationKind,
+        TrxPhase3WriteRole role,
+        long offset,
+        int requestedBytes,
+        int? cut,
+        bool targetPresent,
+        byte[] targetBytes,
+        int flushCount,
+        TrxDocumentClassification classification)
+        => string.Format(
+            CultureInfo.InvariantCulture,
+            "scenario={0}; dimension={1}; operation={2:D3}:{3}; role={4}; offset={5}; requested={6}; cut={7}; targetPresent={8}; targetLength={9}; flushes={10}; classification={11}; window={12}",
+            scenario,
+            dimension,
+            operationIndex,
+            operationKind?.ToString() ?? "-",
+            role,
+            offset,
+            requestedBytes,
+            cut?.ToString(CultureInfo.InvariantCulture) ?? "-",
+            targetPresent,
+            targetBytes.Length,
+            flushCount,
+            classification,
+            CreateHexWindow(targetBytes, offset + (cut ?? 0)));
+
+    private static string CreateHexWindow(byte[] bytes, long center)
+    {
+        const int windowSize = 16;
+        int boundedCenter = checked((int)Math.Min(Math.Max(center, 0), bytes.LongLength));
+        int start = Math.Max(0, boundedCenter - (windowSize / 2));
+        if (start + windowSize > bytes.Length)
+        {
+            start = Math.Max(0, bytes.Length - windowSize);
+        }
+
+        int count = Math.Min(windowSize, bytes.Length - start);
+        byte[] window = new byte[count];
+        Array.Copy(bytes, start, window, 0, count);
+        return $"{start}:{BitConverter.ToString(window).Replace("-", string.Empty)}";
+    }
+
+    private static string ComputeDigest(IEnumerable<string> diagnostics)
+    {
+        byte[] input = Encoding.UTF8.GetBytes(string.Join("\n", diagnostics));
+        using var algorithm = SHA256.Create();
+        return BitConverter.ToString(algorithm.ComputeHash(input)).Replace("-", string.Empty);
+    }
+
+    private sealed class TrxPhase3Scenario
+    {
+        public TrxPhase3Scenario(
+            string name,
+            TrxDocumentExpectation beforeExpectation,
+            TrxDocumentExpectation afterExpectation,
+            Action<TrxIncrementalWriterPrototype> setup,
+            Action<TrxIncrementalWriterPrototype> act,
+            int definitionPadBytes = 4_096,
+            int entryPadBytes = 2_048,
+            int summaryPadBytes = 2_048,
+            int runningSlotCount = 2,
+            int runningSlotByteCapacity = 320,
+            byte[]? seedTarget = null,
+            byte[]? recoveryBytes = null,
+            IReadOnlyList<TrxPhase3WriteRole>? exhaustiveRoles = null,
+            IReadOnlyList<TrxPhase3WriteRole>? selectedRoles = null)
+        {
+            Name = name;
+            BeforeExpectation = beforeExpectation;
+            AfterExpectation = afterExpectation;
+            Setup = setup;
+            Act = act;
+            DefinitionPadBytes = definitionPadBytes;
+            EntryPadBytes = entryPadBytes;
+            SummaryPadBytes = summaryPadBytes;
+            RunningSlotCount = runningSlotCount;
+            RunningSlotByteCapacity = runningSlotByteCapacity;
+            SeedTarget = seedTarget;
+            RecoveryBytes = recoveryBytes;
+            ExhaustiveRoles = [.. exhaustiveRoles ?? []];
+            SelectedRoles = [.. selectedRoles ?? []];
+        }
+
+        public string Name { get; }
+
+        public TrxDocumentExpectation BeforeExpectation { get; }
+
+        public TrxDocumentExpectation AfterExpectation { get; }
+
+        public Action<TrxIncrementalWriterPrototype> Setup { get; }
+
+        public Action<TrxIncrementalWriterPrototype> Act { get; }
+
+        public int DefinitionPadBytes { get; }
+
+        public int EntryPadBytes { get; }
+
+        public int SummaryPadBytes { get; }
+
+        public int RunningSlotCount { get; }
+
+        public int RunningSlotByteCapacity { get; }
+
+        public byte[]? SeedTarget { get; }
+
+        public byte[]? RecoveryBytes { get; }
+
+        public HashSet<TrxPhase3WriteRole> ExhaustiveRoles { get; }
+
+        public HashSet<TrxPhase3WriteRole> SelectedRoles { get; }
+    }
+
+    private sealed class TrxPhase3Run
+    {
+        public TrxPhase3Run(
+            TrxFaultInjectingFileOperations operations,
+            TrxVirtualFileSystemSnapshot preActSnapshot,
+            TrxVirtualFileSystemSnapshot frozenSnapshot,
+            bool completed,
+            byte[] targetBytes)
+        {
+            OperationsOwner = operations;
+            PreActSnapshot = preActSnapshot;
+            FrozenSnapshot = frozenSnapshot;
+            Completed = completed;
+            TargetBytes = targetBytes;
+        }
+
+        public TrxFaultInjectingFileOperations OperationsOwner { get; }
+
+        public TrxVirtualFileSystemSnapshot PreActSnapshot { get; }
+
+        public TrxVirtualFileSystemSnapshot FrozenSnapshot { get; }
+
+        public bool Completed { get; }
+
+        public bool TargetPresent => FrozenSnapshot.Contains(TargetPath);
+
+        public byte[] TargetBytes { get; }
+
+        public IReadOnlyList<TrxFileOperationRecord> Operations => OperationsOwner.Operations;
+
+        public IReadOnlyList<TrxVirtualFileSystemSnapshot> Snapshots => OperationsOwner.Snapshots;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
@@ -1,0 +1,895 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxIncrementalWriterPrototypeTests
+{
+    private const string MachineName = "prototype-machine";
+    private const string TestModule = "Prototype.Tests.dll";
+    private const string FrameworkUid = "prototype-framework";
+    private const string FrameworkVersion = "1.0.0";
+    private const string RunName = "prototype-user@prototype-machine 2026-07-20 10:00:00.0000000";
+    private const int CounterWidth = 10;
+
+    private static readonly Guid RunId = new("10000000-0000-0000-0000-000000000001");
+    private static readonly DateTimeOffset StartTime = new(2026, 7, 20, 10, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset FinishTime = new(2026, 7, 20, 10, 5, 0, TimeSpan.Zero);
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+    private static readonly string[] PrototypeRootOrder =
+        ["Times", "TestSettings", "TestDefinitions", "TestEntries", "TestLists", "ResultSummary", "Results"];
+
+    [TestMethod]
+    public void Initialize_AbsentTarget_WritesCompleteFailedZeroCounterDocument()
+    {
+        using var harness = new PrototypeHarness();
+        Assert.IsFalse(File.Exists(harness.Path));
+
+        harness.Writer.Initialize();
+
+        AssertTruthful(harness.Bytes, [], [], StartTime, "Failed");
+        XDocument document = Load(harness.Bytes);
+        XElement counters = Required(document, "ResultSummary").Element(Ns + "Counters")!;
+        foreach (XAttribute counter in counters.Attributes())
+        {
+            Assert.AreEqual(new string('0', CounterWidth), counter.Value, counter.Name.LocalName);
+        }
+    }
+
+    [TestMethod]
+    public void Initialize_PadsAreWhitespaceAndAllClosersArePresent()
+    {
+        const int definitionPad = 1_003;
+        const int entryPad = 809;
+        const int slotCount = 2;
+        const int slotCapacity = 311;
+        using var harness = new PrototypeHarness(
+            definitionPadBytes: definitionPad,
+            entryPadBytes: entryPad,
+            runningSlotCount: slotCount,
+            runningSlotByteCapacity: slotCapacity);
+
+        harness.Writer.Initialize();
+
+        XDocument document = Load(harness.Bytes);
+        AssertWhitespacePad(Required(document, "TestDefinitions"), definitionPad);
+        AssertWhitespacePad(Required(document, "TestEntries"), entryPad);
+        AssertWhitespacePad(Required(document, "Results"), slotCount * slotCapacity);
+        Assert.IsTrue(StrictUtf8.GetString(harness.Bytes).EndsWith("</Results></TestRun>", StringComparison.Ordinal));
+        Assert.AreSequenceEqual(PrototypeRootOrder, document.Root!.Elements().Select(element => element.Name.LocalName).ToArray());
+    }
+
+    [TestMethod]
+    public void AppendCompleted_OneAndManyResults_PreservesCompletionOrderAndClosers()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult[] results =
+        [
+            CreateResult(1, "first", TrxTestOutcome.Passed),
+            CreateResult(2, "second", TrxTestOutcome.Skipped),
+            CreateResult(3, "third", TrxTestOutcome.Timeout),
+        ];
+        Guid[] executions = [ExecutionId(1), ExecutionId(2), ExecutionId(3)];
+
+        harness.Writer.AppendCompleted(results[0], executions[0]);
+        AssertResultOrder(harness.Bytes, "first");
+        Assert.IsTrue(StrictUtf8.GetString(harness.Bytes).EndsWith("</Results></TestRun>", StringComparison.Ordinal));
+
+        harness.Writer.AppendCompleted(results[1], executions[1]);
+        harness.Writer.AppendCompleted(results[2], executions[2]);
+
+        AssertResultOrder(harness.Bytes, "first", "second", "third");
+        Assert.IsTrue(StrictUtf8.GetString(harness.Bytes).EndsWith("</Results></TestRun>", StringComparison.Ordinal));
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults(results, executions),
+            [],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void AppendCompleted_DefinitionAndEntryUseReservedPadsAndLinkExecutionIds()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult result = CreateResult(1, "linked", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(1);
+
+        harness.Writer.AppendCompleted(result, executionId);
+
+        XDocument document = Load(harness.Bytes);
+        XElement definition = Required(document, "TestDefinitions").Elements(Ns + "UnitTest").Single();
+        XElement entry = Required(document, "TestEntries").Elements(Ns + "TestEntry").Single();
+        XElement completed = CompletedResults(document).Single();
+        Assert.AreEqual(completed.Attribute("testId")!.Value, definition.Attribute("id")!.Value);
+        Assert.AreEqual(executionId.ToString(), definition.Element(Ns + "Execution")!.Attribute("id")!.Value);
+        Assert.AreEqual(completed.Attribute("testId")!.Value, entry.Attribute("testId")!.Value);
+        Assert.AreEqual(executionId.ToString(), entry.Attribute("executionId")!.Value);
+        Assert.IsTrue(Required(document, "TestDefinitions").Nodes().OfType<XText>().All(text => IsWhitespace(text.Value)));
+        Assert.IsTrue(Required(document, "TestEntries").Nodes().OfType<XText>().All(text => IsWhitespace(text.Value)));
+    }
+
+    [TestMethod]
+    public void AppendCompleted_RepeatedTestId_DeduplicatesDefinitionButCreatesEntries()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult first = CreateResult(1, "repeat[1]", TrxTestOutcome.Passed, "Repeated.Definition");
+        TrxTestResult second = CreateResult(1, "repeat[2]", TrxTestOutcome.Passed, "Repeated.Definition");
+        Guid firstExecution = ExecutionId(1);
+        Guid secondExecution = ExecutionId(2);
+
+        harness.Writer.AppendCompleted(first, firstExecution);
+        harness.Writer.AppendCompleted(second, secondExecution);
+
+        XDocument document = Load(harness.Bytes);
+        Assert.HasCount(1, Required(document, "TestDefinitions").Elements(Ns + "UnitTest"));
+        Assert.HasCount(2, Required(document, "TestEntries").Elements(Ns + "TestEntry"));
+        Assert.AreEqual(
+            firstExecution.ToString(),
+            Required(document, "TestDefinitions").Element(Ns + "UnitTest")!.Element(Ns + "Execution")!.Attribute("id")!.Value);
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([first, second], [firstExecution, secondExecution]),
+            [],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void Counters_Transitions0To1_9To10_99To100AndLargeValuesRemainTruthful()
+    {
+        using var harness = new PrototypeHarness(entryPadBytes: 40_000);
+        harness.Writer.Initialize();
+        var results = new List<TrxTestResult>();
+        var executions = new List<Guid>();
+
+        for (int i = 1; i <= 100; i++)
+        {
+            TrxTestResult result = CreateResult(1, $"counter[{i}]", TrxTestOutcome.Passed, "Counter.Definition");
+            Guid executionId = ExecutionId(i);
+            results.Add(result);
+            executions.Add(executionId);
+            harness.Writer.AppendCompleted(result, executionId);
+
+            if (i is 1 or 9 or 10 or 99 or 100)
+            {
+                XElement counters = Required(Load(harness.Bytes), "ResultSummary").Element(Ns + "Counters")!;
+                Assert.AreEqual(i, int.Parse(counters.Attribute("total")!.Value, CultureInfo.InvariantCulture));
+                Assert.AreEqual(i, int.Parse(counters.Attribute("executed")!.Value, CultureInfo.InvariantCulture));
+                Assert.AreEqual(i, int.Parse(counters.Attribute("passed")!.Value, CultureInfo.InvariantCulture));
+                Assert.AreEqual(CounterWidth, counters.Attribute("total")!.Value.Length);
+            }
+        }
+
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults(results, executions),
+            [],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void UpdateFinishTime_ControlledOffsetsAndRoundTripValues_RemainsTruthful()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        long initialLength = harness.Bytes.LongLength;
+        DateTimeOffset first = new(2026, 7, 20, 18, 30, 45, TimeSpan.FromHours(5.5));
+        DateTimeOffset second = new(2026, 7, 20, 15, 45, 30, TimeSpan.FromHours(-4));
+
+        harness.Writer.UpdateFinishTime(first);
+        Assert.AreEqual(first, ReadFinishTime(harness.Bytes));
+        Assert.AreEqual(initialLength, harness.Bytes.LongLength);
+
+        harness.Writer.UpdateFinishTime(second);
+        Assert.AreEqual(second, ReadFinishTime(harness.Bytes));
+        Assert.AreEqual(initialLength, harness.Bytes.LongLength);
+        AssertTruthful(harness.Bytes, [], [], second, "Failed");
+    }
+
+    [TestMethod]
+    public void Complete_FailedToCompleted_RewritesFixedOutcomeWithoutLengthShift()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult result = CreateResult(1, "passing", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(1);
+        harness.Writer.AppendCompleted(result, executionId);
+        long paddedLength = harness.Bytes.LongLength;
+
+        harness.Writer.Complete(new TrxPrototypeCompletion { FinishTime = FinishTime });
+
+        Assert.AreEqual(paddedLength, harness.Bytes.LongLength);
+        string xml = StrictUtf8.GetString(harness.Bytes);
+        Assert.Contains("outcome=\"Completed\">", xml);
+        Assert.DoesNotContain("outcome=\"Failed\"   >", xml);
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([result], [executionId]),
+            [],
+            FinishTime,
+            "Completed");
+    }
+
+    [TestMethod]
+    public void ClaimRunning_ClaimCompleteAndRelease_TracksExactRunningSet()
+    {
+        using var harness = new PrototypeHarness(runningSlotCount: 2);
+        harness.Writer.Initialize();
+        Guid firstExecution = ExecutionId(1);
+        Guid secondExecution = ExecutionId(2);
+        int firstSlot = harness.Writer.ClaimRunning(TestId(1), "running-one", firstExecution, StartTime);
+        int secondSlot = harness.Writer.ClaimRunning(TestId(2), "running-two", secondExecution, StartTime.AddSeconds(1));
+
+        AssertTruthful(
+            harness.Bytes,
+            [],
+            [
+                CreateExpectedRunning(1, firstExecution, "running-one"),
+                CreateExpectedRunning(2, secondExecution, "running-two", StartTime.AddSeconds(1)),
+            ],
+            StartTime,
+            "Failed");
+
+        TrxTestResult second = CreateResult(2, "running-two", TrxTestOutcome.Passed);
+        harness.Writer.AppendCompleted(second, secondExecution, secondSlot);
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([second], [secondExecution]),
+            [CreateExpectedRunning(1, firstExecution, "running-one")],
+            StartTime,
+            "Failed");
+
+        TrxTestResult first = CreateResult(1, "running-one", TrxTestOutcome.Passed);
+        harness.Writer.AppendCompleted(first, firstExecution, firstSlot);
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([second, first], [secondExecution, firstExecution]),
+            [],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void ClaimRunning_DuplicateStartOrCompletionWithoutClaim_IsDiagnosedBeforeMutation()
+    {
+        var operations = new TrxFaultInjectingFileOperations();
+        using var harness = new PrototypeHarness(operations: operations, runningSlotCount: 2);
+        harness.Writer.Initialize();
+        Guid executionId = ExecutionId(1);
+        _ = harness.Writer.ClaimRunning(TestId(1), "running", executionId, StartTime);
+        int operationCount = operations.Operations.Count;
+        byte[] before = harness.Bytes;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => harness.Writer.ClaimRunning(TestId(1), "duplicate", executionId, StartTime));
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => harness.Writer.AppendCompleted(CreateResult(2, "not-claimed", TrxTestOutcome.Passed), ExecutionId(2), 1));
+
+        Assert.HasCount(operationCount, operations.Operations);
+        Assert.AreSequenceEqual(before, harness.Bytes);
+    }
+
+    [TestMethod]
+    public void ClaimRunning_SlotNPlusOne_IsDiagnosedWithoutDamagingCompletedResults()
+    {
+        var operations = new TrxFaultInjectingFileOperations();
+        using var harness = new PrototypeHarness(operations: operations, runningSlotCount: 1);
+        harness.Writer.Initialize();
+        TrxTestResult completed = CreateResult(1, "completed", TrxTestOutcome.Passed);
+        Guid completedExecution = ExecutionId(1);
+        harness.Writer.AppendCompleted(completed, completedExecution);
+        Guid runningExecution = ExecutionId(2);
+        _ = harness.Writer.ClaimRunning(TestId(2), "running", runningExecution, StartTime);
+        int operationCount = operations.Operations.Count;
+        byte[] before = harness.Bytes;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(
+            () => harness.Writer.ClaimRunning(TestId(3), "overflow", ExecutionId(3), StartTime));
+
+        Assert.HasCount(operationCount, operations.Operations);
+        Assert.AreSequenceEqual(before, harness.Bytes);
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([completed], [completedExecution]),
+            [CreateExpectedRunning(2, runningExecution, "running")],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void RunningSlot_LongUnicodeName_TruncatesAtScalarAndEncodedByteBoundary()
+    {
+        const int slotCapacity = 300;
+        using var harness = new PrototypeHarness(runningSlotCount: 1, runningSlotByteCapacity: slotCapacity);
+        harness.Writer.Initialize();
+        string longName = string.Concat("prefix<&>é漢😀", new string('界', 100), "😀tail");
+        Guid executionId = ExecutionId(1);
+
+        _ = harness.Writer.ClaimRunning(TestId(1), longName, executionId, StartTime);
+
+        XDocument document = Load(harness.Bytes);
+        XElement running = Required(document, "Results").Elements(Ns + "UnitTestResult").Single();
+        string truncated = running.Attribute("testName")!.Value;
+        Assert.IsTrue(longName.StartsWith(truncated, StringComparison.Ordinal));
+        Assert.IsLessThan(longName.Length, truncated.Length);
+        Assert.AreNotEqual('\uFFFD', truncated[truncated.Length - 1]);
+        Assert.IsFalse(char.IsHighSurrogate(truncated[truncated.Length - 1]));
+        _ = StrictUtf8.GetString(harness.Bytes);
+        AssertTruthful(
+            harness.Bytes,
+            [],
+            [CreateExpectedRunning(1, executionId, truncated)],
+            StartTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public void Unicode_EntitiesInvalidControlsAndLineBreaks_RoundTripWithCurrentSanitization()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        var result = new TrxTestResult
+        {
+            Uid = TestId(1),
+            DisplayName = "name é漢😀 e\u0301 مرحبا <&\" control:\u0001",
+            Outcome = TrxTestOutcome.Failed,
+            StartTime = StartTime,
+            EndTime = StartTime.AddSeconds(1),
+            Duration = TimeSpan.FromSeconds(1),
+            TrxTestDefinitionName = "definition é漢😀 <&\u0002",
+            TrxFullyQualifiedTypeName = "Prototype.UnicodeTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Prototype",
+                TypeName = "UnicodeTests",
+                MethodName = "RoundTrip",
+            },
+            ExceptionMessage = "message <&> 😀\u0003\r\nline",
+            ExceptionStackTrace = "stack é漢\r\nline",
+            Messages =
+            [
+                new TrxStreamMessage
+                {
+                    Kind = TrxStreamMessageKind.StandardOutput,
+                    Message = "stdout <&> 😀\u0004\r\nline",
+                },
+            ],
+            Metadata =
+            [
+                new TrxTestMetadata { Key = "Custom<&>", Value = "value é漢😀\u0005" },
+            ],
+        };
+
+        harness.Writer.AppendCompleted(result, ExecutionId(1));
+
+        XDocument document = Load(harness.Bytes);
+        XElement completed = CompletedResults(document).Single();
+        Assert.AreEqual("name é漢😀 e\u0301 مرحبا <&\" control:\\u0001", completed.Attribute("testName")!.Value);
+        Assert.AreEqual(
+            "stdout <&> 😀\\u0004\nline",
+            completed.Element(Ns + "Output")!.Element(Ns + "StdOut")!.Value);
+        Assert.AreEqual(
+            "message <&> 😀\\u0003\nline",
+            completed.Descendants(Ns + "Message").Single().Value);
+        XElement property = Required(document, "TestDefinitions").Descendants(Ns + "Property").Single();
+        Assert.AreEqual("Custom<&>", property.Element(Ns + "Key")!.Value);
+        Assert.AreEqual("value é漢😀\\u0005", property.Element(Ns + "Value")!.Value);
+    }
+
+    [TestMethod]
+    public void Metadata_OwnerDescriptionCategoriesAndCustomPropertiesOver500Bytes_UsesActualBytes()
+    {
+        string longValue = string.Concat("é漢😀<&>", new string('界', 260));
+        TrxTestResult result = CreateResult(1, "metadata", TrxTestOutcome.Passed);
+        result = CopyWithMetadata(
+            result,
+            ["fast", "unicode-漢"],
+            [
+                new TrxTestMetadata { Key = "Owner", Value = "Zoë <owner>" },
+                new TrxTestMetadata { Key = "Description", Value = longValue },
+                new TrxTestMetadata { Key = "Priority", Value = "7" },
+                new TrxTestMetadata { Key = "Custom<&>", Value = longValue },
+            ]);
+        var renderer = new TrxPrototypeXmlRenderer(MachineName, TestModule, FrameworkUid, FrameworkVersion);
+        byte[] definition = renderer.RenderDefinition(result, ExecutionId(1));
+        Assert.IsGreaterThan(500, definition.Length);
+        Assert.IsGreaterThan(longValue.Length, StrictUtf8.GetByteCount(longValue));
+
+        using var harness = new PrototypeHarness(definitionPadBytes: definition.Length + 23);
+        harness.Writer.Initialize();
+        harness.Writer.AppendCompleted(result, ExecutionId(1));
+
+        XDocument document = Load(harness.Bytes);
+        XElement unitTest = Required(document, "TestDefinitions").Element(Ns + "UnitTest")!;
+        Assert.AreEqual("Zoë <owner>", unitTest.Descendants(Ns + "Owner").Single().Attribute("name")!.Value);
+        Assert.AreEqual(longValue, unitTest.Element(Ns + "Description")!.Value);
+        Assert.AreSequenceEqual(
+            ["fast", "unicode-漢"],
+            unitTest.Descendants(Ns + "TestCategoryItem").Select(element => element.Attribute("TestCategory")!.Value).ToArray());
+        Assert.AreEqual(longValue, unitTest.Descendants(Ns + "Value").Single().Value);
+        Assert.AreEqual(23, unitTest.NodesAfterSelf().OfType<XText>().Sum(text => text.Value.Length));
+    }
+
+    [TestMethod]
+    public void LargeOutput_OneLargeAndManyAggregateMessages_DoesNotConsumeDefinitionOrEntryPads()
+    {
+        string oneLargeMessage = new('x', (1024 * 1024) - 128);
+        TrxTestResult first = CopyWithMessages(
+            CreateResult(1, "one-large", TrxTestOutcome.Passed),
+            [new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = oneLargeMessage }]);
+        TrxStreamMessage[] manyMessages = Enumerable.Range(0, 80)
+            .Select(index => new TrxStreamMessage
+            {
+                Kind = TrxStreamMessageKind.StandardError,
+                Message = $"{index:D2}:{new string('y', 4_096)}",
+            })
+            .ToArray();
+        TrxTestResult second = CopyWithMessages(CreateResult(2, "many-large", TrxTestOutcome.Passed), manyMessages);
+        var renderer = new TrxPrototypeXmlRenderer(MachineName, TestModule, FrameworkUid, FrameworkVersion);
+        int definitionBytes = renderer.RenderDefinition(first, ExecutionId(1)).Length
+            + renderer.RenderDefinition(second, ExecutionId(2)).Length;
+        int entryBytes = TrxPrototypeXmlRenderer.RenderEntry(first.Uid, ExecutionId(1)).Length
+            + TrxPrototypeXmlRenderer.RenderEntry(second.Uid, ExecutionId(2)).Length;
+        using var harness = new PrototypeHarness(
+            definitionPadBytes: definitionBytes,
+            entryPadBytes: entryBytes);
+        harness.Writer.Initialize();
+
+        harness.Writer.AppendCompleted(first, ExecutionId(1));
+        harness.Writer.AppendCompleted(second, ExecutionId(2));
+
+        XDocument document = Load(harness.Bytes);
+        XElement[] completed = CompletedResults(document).ToArray();
+        Assert.AreEqual(oneLargeMessage, completed[0].Descendants(Ns + "StdOut").Single().Value);
+        Assert.AreEqual(
+            string.Join("\n", manyMessages.Select(message => message.Message)),
+            completed[1].Descendants(Ns + "StdErr").Single().Value);
+        Assert.AreEqual(0, Required(document, "TestDefinitions").Nodes().OfType<XText>().Sum(text => text.Value.Length));
+        Assert.AreEqual(0, Required(document, "TestEntries").Nodes().OfType<XText>().Sum(text => text.Value.Length));
+    }
+
+    [TestMethod]
+    public void LargeOutput_PreservesStdOutStdErrDebugErrorStackAndResultFilesOrder()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult result = CopyWithOutputAndFiles(CreateResult(1, "ordered-output", TrxTestOutcome.Failed));
+
+        harness.Writer.AppendCompleted(result, ExecutionId(1));
+
+        XElement completed = CompletedResults(Load(harness.Bytes)).Single();
+        Assert.AreSequenceEqual(
+            ["Output", "ResultFiles"],
+            completed.Elements().Select(element => element.Name.LocalName).ToArray());
+        XElement output = completed.Element(Ns + "Output")!;
+        Assert.AreSequenceEqual(
+            ["StdOut", "StdErr", "DebugTrace", "ErrorInfo"],
+            output.Elements().Select(element => element.Name.LocalName).ToArray());
+        Assert.AreEqual("stdout-1\nstdout-2", output.Element(Ns + "StdOut")!.Value);
+        Assert.AreEqual("stderr", output.Element(Ns + "StdErr")!.Value);
+        Assert.AreEqual("debug", output.Element(Ns + "DebugTrace")!.Value);
+        Assert.AreEqual("exception", output.Descendants(Ns + "Message").Single().Value);
+        Assert.AreEqual("stack", output.Descendants(Ns + "StackTrace").Single().Value);
+        Assert.AreSequenceEqual(
+            ["first/result.txt", "second/result.txt"],
+            completed.Descendants(Ns + "ResultFile").Select(element => element.Attribute("path")!.Value).ToArray());
+    }
+
+    [TestMethod]
+    public void Summary_CrashExitCodeRunInfosCollectorEntriesAndAttachmentWarnings_PreservesOrder()
+    {
+        using var harness = new PrototypeHarness();
+        harness.Writer.Initialize();
+        TrxTestResult result = CreateResult(1, "summary", TrxTestOutcome.Passed);
+        Guid executionId = ExecutionId(1);
+        harness.Writer.AppendCompleted(result, executionId);
+        var completion = new TrxPrototypeCompletion
+        {
+            FinishTime = FinishTime,
+            IsTestHostCrashed = true,
+            ExitCode = 17,
+            CrashText = "host crashed <&>",
+            CollectorAttachmentHrefs = ["collector/first.bin", "collector/second.bin"],
+            AttachmentWarnings = ["warning one", "warning two"],
+        };
+
+        harness.Writer.Complete(completion);
+
+        XDocument document = Load(harness.Bytes);
+        XElement summary = Required(document, "ResultSummary");
+        Assert.AreSequenceEqual(
+            ["Counters", "RunInfos", "CollectorDataEntries"],
+            summary.Elements().Select(element => element.Name.LocalName).ToArray());
+        Assert.AreSequenceEqual(
+            ["collector/first.bin", "collector/second.bin"],
+            summary.Descendants(Ns + "A").Select(element => element.Attribute("href")!.Value).ToArray());
+        XElement[] runInfos = summary.Descendants(Ns + "RunInfo").ToArray();
+        Assert.AreSequenceEqual(
+            ["Error", "Warning", "Warning"],
+            runInfos.Select(element => element.Attribute("outcome")!.Value).ToArray());
+        Assert.AreSequenceEqual(
+            ["host crashed <&>", "warning one", "warning two"],
+            runInfos.Select(element => element.Element(Ns + "Text")!.Value).ToArray());
+        AssertTruthful(
+            harness.Bytes,
+            CreateExpectedResults([result], [executionId]),
+            [],
+            FinishTime,
+            "Failed");
+    }
+
+    [TestMethod]
+    public async Task NormalPath_SemanticallyMatchesCurrentRendererAfterDynamicIdNormalization()
+    {
+        TrxPrototypeScenario scenario = TrxPrototypeScenarioFactory.CreateMixedResultsScenario();
+        TrxRenderedScenario current = await TrxPrototypeScenarioFactory.RenderAsync(scenario);
+        using var harness = new PrototypeHarness(
+            runId: TrxPrototypeScenarioFactory.RunId,
+            runName: TrxPrototypeScenarioFactory.RunName,
+            machineName: TrxPrototypeScenarioFactory.MachineName,
+            testModule: TrxPrototypeScenarioFactory.TestModule,
+            frameworkUid: TrxPrototypeScenarioFactory.FrameworkUid,
+            frameworkVersion: TrxPrototypeScenarioFactory.FrameworkVersion,
+            startTime: TrxPrototypeScenarioFactory.StartTime);
+        harness.Writer.Initialize();
+
+        Guid[] executions = scenario.Expectation.CompletedResults
+            .Select(result => Guid.Parse(result.ExecutionId))
+            .ToArray();
+        for (int i = 0; i < scenario.Results.Count; i++)
+        {
+            harness.Writer.AppendCompleted(scenario.Results[i], executions[i]);
+        }
+
+        var completion = new TrxPrototypeCompletion { FinishTime = TrxPrototypeScenarioFactory.FinishTime };
+        harness.Writer.Complete(completion);
+        XDocument prototype = Load(harness.Bytes);
+
+        AssertTruthful(
+            harness.Bytes,
+            scenario.Expectation.CompletedResults,
+            [],
+            TrxPrototypeScenarioFactory.FinishTime,
+            "Failed",
+            TrxPrototypeScenarioFactory.RunId,
+            TrxPrototypeScenarioFactory.RunName,
+            TrxPrototypeScenarioFactory.StartTime);
+        AssertSemanticSequenceEqual(
+            CompletedResults(current.Document),
+            CompletedResults(prototype),
+            [
+                "executionId",
+                "testId",
+                "testName",
+                "computerName",
+                "duration",
+                "startTime",
+                "endTime",
+                "testType",
+                "outcome",
+                "testListId",
+                "relativeResultsDirectory",
+            ]);
+        AssertSemanticSequenceEqual(
+            Required(current.Document, "TestDefinitions").Elements(Ns + "UnitTest"),
+            Required(prototype, "TestDefinitions").Elements(Ns + "UnitTest"),
+            ["id", "name", "storage"]);
+        AssertSemanticSequenceEqual(
+            Required(current.Document, "TestEntries").Elements(Ns + "TestEntry"),
+            Required(prototype, "TestEntries").Elements(Ns + "TestEntry"),
+            ["testId", "executionId", "testListId"]);
+
+        XElement currentCounters = Required(current.Document, "ResultSummary").Element(Ns + "Counters")!;
+        XElement prototypeCounters = Required(prototype, "ResultSummary").Element(Ns + "Counters")!;
+        foreach (XAttribute counter in currentCounters.Attributes())
+        {
+            Assert.AreEqual(
+                int.Parse(counter.Value, CultureInfo.InvariantCulture),
+                int.Parse(prototypeCounters.Attribute(counter.Name)!.Value, CultureInfo.InvariantCulture),
+                counter.Name.LocalName);
+        }
+
+        harness.Writer.Compact(completion);
+        TrxDocumentObservation compactObservation = TrxDocumentClassifier.Classify(harness.Bytes, scenario.Expectation);
+        Assert.AreEqual(TrxDocumentClassification.Truthful, compactObservation.Classification, compactObservation.Diagnostic);
+        XDocument compact = Load(harness.Bytes);
+        AssertSemanticSequenceEqual(
+            CompletedResults(current.Document),
+            CompletedResults(compact),
+            [
+                "executionId",
+                "testId",
+                "testName",
+                "computerName",
+                "duration",
+                "startTime",
+                "endTime",
+                "testType",
+                "outcome",
+                "testListId",
+                "relativeResultsDirectory",
+            ]);
+    }
+
+    private static void AssertTruthful(
+        byte[] bytes,
+        IReadOnlyList<TrxExpectedResult> completed,
+        IReadOnlyList<TrxExpectedRunningTest> running,
+        DateTimeOffset finishTime,
+        string outcome,
+        Guid? runId = null,
+        string? runName = null,
+        DateTimeOffset? startTime = null)
+    {
+        var expectation = new TrxDocumentExpectation
+        {
+            RunId = runId ?? RunId,
+            RunName = runName ?? RunName,
+            StartTime = startTime ?? StartTime,
+            FinishTime = finishTime,
+            SummaryOutcome = outcome,
+            CompletedResults = completed,
+            RunningTests = running,
+            RootChildOrder = PrototypeRootOrder,
+        };
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(bytes, expectation);
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+    }
+
+    private static IReadOnlyList<TrxExpectedResult> CreateExpectedResults(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds)
+    {
+        var expected = new TrxExpectedResult[results.Count];
+        for (int i = 0; i < results.Count; i++)
+        {
+            expected[i] = TrxExpectedResultFactory.Create(
+                results[i],
+                executionIds[i],
+                MachineName,
+                TestModule,
+                FrameworkUid,
+                FrameworkVersion,
+                FinishTime);
+        }
+
+        return expected;
+    }
+
+    private static TrxExpectedRunningTest CreateExpectedRunning(
+        int testNumber,
+        Guid executionId,
+        string displayName,
+        DateTimeOffset? startTime = null)
+        => new()
+        {
+            TestId = Guid.Parse(TestId(testNumber)).ToString(),
+            ExecutionId = executionId.ToString(),
+            TestName = displayName,
+            ComputerName = MachineName,
+            StartTime = startTime ?? StartTime,
+        };
+
+    private static TrxTestResult CreateResult(
+        int testNumber,
+        string displayName,
+        TrxTestOutcome outcome,
+        string? definitionName = null)
+        => new()
+        {
+            Uid = TestId(testNumber),
+            DisplayName = displayName,
+            Outcome = outcome,
+            StartTime = StartTime.AddSeconds(testNumber),
+            EndTime = StartTime.AddSeconds(testNumber + 1),
+            Duration = TimeSpan.FromSeconds(1),
+            TrxTestDefinitionName = definitionName ?? displayName,
+            TrxFullyQualifiedTypeName = "Prototype.ContractTests",
+            TestMethodIdentifier = new TrxTestMethodIdentifier
+            {
+                Namespace = "Prototype",
+                TypeName = "ContractTests",
+                MethodName = definitionName ?? displayName,
+            },
+        };
+
+    private static TrxTestResult CopyWithMetadata(
+        TrxTestResult source,
+        IReadOnlyList<string> categories,
+        IReadOnlyList<TrxTestMetadata> metadata)
+        => new()
+        {
+            Uid = source.Uid,
+            DisplayName = source.DisplayName,
+            Outcome = source.Outcome,
+            StartTime = source.StartTime,
+            EndTime = source.EndTime,
+            Duration = source.Duration,
+            TrxTestDefinitionName = source.TrxTestDefinitionName,
+            TrxFullyQualifiedTypeName = source.TrxFullyQualifiedTypeName,
+            TestMethodIdentifier = source.TestMethodIdentifier,
+            Categories = categories,
+            Metadata = metadata,
+        };
+
+    private static TrxTestResult CopyWithMessages(
+        TrxTestResult source,
+        IReadOnlyList<TrxStreamMessage> messages)
+        => new()
+        {
+            Uid = source.Uid,
+            DisplayName = source.DisplayName,
+            Outcome = source.Outcome,
+            StartTime = source.StartTime,
+            EndTime = source.EndTime,
+            Duration = source.Duration,
+            TrxTestDefinitionName = source.TrxTestDefinitionName,
+            TrxFullyQualifiedTypeName = source.TrxFullyQualifiedTypeName,
+            TestMethodIdentifier = source.TestMethodIdentifier,
+            Messages = messages,
+        };
+
+    private static TrxTestResult CopyWithOutputAndFiles(TrxTestResult source)
+        => new()
+        {
+            Uid = source.Uid,
+            DisplayName = source.DisplayName,
+            Outcome = source.Outcome,
+            StartTime = source.StartTime,
+            EndTime = source.EndTime,
+            Duration = source.Duration,
+            TrxTestDefinitionName = source.TrxTestDefinitionName,
+            TrxFullyQualifiedTypeName = source.TrxFullyQualifiedTypeName,
+            TestMethodIdentifier = source.TestMethodIdentifier,
+            ExceptionMessage = "exception",
+            ExceptionStackTrace = "stack",
+            Messages =
+            [
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = "stdout-1" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = "stdout-2" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardError, Message = "stderr" },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.DebugOrTrace, Message = "debug" },
+            ],
+            FileArtifacts =
+            [
+                new TrxTestFileArtifact { FullPath = "first/result.txt" },
+                new TrxTestFileArtifact { FullPath = "second/result.txt" },
+            ],
+        };
+
+    private static void AssertResultOrder(byte[] bytes, params string[] expectedNames)
+        => Assert.AreSequenceEqual(
+            expectedNames,
+            CompletedResults(Load(bytes)).Select(element => element.Attribute("testName")!.Value).ToArray());
+
+    private static void AssertWhitespacePad(XElement element, int expectedLength)
+    {
+        Assert.IsEmpty(element.Elements());
+        string value = string.Concat(element.Nodes().OfType<XText>().Select(text => text.Value));
+        Assert.AreEqual(expectedLength, value.Length);
+        Assert.IsTrue(IsWhitespace(value));
+    }
+
+    private static bool IsWhitespace(string value)
+        => value.All(character => character is ' ' or '\t' or '\r' or '\n');
+
+    private static DateTimeOffset ReadFinishTime(byte[] bytes)
+        => DateTimeOffset.Parse(
+            Required(Load(bytes), "Times").Attribute("finish")!.Value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind);
+
+    private static XDocument Load(byte[] bytes)
+        => XDocument.Parse(StrictUtf8.GetString(bytes), LoadOptions.PreserveWhitespace);
+
+    private static XElement Required(XDocument document, string localName)
+        => document.Root!.Element(Ns + localName)!;
+
+    private static IEnumerable<XElement> CompletedResults(XDocument document)
+        => Required(document, "Results")
+            .Elements(Ns + "UnitTestResult")
+            .Where(element => element.Attribute("outcome")?.Value != "InProgress");
+
+    private static void AssertSemanticSequenceEqual(
+        IEnumerable<XElement> expected,
+        IEnumerable<XElement> actual,
+        IReadOnlyList<string> attributeNames)
+    {
+        XElement[] expectedArray = expected.ToArray();
+        XElement[] actualArray = actual.ToArray();
+        Assert.HasCount(expectedArray.Length, actualArray);
+        for (int i = 0; i < expectedArray.Length; i++)
+        {
+            foreach (string attributeName in attributeNames)
+            {
+                Assert.AreEqual(
+                    expectedArray[i].Attribute(attributeName)!.Value,
+                    actualArray[i].Attribute(attributeName)!.Value,
+                    $"Element {i}, attribute {attributeName}");
+            }
+        }
+    }
+
+    private static string TestId(int value) => $"20000000-0000-0000-0000-{value:D12}";
+
+    private static Guid ExecutionId(int value) => new($"30000000-0000-0000-0000-{value:D12}");
+
+    private sealed class PrototypeHarness : IDisposable
+    {
+        private readonly string? _temporaryDirectory;
+        private readonly TrxFaultInjectingFileOperations? _faultOperations;
+
+        public PrototypeHarness(
+            ITrxPrototypeFileOperations? operations = null,
+            Guid? runId = null,
+            string runName = RunName,
+            string machineName = MachineName,
+            string testModule = TestModule,
+            string frameworkUid = FrameworkUid,
+            string frameworkVersion = FrameworkVersion,
+            DateTimeOffset? startTime = null,
+            int definitionPadBytes = 65_536,
+            int entryPadBytes = 32_768,
+            int summaryPadBytes = 32_768,
+            int counterWidth = CounterWidth,
+            int runningSlotCount = 4,
+            int runningSlotByteCapacity = 512)
+        {
+            if (operations is null)
+            {
+                _temporaryDirectory = System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(),
+                    $"trx-incremental-prototype-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(_temporaryDirectory);
+                operations = new TrxPrototypeFileOperations();
+                Path = System.IO.Path.Combine(_temporaryDirectory, "results.trx");
+            }
+            else
+            {
+                Path = "results.trx";
+                _faultOperations = operations as TrxFaultInjectingFileOperations;
+            }
+
+            Writer = new TrxIncrementalWriterPrototype(
+                operations,
+                Path,
+                runId ?? RunId,
+                runName,
+                machineName,
+                testModule,
+                frameworkUid,
+                frameworkVersion,
+                startTime ?? StartTime,
+                definitionPadBytes,
+                entryPadBytes,
+                summaryPadBytes,
+                counterWidth,
+                runningSlotCount,
+                runningSlotByteCapacity);
+        }
+
+        public string Path { get; }
+
+        public TrxIncrementalWriterPrototype Writer { get; }
+
+        public byte[] Bytes => _faultOperations?.GetFileBytes(Path) ?? File.ReadAllBytes(Path);
+
+        public void Dispose()
+        {
+            if (_temporaryDirectory is not null)
+            {
+                Directory.Delete(_temporaryDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxIncrementalWriterPrototypeTests.cs
@@ -376,10 +376,10 @@ public sealed class TrxIncrementalWriterPrototypeTests
         XElement completed = CompletedResults(document).Single();
         Assert.AreEqual("name é漢😀 e\u0301 مرحبا <&\" control:\\u0001", completed.Attribute("testName")!.Value);
         Assert.AreEqual(
-            "stdout <&> 😀\\u0004\nline",
+            "stdout <&> 😀\\u0004\r\nline",
             completed.Element(Ns + "Output")!.Element(Ns + "StdOut")!.Value);
         Assert.AreEqual(
-            "message <&> 😀\\u0003\nline",
+            "message <&> 😀\\u0003\r\nline",
             completed.Descendants(Ns + "Message").Single().Value);
         XElement property = Required(document, "TestDefinitions").Descendants(Ns + "Property").Single();
         Assert.AreEqual("Custom<&>", property.Element(Ns + "Key")!.Value);
@@ -452,7 +452,7 @@ public sealed class TrxIncrementalWriterPrototypeTests
         XElement[] completed = CompletedResults(document).ToArray();
         Assert.AreEqual(oneLargeMessage, completed[0].Descendants(Ns + "StdOut").Single().Value);
         Assert.AreEqual(
-            string.Join("\n", manyMessages.Select(message => message.Message)),
+            string.Join(Environment.NewLine, manyMessages.Select(message => message.Message)),
             completed[1].Descendants(Ns + "StdErr").Single().Value);
         Assert.AreEqual(0, Required(document, "TestDefinitions").Nodes().OfType<XText>().Sum(text => text.Value.Length));
         Assert.AreEqual(0, Required(document, "TestEntries").Nodes().OfType<XText>().Sum(text => text.Value.Length));
@@ -475,7 +475,7 @@ public sealed class TrxIncrementalWriterPrototypeTests
         Assert.AreSequenceEqual(
             ["StdOut", "StdErr", "DebugTrace", "ErrorInfo"],
             output.Elements().Select(element => element.Name.LocalName).ToArray());
-        Assert.AreEqual("stdout-1\nstdout-2", output.Element(Ns + "StdOut")!.Value);
+        Assert.AreEqual($"stdout-1{Environment.NewLine}stdout-2", output.Element(Ns + "StdOut")!.Value);
         Assert.AreEqual("stderr", output.Element(Ns + "StdErr")!.Value);
         Assert.AreEqual("debug", output.Element(Ns + "DebugTrace")!.Value);
         Assert.AreEqual("exception", output.Descendants(Ns + "Message").Single().Value);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxJournalSnapshotPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxJournalSnapshotPrototypeTests.cs
@@ -1,0 +1,818 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxJournalSnapshotPrototypeTests
+{
+    private const string JournalPath = "results.trx.journal";
+
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+    private static readonly Lazy<JournalFaultEvidence> SnapshotEvidence = new(CreateSnapshotFaultEvidence);
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void JournalAppend_EveryOperationAndByteCut_ReplaysCompletePrefixOnly()
+    {
+        TrxTestResult result = CreateResult(501, "journal append é漢😀", TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(501);
+        TrxFaultInjectingFileOperations baseline = AppendOne(result, executionId, terminationPlan: null);
+        TrxFileOperationRecord[] trace = [.. baseline.Operations];
+        Assert.AreSequenceEqual(
+            [TrxFileOperationKind.Open, TrxFileOperationKind.Write, TrxFileOperationKind.Flush],
+            trace.Select(operation => operation.Kind).ToArray());
+
+        int emptyPrefixes = 0;
+        int completePrefixes = 0;
+        foreach (TrxFileOperationRecord operation in trace)
+        {
+            TrxFaultInjectingFileOperations faulted = AppendOne(
+                result,
+                executionId,
+                new TrxTerminationPlan(operation.OperationIndex),
+                expectTermination: true);
+            int recovered = RecoverPublishedRecordCount(faulted.GetFileBytes(JournalPath));
+            int expected = operation.Kind == TrxFileOperationKind.Open ? 0 : 1;
+            Assert.AreEqual(expected, recovered, operation.ToString());
+            emptyPrefixes += expected == 0 ? 1 : 0;
+            completePrefixes += expected;
+        }
+
+        TrxFileOperationRecord write = trace.Single(operation => operation.Kind == TrxFileOperationKind.Write);
+        for (int cut = 0; cut <= write.RequestedByteCount; cut++)
+        {
+            TrxFaultInjectingFileOperations faulted = AppendOne(
+                result,
+                executionId,
+                new TrxTerminationPlan(write.OperationIndex, cut),
+                expectTermination: true);
+            int expected = cut == write.RequestedByteCount ? 1 : 0;
+            Assert.AreEqual(expected, RecoverPublishedRecordCount(faulted.GetFileBytes(JournalPath)), $"cut={cut}");
+            emptyPrefixes += expected == 0 ? 1 : 0;
+            completePrefixes += expected;
+        }
+
+        TestContext.WriteLine(
+            $"journal-append operations={trace.Length}; byteCuts={write.RequestedByteCount + 1}; emptyPrefixes={emptyPrefixes}; completePrefixes={completePrefixes}; encodedBytes={write.RequestedByteCount}");
+    }
+
+    [TestMethod]
+    public void JournalAppend_TornLengthOrPayload_IgnoresOnlyFinalIncompleteRecord()
+    {
+        TrxTestResult first = CreateResult(502, "first complete", TrxTestOutcome.Passed);
+        TrxTestResult second = CreateResult(503, "second torn", TrxTestOutcome.Failed);
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        journal.Append(first, TrxPhase3EvidenceMatrix.ExecutionId(502));
+        int firstLength = operations.GetFileBytes(JournalPath).Length;
+        journal.Append(second, TrxPhase3EvidenceMatrix.ExecutionId(503));
+        byte[] complete = operations.GetFileBytes(JournalPath);
+        int[] cuts =
+        [
+            firstLength,
+            firstLength + 1,
+            firstLength + 3,
+            firstLength + 4,
+            firstLength + ((complete.Length - firstLength) / 2),
+            complete.Length - 1,
+            complete.Length,
+        ];
+
+        foreach (int cut in cuts)
+        {
+            int expected = cut == complete.Length ? 2 : 1;
+            Assert.AreEqual(expected, RecoverPublishedRecordCount(complete.Take(cut).ToArray()), $"cut={cut}");
+        }
+    }
+
+    [TestMethod]
+    public void JournalAppend_AfterTornRecord_EveryRecoveryOperationAndPartialAppend_RemainsAppendable()
+    {
+        TrxTestResult first = CreateResult(522, "first complete", TrxTestOutcome.Passed);
+        TrxTestResult torn = CreateResult(523, "torn record", TrxTestOutcome.Failed);
+        TrxTestResult resumed = CreateResult(524, "resumed record", TrxTestOutcome.Skipped);
+        TrxTestResult final = CreateResult(525, "final record", TrxTestOutcome.Timeout);
+        var sourceOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype source = CreateJournal(sourceOperations);
+        source.Append(first, TrxPhase3EvidenceMatrix.ExecutionId(522));
+        int firstLength = sourceOperations.GetFileBytes(JournalPath).Length;
+        source.Append(torn, TrxPhase3EvidenceMatrix.ExecutionId(523));
+        byte[] complete = sourceOperations.GetFileBytes(JournalPath);
+        byte[] tornJournal = complete.Take(firstLength + ((complete.Length - firstLength) / 2)).ToArray();
+
+        var baselineOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        baselineOperations.SeedFile(JournalPath, tornJournal);
+        CreateJournal(baselineOperations).Append(resumed, TrxPhase3EvidenceMatrix.ExecutionId(524));
+        TrxFileOperationRecord[] trace = [.. baselineOperations.Operations];
+        Assert.Contains(TrxFileOperationKind.SetLength, trace.Select(operation => operation.Kind).ToArray());
+
+        foreach (TrxFileOperationRecord operation in trace)
+        {
+            AssertJournalCanResumeAfterFault(
+                tornJournal,
+                resumed,
+                TrxPhase3EvidenceMatrix.ExecutionId(524),
+                final,
+                TrxPhase3EvidenceMatrix.ExecutionId(525),
+                new TrxTerminationPlan(operation.OperationIndex),
+                operation.ToString());
+        }
+
+        TrxFileOperationRecord appendWrite = trace.Single(operation => operation.Kind == TrxFileOperationKind.Write);
+        int[] byteCuts =
+        [
+            0,
+            1,
+            appendWrite.RequestedByteCount / 2,
+            appendWrite.RequestedByteCount - 1,
+            appendWrite.RequestedByteCount,
+        ];
+        foreach (int byteCut in byteCuts.Distinct())
+        {
+            AssertJournalCanResumeAfterFault(
+                tornJournal,
+                resumed,
+                TrxPhase3EvidenceMatrix.ExecutionId(524),
+                final,
+                TrxPhase3EvidenceMatrix.ExecutionId(525),
+                new TrxTerminationPlan(appendWrite.OperationIndex, byteCut),
+                $"appendCut={byteCut}");
+        }
+    }
+
+    [TestMethod]
+    public void SnapshotPublish_EveryTempWriteFlushAndReplaceCut_PreservesPriorSnapshot()
+    {
+        JournalFaultEvidence evidence = SnapshotEvidence.Value;
+
+        Assert.IsGreaterThan(0, evidence.OperationCaseCount);
+        Assert.IsGreaterThan(0, evidence.ByteCutCaseCount);
+        Assert.AreEqual(evidence.ObservationCount, evidence.OldTruthfulCount + evidence.NewTruthfulCount);
+        Assert.AreEqual(0, evidence.MalformedCount);
+        Assert.AreEqual(0, evidence.ParseableInconsistentCount);
+        Assert.AreEqual(1, evidence.NewTruthfulCount);
+        Assert.AreEqual(evidence.ObservationCount - 1, evidence.OldTruthfulCount);
+        TestContext.WriteLine(evidence.Summary);
+    }
+
+    [TestMethod]
+    public void SnapshotPublish_AfterReplace_EqualsCanonicalCompleteJournalPrefix()
+    {
+        TrxTestResult[] results =
+        [
+            CreateResult(504, "canonical pass", TrxTestOutcome.Passed),
+            CreateResult(505, "canonical skip", TrxTestOutcome.Skipped),
+        ];
+        Guid[] executionIds =
+        [
+            TrxPhase3EvidenceMatrix.ExecutionId(504),
+            TrxPhase3EvidenceMatrix.ExecutionId(505),
+        ];
+        TrxPrototypeCompletion completion = CreateCompletion();
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        for (int i = 0; i < results.Length; i++)
+        {
+            journal.Append(results[i], executionIds[i]);
+        }
+
+        journal.PublishSnapshot(completion);
+
+        byte[] expected = CreateRenderer().RenderCompact(
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            results,
+            executionIds,
+            completion);
+        Assert.AreSequenceEqual(expected, operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+    }
+
+    [TestMethod]
+    public void SnapshotPublish_RepeatedAndUniqueIds_PreservesOrderDefinitionsEntriesAndCounters()
+    {
+        TrxTestResult[] results =
+        [
+            CreateResult(506, "repeat[1]", TrxTestOutcome.Passed, "Repeated.Definition"),
+            CreateResult(507, "unique", TrxTestOutcome.Failed, "Unique.Definition"),
+            CreateResult(506, "repeat[2]", TrxTestOutcome.Skipped, "Repeated.Definition"),
+            CreateResult(508, "timeout", TrxTestOutcome.Timeout, "Timeout.Definition"),
+        ];
+        Guid[] executionIds =
+        [
+            TrxPhase3EvidenceMatrix.ExecutionId(506),
+            TrxPhase3EvidenceMatrix.ExecutionId(507),
+            TrxPhase3EvidenceMatrix.ExecutionId(509),
+            TrxPhase3EvidenceMatrix.ExecutionId(508),
+        ];
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        for (int i = 0; i < results.Length; i++)
+        {
+            journal.Append(results[i], executionIds[i]);
+        }
+
+        journal.PublishSnapshot(CreateCompletion());
+
+        byte[] bytes = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        AssertTruthful(bytes, CreateExpectation(results, executionIds));
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(bytes);
+        XElement root = document.Root!;
+        Assert.AreSequenceEqual(
+            executionIds.Select(value => value.ToString()).ToArray(),
+            root.Element(Ns + "Results")!.Elements(Ns + "UnitTestResult")
+                .Select(result => result.Attribute("executionId")!.Value).ToArray());
+        Assert.AreSequenceEqual(
+            [
+                Guid.Parse(results[0].Uid).ToString(),
+                Guid.Parse(results[1].Uid).ToString(),
+                Guid.Parse(results[3].Uid).ToString(),
+            ],
+            root.Element(Ns + "TestDefinitions")!.Elements(Ns + "UnitTest")
+                .Select(definition => definition.Attribute("id")!.Value).ToArray());
+        Assert.HasCount(4, root.Element(Ns + "TestEntries")!.Elements(Ns + "TestEntry"));
+        Assert.AreEqual(3, journal.Diagnostics.PublishedDefinitionCount);
+        Assert.AreEqual(4, journal.Diagnostics.PublishedRecordCount);
+    }
+
+    [TestMethod]
+    public void SnapshotPublish_RunningState_CarriesExplicitInProgressBreadcrumbsWithoutChangingJournalOutcomeEnum()
+    {
+        TrxTestResult completed = CreateResult(510, "completed", TrxTestOutcome.Passed);
+        Guid completedExecution = TrxPhase3EvidenceMatrix.ExecutionId(510);
+        TrxPrototypeRunningTest running = new()
+        {
+            Uid = TrxPhase3EvidenceMatrix.TestId(511),
+            DisplayName = "running é漢😀 <&>",
+            ExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(511),
+            StartTime = TrxPhase3EvidenceMatrix.StartTime.AddMinutes(1),
+        };
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        journal.Append(completed, completedExecution);
+
+        journal.PublishSnapshot(CreateCompletion(), [running]);
+
+        TrxDocumentExpectation expectation = CreateExpectation(
+            [completed],
+            [completedExecution],
+            [
+                new TrxExpectedRunningTest
+                {
+                    TestId = Guid.Parse(running.Uid).ToString(),
+                    ExecutionId = running.ExecutionId.ToString(),
+                    TestName = running.DisplayName,
+                    ComputerName = TrxPhase3EvidenceMatrix.MachineName,
+                    StartTime = running.StartTime,
+                },
+            ]);
+        byte[] bytes = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        AssertTruthful(bytes, expectation);
+        XElement runningElement = TrxPrototypeScenarioFactory.LoadStrict(bytes).Root!
+            .Element(Ns + "Results")!
+            .Elements(Ns + "UnitTestResult")
+            .Single(element => element.Attribute("outcome")!.Value == "InProgress");
+        Assert.AreEqual("InProgress", runningElement.Attribute("outcome")!.Value);
+        Assert.DoesNotContain("InProgress", Enum.GetNames(typeof(TrxTestOutcome)));
+    }
+
+    [TestMethod]
+    public void SnapshotPublish_UnicodeMetadataLargeOutputSummaryAndAttachmentReferences_MatchesCanonicalSemantics()
+    {
+        string longMetadata = "é漢😀 <&> e\u0301 مرحبا " + new string('m', 700);
+        string largeOutput = "stdout é漢😀 <&> " + new string('o', 8_192);
+        TrxTestResult result = CreateResult(
+            512,
+            "unicode é漢😀 <test>&",
+            TrxTestOutcome.Failed,
+            metadata:
+            [
+                new TrxTestMetadata { Key = "Owner", Value = "Zoë <owner>" },
+                new TrxTestMetadata { Key = "Description", Value = longMetadata },
+                new TrxTestMetadata { Key = "Custom<&>", Value = longMetadata },
+            ],
+            messages:
+            [
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardOutput, Message = largeOutput },
+                new TrxStreamMessage { Kind = TrxStreamMessageKind.StandardError, Message = "stderr مرحبا" },
+            ]);
+        result = CloneWithArtifacts(
+            result,
+            [
+                new TrxTestFileArtifact { FullPath = "result<&>.txt" },
+                new TrxTestFileArtifact { FullPath = "résultat-漢😀.log" },
+            ]);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(512);
+        TrxPrototypeCompletion completion = new()
+        {
+            FinishTime = TrxPhase3EvidenceMatrix.FinishTime,
+            IsTestHostCrashed = true,
+            CrashText = "crash é漢😀 <&>",
+            AttachmentWarnings = ["warning é漢😀 <&>"],
+            CollectorAttachmentHrefs = ["collector/résultat-漢😀<&>.bin"],
+        };
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        journal.Append(result, executionId);
+
+        journal.PublishSnapshot(completion);
+
+        byte[] actual = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        byte[] canonical = CreateRenderer().RenderCompact(
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            [result],
+            [executionId],
+            completion);
+        Assert.AreSequenceEqual(canonical, actual);
+        AssertTruthful(
+            actual,
+            CreateExpectation([result], [executionId], finishTime: completion.FinishTime));
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(actual);
+        XElement unitResult = document.Root!.Element(Ns + "Results")!.Element(Ns + "UnitTestResult")!;
+        Assert.AreEqual(largeOutput, unitResult.Element(Ns + "Output")!.Element(Ns + "StdOut")!.Value);
+        Assert.HasCount(2, unitResult.Element(Ns + "ResultFiles")!.Elements(Ns + "ResultFile"));
+        Assert.AreEqual(
+            completion.CollectorAttachmentHrefs[0],
+            document.Descendants(Ns + "A").Single().Attribute("href")!.Value);
+        Assert.IsGreaterThan(500, document.Descendants(Ns + "Description").Single().Value.Length);
+        Assert.AreSequenceEqual(
+            ["Counters", "RunInfos", "CollectorDataEntries"],
+            document.Root!.Element(Ns + "ResultSummary")!.Elements().Select(element => element.Name.LocalName).ToArray());
+    }
+
+    [TestMethod]
+    public void JournalAndPaddedWriter_SameEvents_ReportDeterministicClassificationDifferences()
+    {
+        TrxTestResult result = CreateResult(513, "differential", TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(513);
+        var paddedBaselineOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxIncrementalWriterPrototype paddedBaseline = TrxPhase3EvidenceMatrix.CreateWriter(paddedBaselineOperations);
+        paddedBaseline.Initialize();
+        byte[] paddedPrior = paddedBaselineOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        paddedBaselineOperations.BeginFaultWindow(terminationPlan: null);
+        paddedBaseline.AppendCompleted(result, executionId);
+        TrxFileOperationRecord paddedWrite = paddedBaselineOperations.Operations.First(
+            operation => operation.Kind == TrxFileOperationKind.Write
+                && operation.RequestedByteCount > TrxPhase3EvidenceMatrix.CounterWidth);
+
+        var paddedFaultOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxIncrementalWriterPrototype paddedFault = TrxPhase3EvidenceMatrix.CreateWriter(paddedFaultOperations);
+        paddedFault.Initialize();
+        Assert.AreSequenceEqual(paddedPrior, paddedFaultOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        paddedFaultOperations.BeginFaultWindow(
+            new TrxTerminationPlan(paddedWrite.OperationIndex, committedByteCount: 1));
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => paddedFault.AppendCompleted(result, executionId));
+        TrxDocumentObservation paddedObservation = TrxDocumentClassifier.Classify(
+            paddedFaultOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+            CreateExpectation([], []));
+
+        JournalFaultEvidence journalEvidence = SnapshotEvidence.Value;
+        Assert.AreEqual(
+            TrxDocumentClassification.Malformed,
+            paddedObservation.Classification,
+            paddedObservation.Diagnostic);
+        Assert.AreEqual(0, journalEvidence.MalformedCount);
+        Assert.AreEqual(0, journalEvidence.ParseableInconsistentCount);
+    }
+
+    [TestMethod]
+    public void Replay_UsesBoundedRecordBufferAndDoesNotRetainAllResultsOrXDocument()
+    {
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype journal = CreateJournal(operations);
+        for (int i = 0; i < 50; i++)
+        {
+            journal.Append(
+                CreateResult(520 + (i % 5), $"bounded-{i}", TrxTestOutcome.Passed, $"Definition.{i % 5}"),
+                TrxPhase3EvidenceMatrix.ExecutionId(520 + i));
+        }
+
+        journal.PublishSnapshot(CreateCompletion());
+
+        TrxJournalSnapshotDiagnostics diagnostics = journal.Diagnostics;
+        Assert.AreEqual(0, diagnostics.CurrentReplayRecordCount);
+        Assert.AreEqual(1, diagnostics.PeakReplayRecordCount);
+        Assert.AreEqual(0, diagnostics.CurrentRecordBufferBytes);
+        Assert.IsGreaterThan(diagnostics.MaxEncodedRecordBytes, diagnostics.PeakRecordBufferBytes);
+        Assert.AreEqual(0, diagnostics.CurrentDefinitionIdCount);
+        Assert.AreEqual(5, diagnostics.PeakDefinitionIdCount);
+        Assert.IsFalse(diagnostics.RetainsResultCollection);
+        Assert.IsFalse(diagnostics.RetainsXDocument);
+        Assert.AreEqual(50, diagnostics.PublishedRecordCount);
+        Assert.AreEqual(5, diagnostics.PublishedDefinitionCount);
+        Assert.IsGreaterThan(0, diagnostics.MaxEncodedRecordBytes);
+        Assert.IsGreaterThan(0, diagnostics.MaxRenderedFragmentBytes);
+        Assert.IsLessThan(
+            operations.GetFileBytes(JournalPath).Length,
+            diagnostics.PeakLogicalBufferBytes);
+        AssertNoRetainedResultCollectionOrXDocument(journal);
+    }
+
+    [TestMethod]
+    public void JournalSnapshot_FullFaultMatrix_HasNoMalformedOrParseableInconsistentPublishedTarget()
+    {
+        JournalFaultEvidence evidence = SnapshotEvidence.Value;
+
+        Assert.AreEqual(0, evidence.MalformedCount);
+        Assert.AreEqual(0, evidence.ParseableInconsistentCount);
+        Assert.AreEqual(evidence.ObservationCount, evidence.OldTruthfulCount + evidence.NewTruthfulCount);
+        Assert.Contains(TrxFileOperationKind.Open, evidence.AllPrimitiveKinds);
+        Assert.Contains(TrxFileOperationKind.Read, evidence.AllPrimitiveKinds);
+        Assert.Contains(TrxFileOperationKind.Write, evidence.AllPrimitiveKinds);
+        Assert.Contains(TrxFileOperationKind.Flush, evidence.AllPrimitiveKinds);
+        Assert.Contains(TrxFileOperationKind.Replace, evidence.AllPrimitiveKinds);
+    }
+
+    private static JournalFaultEvidence CreateSnapshotFaultEvidence()
+    {
+        TrxTestResult oldResult = CreateResult(530, "prior", TrxTestOutcome.Passed);
+        TrxTestResult newResult = CreateResult(531, "next é漢😀", TrxTestOutcome.Failed);
+        Guid oldExecution = TrxPhase3EvidenceMatrix.ExecutionId(530);
+        Guid newExecution = TrxPhase3EvidenceMatrix.ExecutionId(531);
+        TrxDocumentExpectation oldExpectation = CreateExpectation([oldResult], [oldExecution]);
+        TrxDocumentExpectation newExpectation = CreateExpectation(
+            [oldResult, newResult],
+            [oldExecution, newExecution]);
+
+        var stateOperations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxJournalSnapshotPrototype state = CreateJournal(stateOperations);
+        state.Append(oldResult, oldExecution);
+        state.PublishSnapshot(CreateCompletion());
+        byte[] oldSnapshot = stateOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        state.Append(newResult, newExecution);
+        byte[] journalBytes = stateOperations.GetFileBytes(JournalPath);
+
+        TrxFaultInjectingFileOperations baseline = PublishFromState(
+            journalBytes,
+            oldSnapshot,
+            terminationPlan: null);
+        TrxFileOperationRecord[] baselineTrace = [.. baseline.Operations];
+        int oldTruthful = 0;
+        int newTruthful = 0;
+        int malformed = 0;
+        int inconsistent = 0;
+        int operationCases = 0;
+        int byteCases = 0;
+
+        foreach (TrxFileOperationRecord operation in baselineTrace)
+        {
+            TrxFaultInjectingFileOperations faulted = PublishFromState(
+                journalBytes,
+                oldSnapshot,
+                new TrxTerminationPlan(operation.OperationIndex),
+                expectTermination: true);
+            ClassifyPublished(
+                faulted.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+                oldSnapshot,
+                oldExpectation,
+                newExpectation,
+                operation.Kind == TrxFileOperationKind.Replace,
+                ref oldTruthful,
+                ref newTruthful,
+                ref malformed,
+                ref inconsistent);
+            operationCases++;
+
+            if (operation.Kind != TrxFileOperationKind.Write)
+            {
+                continue;
+            }
+
+            for (int cut = 0; cut <= operation.RequestedByteCount; cut++)
+            {
+                faulted = PublishFromState(
+                    journalBytes,
+                    oldSnapshot,
+                    new TrxTerminationPlan(operation.OperationIndex, cut),
+                    expectTermination: true);
+                ClassifyPublished(
+                    faulted.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+                    oldSnapshot,
+                    oldExpectation,
+                    newExpectation,
+                    expectNew: false,
+                    ref oldTruthful,
+                    ref newTruthful,
+                    ref malformed,
+                    ref inconsistent);
+                byteCases++;
+            }
+        }
+
+        return new JournalFaultEvidence
+        {
+            OperationCaseCount = operationCases,
+            ByteCutCaseCount = byteCases,
+            ObservationCount = operationCases + byteCases,
+            OldTruthfulCount = oldTruthful,
+            NewTruthfulCount = newTruthful,
+            MalformedCount = malformed,
+            ParseableInconsistentCount = inconsistent,
+            AllPrimitiveKinds = baselineTrace.Select(operation => operation.Kind).Distinct().ToArray(),
+            Summary = string.Format(
+                CultureInfo.InvariantCulture,
+                "journal-snapshot operations={0}; byteCuts={1}; observations={2}; oldTruthful={3}; newTruthful={4}; malformed={5}; inconsistent={6}",
+                operationCases,
+                byteCases,
+                operationCases + byteCases,
+                oldTruthful,
+                newTruthful,
+                malformed,
+                inconsistent),
+        };
+    }
+
+    private static void AssertNoRetainedResultCollectionOrXDocument(TrxJournalSnapshotPrototype journal)
+    {
+        foreach (System.Reflection.FieldInfo field in typeof(TrxJournalSnapshotPrototype).GetFields(
+                     System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic))
+        {
+            object? value = field.GetValue(journal);
+            Assert.IsFalse(
+                value is XDocument || typeof(XDocument).IsAssignableFrom(field.FieldType),
+                $"Prototype field '{field.Name}' retains an XDocument.");
+            Assert.IsFalse(
+                ContainsResultType(field.FieldType, []),
+                $"Prototype field '{field.Name}' retains a result collection.");
+        }
+    }
+
+    private static bool ContainsResultType(Type type, HashSet<Type> visited)
+    {
+        if (type == typeof(TrxTestResult))
+        {
+            return true;
+        }
+
+        if (!visited.Add(type))
+        {
+            return false;
+        }
+
+        Type? elementType = type.HasElementType ? type.GetElementType() : null;
+        bool genericContainsResult = type.IsGenericType
+            && type.GetGenericArguments().Any(argument => ContainsResultType(argument, visited));
+        bool fieldContainsResult = type.Assembly == typeof(TrxTestResult).Assembly
+            && type.GetFields(System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.NonPublic)
+                .Any(field => ContainsResultType(field.FieldType, visited));
+        return elementType is not null
+            ? ContainsResultType(elementType, visited)
+            : genericContainsResult || fieldContainsResult;
+    }
+
+    private static void ClassifyPublished(
+        byte[] actual,
+        byte[] oldSnapshot,
+        TrxDocumentExpectation oldExpectation,
+        TrxDocumentExpectation newExpectation,
+        bool expectNew,
+        ref int oldTruthful,
+        ref int newTruthful,
+        ref int malformed,
+        ref int inconsistent)
+    {
+        TrxDocumentExpectation expectation = expectNew ? newExpectation : oldExpectation;
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(actual, expectation);
+        switch (observation.Classification)
+        {
+            case TrxDocumentClassification.Truthful:
+                if (expectNew)
+                {
+                    newTruthful++;
+                }
+                else
+                {
+                    oldTruthful++;
+                    Assert.AreSequenceEqual(oldSnapshot, actual);
+                }
+
+                break;
+            case TrxDocumentClassification.Malformed:
+                malformed++;
+                break;
+            case TrxDocumentClassification.ParseableInconsistent:
+                inconsistent++;
+                break;
+            default:
+                Assert.Fail(observation.Diagnostic);
+                break;
+        }
+    }
+
+    private static TrxFaultInjectingFileOperations PublishFromState(
+        byte[] journalBytes,
+        byte[] oldSnapshot,
+        TrxTerminationPlan? terminationPlan,
+        bool expectTermination = false)
+    {
+        var operations = new TrxFaultInjectingFileOperations(
+            terminationPlan: terminationPlan,
+            captureSnapshots: false);
+        operations.SeedFile(JournalPath, journalBytes);
+        operations.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, oldSnapshot);
+        void Publish() => CreateJournal(operations).PublishSnapshot(CreateCompletion());
+        if (expectTermination)
+        {
+            _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(Publish);
+        }
+        else
+        {
+            Publish();
+        }
+
+        return operations;
+    }
+
+    private static TrxFaultInjectingFileOperations AppendOne(
+        TrxTestResult result,
+        Guid executionId,
+        TrxTerminationPlan? terminationPlan,
+        bool expectTermination = false)
+    {
+        var operations = new TrxFaultInjectingFileOperations(
+            terminationPlan: terminationPlan,
+            captureSnapshots: false);
+        void Append() => CreateJournal(operations).Append(result, executionId);
+        if (expectTermination)
+        {
+            _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(Append);
+        }
+        else
+        {
+            Append();
+        }
+
+        return operations;
+    }
+
+    private static int RecoverPublishedRecordCount(byte[] journalBytes)
+    {
+        var recovery = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        recovery.SeedFile(JournalPath, journalBytes);
+        TrxJournalSnapshotPrototype journal = CreateJournal(recovery);
+        journal.PublishSnapshot(CreateCompletion());
+        return journal.Diagnostics.PublishedRecordCount;
+    }
+
+    private static void AssertJournalCanResumeAfterFault(
+        byte[] initialJournal,
+        TrxTestResult interruptedResult,
+        Guid interruptedExecutionId,
+        TrxTestResult resumedResult,
+        Guid resumedExecutionId,
+        TrxTerminationPlan terminationPlan,
+        string context)
+    {
+        var faulted = new TrxFaultInjectingFileOperations(
+            terminationPlan: terminationPlan,
+            captureSnapshots: false);
+        faulted.SeedFile(JournalPath, initialJournal);
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => CreateJournal(faulted).Append(interruptedResult, interruptedExecutionId),
+            context);
+        byte[] persisted = faulted.GetFileBytes(JournalPath);
+        int completePrefixCount = RecoverPublishedRecordCount(persisted);
+
+        var restarted = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        restarted.SeedFile(JournalPath, persisted);
+        TrxJournalSnapshotPrototype journal = CreateJournal(restarted);
+        journal.Append(resumedResult, resumedExecutionId);
+        journal.PublishSnapshot(CreateCompletion());
+
+        Assert.AreEqual(completePrefixCount + 1, journal.Diagnostics.PublishedRecordCount, context);
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(
+            restarted.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        Assert.Contains(
+            resumedResult.DisplayName,
+            document.Descendants(Ns + "UnitTestResult")
+                .Select(element => element.Attribute("testName")!.Value)
+                .ToArray(),
+            context);
+    }
+
+    private static TrxJournalSnapshotPrototype CreateJournal(ITrxPrototypeFileOperations operations)
+        => new(
+            operations,
+            JournalPath,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime);
+
+    private static TrxPrototypeXmlRenderer CreateRenderer()
+        => new(
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion);
+
+    private static TrxTestResult CreateResult(
+        int number,
+        string displayName,
+        TrxTestOutcome outcome,
+        string? definitionName = null,
+        IReadOnlyList<TrxTestMetadata>? metadata = null,
+        IReadOnlyList<TrxStreamMessage>? messages = null)
+        => TrxPhase3EvidenceMatrix.CreateResult(
+            number,
+            displayName,
+            outcome,
+            definitionName,
+            metadata,
+            categories: ["phase5", "journal"],
+            messages);
+
+    private static TrxTestResult CloneWithArtifacts(
+        TrxTestResult source,
+        IReadOnlyList<TrxTestFileArtifact> artifacts)
+        => new()
+        {
+            Uid = source.Uid,
+            DisplayName = source.DisplayName,
+            Outcome = source.Outcome,
+            StartTime = source.StartTime,
+            EndTime = source.EndTime,
+            Duration = source.Duration,
+            TrxTestDefinitionName = source.TrxTestDefinitionName,
+            TrxFullyQualifiedTypeName = source.TrxFullyQualifiedTypeName,
+            TestMethodIdentifier = source.TestMethodIdentifier,
+            ExceptionMessage = "exception é漢😀 <&>",
+            ExceptionStackTrace = "stack e\u0301 مرحبا",
+            Messages = source.Messages,
+            Categories = source.Categories,
+            Metadata = source.Metadata,
+            FileArtifacts = artifacts,
+        };
+
+    private static TrxPrototypeCompletion CreateCompletion()
+        => new()
+        {
+            FinishTime = TrxPhase3EvidenceMatrix.StartTime,
+            ExitCode = 1,
+        };
+
+    private static TrxDocumentExpectation CreateExpectation(
+        IReadOnlyList<TrxTestResult> results,
+        IReadOnlyList<Guid> executionIds,
+        IReadOnlyList<TrxExpectedRunningTest>? running = null,
+        DateTimeOffset? finishTime = null)
+    {
+        TrxDocumentExpectation padded = TrxPhase3EvidenceMatrix.CreateExpectation(
+            results,
+            executionIds,
+            running,
+            finishTime: finishTime ?? TrxPhase3EvidenceMatrix.StartTime);
+        return new TrxDocumentExpectation
+        {
+            RunId = padded.RunId,
+            RunName = padded.RunName,
+            StartTime = padded.StartTime,
+            FinishTime = padded.FinishTime,
+            SummaryOutcome = padded.SummaryOutcome,
+            CompletedResults = padded.CompletedResults,
+            RunningTests = padded.RunningTests,
+            Counters = padded.Counters,
+        };
+    }
+
+    private static void AssertTruthful(byte[] bytes, TrxDocumentExpectation expectation)
+    {
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(bytes, expectation);
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+    }
+
+    private sealed class JournalFaultEvidence
+    {
+        public required int OperationCaseCount { get; init; }
+
+        public required int ByteCutCaseCount { get; init; }
+
+        public required int ObservationCount { get; init; }
+
+        public required int OldTruthfulCount { get; init; }
+
+        public required int NewTruthfulCount { get; init; }
+
+        public required int MalformedCount { get; init; }
+
+        public required int ParseableInconsistentCount { get; init; }
+
+        public required IReadOnlyList<TrxFileOperationKind> AllPrimitiveKinds { get; init; }
+
+        public required string Summary { get; init; }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeDiagnosticsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeDiagnosticsTests.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxPrototypeDiagnosticsTests
+{
+    private static readonly Lazy<TrxPrototypeDiagnosticRun> PaddedRun = new(TrxPrototypeDiagnostics.RunPadded);
+    private static readonly Lazy<TrxPrototypeDiagnosticRun> JournalRun = new(TrxPrototypeDiagnostics.RunJournal);
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void TenThousandResults_PaddedPrototype_ReportsExactOperationsBytesFlushesSizesAndReflows()
+    {
+        TrxPrototypeDiagnosticRun run = PaddedRun.Value;
+        WriteMetrics("padded", run);
+
+        Assert.AreEqual(10_000, run.ResultCount);
+        Assert.AreEqual(100, run.UniqueDefinitionCount);
+        Assert.AreEqual(2_500, run.PassedCount);
+        Assert.AreEqual(2_500, run.FailedCount);
+        Assert.AreEqual(2_500, run.SkippedCount);
+        Assert.AreEqual(2_500, run.TimeoutCount);
+        Assert.AreEqual(run.Operations.RequestedWriteBytes, run.Operations.CommittedWriteBytes);
+        Assert.AreEqual(0, run.Operations.RequestedReadBytes);
+        Assert.AreEqual(run.PublishCount, run.Operations[TrxFileOperationKind.Replace]);
+        Assert.AreEqual(run.PublishCount - 2, run.ReflowCount);
+        Assert.AreEqual(1_024, run.InitialDefinitionPadBytes);
+        Assert.AreEqual(1_024, run.InitialEntryPadBytes);
+        Assert.IsGreaterThan(0, run.ReflowCount);
+        Assert.IsGreaterThan(0, run.RemainingDefinitionPadBytes);
+        Assert.IsGreaterThan(0, run.RemainingEntryPadBytes);
+        Assert.IsGreaterThan(0, run.RemainingSummaryPadBytes);
+        Assert.IsLessThan(run.PaddedSnapshotBytes, run.CompactSnapshotBytes);
+        Assert.AreEqual(10_000, run.FixtureInputResultCount);
+    }
+
+    [TestMethod]
+    public void TenThousandResults_JournalSnapshot_ReportsExactOperationsBytesFlushesSizesAndPublishes()
+    {
+        TrxPrototypeDiagnosticRun run = JournalRun.Value;
+        WriteMetrics("journal", run);
+
+        Assert.AreEqual(10_000, run.ResultCount);
+        Assert.AreEqual(4, run.PublishCount);
+        Assert.AreEqual(10_016, run.Operations[TrxFileOperationKind.Open]);
+        Assert.AreEqual(150_012, run.Operations[TrxFileOperationKind.Read]);
+        Assert.AreEqual(60_419, run.Operations[TrxFileOperationKind.Write]);
+        Assert.AreEqual(10_004, run.Operations[TrxFileOperationKind.Flush]);
+        Assert.AreEqual(4, run.Operations[TrxFileOperationKind.Replace]);
+        Assert.AreEqual(0, run.Operations[TrxFileOperationKind.Seek]);
+        Assert.AreEqual(0, run.Operations[TrxFileOperationKind.SetLength]);
+        Assert.AreEqual(0, run.Operations[TrxFileOperationKind.Delete]);
+        Assert.AreEqual(230_455, run.Operations.TotalOperations);
+        Assert.AreEqual(
+            run.JournalBytes.LongLength + run.Operations.ReplacementSizes.Sum(),
+            run.Operations.RequestedWriteBytes);
+        Assert.AreEqual(run.Operations.RequestedWriteBytes, run.Operations.CommittedWriteBytes);
+        Assert.AreEqual(10_000, run.JournalDiagnostics!.PublishedRecordCount);
+        Assert.AreEqual(100, run.JournalDiagnostics.PublishedDefinitionCount);
+    }
+
+    [TestMethod]
+    public void TenThousandResults_MixedOutcomesRepeatedIdsMetadataAndRunningSlots_IsTruthfulAndOrdered()
+    {
+        TrxPrototypeDiagnosticRun run = JournalRun.Value;
+        TrxDocumentExpectation expectation = CreateExpectation(run);
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(run.SnapshotBytes, expectation);
+
+        Assert.AreEqual(TrxDocumentClassification.Truthful, observation.Classification, observation.Diagnostic);
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(run.SnapshotBytes);
+        XNamespace ns = TrxDocumentClassifier.TeamTest2010Namespace;
+        XElement root = document.Root!;
+        Assert.AreEqual(10_000, root.Element(ns + "Results")!.Elements(ns + "UnitTestResult")
+            .Count(element => element.Attribute("outcome")!.Value != "InProgress"));
+        Assert.AreEqual(3, root.Element(ns + "Results")!.Elements(ns + "UnitTestResult")
+            .Count(element => element.Attribute("outcome")!.Value == "InProgress"));
+        Assert.HasCount(100, root.Element(ns + "TestDefinitions")!.Elements(ns + "UnitTest"));
+        Assert.HasCount(10_000, root.Element(ns + "TestEntries")!.Elements(ns + "TestEntry"));
+        Assert.AreSequenceEqual(
+            run.ExecutionIds.Take(20).Select(value => value.ToString()).ToArray(),
+            root.Element(ns + "Results")!.Elements(ns + "UnitTestResult")
+                .Take(20)
+                .Select(element => element.Attribute("executionId")!.Value)
+                .ToArray());
+        Assert.IsGreaterThan(500, root.Descendants(ns + "Description").Single().Value.Length);
+        Assert.Contains(element => element.Value.Length > 1_000, root.Descendants(ns + "StdOut"));
+        Assert.AreEqual(
+            "diagnostic/collector-é漢😀<&>.bin",
+            root.Descendants(ns + "A").Single().Attribute("href")!.Value);
+    }
+
+    [TestMethod]
+    public void TenThousandResults_ReplayDiagnostics_ShowOneRecordAtATimeAndReleasedDefinitionState()
+    {
+        TrxPrototypeDiagnosticRun run = JournalRun.Value;
+        TrxJournalSnapshotDiagnostics diagnostics = run.JournalDiagnostics!;
+
+        Assert.AreEqual(0, diagnostics.CurrentReplayRecordCount);
+        Assert.AreEqual(1, diagnostics.PeakReplayRecordCount);
+        Assert.AreEqual(0, diagnostics.CurrentRecordBufferBytes);
+        Assert.IsGreaterThan(diagnostics.MaxEncodedRecordBytes, diagnostics.PeakRecordBufferBytes);
+        Assert.AreEqual(0, diagnostics.CurrentDefinitionIdCount);
+        Assert.AreEqual(100, diagnostics.PeakDefinitionIdCount);
+        Assert.IsFalse(diagnostics.RetainsResultCollection);
+        Assert.IsFalse(diagnostics.RetainsXDocument);
+        Assert.IsGreaterThan(0, diagnostics.MaxEncodedRecordBytes);
+        Assert.IsGreaterThan(0, diagnostics.MaxRenderedFragmentBytes);
+        Assert.IsLessThanOrEqualTo(
+            diagnostics.MaxEncodedRecordBytes + diagnostics.MaxRenderedFragmentBytes,
+            diagnostics.PeakLogicalBufferBytes);
+        Assert.IsLessThan(run.JournalBytes.Length, diagnostics.PeakLogicalBufferBytes);
+        Assert.IsLessThan(run.SnapshotBytes.Length, diagnostics.PeakLogicalBufferBytes);
+    }
+
+    [TestMethod]
+    public void TenThousandResults_ManualMeasurement_EmitsReproducibleMetricsWithoutTimingAssertions()
+    {
+#if NETCOREAPP
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+#else
+        long allocatedBefore = GC.GetTotalMemory(forceFullCollection: false);
+#endif
+        var stopwatch = Stopwatch.StartNew();
+        TrxPrototypeDiagnosticRun run = TrxPrototypeDiagnostics.RunJournal();
+        stopwatch.Stop();
+#if NETCOREAPP
+        long allocatedAfter = GC.GetAllocatedBytesForCurrentThread();
+#else
+        long allocatedAfter = GC.GetTotalMemory(forceFullCollection: false);
+#endif
+        using var process = Process.GetCurrentProcess();
+
+        TestContext.WriteLine(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "manual-10k seed=phase5-fixed-v1; results={0}; uniqueDefinitions={1}; cadence={2}; elapsedMs={3}; gcAllocatedBytes={4}; workingSetBytes={5}; journalBytes={6}; snapshotBytes={7}; operations={8}; writes={9}; flushes={10}; replaces={11}",
+                run.ResultCount,
+                run.UniqueDefinitionCount,
+                TrxPrototypeDiagnostics.PublicationCadence,
+                stopwatch.ElapsedMilliseconds,
+                allocatedAfter - allocatedBefore,
+                process.WorkingSet64,
+                run.JournalBytes.Length,
+                run.SnapshotBytes.Length,
+                run.Operations.TotalOperations,
+                run.Operations[TrxFileOperationKind.Write],
+                run.Operations[TrxFileOperationKind.Flush],
+                run.Operations[TrxFileOperationKind.Replace]));
+
+        Assert.AreEqual(10_000, run.ResultCount);
+        Assert.AreEqual(100, run.UniqueDefinitionCount);
+        Assert.AreEqual(4, run.PublishCount);
+    }
+
+    private void WriteMetrics(string name, TrxPrototypeDiagnosticRun run)
+    {
+        string operationCounts = string.Join(
+            ",",
+            run.Operations.Counts.OrderBy(pair => pair.Key).Select(pair => $"{pair.Key}={pair.Value}"));
+        string replacementSizes = string.Join(",", run.Operations.ReplacementSizes);
+        TrxJournalSnapshotDiagnostics? journal = run.JournalDiagnostics;
+        TestContext.WriteLine(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}-10k results={1}; uniqueDefinitions={2}; running={3}; outcomes=passed:{4},failed:{5},skipped:{6},timeout:{7}; operations={8}; totalOperations={9}; requestedReadBytes={10}; committedReadBytes={11}; requestedWriteBytes={12}; committedWriteBytes={13}; flushes={14}; replaces={15}; replacementSizes=[{16}]; journalBytes={17}; paddedBytes={18}; compactOrSnapshotBytes={19}; reflows={20}; pads=initialDefinition:{21},initialEntry:{22},remainingDefinition:{23},remainingEntry:{24},remainingSummary:{25}; maxWriteBytes={26}; maxFileBytes={27}; fixtureInputResults={28}; maxEncodedRecordBytes={29}; maxRenderedFragmentBytes={30}; peakLogicalBufferBytes={31}; currentReplayRecords={32}; peakReplayRecords={33}; currentRecordBufferBytes={34}; peakRecordBufferBytes={35}; currentDefinitionIds={36}; peakDefinitionIds={37}; retainsResultCollection={38}; retainsXDocument={39}",
+                name,
+                run.ResultCount,
+                run.UniqueDefinitionCount,
+                run.RunningCount,
+                run.PassedCount,
+                run.FailedCount,
+                run.SkippedCount,
+                run.TimeoutCount,
+                operationCounts,
+                run.Operations.TotalOperations,
+                run.Operations.RequestedReadBytes,
+                run.Operations.CommittedReadBytes,
+                run.Operations.RequestedWriteBytes,
+                run.Operations.CommittedWriteBytes,
+                run.Operations[TrxFileOperationKind.Flush],
+                run.Operations[TrxFileOperationKind.Replace],
+                replacementSizes,
+                run.JournalBytes.Length,
+                run.PaddedSnapshotBytes,
+                run.CompactSnapshotBytes,
+                run.ReflowCount,
+                run.InitialDefinitionPadBytes,
+                run.InitialEntryPadBytes,
+                run.RemainingDefinitionPadBytes,
+                run.RemainingEntryPadBytes,
+                run.RemainingSummaryPadBytes,
+                run.Operations.MaxWriteBytes,
+                run.Operations.MaxFileBytes,
+                run.FixtureInputResultCount,
+                journal?.MaxEncodedRecordBytes ?? 0,
+                journal?.MaxRenderedFragmentBytes ?? 0,
+                journal?.PeakLogicalBufferBytes ?? run.Operations.MaxWriteBytes,
+                journal?.CurrentReplayRecordCount ?? 0,
+                journal?.PeakReplayRecordCount ?? 0,
+                journal?.CurrentRecordBufferBytes ?? 0,
+                journal?.PeakRecordBufferBytes ?? 0,
+                journal?.CurrentDefinitionIdCount ?? 0,
+                journal?.PeakDefinitionIdCount ?? 0,
+                journal?.RetainsResultCollection ?? true,
+                journal?.RetainsXDocument ?? true));
+    }
+
+    private static TrxDocumentExpectation CreateExpectation(TrxPrototypeDiagnosticRun run)
+    {
+        var completed = new TrxExpectedResult[run.Results.Count];
+        for (int i = 0; i < completed.Length; i++)
+        {
+            completed[i] = TrxExpectedResultFactory.Create(
+                run.Results[i],
+                run.ExecutionIds[i],
+                TrxPhase3EvidenceMatrix.MachineName,
+                TrxPhase3EvidenceMatrix.TestModule,
+                TrxPhase3EvidenceMatrix.FrameworkUid,
+                TrxPhase3EvidenceMatrix.FrameworkVersion,
+                TrxPhase3EvidenceMatrix.FinishTime);
+        }
+
+        return new TrxDocumentExpectation
+        {
+            RunId = TrxPhase3EvidenceMatrix.RunId,
+            RunName = TrxPhase3EvidenceMatrix.RunName,
+            StartTime = TrxPhase3EvidenceMatrix.StartTime,
+            FinishTime = TrxPhase3EvidenceMatrix.FinishTime,
+            SummaryOutcome = "Failed",
+            CompletedResults = completed,
+            RunningTests =
+            [
+                .. run.RunningTests.Select(
+                    running => new TrxExpectedRunningTest
+                    {
+                        TestId = Guid.Parse(running.Uid).ToString(),
+                        ExecutionId = running.ExecutionId.ToString(),
+                        TestName = running.DisplayName,
+                        ComputerName = TrxPhase3EvidenceMatrix.MachineName,
+                        StartTime = running.StartTime,
+                    }),
+            ],
+        };
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeFileOperationsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeFileOperationsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeFileOperationsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeFileOperationsTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxPrototypeFileOperationsTests
+{
+    private static readonly Encoding Utf8 = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    [TestMethod]
+    public void CreateTemporarySiblingPath_IsInDestinationDirectory()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string destinationPath = Path.Combine(directory, "results.trx");
+            TrxPrototypeFileOperations operations = new();
+
+            string first = operations.CreateTemporarySiblingPath(destinationPath);
+            string second = operations.CreateTemporarySiblingPath(destinationPath);
+
+            Assert.AreEqual(directory, Path.GetDirectoryName(first));
+            Assert.AreEqual(directory, Path.GetDirectoryName(second));
+            Assert.AreNotEqual(destinationPath, first);
+            Assert.AreNotEqual(first, second);
+            Assert.IsTrue(Path.GetFileName(first).StartsWith("results.trx.", StringComparison.Ordinal));
+            Assert.IsTrue(first.EndsWith(".tmp", StringComparison.Ordinal));
+            Assert.IsFalse(File.Exists(first));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReplaceTemporarySibling_TargetAbsentOrPresent_PublishesCompleteTemp()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            TrxPrototypeFileOperations operations = new();
+            if (!operations.SupportsAtomicReplace)
+            {
+                Assert.IsFalse(operations.SupportsAtomicReplace);
+                return;
+            }
+
+            string destinationPath = Path.Combine(directory, "results.trx");
+            string firstTemporaryPath = operations.CreateTemporarySiblingPath(destinationPath);
+            WriteFile(operations, firstTemporaryPath, "first complete document");
+
+            operations.ReplaceTemporarySibling(firstTemporaryPath, destinationPath);
+
+            Assert.AreEqual("first complete document", File.ReadAllText(destinationPath));
+            Assert.IsFalse(File.Exists(firstTemporaryPath));
+
+            string secondTemporaryPath = operations.CreateTemporarySiblingPath(destinationPath);
+            WriteFile(operations, secondTemporaryPath, "second complete document");
+
+            operations.ReplaceTemporarySibling(secondTemporaryPath, destinationPath);
+
+            Assert.AreEqual("second complete document", File.ReadAllText(destinationPath));
+            Assert.IsFalse(File.Exists(secondTemporaryPath));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReplaceTemporarySibling_WhenAtomicReplaceUnsupported_FailsBeforeTargetMutation()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            TrxPrototypeFileOperations operations = new();
+            if (operations.SupportsAtomicReplace)
+            {
+                Assert.IsTrue(operations.SupportsAtomicReplace);
+                return;
+            }
+
+            string destinationPath = Path.Combine(directory, "results.trx");
+            string temporaryPath = operations.CreateTemporarySiblingPath(destinationPath);
+            File.WriteAllText(destinationPath, "prior document");
+            File.WriteAllText(temporaryPath, "new document");
+
+            _ = Assert.ThrowsExactly<PlatformNotSupportedException>(
+                () => operations.ReplaceTemporarySibling(temporaryPath, destinationPath));
+
+            Assert.AreEqual("prior document", File.ReadAllText(destinationPath));
+            Assert.AreEqual("new document", File.ReadAllText(temporaryPath));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void Open_RequestedFileShareIsApplied()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "results.trx");
+            File.WriteAllText(path, "abcdef");
+            TrxPrototypeFileOperations operations = new();
+
+            using (ITrxPrototypeFile file = operations.Open(
+                       path,
+                       FileMode.Open,
+                       FileAccess.ReadWrite,
+                       FileShare.None))
+            {
+                Assert.AreEqual(6, file.Length);
+                byte[] readBuffer = new byte[2];
+                Assert.AreEqual(2, file.Read(readBuffer, 0, readBuffer.Length));
+                Assert.AreEqual("ab", Utf8.GetString(readBuffer));
+
+                file.Seek(2, SeekOrigin.Begin);
+                file.Write(Utf8.GetBytes("XY"), 0, 2);
+                file.SetLength(4);
+                file.Flush();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    _ = Assert.ThrowsExactly<IOException>(
+                        () =>
+                        {
+                            using FileStream ignored = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                        });
+                }
+            }
+
+            Assert.AreEqual("abXY", File.ReadAllText(path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"trx-prototype-file-operations-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void WriteFile(TrxPrototypeFileOperations operations, string path, string content)
+    {
+        byte[] bytes = Utf8.GetBytes(content);
+        using ITrxPrototypeFile file = operations.Open(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.Read | FileShare.Delete);
+        file.Write(bytes, 0, bytes.Length);
+        file.Flush();
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeRealFileSystemTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeRealFileSystemTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeRealFileSystemTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeRealFileSystemTests.cs
@@ -1,0 +1,637 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxPrototypeRealFileSystemTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void RealFile_ReopenAfterEveryControlledBarrier_ParsesBytesFromDisk()
+    {
+        using var directory = new TempDirectory("trx-phase4-reopen");
+        string path = Path.Combine(directory.Path, "results.trx");
+        TrxPrototypeFileOperations realOperations = new();
+        if (!realOperations.SupportsAtomicReplace)
+        {
+            Assert.IsFalse(realOperations.SupportsAtomicReplace);
+            return;
+        }
+
+        using var operations = new BarrierFileOperations(realOperations, TestContext.CancellationToken);
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            420,
+            "real barrier reflow é漢😀",
+            TrxTestOutcome.Passed,
+            metadata:
+            [
+                new TrxTestMetadata
+                {
+                    Key = "Description",
+                    Value = new string('r', 600),
+                },
+            ]);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(420);
+        int definitionBytes = CreateRenderer().RenderDefinition(result, executionId).Length;
+        TrxIncrementalWriterPrototype writer = CreateRealWriter(
+            operations,
+            path,
+            definitionPadBytes: definitionBytes - 1);
+        writer.Initialize();
+        byte[] oldBytes = File.ReadAllBytes(path);
+        TrxDocumentExpectation oldExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([], []);
+        TrxDocumentExpectation newExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+        operations.EnableBarriers();
+
+        var publish = Task.Run(
+            () => writer.AppendCompleted(result, executionId),
+            TestContext.CancellationToken);
+        TrxFileOperationKind[] expected =
+        [
+            TrxFileOperationKind.Open,
+            TrxFileOperationKind.Write,
+            TrxFileOperationKind.Flush,
+            TrxFileOperationKind.Replace,
+        ];
+        var observed = new List<TrxFileOperationKind>();
+        foreach (TrxFileOperationKind expectedKind in expected)
+        {
+            TrxFileOperationKind kind = operations.WaitForOperation();
+            observed.Add(kind);
+            try
+            {
+                Assert.AreEqual(expectedKind, kind);
+                byte[] reopened = File.ReadAllBytes(path);
+                _ = TrxPrototypeScenarioFactory.LoadStrict(reopened);
+                if (kind == TrxFileOperationKind.Replace)
+                {
+                    AssertTruthful(reopened, newExpectation);
+                }
+                else
+                {
+                    Assert.AreSequenceEqual(oldBytes, reopened);
+                    AssertTruthful(reopened, oldExpectation);
+                }
+            }
+            finally
+            {
+                operations.Continue();
+            }
+        }
+
+        publish.GetAwaiter().GetResult();
+        Assert.AreSequenceEqual(expected, observed);
+        AssertTruthful(File.ReadAllBytes(path), newExpectation);
+        TestContext.WriteLine(
+            "phase4 real barriers: runtime={0}; os={1}; operations={2}; finalBytes={3}",
+            RuntimeInformation.FrameworkDescription,
+            RuntimeInformation.OSDescription,
+            string.Join(",", observed),
+            new FileInfo(path).Length);
+    }
+
+    [TestMethod]
+    public void RealReplace_OpenReaderWithDeleteShare_SeesOldOrNewCompleteDocument()
+    {
+        using var directory = new TempDirectory("trx-phase4-reader-delete-share");
+        string path = Path.Combine(directory.Path, "results.trx");
+        TrxPrototypeFileOperations operations = new();
+        if (!operations.SupportsAtomicReplace)
+        {
+            Assert.IsFalse(operations.SupportsAtomicReplace);
+            return;
+        }
+
+        byte[] oldBytes = CreateInitialBytes(421);
+        byte[] newBytes = CreateInitialBytes(422);
+        File.WriteAllBytes(path, oldBytes);
+        using FileStream reader = new(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read | FileShare.Delete);
+
+        new TrxSnapshotPublisherPrototype(operations).Publish(
+            path,
+            file => file.Write(newBytes, 0, newBytes.Length));
+
+        byte[] heldHandleBytes = ReadAll(reader);
+        byte[] reopenedBytes = File.ReadAllBytes(path);
+        _ = TrxPrototypeScenarioFactory.LoadStrict(heldHandleBytes);
+        _ = TrxPrototypeScenarioFactory.LoadStrict(reopenedBytes);
+        Assert.AreSequenceEqual(oldBytes, heldHandleBytes);
+        Assert.AreSequenceEqual(newBytes, reopenedBytes);
+    }
+
+    [TestMethod]
+    public void RealReplace_OpenReaderWithoutDeleteShare_OnWindowsFailsWithoutTargetLoss()
+    {
+        using var directory = new TempDirectory("trx-phase4-reader-no-delete-share");
+        string path = Path.Combine(directory.Path, "results.trx");
+        TrxPrototypeFileOperations operations = new();
+        if (!operations.SupportsAtomicReplace)
+        {
+            Assert.IsFalse(operations.SupportsAtomicReplace);
+            return;
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.IsFalse(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            return;
+        }
+
+        byte[] oldBytes = CreateInitialBytes(423);
+        byte[] newBytes = CreateInitialBytes(424);
+        File.WriteAllBytes(path, oldBytes);
+        using FileStream reader = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        _ = AssertSharingFailure(
+            () => new TrxSnapshotPublisherPrototype(operations).Publish(
+                path,
+                file => file.Write(newBytes, 0, newBytes.Length)));
+
+        Assert.AreSequenceEqual(oldBytes, File.ReadAllBytes(path));
+        Assert.AreSequenceEqual(oldBytes, ReadAll(reader));
+        Assert.IsEmpty(Directory.EnumerateFiles(directory.Path, "*.tmp"));
+    }
+
+    [TestMethod]
+    public void RealReplace_OpenWriterOrTransientLock_FailsWithoutIndefiniteWait()
+    {
+        using var directory = new TempDirectory("trx-phase4-writer-lock");
+        string path = Path.Combine(directory.Path, "results.trx");
+        TrxPrototypeFileOperations operations = new();
+        if (!operations.SupportsAtomicReplace)
+        {
+            Assert.IsFalse(operations.SupportsAtomicReplace);
+            return;
+        }
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Assert.IsFalse(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+            return;
+        }
+
+        byte[] oldBytes = CreateInitialBytes(425);
+        byte[] newBytes = CreateInitialBytes(426);
+        File.WriteAllBytes(path, oldBytes);
+        using (FileStream writerLock = new(
+                   path,
+                   FileMode.Open,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            _ = AssertSharingFailure(
+                () => new TrxSnapshotPublisherPrototype(operations).Publish(
+                    path,
+                    file => file.Write(newBytes, 0, newBytes.Length)));
+            Assert.AreSequenceEqual(oldBytes, ReadAll(writerLock));
+        }
+
+        new TrxSnapshotPublisherPrototype(operations).Publish(
+            path,
+            file => file.Write(newBytes, 0, newBytes.Length));
+        Assert.AreSequenceEqual(newBytes, File.ReadAllBytes(path));
+    }
+
+    [TestMethod]
+    public void RealReplace_TargetAbsentAndPresent_UsesSameFilesystemSibling()
+    {
+        using var directory = new TempDirectory("trx-phase4-absent-present");
+        string path = Path.Combine(directory.Path, "results.trx");
+        TrxPrototypeFileOperations realOperations = new();
+        if (!realOperations.SupportsAtomicReplace)
+        {
+            Assert.IsFalse(realOperations.SupportsAtomicReplace);
+            return;
+        }
+
+        var operations = new RecordingTemporaryPathOperations(realOperations);
+        byte[] first = CreateInitialBytes(427);
+        byte[] second = CreateInitialBytes(428);
+        TrxSnapshotPublisherPrototype publisher = new(operations);
+
+        publisher.Publish(path, file => file.Write(first, 0, first.Length));
+        Assert.AreSequenceEqual(first, File.ReadAllBytes(path));
+        publisher.Publish(path, file => file.Write(second, 0, second.Length));
+        Assert.AreSequenceEqual(second, File.ReadAllBytes(path));
+
+        Assert.HasCount(2, operations.TemporaryPaths);
+        foreach (string temporaryPath in operations.TemporaryPaths)
+        {
+            Assert.AreEqual(Path.GetDirectoryName(Path.GetFullPath(path)), Path.GetDirectoryName(temporaryPath));
+            Assert.AreEqual(Path.GetPathRoot(Path.GetFullPath(path)), Path.GetPathRoot(temporaryPath));
+            Assert.IsFalse(File.Exists(temporaryPath));
+        }
+    }
+
+    [TestMethod]
+    public void RealReplace_NetFrameworkCapability_IsExplicitlyUnsupportedAndNonDestructive()
+    {
+        using var directory = new TempDirectory("trx-phase4-netframework");
+        string path = Path.Combine(directory.Path, "results.trx");
+        byte[] oldBytes = CreateInitialBytes(429);
+        byte[] newBytes = CreateInitialBytes(430);
+        File.WriteAllBytes(path, oldBytes);
+        TrxPrototypeFileOperations operations = new();
+
+#if NETFRAMEWORK
+        Assert.IsFalse(operations.SupportsAtomicReplace);
+        _ = Assert.ThrowsExactly<PlatformNotSupportedException>(
+            () => new TrxSnapshotPublisherPrototype(operations).Publish(
+                path,
+                file => file.Write(newBytes, 0, newBytes.Length)));
+        Assert.AreSequenceEqual(oldBytes, File.ReadAllBytes(path));
+        Assert.IsEmpty(Directory.EnumerateFiles(directory.Path, "*.tmp"));
+#else
+        Assert.IsTrue(operations.SupportsAtomicReplace);
+        new TrxSnapshotPublisherPrototype(operations).Publish(
+            path,
+            file => file.Write(newBytes, 0, newBytes.Length));
+        Assert.AreSequenceEqual(newBytes, File.ReadAllBytes(path));
+#endif
+    }
+
+    [TestMethod]
+    public void Startup_DirectCreateTruncatesExistingFile_ButSnapshotInitializeDoesNot()
+    {
+        using var directory = new TempDirectory("trx-phase4-startup");
+        string path = Path.Combine(directory.Path, "results.trx");
+        byte[] prior = CreateInitialBytes(431);
+        File.WriteAllBytes(path, prior);
+        TrxPrototypeFileOperations realOperations = new();
+
+        using (ITrxPrototypeFile direct = realOperations.Open(
+                   path,
+                   FileMode.Create,
+                   FileAccess.ReadWrite,
+                   FileShare.Read | FileShare.Delete))
+        {
+            Assert.AreEqual(0, direct.Length);
+        }
+
+        Assert.IsEmpty(File.ReadAllBytes(path));
+        File.WriteAllBytes(path, prior);
+        if (!realOperations.SupportsAtomicReplace)
+        {
+            TrxIncrementalWriterPrototype unsupportedWriter = CreateRealWriter(
+                realOperations,
+                path,
+                definitionPadBytes: 1_024);
+            _ = Assert.ThrowsExactly<PlatformNotSupportedException>(() => unsupportedWriter.Initialize());
+            Assert.AreSequenceEqual(prior, File.ReadAllBytes(path));
+            return;
+        }
+
+        using var barriers = new BarrierFileOperations(realOperations, TestContext.CancellationToken);
+        TrxIncrementalWriterPrototype writer = CreateRealWriter(
+            barriers,
+            path,
+            definitionPadBytes: 1_024);
+        barriers.EnableBarriers();
+        var initialize = Task.Run(writer.Initialize, TestContext.CancellationToken);
+        foreach (TrxFileOperationKind expected in new[]
+                 {
+                     TrxFileOperationKind.Open,
+                     TrxFileOperationKind.Write,
+                     TrxFileOperationKind.Flush,
+                     TrxFileOperationKind.Replace,
+                 })
+        {
+            TrxFileOperationKind actual = barriers.WaitForOperation();
+            try
+            {
+                Assert.AreEqual(expected, actual);
+                byte[] target = File.ReadAllBytes(path);
+                if (actual == TrxFileOperationKind.Replace)
+                {
+                    Assert.IsNotEmpty(target);
+                    _ = TrxPrototypeScenarioFactory.LoadStrict(target);
+                }
+                else
+                {
+                    Assert.AreSequenceEqual(prior, target);
+                }
+            }
+            finally
+            {
+                barriers.Continue();
+            }
+        }
+
+        initialize.GetAwaiter().GetResult();
+        AssertTruthful(
+            File.ReadAllBytes(path),
+            TrxPhase3EvidenceMatrix.CreateExpectation([], []));
+    }
+
+    private static TrxIncrementalWriterPrototype CreateRealWriter(
+        ITrxPrototypeFileOperations operations,
+        string path,
+        int definitionPadBytes)
+        => new(
+            operations,
+            path,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes,
+            entryPadBytes: 2_048,
+            summaryPadBytes: 2_048,
+            counterWidth: TrxPhase3EvidenceMatrix.CounterWidth,
+            runningSlotCount: 2,
+            runningSlotByteCapacity: 320,
+            snapshotPublisher: new TrxSnapshotPublisherPrototype(operations));
+
+    private static TrxPrototypeXmlRenderer CreateRenderer()
+        => new(
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion);
+
+    private static byte[] CreateInitialBytes(int runNumber)
+        => TrxPrototypeXmlRenderer.RenderInitial(
+            new Guid($"10000000-0000-0000-0000-{runNumber:D12}"),
+            $"phase4-real-{runNumber}",
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes: 512,
+            entryPadBytes: 256,
+            summaryPadBytes: 256,
+            counterWidth: TrxPhase3EvidenceMatrix.CounterWidth,
+            runningSlotCount: 1,
+            runningSlotByteCapacity: 256);
+
+    private static byte[] ReadAll(FileStream stream)
+    {
+        stream.Seek(0, SeekOrigin.Begin);
+        byte[] bytes = new byte[stream.Length];
+        int offset = 0;
+        while (offset < bytes.Length)
+        {
+            int read = stream.Read(bytes, offset, bytes.Length - offset);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            offset += read;
+        }
+
+        return bytes;
+    }
+
+    private static void AssertTruthful(byte[] bytes, TrxDocumentExpectation expectation)
+    {
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(bytes, expectation);
+        Assert.AreEqual(
+            TrxDocumentClassification.Truthful,
+            observation.Classification,
+            observation.Diagnostic);
+    }
+
+    private static Exception AssertSharingFailure(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return exception;
+        }
+
+        Assert.Fail("Expected the open Windows handle to reject atomic replacement.");
+        throw new InvalidOperationException("Unreachable.");
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string? subdirectoryName = null)
+        {
+            string uniqueName = Guid.NewGuid().ToString("N");
+            Path = subdirectoryName is null
+                ? System.IO.Path.Combine(System.IO.Path.GetTempPath(), uniqueName)
+                : System.IO.Path.Combine(System.IO.Path.GetTempPath(), subdirectoryName, uniqueName);
+
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            TryDelete(Path);
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    TryDeleteFile(path);
+                    return;
+                }
+
+                if (!Directory.Exists(path))
+                {
+                    return;
+                }
+
+                foreach (string directory in Directory.EnumerateDirectories(path))
+                {
+                    TryDelete(directory);
+                }
+
+                foreach (string file in Directory.EnumerateFiles(path))
+                {
+                    TryDeleteFile(file);
+                }
+
+                try
+                {
+                    Directory.Delete(path, recursive: false);
+                }
+                catch
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private sealed class RecordingTemporaryPathOperations(ITrxPrototypeFileOperations inner)
+        : ITrxPrototypeFileOperations
+    {
+        public List<string> TemporaryPaths { get; } = [];
+
+        public bool SupportsAtomicReplace => inner.SupportsAtomicReplace;
+
+        public ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+            => inner.Open(path, mode, access, share);
+
+        public string CreateTemporarySiblingPath(string destinationPath)
+        {
+            string temporaryPath = inner.CreateTemporarySiblingPath(destinationPath);
+            TemporaryPaths.Add(temporaryPath);
+            return temporaryPath;
+        }
+
+        public void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+            => inner.ReplaceTemporarySibling(temporaryPath, destinationPath);
+
+        public bool Exists(string path) => inner.Exists(path);
+
+        public void Delete(string path) => inner.Delete(path);
+    }
+
+    private sealed class BarrierFileOperations(
+        ITrxPrototypeFileOperations inner,
+        CancellationToken cancellationToken)
+        : ITrxPrototypeFileOperations, IDisposable
+    {
+        private readonly ManualResetEventSlim _operationReached = new(initialState: false);
+        private readonly ManualResetEventSlim _continue = new(initialState: false);
+        private readonly object _sync = new();
+        private TrxFileOperationKind _currentOperation;
+        private bool _barriersEnabled;
+
+        public bool SupportsAtomicReplace => inner.SupportsAtomicReplace;
+
+        public void EnableBarriers() => _barriersEnabled = true;
+
+        public TrxFileOperationKind WaitForOperation()
+        {
+            _operationReached.Wait(cancellationToken);
+            lock (_sync)
+            {
+                _operationReached.Reset();
+                return _currentOperation;
+            }
+        }
+
+        public void Continue() => _continue.Set();
+
+        public ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+        {
+            ITrxPrototypeFile file = inner.Open(path, mode, access, share);
+            Pause(TrxFileOperationKind.Open);
+            return new BarrierFile(this, file);
+        }
+
+        public string CreateTemporarySiblingPath(string destinationPath)
+            => inner.CreateTemporarySiblingPath(destinationPath);
+
+        public void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+        {
+            inner.ReplaceTemporarySibling(temporaryPath, destinationPath);
+            Pause(TrxFileOperationKind.Replace);
+        }
+
+        public bool Exists(string path) => inner.Exists(path);
+
+        public void Delete(string path)
+        {
+            inner.Delete(path);
+            Pause(TrxFileOperationKind.Delete);
+        }
+
+        public void Dispose()
+        {
+            _operationReached.Dispose();
+            _continue.Dispose();
+        }
+
+        private void Pause(TrxFileOperationKind operation)
+        {
+            if (!_barriersEnabled)
+            {
+                return;
+            }
+
+            lock (_sync)
+            {
+                _currentOperation = operation;
+                _continue.Reset();
+                _operationReached.Set();
+            }
+
+            _continue.Wait(cancellationToken);
+        }
+
+        private sealed class BarrierFile(BarrierFileOperations owner, ITrxPrototypeFile innerFile)
+            : ITrxPrototypeFile
+        {
+            public long Length => innerFile.Length;
+
+            public long Position => innerFile.Position;
+
+            public int Read(byte[] buffer, int offset, int count)
+            {
+                int read = innerFile.Read(buffer, offset, count);
+                owner.Pause(TrxFileOperationKind.Read);
+                return read;
+            }
+
+            public void Seek(long offset, SeekOrigin origin)
+            {
+                innerFile.Seek(offset, origin);
+                owner.Pause(TrxFileOperationKind.Seek);
+            }
+
+            public void Write(byte[] buffer, int offset, int count)
+            {
+                innerFile.Write(buffer, offset, count);
+                owner.Pause(TrxFileOperationKind.Write);
+            }
+
+            public void Flush()
+            {
+                innerFile.Flush();
+                owner.Pause(TrxFileOperationKind.Flush);
+            }
+
+            public void SetLength(long length)
+            {
+                innerFile.SetLength(length);
+                owner.Pause(TrxFileOperationKind.SetLength);
+            }
+
+            public void Dispose() => innerFile.Dispose();
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeWarningSuppressions.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxPrototypeWarningSuppressions.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0022:Use expression body for method",
+    Justification = "The Phase 4 test file is append-only.",
+    Scope = "member",
+    Target = "~M:Microsoft.Testing.Extensions.UnitTests.TrxPrototypeRealFileSystemTests.TempDirectory.Dispose")]
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0330:Use 'System.Threading.Lock'",
+    Justification = "The Phase 4 test file is append-only.",
+    Scope = "member",
+    Target = "~F:Microsoft.Testing.Extensions.UnitTests.TrxPrototypeRealFileSystemTests.BarrierFileOperations._sync")]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxSnapshotPublisherPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxSnapshotPublisherPrototypeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxSnapshotPublisherPrototypeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxSnapshotPublisherPrototypeTests.cs
@@ -1,0 +1,920 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxSnapshotPublisherPrototypeTests
+{
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly XNamespace Ns = TrxDocumentClassifier.TeamTest2010Namespace;
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public void DefinitionPadOverflow_ReflowsToLargerCapacityWithoutDataLoss()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            401,
+            "definition overflow é漢😀",
+            TrxTestOutcome.Passed,
+            metadata:
+            [
+                new TrxTestMetadata
+                {
+                    Key = "Description",
+                    Value = new string('d', 700),
+                },
+            ]);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(401);
+        int definitionBytes = CreateRenderer().RenderDefinition(result, executionId).Length;
+        int entryBytes = TrxPrototypeXmlRenderer.RenderEntry(result.Uid, executionId).Length;
+        var operations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(
+            operations,
+            definitionPadBytes: definitionBytes - 1,
+            entryPadBytes: entryBytes + 64);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+
+        writer.AppendCompleted(result, executionId);
+
+        _ = Assert.ContainsSingle(
+            operation => operation.Kind == TrxFileOperationKind.Replace,
+            operations.Operations);
+        AssertTruthful(
+            operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+            TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]));
+        Assert.IsGreaterThan(
+            0,
+            GetWhitespaceBytes(
+                TrxPrototypeScenarioFactory.LoadStrict(
+                    operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath)),
+                "TestDefinitions"));
+    }
+
+    [TestMethod]
+    public void EntryPadOverflow_ReflowsToLargerCapacityWithoutDataLoss()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            402,
+            "entry overflow",
+            TrxTestOutcome.Skipped);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(402);
+        int definitionBytes = CreateRenderer().RenderDefinition(result, executionId).Length;
+        int entryBytes = TrxPrototypeXmlRenderer.RenderEntry(result.Uid, executionId).Length;
+        var operations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(
+            operations,
+            definitionPadBytes: definitionBytes + 64,
+            entryPadBytes: entryBytes - 1);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+
+        writer.AppendCompleted(result, executionId);
+
+        _ = Assert.ContainsSingle(
+            operation => operation.Kind == TrxFileOperationKind.Replace,
+            operations.Operations);
+        AssertTruthful(
+            operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+            TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]));
+        Assert.IsGreaterThan(
+            0,
+            GetWhitespaceBytes(
+                TrxPrototypeScenarioFactory.LoadStrict(
+                    operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath)),
+                "TestEntries"));
+    }
+
+    [TestMethod]
+    public void SimultaneousPadOverflow_ReflowsOnceWithBothCapacitiesIncreased()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            403,
+            "both pads overflow",
+            TrxTestOutcome.Failed,
+            metadata:
+            [
+                new TrxTestMetadata
+                {
+                    Key = "Custom",
+                    Value = new string('x', 600),
+                },
+            ]);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(403);
+        int definitionBytes = CreateRenderer().RenderDefinition(result, executionId).Length;
+        int entryBytes = TrxPrototypeXmlRenderer.RenderEntry(result.Uid, executionId).Length;
+        var operations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(
+            operations,
+            definitionPadBytes: definitionBytes - 1,
+            entryPadBytes: entryBytes - 1);
+        writer.Initialize();
+        long oldLength = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath).LongLength;
+        operations.BeginFaultWindow(terminationPlan: null);
+
+        writer.AppendCompleted(result, executionId);
+
+        byte[] published = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        _ = Assert.ContainsSingle(
+            operation => operation.Kind == TrxFileOperationKind.Replace,
+            operations.Operations);
+        Assert.IsGreaterThan(oldLength, published.LongLength);
+        AssertTruthful(
+            published,
+            TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]));
+        XDocument document = TrxPrototypeScenarioFactory.LoadStrict(published);
+        Assert.IsGreaterThan(0, GetWhitespaceBytes(document, "TestDefinitions"));
+        Assert.IsGreaterThan(0, GetWhitespaceBytes(document, "TestEntries"));
+    }
+
+    [TestMethod]
+    public void RunningSlotOverflow_IsDiagnosedOrReflowedWithoutLosingCompletedResults()
+    {
+        TrxTestResult completed = TrxPhase3EvidenceMatrix.CreateResult(
+            404,
+            "completed before slot overflow",
+            TrxTestOutcome.Passed);
+        Guid completedExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(404);
+        Guid runningExecutionId = TrxPhase3EvidenceMatrix.ExecutionId(405);
+        var operations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(
+            operations,
+            definitionPadBytes: 4_096,
+            entryPadBytes: 2_048,
+            runningSlotCount: 1);
+        writer.Initialize();
+        writer.AppendCompleted(completed, completedExecutionId);
+        _ = writer.ClaimRunning(
+            TrxPhase3EvidenceMatrix.TestId(405),
+            "occupied running slot",
+            runningExecutionId,
+            TrxPhase3EvidenceMatrix.StartTime.AddMinutes(1));
+        byte[] before = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        operations.BeginFaultWindow(terminationPlan: null);
+
+        InvalidOperationException error = Assert.ThrowsExactly<InvalidOperationException>(
+            () => writer.ClaimRunning(
+                TrxPhase3EvidenceMatrix.TestId(406),
+                "overflow",
+                TrxPhase3EvidenceMatrix.ExecutionId(406),
+                TrxPhase3EvidenceMatrix.StartTime));
+
+        Assert.Contains("All 1 running-test slots are occupied", error.Message);
+        Assert.IsEmpty(operations.Operations);
+        Assert.AreSequenceEqual(before, operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        AssertTruthful(
+            before,
+            TrxPhase3EvidenceMatrix.CreateExpectation(
+                [completed],
+                [completedExecutionId],
+                [
+                    new TrxExpectedRunningTest
+                    {
+                        TestId = Guid.Parse(TrxPhase3EvidenceMatrix.TestId(405)).ToString(),
+                        ExecutionId = runningExecutionId.ToString(),
+                        TestName = "occupied running slot",
+                        ComputerName = TrxPhase3EvidenceMatrix.MachineName,
+                        StartTime = TrxPhase3EvidenceMatrix.StartTime.AddMinutes(1),
+                    },
+                ]));
+    }
+
+    [TestMethod]
+    public void Reflow_EveryOpenReadSeekWriteFlushReplaceCleanupAndTempByteCut_PreservesTarget()
+    {
+        PublishedPair pair = CreatePublishedPair();
+        TrxFaultInjectingFileOperations baselineOperations = PublishVerified(
+            pair.OldBytes,
+            pair.NewBytes,
+            terminationPlan: null);
+        TrxFileOperationRecord[] baseline = [.. baselineOperations.Operations];
+        Assert.AreSequenceEqual(
+            [
+                TrxFileOperationKind.Open,
+                TrxFileOperationKind.Write,
+                TrxFileOperationKind.Seek,
+                TrxFileOperationKind.Read,
+                TrxFileOperationKind.Flush,
+                TrxFileOperationKind.Replace,
+            ],
+            baseline.Select(operation => operation.Kind).ToArray());
+
+        int oldClassifications = 0;
+        int newClassifications = 0;
+        foreach (TrxFileOperationRecord operation in baseline)
+        {
+            TrxFaultInjectingFileOperations faulted = PublishVerified(
+                pair.OldBytes,
+                pair.NewBytes,
+                new TrxTerminationPlan(operation.OperationIndex),
+                expectTermination: true);
+            byte[] target = faulted.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+            if (operation.Kind == TrxFileOperationKind.Replace)
+            {
+                Assert.AreSequenceEqual(pair.NewBytes, target);
+                AssertTruthful(target, pair.NewExpectation);
+                newClassifications++;
+            }
+            else
+            {
+                Assert.AreSequenceEqual(pair.OldBytes, target);
+                AssertTruthful(target, pair.OldExpectation);
+                oldClassifications++;
+            }
+        }
+
+        TrxFileOperationRecord write = baseline.Single(operation => operation.Kind == TrxFileOperationKind.Write);
+        for (int cut = 0; cut <= write.RequestedByteCount; cut++)
+        {
+            TrxFaultInjectingFileOperations faulted = PublishVerified(
+                pair.OldBytes,
+                pair.NewBytes,
+                new TrxTerminationPlan(write.OperationIndex, cut),
+                expectTermination: true);
+            Assert.AreSequenceEqual(pair.OldBytes, faulted.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+            string temporaryPath = faulted.CaptureSnapshot().Paths.Single(
+                path => !string.Equals(path, TrxPhase3EvidenceMatrix.TargetPath, StringComparison.Ordinal));
+            byte[] partial = faulted.GetFileBytes(temporaryPath);
+            Assert.HasCount(cut, partial);
+            Assert.AreSequenceEqual(pair.NewBytes.Take(cut).ToArray(), partial);
+            oldClassifications++;
+        }
+
+        var cleanupBaselineInner = new TrxFaultInjectingFileOperations();
+        cleanupBaselineInner.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, pair.OldBytes);
+        var cleanupBaseline = new ThrowingReplaceOperations(cleanupBaselineInner);
+        _ = Assert.ThrowsExactly<IOException>(
+            () => new TrxSnapshotPublisherPrototype(cleanupBaseline).Publish(
+                TrxPhase3EvidenceMatrix.TargetPath,
+                file => WriteAndReadBack(file, pair.NewBytes)));
+        TrxFileOperationRecord cleanup = cleanupBaselineInner.Operations.Single(
+            operation => operation.Kind == TrxFileOperationKind.Delete);
+        Assert.AreSequenceEqual(pair.OldBytes, cleanupBaselineInner.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+
+        var cleanupFaultInner = new TrxFaultInjectingFileOperations(
+            terminationPlan: new TrxTerminationPlan(cleanup.OperationIndex));
+        cleanupFaultInner.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, pair.OldBytes);
+        var cleanupFault = new ThrowingReplaceOperations(cleanupFaultInner);
+        _ = Assert.ThrowsExactly<IOException>(
+            () => new TrxSnapshotPublisherPrototype(cleanupFault).Publish(
+                TrxPhase3EvidenceMatrix.TargetPath,
+                file => WriteAndReadBack(file, pair.NewBytes)));
+        Assert.IsTrue(cleanupFaultInner.IsProcessDead);
+        Assert.AreSequenceEqual(pair.OldBytes, cleanupFaultInner.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+
+        TestContext.WriteLine(
+            "phase4 publication matrix: operations={0}; tempByteCuts={1}; oldTruthful={2}; newTruthful={3}; cleanup={4}",
+            baseline.Length,
+            write.RequestedByteCount + 1,
+            oldClassifications,
+            newClassifications,
+            cleanup.Kind);
+    }
+
+    [TestMethod]
+    public void Reflow_BeforeReplace_TargetIsPriorTruthfulSnapshot()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            407,
+            "before replace",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(407);
+        TrxDocumentExpectation oldExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([], []);
+        TrxDocumentExpectation newExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+        bool observe = false;
+        int oldBarriers = 0;
+        var operations = new TrxFaultInjectingFileOperations(
+            afterOperation: (operation, snapshot) =>
+            {
+                if (!observe || operation.Kind == TrxFileOperationKind.Replace)
+                {
+                    return;
+                }
+
+                AssertTruthful(
+                    snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+                    oldExpectation);
+                oldBarriers++;
+            });
+        TrxIncrementalWriterPrototype writer = CreateOverflowingSafeWriter(operations, result, executionId);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+        observe = true;
+
+        writer.AppendCompleted(result, executionId);
+
+        Assert.IsGreaterThan(0, oldBarriers);
+        AssertTruthful(operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath), newExpectation);
+    }
+
+    [TestMethod]
+    public void Reflow_AfterReplace_TargetIsNewTruthfulSnapshot()
+    {
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            408,
+            "after replace",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(408);
+        TrxDocumentExpectation expectation = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]);
+        bool observe = false;
+        int replaceBarriers = 0;
+        var operations = new TrxFaultInjectingFileOperations(
+            afterOperation: (operation, snapshot) =>
+            {
+                if (observe && operation.Kind == TrxFileOperationKind.Replace)
+                {
+                    AssertTruthful(
+                        snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+                        expectation);
+                    Assert.DoesNotContain(
+                        path => path.EndsWith(".tmp", StringComparison.Ordinal),
+                        snapshot.Paths);
+                    replaceBarriers++;
+                }
+            });
+        TrxIncrementalWriterPrototype writer = CreateOverflowingSafeWriter(operations, result, executionId);
+        writer.Initialize();
+        operations.BeginFaultWindow(terminationPlan: null);
+        observe = true;
+
+        writer.AppendCompleted(result, executionId);
+
+        Assert.AreEqual(1, replaceBarriers);
+    }
+
+    [TestMethod]
+    public void FailedReplace_LeavesPriorTargetAndCompleteOrPartialTempOnly()
+    {
+        PublishedPair pair = CreatePublishedPair();
+        var completeInner = new TrxFaultInjectingFileOperations();
+        completeInner.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, pair.OldBytes);
+        var completeFailure = new ThrowingReplaceOperations(completeInner, failDelete: true);
+
+        _ = Assert.ThrowsExactly<IOException>(
+            () => new TrxSnapshotPublisherPrototype(completeFailure).Publish(
+                TrxPhase3EvidenceMatrix.TargetPath,
+                file => file.Write(pair.NewBytes, 0, pair.NewBytes.Length)));
+
+        Assert.AreSequenceEqual(pair.OldBytes, completeInner.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        string completeTemporaryPath = completeInner.CaptureSnapshot().Paths.Single(
+            path => !string.Equals(path, TrxPhase3EvidenceMatrix.TargetPath, StringComparison.Ordinal));
+        Assert.AreSequenceEqual(pair.NewBytes, completeInner.GetFileBytes(completeTemporaryPath));
+
+        var trace = new TrxFaultInjectingFileOperations();
+        trace.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, pair.OldBytes);
+        new TrxSnapshotPublisherPrototype(trace).Publish(
+            TrxPhase3EvidenceMatrix.TargetPath,
+            file => file.Write(pair.NewBytes, 0, pair.NewBytes.Length));
+        int writeIndex = trace.Operations.Single(operation => operation.Kind == TrxFileOperationKind.Write).OperationIndex;
+        var partial = new TrxFaultInjectingFileOperations(
+            terminationPlan: new TrxTerminationPlan(writeIndex, committedByteCount: 7));
+        partial.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, pair.OldBytes);
+
+        _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+            () => new TrxSnapshotPublisherPrototype(partial).Publish(
+                TrxPhase3EvidenceMatrix.TargetPath,
+                file => file.Write(pair.NewBytes, 0, pair.NewBytes.Length)));
+
+        Assert.AreSequenceEqual(pair.OldBytes, partial.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        string partialTemporaryPath = partial.CaptureSnapshot().Paths.Single(
+            path => !string.Equals(path, TrxPhase3EvidenceMatrix.TargetPath, StringComparison.Ordinal));
+        Assert.AreSequenceEqual(pair.NewBytes.Take(7).ToArray(), partial.GetFileBytes(partialTemporaryPath));
+    }
+
+    [TestMethod]
+    public void Compact_EveryOperationAndByteCut_LeavesPaddedOldOrCompactNewDocument()
+    {
+        CompactRun baseline = CreateCompactRun(terminationPlan: null);
+        baseline.Writer.Compact(baseline.Completion);
+        byte[] compact = baseline.Operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        TrxFileOperationRecord[] operations = [.. baseline.Operations.Operations];
+        Assert.AreSequenceEqual(
+            [
+                TrxFileOperationKind.Open,
+                TrxFileOperationKind.Write,
+                TrxFileOperationKind.Flush,
+                TrxFileOperationKind.Replace,
+            ],
+            operations.Select(operation => operation.Kind).ToArray());
+        AssertTruthful(compact, baseline.CompactExpectation);
+
+        foreach (TrxFileOperationRecord operation in operations)
+        {
+            CompactRun fault = CreateCompactRun(new TrxTerminationPlan(operation.OperationIndex));
+            _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+                () => fault.Writer.Compact(fault.Completion));
+            byte[] target = fault.Operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+            if (operation.Kind == TrxFileOperationKind.Replace)
+            {
+                Assert.AreSequenceEqual(compact, target);
+                AssertTruthful(target, fault.CompactExpectation);
+            }
+            else
+            {
+                Assert.AreSequenceEqual(fault.PaddedBytes, target);
+                AssertTruthful(target, fault.PaddedExpectation);
+            }
+        }
+
+        TrxFileOperationRecord write = operations.Single(operation => operation.Kind == TrxFileOperationKind.Write);
+        for (int cut = 0; cut <= write.RequestedByteCount; cut++)
+        {
+            CompactRun fault = CreateCompactRun(
+                new TrxTerminationPlan(write.OperationIndex, cut));
+            _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(
+                () => fault.Writer.Compact(fault.Completion));
+            Assert.AreSequenceEqual(
+                fault.PaddedBytes,
+                fault.Operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+            AssertTruthful(fault.PaddedBytes, fault.PaddedExpectation);
+        }
+
+        TestContext.WriteLine(
+            "phase4 compaction matrix: operations={0}; compactByteCuts={1}; paddedBytes={2}; compactBytes={3}",
+            operations.Length,
+            write.RequestedByteCount + 1,
+            baseline.PaddedBytes.Length,
+            compact.Length);
+    }
+
+    [TestMethod]
+    public void Compact_OnlyAfterSuccessfulReplace_HasCanonicalSemanticParity()
+    {
+        CompactRun run = CreateCompactRun(terminationPlan: null);
+        XDocument padded = TrxPrototypeScenarioFactory.LoadStrict(run.PaddedBytes);
+
+        run.Writer.Compact(run.Completion);
+
+        byte[] compactBytes = run.Operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        XDocument compact = TrxPrototypeScenarioFactory.LoadStrict(compactBytes);
+        AssertTruthful(run.PaddedBytes, run.PaddedExpectation);
+        AssertTruthful(compactBytes, run.CompactExpectation);
+        Assert.AreEqual(CreateSemanticProjection(padded), CreateSemanticProjection(compact));
+        Assert.IsLessThan(run.PaddedBytes.Length, compactBytes.Length);
+    }
+
+    [TestMethod]
+    public void TemporaryPath_IsSiblingAndDifferentVolumeIsRejectedBeforeMutation()
+    {
+        string destination = Path.Combine("phase4", "results.trx");
+        var inner = new TrxFaultInjectingFileOperations();
+        byte[] prior = StrictUtf8.GetBytes("prior");
+        inner.SeedFile(destination, prior);
+        var outOfDirectory = new OutOfDirectoryOperations(inner);
+
+        InvalidOperationException error = Assert.ThrowsExactly<InvalidOperationException>(
+            () => new TrxSnapshotPublisherPrototype(outOfDirectory).Publish(
+                destination,
+                file => file.Write([1, 2, 3], 0, 3)));
+
+        Assert.Contains("distinct sibling", error.Message);
+        Assert.IsEmpty(inner.Operations);
+        Assert.AreSequenceEqual(prior, inner.GetFileBytes(destination));
+
+        string realDirectory = Path.Combine(Path.GetTempPath(), $"trx-phase4-sibling-{Guid.NewGuid():N}");
+        string realDestination = Path.Combine(realDirectory, "results.trx");
+        string realTemporary = new TrxPrototypeFileOperations().CreateTemporarySiblingPath(realDestination);
+        Assert.AreEqual(Path.GetFullPath(realDirectory), Path.GetDirectoryName(realTemporary));
+        Assert.AreNotEqual(Path.GetFullPath(realDestination), Path.GetFullPath(realTemporary));
+    }
+
+    [TestMethod]
+    public void AtomicAndDeleteThenMoveModels_ProduceExplicitlyDifferentGuarantees()
+    {
+        byte[] oldBytes = StrictUtf8.GetBytes("old");
+        byte[] newBytes = StrictUtf8.GetBytes("new");
+        var atomic = new TrxFaultInjectingFileOperations();
+        atomic.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, oldBytes);
+        new TrxSnapshotPublisherPrototype(atomic).Publish(
+            TrxPhase3EvidenceMatrix.TargetPath,
+            file => file.Write(newBytes, 0, newBytes.Length));
+        Assert.AreSequenceEqual(newBytes, atomic.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        _ = Assert.ContainsSingle(
+            operation => operation.Kind == TrxFileOperationKind.Replace,
+            atomic.Operations);
+
+        var targetPresence = new List<bool>();
+        var deleteThenMove = new TrxFaultInjectingFileOperations(
+            TrxReplacementModel.DeleteThenMove,
+            afterOperation: (_, snapshot) =>
+                targetPresence.Add(snapshot.Contains(TrxPhase3EvidenceMatrix.TargetPath)));
+        deleteThenMove.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, oldBytes);
+        deleteThenMove.SeedFile("results.trx.tmp", newBytes);
+        _ = Assert.ThrowsExactly<PlatformNotSupportedException>(
+            () => new TrxSnapshotPublisherPrototype(deleteThenMove).Publish(
+                TrxPhase3EvidenceMatrix.TargetPath,
+                file => file.Write(newBytes, 0, newBytes.Length)));
+        Assert.IsEmpty(deleteThenMove.Operations);
+        Assert.AreSequenceEqual(oldBytes, deleteThenMove.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+
+        deleteThenMove.ReplaceTemporarySibling("results.trx.tmp", TrxPhase3EvidenceMatrix.TargetPath);
+        Assert.AreSequenceEqual([false, true], targetPresence);
+        Assert.AreSequenceEqual(
+            [TrxFileOperationKind.Delete, TrxFileOperationKind.Replace],
+            deleteThenMove.Operations.Select(operation => operation.Kind).ToArray());
+    }
+
+    [TestMethod]
+    public void Startup_PreExistingTargetOrOrphanTemp_NeverTruncatesTargetBeforeReplace()
+    {
+        byte[] prior = TrxPrototypeXmlRenderer.RenderInitial(
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes: 512,
+            entryPadBytes: 256,
+            summaryPadBytes: 256,
+            counterWidth: TrxPhase3EvidenceMatrix.CounterWidth,
+            runningSlotCount: 1,
+            runningSlotByteCapacity: 256);
+        const string orphan = "results.trx.prototype-0001.tmp";
+        byte[] orphanBytes = StrictUtf8.GetBytes("orphan partial bytes");
+        bool observe = false;
+        int oldBarriers = 0;
+        int newBarriers = 0;
+        var operations = new TrxFaultInjectingFileOperations(
+            afterOperation: (operation, snapshot) =>
+            {
+                if (!observe)
+                {
+                    return;
+                }
+
+                byte[] target = snapshot.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+                if (operation.Kind == TrxFileOperationKind.Replace)
+                {
+                    AssertTruthful(
+                        target,
+                        TrxPhase3EvidenceMatrix.CreateExpectation([], []));
+                    newBarriers++;
+                }
+                else
+                {
+                    Assert.AreSequenceEqual(prior, target);
+                    oldBarriers++;
+                }
+            });
+        operations.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, prior);
+        operations.SeedFile(orphan, orphanBytes);
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(
+            operations,
+            definitionPadBytes: 1_024,
+            entryPadBytes: 512);
+        observe = true;
+
+        writer.Initialize();
+
+        Assert.IsGreaterThan(0, oldBarriers);
+        Assert.AreEqual(1, newBarriers);
+        Assert.AreSequenceEqual(orphanBytes, operations.GetFileBytes(orphan));
+        AssertTruthful(
+            operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+            TrxPhase3EvidenceMatrix.CreateExpectation([], []));
+    }
+
+    [TestMethod]
+    public void Startup_NoDirectoryPermissionOrLockFailure_LeavesPriorTargetUntouched()
+    {
+        byte[] prior = StrictUtf8.GetBytes("prior target");
+        var permissionInner = new TrxFaultInjectingFileOperations();
+        permissionInner.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, prior);
+        var denied = new DenyTemporaryOpenOperations(permissionInner);
+        TrxIncrementalWriterPrototype deniedWriter = CreateSafeWriter(denied);
+
+        _ = Assert.ThrowsExactly<UnauthorizedAccessException>(() => deniedWriter.Initialize());
+
+        Assert.AreSequenceEqual(prior, permissionInner.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        Assert.IsEmpty(permissionInner.Operations);
+
+        var locked = new TrxFaultInjectingFileOperations();
+        locked.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, prior);
+        using ITrxPrototypeFile lockHandle = locked.Open(
+            TrxPhase3EvidenceMatrix.TargetPath,
+            FileMode.Open,
+            FileAccess.ReadWrite,
+            FileShare.Read);
+        TrxIncrementalWriterPrototype lockedWriter = CreateSafeWriter(locked);
+
+        _ = Assert.ThrowsExactly<IOException>(() => lockedWriter.Initialize());
+
+        Assert.AreSequenceEqual(prior, locked.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath));
+        Assert.DoesNotContain(
+            path => path.EndsWith(".tmp", StringComparison.Ordinal),
+            locked.CaptureSnapshot().Paths);
+    }
+
+    private static TrxIncrementalWriterPrototype CreateSafeWriter(
+        ITrxPrototypeFileOperations operations,
+        int definitionPadBytes = 4_096,
+        int entryPadBytes = 2_048,
+        int summaryPadBytes = 2_048,
+        int counterWidth = TrxPhase3EvidenceMatrix.CounterWidth,
+        int runningSlotCount = 2,
+        int runningSlotByteCapacity = 320)
+        => new(
+            operations,
+            TrxPhase3EvidenceMatrix.TargetPath,
+            TrxPhase3EvidenceMatrix.RunId,
+            TrxPhase3EvidenceMatrix.RunName,
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion,
+            TrxPhase3EvidenceMatrix.StartTime,
+            definitionPadBytes,
+            entryPadBytes,
+            summaryPadBytes,
+            counterWidth,
+            runningSlotCount,
+            runningSlotByteCapacity,
+            new TrxSnapshotPublisherPrototype(operations));
+
+    private static TrxIncrementalWriterPrototype CreateOverflowingSafeWriter(
+        ITrxPrototypeFileOperations operations,
+        TrxTestResult result,
+        Guid executionId)
+    {
+        int definitionBytes = CreateRenderer().RenderDefinition(result, executionId).Length;
+        return CreateSafeWriter(
+            operations,
+            definitionPadBytes: definitionBytes - 1,
+            entryPadBytes: 2_048);
+    }
+
+    private static TrxPrototypeXmlRenderer CreateRenderer()
+        => new(
+            TrxPhase3EvidenceMatrix.MachineName,
+            TrxPhase3EvidenceMatrix.TestModule,
+            TrxPhase3EvidenceMatrix.FrameworkUid,
+            TrxPhase3EvidenceMatrix.FrameworkVersion);
+
+    private static void AssertTruthful(byte[] bytes, TrxDocumentExpectation expectation)
+    {
+        TrxDocumentObservation observation = TrxDocumentClassifier.Classify(bytes, expectation);
+        Assert.AreEqual(
+            TrxDocumentClassification.Truthful,
+            observation.Classification,
+            observation.Diagnostic);
+    }
+
+    private static int GetWhitespaceBytes(XDocument document, string localName)
+        => StrictUtf8.GetByteCount(
+            string.Concat(
+                document.Root!
+                    .Element(Ns + localName)!
+                    .Nodes()
+                    .OfType<XText>()
+                    .Select(text => text.Value)));
+
+    private static PublishedPair CreatePublishedPair()
+    {
+        var oldOperations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype oldWriter = TrxPhase3EvidenceMatrix.CreateWriter(oldOperations);
+        oldWriter.Initialize();
+        byte[] oldBytes = oldOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+
+        TrxTestResult result = TrxPhase3EvidenceMatrix.CreateResult(
+            409,
+            "published replacement é漢😀",
+            TrxTestOutcome.Passed);
+        Guid executionId = TrxPhase3EvidenceMatrix.ExecutionId(409);
+        var newOperations = new TrxFaultInjectingFileOperations();
+        TrxIncrementalWriterPrototype newWriter = TrxPhase3EvidenceMatrix.CreateWriter(newOperations);
+        newWriter.Initialize();
+        newWriter.AppendCompleted(result, executionId);
+        return new PublishedPair
+        {
+            OldBytes = oldBytes,
+            NewBytes = newOperations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath),
+            OldExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([], []),
+            NewExpectation = TrxPhase3EvidenceMatrix.CreateExpectation([result], [executionId]),
+        };
+    }
+
+    private static TrxFaultInjectingFileOperations PublishVerified(
+        byte[] oldBytes,
+        byte[] newBytes,
+        TrxTerminationPlan? terminationPlan,
+        bool expectTermination = false)
+    {
+        var operations = new TrxFaultInjectingFileOperations(
+            terminationPlan: terminationPlan,
+            captureSnapshots: false);
+        operations.SeedFile(TrxPhase3EvidenceMatrix.TargetPath, oldBytes);
+        Action publish = () => new TrxSnapshotPublisherPrototype(operations).Publish(
+            TrxPhase3EvidenceMatrix.TargetPath,
+            file => WriteAndReadBack(file, newBytes));
+        if (expectTermination)
+        {
+            _ = Assert.ThrowsExactly<TrxSimulatedProcessTerminationException>(publish);
+        }
+        else
+        {
+            publish();
+        }
+
+        return operations;
+    }
+
+    private static void WriteAndReadBack(ITrxPrototypeFile file, byte[] bytes)
+    {
+        file.Write(bytes, 0, bytes.Length);
+        file.Seek(0, SeekOrigin.Begin);
+        byte[] readBack = new byte[bytes.Length];
+        int read = file.Read(readBack, 0, readBack.Length);
+        if (read != readBack.Length)
+        {
+            throw new IOException($"Expected to read {readBack.Length} temporary bytes but read {read}.");
+        }
+
+        if (!bytes.SequenceEqual(readBack))
+        {
+            throw new IOException("Temporary snapshot read-back did not match the complete document.");
+        }
+    }
+
+    private static CompactRun CreateCompactRun(TrxTerminationPlan? terminationPlan)
+    {
+        var operations = new TrxFaultInjectingFileOperations(captureSnapshots: false);
+        TrxIncrementalWriterPrototype writer = CreateSafeWriter(operations);
+        TrxTestResult[] results =
+        [
+            TrxPhase3EvidenceMatrix.CreateResult(410, "compact pass", TrxTestOutcome.Passed),
+            TrxPhase3EvidenceMatrix.CreateResult(411, "compact skip", TrxTestOutcome.Skipped),
+        ];
+        Guid[] executionIds =
+        [
+            TrxPhase3EvidenceMatrix.ExecutionId(410),
+            TrxPhase3EvidenceMatrix.ExecutionId(411),
+        ];
+        var completion = new TrxPrototypeCompletion
+        {
+            FinishTime = TrxPhase3EvidenceMatrix.FinishTime,
+        };
+        writer.Initialize();
+        writer.AppendCompleted(results[0], executionIds[0]);
+        writer.AppendCompleted(results[1], executionIds[1]);
+        writer.Complete(completion);
+        byte[] padded = operations.GetFileBytes(TrxPhase3EvidenceMatrix.TargetPath);
+        TrxDocumentExpectation paddedExpectation = TrxPhase3EvidenceMatrix.CreateExpectation(
+            results,
+            executionIds,
+            finishTime: TrxPhase3EvidenceMatrix.FinishTime,
+            summaryOutcome: "Completed");
+        operations.BeginFaultWindow(terminationPlan);
+        return new CompactRun
+        {
+            Operations = operations,
+            Writer = writer,
+            Completion = completion,
+            PaddedBytes = padded,
+            PaddedExpectation = paddedExpectation,
+            CompactExpectation = CreateCompactExpectation(paddedExpectation),
+        };
+    }
+
+    private static TrxDocumentExpectation CreateCompactExpectation(TrxDocumentExpectation padded)
+        => new()
+        {
+            RunId = padded.RunId,
+            RunName = padded.RunName,
+            StartTime = padded.StartTime,
+            FinishTime = padded.FinishTime,
+            SummaryOutcome = padded.SummaryOutcome,
+            CompletedResults = padded.CompletedResults,
+            RunningTests = padded.RunningTests,
+            Counters = padded.Counters,
+        };
+
+    private static string CreateSemanticProjection(XDocument document)
+    {
+        XElement root = document.Root!;
+        XElement summary = root.Element(Ns + "ResultSummary")!;
+        string counters = string.Join(
+            ";",
+            summary.Element(Ns + "Counters")!
+                .Attributes()
+                .Select(attribute => $"{attribute.Name.LocalName}={int.Parse(attribute.Value, CultureInfo.InvariantCulture)}"));
+        string results = string.Join(
+            ";",
+            root.Element(Ns + "Results")!
+                .Elements(Ns + "UnitTestResult")
+                .Select(
+                    result => string.Join(
+                        "|",
+                        result.Attribute("executionId")!.Value,
+                        result.Attribute("testId")!.Value,
+                        result.Attribute("testName")!.Value,
+                        result.Attribute("outcome")!.Value)));
+        string definitions = string.Join(
+            ";",
+            root.Element(Ns + "TestDefinitions")!
+                .Elements(Ns + "UnitTest")
+                .Select(definition => definition.Attribute("id")!.Value));
+        string entries = string.Join(
+            ";",
+            root.Element(Ns + "TestEntries")!
+                .Elements(Ns + "TestEntry")
+                .Select(
+                    entry => $"{entry.Attribute("testId")!.Value}|{entry.Attribute("executionId")!.Value}"));
+        return string.Join(
+            "#",
+            root.Attribute("id")!.Value,
+            root.Attribute("name")!.Value,
+            root.Element(Ns + "Times")!.Attribute("finish")!.Value,
+            summary.Attribute("outcome")!.Value,
+            counters,
+            results,
+            definitions,
+            entries);
+    }
+
+    private sealed class PublishedPair
+    {
+        public required byte[] OldBytes { get; init; }
+
+        public required byte[] NewBytes { get; init; }
+
+        public required TrxDocumentExpectation OldExpectation { get; init; }
+
+        public required TrxDocumentExpectation NewExpectation { get; init; }
+    }
+
+    private sealed class CompactRun
+    {
+        public required TrxFaultInjectingFileOperations Operations { get; init; }
+
+        public required TrxIncrementalWriterPrototype Writer { get; init; }
+
+        public required TrxPrototypeCompletion Completion { get; init; }
+
+        public required byte[] PaddedBytes { get; init; }
+
+        public required TrxDocumentExpectation PaddedExpectation { get; init; }
+
+        public required TrxDocumentExpectation CompactExpectation { get; init; }
+    }
+
+    private abstract class ForwardingOperations(TrxFaultInjectingFileOperations inner)
+        : ITrxPrototypeFileOperations
+    {
+        protected TrxFaultInjectingFileOperations Inner { get; } = inner;
+
+        public virtual bool SupportsAtomicReplace => Inner.SupportsAtomicReplace;
+
+        public virtual ITrxPrototypeFile Open(string path, FileMode mode, FileAccess access, FileShare share)
+            => Inner.Open(path, mode, access, share);
+
+        public virtual string CreateTemporarySiblingPath(string destinationPath)
+            => Inner.CreateTemporarySiblingPath(destinationPath);
+
+        public virtual void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+            => Inner.ReplaceTemporarySibling(temporaryPath, destinationPath);
+
+        public virtual bool Exists(string path) => Inner.Exists(path);
+
+        public virtual void Delete(string path) => Inner.Delete(path);
+    }
+
+    private sealed class ThrowingReplaceOperations(
+        TrxFaultInjectingFileOperations inner,
+        bool failDelete = false)
+        : ForwardingOperations(inner)
+    {
+        public override void ReplaceTemporarySibling(string temporaryPath, string destinationPath)
+            => throw new IOException("Deterministic replacement failure.");
+
+        public override void Delete(string path)
+        {
+            if (failDelete)
+            {
+                throw new UnauthorizedAccessException("Deterministic temp cleanup denial.");
+            }
+
+            base.Delete(path);
+        }
+    }
+
+    private sealed class OutOfDirectoryOperations(TrxFaultInjectingFileOperations inner)
+        : ForwardingOperations(inner)
+    {
+        public override string CreateTemporarySiblingPath(string destinationPath)
+            => Path.Combine(Path.GetTempPath(), "different-filesystem-probe", "results.trx.tmp");
+    }
+
+    private sealed class DenyTemporaryOpenOperations(TrxFaultInjectingFileOperations inner)
+        : ForwardingOperations(inner)
+    {
+        public override ITrxPrototypeFile Open(
+            string path,
+            FileMode mode,
+            FileAccess access,
+            FileShare share)
+            => throw new UnauthorizedAccessException("Deterministic directory permission denial.");
+    }
+}


### PR DESCRIPTION
Related #10016

Wanted to implement both options and see what actually survives interrupted writes. Neither implementation is wired into production.

The padded file cannot provide the guarantee from the issue. Across 5,656 injected operation failures and byte cuts:

- 4,545 were malformed
- 719 were parseable but inconsistent
- 22 were repairable
- 370 were truthful

The append-only journal recovered a complete prefix in all 246 interruption cases, including restart and append after a torn final record. Publishing complete streamed snapshots through sibling-file replacement kept the destination old or new and truthful in all 3,519 observations.

For 10k synthetic results, journal plus snapshots did 10,004 flushes and wrote 18.3 MB. The padded writer did 89,959 flushes and wrote 24.6 MB. Replay keeps one record, no result collection, and no `XDocument`.

## Changes

- Add an isolated padded incremental writer with fixed pads, counters, running slots, reflow, and compaction.
- Add an append-only journal with torn-tail recovery and streamed snapshot publication.
- Add deterministic operation and partial-write injection, semantic TRX classification, concurrent-reader barriers, and real-file-system tests.
- Cover CRLF preservation, UTF-8-safe truncation, long metadata, large output, summary data, startup overwrite, replacement sharing modes, and 10k-result diagnostics.

## Verification

- 148 focused tests passed across `net462`, `net472`, `net8.0`, and `net9.0`.
- 3,432 extension unit tests passed, with 20 existing skips.
- 20 Release diagnostics passed.
- TRX acceptance passed: 40 MTP, 6 MSTest TRX, and 6 MSTest output tests.
- Debug and Release builds, full repository build, and package production passed.

This does not claim XSD, Visual Studio, Azure DevOps, third-party reader, network filesystem, antivirus, physical power-loss, or actual attachment-copying compatibility. Atomic overwrite intentionally fails closed on .NET Framework where the same replacement guarantee is not available.

LMK if this should stay as evidence only, or if I should follow with the production journal and snapshot path.

🤖