### PR TITLE
Clarify .NET Framework runner compatibility tests

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NetFrameworkRunnerCompatibilityTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NetFrameworkRunnerCompatibilityTests.cs
@@ -9,14 +9,12 @@ using Microsoft.Testing.TestInfrastructure;
 namespace MSTest.Acceptance.IntegrationTests;
 
 /// <summary>
-/// Acceptance-style rewrite of the former CLITestBase-based desktop tests. Instead of referencing
-/// pre-built desktop test-asset projects, the test asset is generated inline and built for every
-/// (platform, configuration) combination, then executed out-of-process through the MSTest runner
-/// (Microsoft.Testing.Platform) host.
+/// Verifies that the standalone MSTest runner can discover and execute .NET Framework tests for
+/// every supported architecture and build configuration.
 /// </summary>
 [TestClass]
 [OSCondition(OperatingSystems.Windows)]
-public sealed class DesktopCSharpCLITests : AcceptanceTestBase<DesktopCSharpCLITests.TestAssetFixture>
+public sealed class NetFrameworkRunnerCompatibilityTests : AcceptanceTestBase<NetFrameworkRunnerCompatibilityTests.TestAssetFixture>
 {
     private static readonly string[] Platforms = ["x86", "x64"];
 


### PR DESCRIPTION
The former `DesktopCSharpCLITests` name obscured the test's unique purpose and suggested broader CLI coverage than it provides. The test specifically protects standalone MSTest runner compatibility for .NET Framework across x86/x64 and Debug/Release configurations.

Rename the class and file to `NetFrameworkRunnerCompatibilityTests`, and update the summary to describe that contract directly. The Windows-only `net462` matrix remains intentional; cross-platform .NET discovery and execution are already covered by `TestDiscoveryTests` and `RunnerTests`.