### PR TITLE
Enable NuGet Audit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,6 +84,8 @@
     <NoWarn>$(NoWarn);TPINTERNAL</NoWarn>
     <!-- netfx and netstandard don't have nullability info so the IDE0370 warning should be suppressed -->
     <NoWarn Condition="'$(TargetFramework)' == 'netstandard2.0' OR $(TargetFramework.StartsWith('net4')) OR '$(TargetFramework)' == '$(UwpMinimum)'">$(NoWarn);IDE0370</NoWarn>
+    <!-- Only upgrade NuGetAudit warnings to errors for official builds. -->
+    <WarningsNotAsErrors Condition="'$(OfficialBuild)' != 'true'">$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Versioning -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,6 +19,10 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
   </packageSources>
+  <auditSources>
+    <clear />
+    <add key="nuget.org" value="https://data.nuget.org/v3/index.json" />
+  </auditSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>


### PR DESCRIPTION
NuGet Audit needs a dedicated vulnerability source because testfx restores packages exclusively from internal feeds, which do not expose the nuget.org vulnerability database. This applies the repository rollout described in dotnet/arcade#15019.

## Changes

- Configure `https://data.nuget.org/v3/index.json` as an audit-only source without changing package sources or source mapping.
- Keep `NU1901` through `NU1904` as warnings in non-official builds. The Arcade SDK continues to provide transitive auditing with `NuGetAuditMode=all` and its official-build workaround for dotnet/msbuild#10801.

## Validation

A full `TestFx.slnx` restore completed with NuGet Audit enabled, fetched the current vulnerability database from `data.nuget.org`, and reported no vulnerability findings.

Related: https://github.com/dotnet/arcade/issues/15019