### PR TITLE
Optimize IPC primitive serialization

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -25,9 +25,7 @@ internal abstract class BaseSerializer
 
     protected static string ReadString(Stream stream)
     {
-        byte[] len = new byte[sizeof(int)];
-        ReadExactly(stream, len, 0, len.Length);
-        int length = BitConverter.ToInt32(len, 0);
+        int length = ReadInt(stream);
         byte[] bytes = new byte[length];
         ReadExactly(stream, bytes, 0, length);
         return Encoding.UTF8.GetString(bytes, 0, length);
@@ -43,69 +41,112 @@ internal abstract class BaseSerializer
     protected static void WriteString(Stream stream, string str)
     {
         byte[] bytes = Encoding.UTF8.GetBytes(str);
-        byte[] len = BitConverter.GetBytes(bytes.Length);
-        stream.Write(len, 0, len.Length);
+        WriteInt(stream, bytes.Length);
         stream.Write(bytes, 0, bytes.Length);
     }
 
     protected static void WriteSize<T>(Stream stream)
         where T : struct
-    {
-        int sizeInBytes = GetSize<T>();
-        byte[] len = BitConverter.GetBytes(sizeInBytes);
-        stream.Write(len, 0, len.Length);
-    }
+        => WriteInt(stream, GetSize<T>());
 
     protected static void WriteInt(Stream stream, int value)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
+        stream.Write(bytes);
+#else
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
+#endif
     }
 
     protected static int ReadInt(Stream stream)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(int)];
+        stream.ReadExactly(bytes);
+        return System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(bytes);
+#else
         byte[] bytes = new byte[sizeof(int)];
         ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToInt32(bytes, 0);
+#endif
     }
 
     protected static void WriteLong(Stream stream, long value)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
+        stream.Write(bytes);
+#else
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
+#endif
     }
 
     protected static long ReadLong(Stream stream)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(long)];
+        stream.ReadExactly(bytes);
+        return System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(bytes);
+#else
         byte[] bytes = new byte[sizeof(long)];
         ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToInt64(bytes, 0);
+#endif
     }
 
     protected static void WriteUShort(Stream stream, ushort value)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes, value);
+        stream.Write(bytes);
+#else
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
+#endif
     }
 
     protected static ushort ReadUShort(Stream stream)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(ushort)];
+        stream.ReadExactly(bytes);
+        return System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(bytes);
+#else
         byte[] bytes = new byte[sizeof(ushort)];
         ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToUInt16(bytes, 0);
+#endif
     }
 
     protected static void WriteBool(Stream stream, bool value)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(bool)];
+        bytes.Fill(value ? (byte)1 : (byte)0);
+        stream.Write(bytes);
+#else
         byte[] bytes = BitConverter.GetBytes(value);
         stream.Write(bytes, 0, bytes.Length);
+#endif
     }
 
     protected static bool ReadBool(Stream stream)
     {
+#if NETCOREAPP
+        Span<byte> bytes = stackalloc byte[sizeof(bool)];
+        stream.ReadExactly(bytes);
+        return bytes[0] != 0;
+#else
         byte[] bytes = new byte[sizeof(bool)];
         ReadExactly(stream, bytes, 0, bytes.Length);
         return BitConverter.ToBoolean(bytes, 0);
+#endif
     }
 
     // Reads exactly 'count' bytes into 'buffer' starting at 'offset', looping until the request is

--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -53,7 +53,15 @@ internal abstract class BaseSerializer
     {
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(int)];
-        System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
+        if (BitConverter.IsLittleEndian)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32LittleEndian(bytes, value);
+        }
+        else
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(bytes, value);
+        }
+
         stream.Write(bytes);
 #else
         byte[] bytes = BitConverter.GetBytes(value);
@@ -66,7 +74,9 @@ internal abstract class BaseSerializer
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(int)];
         stream.ReadExactly(bytes);
-        return System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(bytes);
+        return BitConverter.IsLittleEndian
+            ? System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(bytes)
+            : System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(bytes);
 #else
         byte[] bytes = new byte[sizeof(int)];
         ReadExactly(stream, bytes, 0, bytes.Length);
@@ -78,7 +88,15 @@ internal abstract class BaseSerializer
     {
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(long)];
-        System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
+        if (BitConverter.IsLittleEndian)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64LittleEndian(bytes, value);
+        }
+        else
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteInt64BigEndian(bytes, value);
+        }
+
         stream.Write(bytes);
 #else
         byte[] bytes = BitConverter.GetBytes(value);
@@ -91,7 +109,9 @@ internal abstract class BaseSerializer
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(long)];
         stream.ReadExactly(bytes);
