### PR TITLE
Pool IPC serializer string buffers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -26,23 +26,49 @@ internal abstract class BaseSerializer
     protected static string ReadString(Stream stream)
     {
         int length = ReadInt(stream);
-        byte[] bytes = new byte[length];
-        ReadExactly(stream, bytes, 0, length);
-        return Encoding.UTF8.GetString(bytes, 0, length);
+        return ReadStringValue(stream, length);
     }
 
     protected static string ReadStringValue(Stream stream, int size)
     {
+#if NETCOREAPP
+        byte[] rentedBytes = System.Buffers.ArrayPool<byte>.Shared.Rent(size);
+        try
+        {
+            ReadExactly(stream, rentedBytes, 0, size);
+            return Encoding.UTF8.GetString(rentedBytes, 0, size);
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(rentedBytes);
+        }
+#else
         byte[] bytes = new byte[size];
         ReadExactly(stream, bytes, 0, size);
         return Encoding.UTF8.GetString(bytes, 0, size);
+#endif
     }
 
     protected static void WriteString(Stream stream, string str)
     {
+#if NETCOREAPP
+        int byteCount = Encoding.UTF8.GetByteCount(str);
+        byte[] rentedBytes = System.Buffers.ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            Encoding.UTF8.GetBytes(str, rentedBytes);
+            WriteInt(stream, byteCount);
+            stream.Write(rentedBytes, 0, byteCount);
+        }
+        finally
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(rentedBytes);
+        }
+#else
         byte[] bytes = Encoding.UTF8.GetBytes(str);
         WriteInt(stream, bytes.Length);
         stream.Write(bytes, 0, bytes.Length);
+#endif
     }
 
     protected static void WriteSize<T>(Stream stream)


### PR DESCRIPTION
## Summary
- rent temporary UTF-8 byte arrays from `ArrayPool<byte>.Shared` for IPC string reads and writes on `NETCOREAPP`
- return rented buffers in `finally` blocks, including when stream operations fail
- reuse `ReadStringValue` from the length-prefixed string reader and preserve the existing legacy-target fallback
- size write buffers using the exact UTF-8 byte count to avoid oversized pool rentals

## Validation
- `build.cmd -projects test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj -test -bl`
- passed on net8.0, net9.0, and net462 with 0 warnings and 0 errors

Fixes #10140