### PR TITLE
Add MSTEST0071 edge-case tests

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
@@ -200,4 +200,106 @@ public sealed class RedundantTestMethodDisplayNameAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenDisplayNameIsFirstArgumentBeforeOtherArgs_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [[|TestMethod(DisplayName = "MyTestMethod", UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Auto)|]]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Auto)]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodIsNotInTestClass_Diagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                [[|TestMethod(DisplayName = "MyTestMethod")|]]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class MyClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodHasCustomDerivedAttributeAndBuiltinTestMethodAttributeAndOnlyCustomHasRedundantDisplayName_SingleDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [[|CustomTestMethod(DisplayName = "MyTestMethod")|]]
+                [DataTestMethod(DisplayName = "My friendly name")]
+                [DataRow(1)]
+                public void MyTestMethod(int value)
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestMethodAttribute : TestMethodAttribute { }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [CustomTestMethod]
+                [DataTestMethod(DisplayName = "My friendly name")]
+                [DataRow(1)]
+                public void MyTestMethod(int value)
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/RedundantTestMethodDisplayNameAnalyzerTests.cs
@@ -202,38 +202,6 @@ public sealed class RedundantTestMethodDisplayNameAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenDisplayNameIsFirstArgumentBeforeOtherArgs_Diagnostic()
-    {
-        string code = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [[|TestMethod(DisplayName = "MyTestMethod", UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Auto)|]]
-                public void MyTestMethod()
-                {
-                }
-            }
-            """;
-
-        string fixedCode = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Auto)]
-                public void MyTestMethod()
-                {
-                }
-            }
-            """;
-
-        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
-    }
-
-    [TestMethod]
     public async Task WhenMethodIsNotInTestClass_Diagnostic()
     {
         string code = """


### PR DESCRIPTION
## Summary

- verify MSTEST0071 diagnostics and code-fix behavior outside a `[TestClass]`
- verify only the offending `TestMethod`-derived attribute is changed when multiple attributes are present
- retain the existing coverage for removing first-position `DisplayName` while preserving other arguments

## Tests

- `eng\common\dotnet.cmd test --project test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj --framework net8.0 --filter "FullyQualifiedName~RedundantTestMethodDisplayNameAnalyzerTests" --verbosity minimal /bl:artifacts\log\mstest0071-review-validation.binlog` (9 passed)

Fixes #10097