### PR TITLE
Support comments in testconfig on .NET Framework

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationFileParser.netstandard.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationFileParser.netstandard.cs
@@ -18,6 +18,7 @@ internal sealed class JsonConfigurationFileParser
     private readonly Stack<string> _paths = new();
     private readonly JsonSettings _settings = new()
     {
+        AllowComments = true,
         AllowTrailingCommas = true,
     };
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Jsonite/JsonReader.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Jsonite/JsonReader.cs
@@ -445,11 +445,7 @@ namespace Jsonite
                     } while (IsDigit(c));
                 }
 
-                // Skip any whitespaces after a value
-                while (IsWhiteSpace(c))
-                {
-                    NextChar();
-                }
+                SkipWhitespacesAndComments();
 
                 // If we are expecting to parse only things into strings, early exit here
                 if (settings.ParseValuesAsStrings)
@@ -604,10 +600,58 @@ namespace Jsonite
 
             private void NextCharSkipWhitespaces()
             {
-                do
+                NextChar();
+                SkipWhitespacesAndComments();
+            }
+
+            private void SkipWhitespacesAndComments()
+            {
+                while (true)
                 {
-                    NextChar();
-                } while (IsWhiteSpace(c));
+                    while (IsWhiteSpace(c))
+                    {
+                        NextChar();
+                    }
+
+                    if (!settings.AllowComments || c != '/')
+                    {
+                        return;
+                    }
+
+                    switch (Reader.Peek())
+                    {
+                        case '/':
+                            do
+                            {
+                                NextChar();
+                            }
+                            while (!isEof && c is not ('\r' or '\n'));
+                            break;
+
+                        case '*':
+                            NextChar();
+                            while (true)
+                            {
+                                NextChar();
+                                if (isEof)
+                                {
+                                    RaiseUnexpected("while parsing a comment. Expecting the end of a comment '*/'");
+                                }
+
+                                if (c == '*' && Reader.Peek() == '/')
+                                {
+                                    NextChar();
+                                    NextChar();
+                                    break;
+                                }
+                            }
+
+                            break;
+
+                        default:
+                            return;
+                    }
+                }
             }
 
             [MethodImpl((MethodImplOptions)256)]

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Jsonite/JsonTypes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Jsonite/JsonTypes.cs
@@ -167,6 +167,11 @@ namespace Jsonite
         public bool ParseValuesAsStrings { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to allow comments.
+        /// </summary>
+        public bool AllowComments { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to allow trailing commas in object and array declaration.
         /// </summary>
         public bool AllowTrailingCommas { get; set; }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -45,6 +45,12 @@ public sealed class ConfigurationManagerTests
         yield return ("{\"platformOptions\": [1,2] }", "platformOptions:0", "1");
         yield return ("{\"platformOptions\": [1,2] }", "platformOptions:1", "2");
         yield return ("{\"platformOptions\": [1,2] }", "platformOptions", "[1,2]");
+        yield return ("{// Configure crash dumps\n\"platformOptions\": {\"Troubleshooting\": {\"CrashDump\": {\"Enable\": true}}}}", "platformOptions:Troubleshooting:CrashDump:Enable", "True");
+        yield return ("{// Comment containing \0 a null character\n\"platformOptions\": {\"Troubleshooting\": {\"CrashDump\": {\"Enable\": true}}}}", "platformOptions:Troubleshooting:CrashDump:Enable", "True");
+        yield return ("{\"platformOptions\": {/* Configure crash dumps */\"Troubleshooting\": {\"CrashDump\": {\"Enable\": true}}}}", "platformOptions:Troubleshooting:CrashDump:Enable", "True");
+        yield return ("{\"platformOptions\": {/* Comment containing \0 a null character */\"Troubleshooting\": {\"CrashDump\": {\"Enable\": true}}}}", "platformOptions:Troubleshooting:CrashDump:Enable", "True");
+        yield return ("{\"platformOptions\": {\"Count\": 1 /* Number of retries */}}", "platformOptions:Count", "1");
+        yield return ("{\"platformOptions\": {\"Url\": \"https://example.com\"}}", "platformOptions:Url", "https://example.com");
         yield return ("{\"platformOptions\": { \"Array\" : [ {\"Key\" : \"Value\"} , {\"Key\" : 3} ] } }", "platformOptions:Array:0", null);
         yield return ("{\"platformOptions\": { \"Array\" : [ {\"Key\" : \"Value\"} , {\"Key\" : 3} ] } }", "platformOptions:Array:0:Key", "Value");
         yield return ("{\"platformOptions\": { \"Array\" : [ {\"Key\" : \"Value\"} , {\"Key\" : 3} ] } }", "platformOptions:Array:1:Key", "3");

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsoniteTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsoniteTests.cs
@@ -18,6 +18,34 @@ public sealed class JsoniteTests
     }
 
     [TestMethod]
+    public void Deserialize_CommentsAreDisallowedByDefault()
+        => Assert.ThrowsExactly<Jsonite.JsonException>(() => Jsonite.Json.Deserialize("{// Comment\n\"value\": true}"));
+
+    [TestMethod]
+    public void Deserialize_CommentsCanBeAllowed()
+    {
+        Jsonite.JsonSettings settings = new()
+        {
+            AllowComments = true,
+        };
+
+        var result = (Jsonite.JsonObject)Jsonite.Json.Deserialize("{// Line comment\n\"value\": /* Block comment */ true}", settings);
+
+        Assert.IsTrue((bool)result["value"]!);
+    }
+
+    [TestMethod]
+    public void Deserialize_UnterminatedBlockCommentThrows()
+    {
+        Jsonite.JsonSettings settings = new()
+        {
+            AllowComments = true,
+        };
+
+        Assert.ThrowsExactly<Jsonite.JsonException>(() => Jsonite.Json.Deserialize("{/* Comment", settings));
+    }
+
+    [TestMethod]
     public void SerializeJsoniteInvalidStringHighSurrogateAtTheEnd()
     {
         const string Input = "Hello\uD800";


### PR DESCRIPTION
## Summary

- add opt-in `//` and `/* ... */` comment skipping to the vendored Jsonite reader
- enable comment handling only for the .NET Framework `testconfig.json` parser, keeping server JSON strict by default
- cover comments around properties and values, numeric values, URL strings, literal NUL characters, and unterminated block comments

Jsonite upstream is archived and does not provide a newer version with comment support.

Fixes #10137

## Testing

- `Microsoft.Testing.Platform.UnitTests` on `net462`: 1,443 passed
- `Microsoft.Testing.Platform.UnitTests` on `net8.0`: 1,462 passed