### PR TITLE
Document UTF-8 BOM requirement for AI changes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,8 @@ For acceptance tests that drive generated assets, prefer running them through th
 
 You MUST follow all code-formatting and naming conventions defined in [`.editorconfig`](../.editorconfig).
 
+All C# and Visual Basic code files (`*.cs`, `*.csx`, `*.vb`, and `*.vbx`) MUST be encoded as UTF-8 with BOM, as required by `.editorconfig`. When creating or rewriting one of these files, preserve or add the BOM; do not emit BOM-less UTF-8.
+
 In addition to the rules enforced by `.editorconfig`, you SHOULD:
 
 - Favor style and conventions that are consistent with the existing codebase.


### PR DESCRIPTION
## Summary

- explicitly require UTF-8 with BOM for C# and Visual Basic files in the repository's Copilot instructions
- call out new-file creation and file rewrites, where AI-generated changes commonly drop the BOM

Fixes the recurring review issue seen in #10147.