### PR TITLE
Add test for MSTEST0026 right operand conditional access

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldAvoidConditionalAccessAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/AssertionArgsShouldAvoidConditionalAccessAnalyzerTests.cs
@@ -820,4 +820,56 @@ public sealed class AssertionArgsShouldAvoidConditionalAccessAnalyzerTests
             NumberOfIncrementalIterations = 2,
         }.RunAsync();
     }
+
+    [TestMethod]
+    public async Task WhenConditionalAccessIsRightOperandOfBinaryExpression_Diagnostic()
+    {
+        // Covers the binaryOperation.RightOperand path in HasAnyConditionalAccessOperationChild:
+        // when the conditional access appears on the right side of a comparison (e.g. 32 < s?.Length),
+        // the analyzer must still fire and the fixer must insert Assert.IsNotNull before the statement.
+        string code = """
+            #nullable enable
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    string? s = "";
+                    [|Assert.IsTrue(32 < s?.Length)|];
+                    [|Assert.IsFalse(0 == s?.Length)|];
+                }
+            }
+            """;
+
+        string fixedCode = """
+            #nullable enable
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                    string? s = "";
+                    Assert.IsNotNull(s);
+                    Assert.IsTrue(32 < s.Length);
+                    Assert.IsFalse(0 == s.Length);
+                }
+            }
+            """;
+
+        await new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            NumberOfFixAllIterations = 1,
+            NumberOfFixAllInDocumentIterations = 1,
+            NumberOfFixAllInProjectIterations = 1,
+            NumberOfIncrementalIterations = 2,
+        }.RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary

- cover conditional access in the right operand of binary expressions for MSTEST0026
- verify diagnostics for `Assert.IsTrue` and `Assert.IsFalse`
- verify the code fix inserts a null assertion and removes conditional access

## Testing

- targeted `MSTest.Analyzers.UnitTests` test passed on `net8.0`

Closes #10153