### PR TITLE
Add MSTEST0066 derived attribute tests

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/IgnoreShouldHaveJustificationAnalyzerTests.cs
@@ -523,4 +523,80 @@ public sealed class IgnoreShouldHaveJustificationAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"), fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenDerivedTestMethodAttributeHasIgnoreWithoutMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                [{|#0:Ignore|}]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyTestMethod]
+                [Ignore("TODO: explain why this is ignored")]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod1"), fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenDerivedTestClassAttributeHasIgnoreWithoutMessage_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestClassAttribute : TestClassAttribute { }
+
+            [MyTestClass]
+            [{|#0:Ignore|}]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyTestClassAttribute : TestClassAttribute { }
+
+            [MyTestClass]
+            [Ignore("TODO: explain why this is ignored")]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod1()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"), fixedCode);
+    }
 }


### PR DESCRIPTION
## Summary

- add diagnostic coverage for `[Ignore]` on methods using an attribute derived from `TestMethodAttribute`
- add diagnostic coverage for `[Ignore]` on classes using an attribute derived from `TestClassAttribute`
- verify the code fix supplies the default justification in both cases

## Testing

- `MSTest.Analyzers.UnitTests` build passed for `net472` and `net8.0`
- all 20 filtered `IgnoreShouldHaveJustification` tests passed

Fixes #10121