### PR TITLE
Deduplicate coverage measurement properties

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -113,6 +113,13 @@ Microsoft.Testing.Platform.OutputDevice.TerminalOutputDevice.TerminalOutputDevic
 *REMOVED*Microsoft.Testing.Platform.OutputDevice.TerminalOutputDevice.TerminalOutputDevice(Microsoft.Testing.Platform.Helpers.IConsole! console, Microsoft.Testing.Platform.Services.ITestApplicationModuleInfo! testApplicationModuleInfo, Microsoft.Testing.Platform.TestHostControllers.ITestHostControllerInfo! testHostControllerInfo, Microsoft.Testing.Platform.Helpers.IAsyncMonitor! asyncMonitor, Microsoft.Testing.Platform.Helpers.IRuntimeFeature! runtimeFeature, Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Services.IPlatformInformation! platformInformation, Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.Testing.Platform.Logging.IFileLoggerInformation? fileLoggerInformation, Microsoft.Testing.Platform.Logging.ILoggerFactory! loggerFactory, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Services.IStopPoliciesService! policiesService, Microsoft.Testing.Platform.Services.ITestApplicationCancellationTokenSource! testApplicationCancellationTokenSource) -> void
 Microsoft.Testing.Platform.Services.ExitCodeIgnorePolicy
 Microsoft.Testing.Platform.Services.CoverageThresholdExitCodePolicy
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.CoverableCount.get -> long
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.CoverageCounts() -> void
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.CoverageCounts(long coveredCount, long coverableCount) -> void
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.CoveredCount.get -> long
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.HasCoverableData.get -> bool
+Microsoft.Testing.Platform.Extensions.Messages.CoverageCounts.Percentage.get -> double
 Microsoft.Testing.Platform.Extensions.Messages.CoverageMetricHelper
 Microsoft.Testing.Platform.Extensions.Messages.CoverageReportHelper
 static Microsoft.Testing.Platform.Extensions.Messages.CoverageMetricHelper.ValidateCounts(long coveredCount, long coverableCount) -> void

--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestCoverageMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestCoverageMessages.cs
@@ -184,6 +184,8 @@ public readonly struct CoverageScope : IEquatable<CoverageScope>
 /// </summary>
 public sealed class TestCoverageMessage : DataWithSessionUid
 {
+    private readonly CoverageCounts _coverageCounts;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestCoverageMessage"/> class.
     /// </summary>
@@ -204,14 +206,12 @@ public sealed class TestCoverageMessage : DataWithSessionUid
         string? customMetricName = null)
         : base("Test coverage", "Reports a code coverage measurement for a scope.", sessionUid)
     {
-        CoverageMetricHelper.ValidateCounts(coveredCount, coverableCount);
+        _coverageCounts = new CoverageCounts(coveredCount, coverableCount);
         CoverageMetricHelper.ValidateProducerId(producerId);
         CoverageMetricHelper.ValidateCustomMetricName(metric, customMetricName);
 
         Scope = scope;
         Metric = metric;
-        CoveredCount = coveredCount;
-        CoverableCount = coverableCount;
         ProducerId = producerId;
         CustomMetricName = customMetricName;
     }
@@ -235,16 +235,16 @@ public sealed class TestCoverageMessage : DataWithSessionUid
     public string? CustomMetricName { get; }
 
     /// <summary>Gets the number of covered units.</summary>
-    public long CoveredCount { get; }
+    public long CoveredCount => _coverageCounts.CoveredCount;
 
     /// <summary>Gets the number of coverable units.</summary>
-    public long CoverableCount { get; }
+    public long CoverableCount => _coverageCounts.CoverableCount;
 
     /// <summary>Gets a value indicating whether there is any coverable data.</summary>
-    public bool HasCoverableData => CoverableCount > 0;
+    public bool HasCoverableData => _coverageCounts.HasCoverableData;
 
     /// <summary>Gets the coverage as a percentage in the range 0–100; 0 when nothing is coverable.</summary>
-    public double Percentage => HasCoverableData ? (double)CoveredCount / CoverableCount * 100d : 0d;
+    public double Percentage => _coverageCounts.Percentage;
 }
 
 /// <summary>Reports the result of a coverage threshold evaluation.</summary>
@@ -441,7 +441,26 @@ public sealed class TestCoverageReportMessage : DataWithSessionUid
     public string ProducerId { get; }
 }
 
-/// <summary>Shared validation for the custom-metric escape hatch.</summary>
+internal readonly struct CoverageCounts
+{
+    internal CoverageCounts(long coveredCount, long coverableCount)
+    {
+        CoverageMetricHelper.ValidateCounts(coveredCount, coverableCount);
+
+        CoveredCount = coveredCount;
+        CoverableCount = coverableCount;
+    }
+
+    internal long CoveredCount { get; }
+
+    internal long CoverableCount { get; }
+
+    internal bool HasCoverableData => CoverableCount > 0;
+
+    internal double Percentage => HasCoverableData ? (double)CoveredCount / CoverableCount * 100d : 0d;
+}
+
+/// <summary>Shared validation for coverage metrics.</summary>
 internal static class CoverageMetricHelper
 {
     public static void ValidateCounts(long coveredCount, long coverableCount)

--- a/src/Platform/Microsoft.Testing.Platform/Services/CoverageMetricResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/CoverageMetricResult.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Testing.Platform.Services;
 /// </summary>
 public sealed class CoverageMetricResult
 {
+    private readonly CoverageCounts _coverageCounts;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CoverageMetricResult"/> class.
     /// </summary>
@@ -26,13 +28,11 @@ public sealed class CoverageMetricResult
         string producerId,
         string? customMetricName = null)
     {
-        CoverageMetricHelper.ValidateCounts(coveredCount, coverableCount);
+        _coverageCounts = new CoverageCounts(coveredCount, coverableCount);
         CoverageMetricHelper.ValidateProducerId(producerId);
         CoverageMetricHelper.ValidateCustomMetricName(metric, customMetricName);
 
         Metric = metric;
-        CoveredCount = coveredCount;
-        CoverableCount = coverableCount;
         ProducerId = producerId;
         CustomMetricName = customMetricName;
     }
@@ -47,14 +47,14 @@ public sealed class CoverageMetricResult
     public string ProducerId { get; }
 
     /// <summary>Gets the number of covered units.</summary>
-    public long CoveredCount { get; }
+    public long CoveredCount => _coverageCounts.CoveredCount;
 
     /// <summary>Gets the number of coverable units.</summary>
-    public long CoverableCount { get; }
+    public long CoverableCount => _coverageCounts.CoverableCount;
 
     /// <summary>Gets a value indicating whether there is any coverable data.</summary>
-    public bool HasCoverableData => CoverableCount > 0;
+    public bool HasCoverableData => _coverageCounts.HasCoverableData;
 
     /// <summary>Gets the coverage as a percentage in the range 0–100; 0 when nothing is coverable.</summary>
-    public double Percentage => HasCoverableData ? (double)CoveredCount / CoverableCount * 100d : 0d;
+    public double Percentage => _coverageCounts.Percentage;
 }


### PR DESCRIPTION
## Summary
- extract shared `CoverageCounts` value type for coverage counts and derived values
- delegate `TestCoverageMessage` and `CoverageMetricResult` properties to the shared implementation
- preserve the existing public API and validation behavior

## Testing
- targeted `Microsoft.Testing.Platform.UnitTests` build
- 46 coverage message/result tests on `net8.0`

Fixes #10157