### PR TITLE
Regenerate Platform localization sources

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -622,14 +622,39 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -622,14 +622,39 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Eine globale Testausführungszeitüberschreitung.
 Verwendet ein Argument als Zeitwert mit einem expliziten Einheitensuffix. Akzeptierte Suffixe sind 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', z. B. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -622,14 +622,39 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -622,14 +622,39 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Délai global d’exécution du test.
 Prend un argument correspondant à une valeur de temps avec un suffixe d’unité explicite. Les suffixes acceptés sont 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' et 'd'/'day(s)', par exemple '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -622,14 +622,39 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Timeout globale per l'esecuzione dei test.
 Accetta un argomento come valore di ora con un suffisso di unità esplicito. I suffissi accettati sono 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)', ad esempio '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -754,14 +749,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -823,11 +818,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">グローバル テスト実行のタイムアウト。
 明示的な単位サフィックスを持つ時間値を 1 つ、引数として指定します。使用可能なサフィックスは、'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)'、'd'/'day(s)' です (例: '500ms'、'5400s'、'90m'、'1.5h'、'1d')。</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">전역 테스트 실행 시간 제한입니다.
 명시적 단위 접미사가 포함된 시간 값을 하나의 인수로 입력해야 합니다. 허용되는 접미사는 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', 'd'/'day(s)'입니다. (예: '500ms', '5400s', '90m', '1.5h', '1d')</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -622,14 +622,39 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -622,14 +622,39 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Um tempo limite global de execução de teste.
 Recebe um argumento como valor temporal, com um sufixo de unidade explícito. Os sufixos aceitos são 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)' e 'd'/'day(s)'. Por exemplo: '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">Genel bir test yürütme zaman aşımı.
 Açık bir birim soneki bulunan bir zaman değeri olarak bir bağımsız değişken alır. Kabul edilen sonekler: 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', ör. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="new">A global test execution timeout.
 Takes one argument as a time value with an explicit unit suffix. Accepted suffixes are 'ms'/'mil(s)'/'millisecond(s)', 's'/'sec(s)'/'second(s)', 'm'/'min(s)'/'minute(s)', 'h'/'hour(s)', and 'd'/'day(s)', e.g. '500ms', '5400s', '90m', '1.5h', '1d'.</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -622,14 +622,39 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{0} is the server protocol value. {1} is the required option name without the leading dashes. {Locked="--server"}{Locked="dotnettestcli"}{Locked="dotnet-test-pipe"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestCliRequiresTransport">
-        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</source>
-        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport websocket' with both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token'.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</source>
+        <target state="new">'--server dotnettestcli' requires either '--dotnet-test-pipe' or '--dotnet-test-transport http'.</target>
+        <note>{Locked="--server dotnettestcli"}{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestOptionsRequireServer">
-        <source>'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</source>
-        <target state="new">'--dotnet-test-pipe', '--dotnet-test-transport', '--dotnet-test-websocket-endpoint', and '--dotnet-test-websocket-token' require '--server dotnettestcli'.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--server dotnettestcli"}</note>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointInvalid">
+        <source>'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</source>
+        <target state="new">'--dotnet-test-http-endpoint' requires an absolute HTTPS URL, or an HTTP loopback URL, without user information, query, or fragment.</target>
+        <note>{Locked="--dotnet-test-http-endpoint"}{Locked="HTTP"}{Locked="HTTPS"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpEndpointOptionDescription">
+        <source>Specifies the authenticated HTTP endpoint for the dotnet test protocol.</source>
+        <target state="new">Specifies the authenticated HTTP endpoint for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpOptionsRequireTransport">
+        <source>The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test HTTP endpoint and token options require '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}{Locked="--dotnet-test-transport http"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpRequiresEndpointAndToken">
+        <source>'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</source>
+        <target state="new">'--dotnet-test-transport http' requires both '--dotnet-test-http-endpoint' and '--dotnet-test-http-token'.</target>
+        <note>{Locked="--dotnet-test-transport http"}{Locked="--dotnet-test-http-endpoint"}{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenInvalid">
+        <source>'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</source>
+        <target state="new">'--dotnet-test-http-token' requires a non-empty valid bearer token without whitespace or control characters.</target>
+        <note>{Locked="--dotnet-test-http-token"}</note>
+      </trans-unit>
+      <trans-unit id="PlatformCommandLineDotnetTestHttpTokenOptionDescription">
+        <source>Specifies the per-run HTTP bearer token for the dotnet test protocol.</source>
+        <target state="new">Specifies the per-run HTTP bearer token for the dotnet test protocol.</target>
+        <note>{Locked="HTTP"}{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestPipe">
         <source>dotnet test pipe.</source>
@@ -637,49 +662,19 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportConflict">
-        <source>'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</source>
-        <target state="new">'--dotnet-test-pipe' cannot be combined with '--dotnet-test-transport websocket', '--dotnet-test-websocket-endpoint', or '--dotnet-test-websocket-token'. Choose a single transport.</target>
-        <note>{Locked="--dotnet-test-pipe"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe and HTTP transports cannot be selected together.</source>
+        <target state="new">The dotnet test named-pipe and HTTP transports cannot be selected together.</target>
+        <note>{Locked="dotnet test"}{Locked="HTTP"}</note>
       </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalidArgument">
+      <trans-unit id="PlatformCommandLineDotnetTestTransportInvalid">
         <source>'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</source>
         <target state="new">'--dotnet-test-transport' received unexpected value '{0}'. Supported values are: {1}.</target>
-        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}</note>
+        <note>{0} is the unexpected transport value. {1} is the comma-separated list of supported transport values. {Locked="--dotnet-test-transport"}{Locked="pipe"}{Locked="http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineDotnetTestTransportOptionDescription">
-        <source>Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</source>
-        <target state="new">Pre-launch transport used to carry the 'dotnet test' pipe protocol. The available values are 'pipe' and 'websocket'. Defaults to 'pipe' (implied whenever only '--dotnet-test-pipe' is specified).</target>
-        <note>{Locked="dotnet test"}{Locked="pipe"}{Locked="websocket"}{Locked="--dotnet-test-pipe"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointInvalid">
-        <source>'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' requires an absolute 'ws' or 'wss' URI with a host and without user information or a fragment.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="ws"}{Locked="wss"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketEndpointOptionDescription">
-        <source>The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</source>
-        <target state="new">The WebSocket endpoint URI the test host connects to when '--dotnet-test-transport websocket' is selected.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketOptionsRequireTransport">
-        <source>'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</source>
-        <target state="new">'--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' require '--dotnet-test-transport websocket' to be specified.</target>
-        <note>{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}{Locked="--dotnet-test-transport websocket"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketRequiresEndpointAndToken">
-        <source>'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</source>
-        <target state="new">'--dotnet-test-transport websocket' requires both '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' to be specified.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenEmpty">
-        <source>'--dotnet-test-websocket-token' requires a non-empty value.</source>
-        <target state="new">'--dotnet-test-websocket-token' requires a non-empty value.</target>
-        <note>{Locked="--dotnet-test-websocket-token"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineDotnetTestWebSocketTokenOptionDescription">
-        <source>The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</source>
-        <target state="new">The per-run authentication token the test host presents when connecting via '--dotnet-test-transport websocket'.</target>
-        <note>{Locked="--dotnet-test-transport websocket"}</note>
+        <source>Selects the pre-launch transport for the dotnet test protocol.</source>
+        <target state="new">Selects the pre-launch transport for the dotnet test protocol.</target>
+        <note>{Locked="dotnet test"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineExitOnProcessExitInvalidDependentProcess">
         <source>Invalid PID '{0}'
@@ -753,14 +748,14 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnBrowser">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on browser-wasm (System.IO.Pipes is unavailable). Use '--dotnet-test-transport websocket' with '--dotnet-test-websocket-endpoint' and '--dotnet-test-websocket-token' instead.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}{Locked="--dotnet-test-transport websocket"}{Locked="--dotnet-test-websocket-endpoint"}{Locked="--dotnet-test-websocket-token"}</note>
+        <source>The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on browser-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="browser-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePipeTransportNotSupportedOnWasi">
-        <source>The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The named-pipe transport for '--server dotnettestcli' is not supported when running on wasi-wasm (System.IO.Pipes is unavailable). No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}{Locked="System.IO.Pipes"}</note>
+        <source>The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</source>
+        <target state="new">The dotnet test named-pipe transport is not supported on wasi-wasm. Use '--dotnet-test-transport http'.</target>
+        <note>{Locked="dotnet test"}{Locked="wasi-wasm"}{Locked="--dotnet-test-transport http"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLinePortOptionDescription">
         <source>Specify the port of the server.</source>
@@ -822,11 +817,6 @@ Takes one argument as a time value with an explicit unit suffix. Accepted suffix
         <target state="translated">全域測試執行逾時。
 採用一個引數做為具有明確單位後置詞的時間值。接受的後置詞為 'ms'/'mil(s)'/'millisecond(s)'、's'/'sec(s)'/'second(s)'、'm'/'min(s)'/'minute(s)'、'h'/'hour(s)' 和 'd'/'day(s)'，例如 '500ms'、'5400s'、'90m'、'1.5h'、'1d'。</target>
         <note>{Locked="'ms'"}{Locked="'mil(s)'"}{Locked="'millisecond(s)'"}{Locked="'s'"}{Locked="'sec(s)'"}{Locked="'second(s)'"}{Locked="'m'"}{Locked="'min(s)'"}{Locked="'minute(s)'"}{Locked="'h'"}{Locked="'hour(s)'"}{Locked="'d'"}{Locked="'day(s)'"}{Locked="'500ms'"}{Locked="'5400s'"}{Locked="'90m'"}{Locked="'1.5h'"}{Locked="'1d'"}</note>
-      </trans-unit>
-      <trans-unit id="PlatformCommandLineWebSocketTransportNotSupportedOnWasi">
-        <source>The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</source>
-        <target state="new">The websocket transport for '--server dotnettestcli' is not supported when running on wasi-wasm. No transport is currently implemented for wasi-wasm.</target>
-        <note>{Locked="--server dotnettestcli"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineZeroTestsPolicyInvalidArgument">
         <source>Invalid value '{0}' for '--zero-tests-policy'. Valid values are {1}.</source>


### PR DESCRIPTION
Follow-up to #10175. Regenerates all Microsoft.Testing.Platform XLF files from the current neutral RESX so HTTP transport resources replace the stale WebSocket units. Generated with the project UpdateXlf target.