### PR TITLE
Use pattern matching for adapter null checks

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Execution/TcmTestPropertiesProvider.cs
+++ b/src/Adapter/MSTest.TestAdapter/Execution/TcmTestPropertiesProvider.cs
@@ -26,7 +26,7 @@ internal static class TcmTestPropertiesProvider
     public static IReadOnlyDictionary<string, object?>? GetTcmProperties(TestPlatformObjectModel.TestCase? testCase)
     {
         // Return empty properties when testCase is null or when test case id is zero.
-        if (testCase == null ||
+        if (testCase is null ||
             testCase.GetPropertyValue<int>(AdapterTestProperties.TestCaseIdProperty, default) == 0)
         {
             return null;

--- a/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
@@ -84,7 +84,7 @@ internal static class UnitTestElementExtensions
         }
 
         // Set priority if present
-        if (element.Priority != null)
+        if (element.Priority is not null)
         {
             testCase.SetPropertyValue(AdapterTestProperties.PriorityProperty, element.Priority.Value);
         }
@@ -97,7 +97,7 @@ internal static class UnitTestElementExtensions
             }
         }
 
-        if (element.WorkItemIds != null)
+        if (element.WorkItemIds is not null)
         {
             testCase.SetPropertyValue(AdapterTestProperties.WorkItemIdsProperty, element.WorkItemIds);
         }

--- a/src/Adapter/MSTest.TestAdapter/TestMethodFilter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestMethodFilter.cs
@@ -37,7 +37,7 @@ internal sealed class TestMethodFilter
     internal ITestCaseFilterExpression? GetFilterExpression(IDiscoveryContext? context, IAdapterMessageLogger logger, out bool filterHasError)
     {
         filterHasError = false;
-        if (context == null)
+        if (context is null)
         {
             return null;
         }
@@ -96,7 +96,7 @@ internal sealed class TestMethodFilter
     /// <returns>The property value.</returns>
     internal object? PropertyValueProvider(TestCase? currentTest, string? propertyName)
     {
-        if (currentTest != null && propertyName != null)
+        if (currentTest is not null && propertyName is not null)
         {
             if (_supportedProperties.TryGetValue(propertyName, out TestProperty? testProperty))
             {


### PR DESCRIPTION
## Summary
- replace equality-based null checks in the new adapter code with `is null` and `is not null`
- align the affected files with the repository coding standards without changing behavior

Fixes #10138

## Testing
- `./build.cmd -projects "src\\Adapter\\MSTest.TestAdapter\\MSTest.TestAdapter.csproj" -bl -v:minimal`