-        return System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(bytes);
+        return BitConverter.IsLittleEndian
+            ? System.Buffers.Binary.BinaryPrimitives.ReadInt64LittleEndian(bytes)
+            : System.Buffers.Binary.BinaryPrimitives.ReadInt64BigEndian(bytes);
 #else
         byte[] bytes = new byte[sizeof(long)];
         ReadExactly(stream, bytes, 0, bytes.Length);
@@ -103,7 +123,15 @@ internal abstract class BaseSerializer
     {
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(ushort)];
-        System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes, value);
+        if (BitConverter.IsLittleEndian)
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16LittleEndian(bytes, value);
+        }
+        else
+        {
+            System.Buffers.Binary.BinaryPrimitives.WriteUInt16BigEndian(bytes, value);
+        }
+
         stream.Write(bytes);
 #else
         byte[] bytes = BitConverter.GetBytes(value);
@@ -116,7 +144,9 @@ internal abstract class BaseSerializer
 #if NETCOREAPP
         Span<byte> bytes = stackalloc byte[sizeof(ushort)];
         stream.ReadExactly(bytes);
-        return System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(bytes);
+        return BitConverter.IsLittleEndian
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(bytes)
+            : System.Buffers.Binary.BinaryPrimitives.ReadUInt16BigEndian(bytes);
 #else
         byte[] bytes = new byte[sizeof(ushort)];
         ReadExactly(stream, bytes, 0, bytes.Length);
@@ -125,29 +155,15 @@ internal abstract class BaseSerializer
     }
 
     protected static void WriteBool(Stream stream, bool value)
-    {
-#if NETCOREAPP
-        Span<byte> bytes = stackalloc byte[sizeof(bool)];
-        bytes.Fill(value ? (byte)1 : (byte)0);
-        stream.Write(bytes);
-#else
-        byte[] bytes = BitConverter.GetBytes(value);
-        stream.Write(bytes, 0, bytes.Length);
-#endif
-    }
+        => stream.WriteByte(value ? (byte)1 : (byte)0);
 
     protected static bool ReadBool(Stream stream)
