### PR TITLE
Fix Visual Studio version in development guide

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -4,7 +4,7 @@ This document contains all the required information to build, test, and consume 
 
 ## Prerequisites
 
-To build and test all functionalities of MSTest, we recommend installing [Visual Studio 2026](https://visualstudio.microsoft.com/) with the following workloads:
+To build and test all functionalities of MSTest, we recommend installing [Visual Studio 2022](https://visualstudio.microsoft.com/) with the following workloads:
 
 - `.NET desktop development`
 - `Universal Windows Platform development`


### PR DESCRIPTION
## Summary

- Correct the development guide prerequisite from Visual Studio 2026 to Visual Studio 2022

Fixes #10123