### PR TITLE
Remove non-compliant NuGet source

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -18,8 +18,6 @@
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
-    <!-- Microsoft.MSBuildCache.AzurePipelines is not mirrored by dotnet-public. Package source mapping below restricts this source to that package. -->
-    <add key="nuget.org-msbuildcache" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
@@ -54,9 +52,6 @@
     </packageSource>
     <packageSource key="dotnet11">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="nuget.org-msbuildcache">
-      <package pattern="Microsoft.MSBuildCache.AzurePipelines" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
## Summary

- remove the direct NuGet.org source that violates Secure Supply Chain policy
- restore `Microsoft.MSBuildCache.AzurePipelines` from the existing `dotnet-public` Azure Artifacts feed
- remove the obsolete package source mapping

## Validation

- built successfully with `MSBuildCachePackageEnabled=true` and `TF_BUILD=true`
- confirmed `NuGet.config` contains only Azure Artifacts package sources

Fixes the CFS0013 failure in Azure DevOps build 3029583.