-    {
-#if NETCOREAPP
-        Span<byte> bytes = stackalloc byte[sizeof(bool)];
-        stream.ReadExactly(bytes);
-        return bytes[0] != 0;
-#else
-        byte[] bytes = new byte[sizeof(bool)];
-        ReadExactly(stream, bytes, 0, bytes.Length);
-        return BitConverter.ToBoolean(bytes, 0);
-#endif
-    }
+        => stream.ReadByte() switch
+        {
+            -1 => throw new EndOfStreamException(),
+            0 => false,
+            _ => true,
+        };
 
     // Reads exactly 'count' bytes into 'buffer' starting at 'offset', looping until the request is
     // satisfied or the end of the stream is reached. This centralizes the previously duplicated

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.IPC.Serializers;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Testing.Platform.UnitTests;
 public sealed class BaseSerializerPrimitiveTests
 {
     [TestMethod]
-    public void WritePrimitives_WritesLittleEndianWireFormat()
+    public void WritePrimitives_WritesNativeEndianWireFormat()
     {
         using var stream = new MemoryStream();
 
@@ -21,32 +21,17 @@ public sealed class BaseSerializerPrimitiveTests
         SerializerProbe.WriteStringValue(stream, "A");
         SerializerProbe.WriteLongSize(stream);
 
-        byte[] expected =
-        [
-            0x04, 0x03, 0x02, 0x01,
-            0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01,
-            0x02, 0x01,
-            0x00,
-            0x01,
-            0x01, 0x00, 0x00, 0x00, 0x41,
-            0x08, 0x00, 0x00, 0x00,
-        ];
+        byte[] expected = [.. BitConverter.GetBytes(0x01020304), .. BitConverter.GetBytes(0x0102030405060708), .. BitConverter.GetBytes((ushort)0x0102), 0x00, 0x01, .. BitConverter.GetBytes(1), 0x41, .. BitConverter.GetBytes(sizeof(long))];
         Assert.AreSequenceEqual(
             expected,
             stream.ToArray());
     }
 
     [TestMethod]
-    public void ReadPrimitives_ReadsLittleEndianWireFormat()
+    public void ReadPrimitives_ReadsNativeEndianWireFormat()
     {
-        using var stream = new MemoryStream(
-            [
-                0x04, 0x03, 0x02, 0x01,
-                0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01,
-                0x02, 0x01,
-                0xFF,
-                0x01, 0x00, 0x00, 0x00, 0x41,
-            ]);
+        byte[] bytes = [.. BitConverter.GetBytes(0x01020304), .. BitConverter.GetBytes(0x0102030405060708), .. BitConverter.GetBytes((ushort)0x0102), 0xFF, .. BitConverter.GetBytes(1), 0x41];
+        using var stream = new MemoryStream(bytes);
 
         Assert.AreEqual(0x01020304, SerializerProbe.ReadIntValue(stream));
         Assert.AreEqual(0x0102030405060708, SerializerProbe.ReadLongValue(stream));

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/BaseSerializerPrimitiveTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.IPC.Serializers;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class BaseSerializerPrimitiveTests
+{
+    [TestMethod]
+    public void WritePrimitives_WritesLittleEndianWireFormat()
+    {
+        using var stream = new MemoryStream();
+
+        SerializerProbe.WriteIntValue(stream, 0x01020304);
+        SerializerProbe.WriteLongValue(stream, 0x0102030405060708);
+        SerializerProbe.WriteUShortValue(stream, 0x0102);
+        SerializerProbe.WriteBoolValue(stream, false);
+        SerializerProbe.WriteBoolValue(stream, true);
+        SerializerProbe.WriteStringValue(stream, "A");
+        SerializerProbe.WriteLongSize(stream);
+
+        byte[] expected =
+        [
+            0x04, 0x03, 0x02, 0x01,
+            0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01,
+            0x02, 0x01,
+            0x00,
+            0x01,
+            0x01, 0x00, 0x00, 0x00, 0x41,
+            0x08, 0x00, 0x00, 0x00,
+        ];
+        Assert.AreSequenceEqual(
+            expected,
+            stream.ToArray());
+    }
+
+    [TestMethod]
+    public void ReadPrimitives_ReadsLittleEndianWireFormat()
+    {
+        using var stream = new MemoryStream(
+            [
+                0x04, 0x03, 0x02, 0x01,
+                0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01,
+                0x02, 0x01,
+                0xFF,
+                0x01, 0x00, 0x00, 0x00, 0x41,
+            ]);
+
+        Assert.AreEqual(0x01020304, SerializerProbe.ReadIntValue(stream));
+        Assert.AreEqual(0x0102030405060708, SerializerProbe.ReadLongValue(stream));
+        Assert.AreEqual((ushort)0x0102, SerializerProbe.ReadUShortValue(stream));
+        Assert.IsTrue(SerializerProbe.ReadBoolValue(stream));
+        Assert.AreEqual("A", SerializerProbe.ReadStringValue(stream));
+    }
+
+    [TestMethod]
+    public void ReadPrimitives_WhenStreamIsTruncated_ThrowsEndOfStreamException()
+    {
+        Assert.ThrowsExactly<EndOfStreamException>(
+            () => SerializerProbe.ReadIntValue(new MemoryStream(new byte[sizeof(int) - 1])));
+        Assert.ThrowsExactly<EndOfStreamException>(
+            () => SerializerProbe.ReadLongValue(new MemoryStream(new byte[sizeof(long) - 1])));
+        Assert.ThrowsExactly<EndOfStreamException>(
+            () => SerializerProbe.ReadUShortValue(new MemoryStream(new byte[sizeof(ushort) - 1])));
+        Assert.ThrowsExactly<EndOfStreamException>(
+            () => SerializerProbe.ReadBoolValue(new MemoryStream()));
+    }
+
+    private sealed class SerializerProbe : BaseSerializer
+    {
+        public static void WriteIntValue(Stream stream, int value) => WriteInt(stream, value);
+
+        public static int ReadIntValue(Stream stream) => ReadInt(stream);
+
+        public static void WriteLongValue(Stream stream, long value) => WriteLong(stream, value);
+
+        public static long ReadLongValue(Stream stream) => ReadLong(stream);
+
+        public static void WriteUShortValue(Stream stream, ushort value) => WriteUShort(stream, value);
+
+        public static ushort ReadUShortValue(Stream stream) => ReadUShort(stream);
+
+        public static void WriteBoolValue(Stream stream, bool value) => WriteBool(stream, value);
+
+        public static bool ReadBoolValue(Stream stream) => ReadBool(stream);
+
+        public static void WriteStringValue(Stream stream, string value) => WriteString(stream, value);
+
+        public static string ReadStringValue(Stream stream) => ReadString(stream);
+
+        public static void WriteLongSize(Stream stream) => WriteSize<long>(stream);
+    }
+}


### PR DESCRIPTION
## Summary
- replace NETCOREAPP primitive byte-array allocations with stack-allocated spans and native-endian `BinaryPrimitives`
- route string and fixed-size length prefixes through the optimized integer helpers while retaining the existing legacy fallback
- add focused wire-format, bool compatibility, and truncated-stream tests

## Validation
- `build.cmd` for `Microsoft.Testing.Platform.UnitTests` on net8.0, net9.0, and net462
- `build.cmd` for `Microsoft.Testing.Platform.MSBuild`, including `Microsoft.Testing.Extensions.MSBuild`, on net8.0, net9.0, and netstandard2.0

Fixes #10117