### PR TITLE
Fix duplicate data consumer disposal during teardown

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/CommonTestHost.cs
@@ -424,7 +424,7 @@ internal abstract class CommonHost(ServiceProvider serviceProvider) : IHost
                     if (!alreadyDisposed.Contains(dataConsumer))
                     {
                         await DisposeHelper.DisposeAsync(dataConsumer).ConfigureAwait(false);
-                        alreadyDisposed.Add(service);
+                        alreadyDisposed.Add(dataConsumer);
                     }
                 }
             }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Hosts/CommonHostTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Hosts/CommonHostTests.cs
@@ -90,11 +90,31 @@ public sealed class CommonHostTests
         Assert.AreEqual(1, testApplicationLifetime.CleanupCount);
     }
 
+    [TestMethod]
+    public async Task DisposeServiceProviderAsync_WhenDataConsumerIsAlsoRegisteredAsService_DisposesOnce()
+    {
+        Mock<IDataConsumer> dataConsumer = new();
+        Mock<IDisposable> disposableDataConsumer = dataConsumer.As<IDisposable>();
+        Mock<BaseMessageBus> messageBus = new();
+        messageBus.SetupGet(x => x.DataConsumerServices).Returns([dataConsumer.Object]);
+
+        ServiceProvider serviceProvider = new();
+        serviceProvider.AddService(messageBus.Object);
+        serviceProvider.AddService(dataConsumer.Object);
+
+        await TestableCommonHost.DisposeServiceProviderForTestingAsync(serviceProvider);
+
+        disposableDataConsumer.Verify(x => x.Dispose(), Times.Once);
+    }
+
     private sealed class TestableCommonHost(ServiceProvider serviceProvider, bool runTestApplicationLifeCycleCallbacks = false) : CommonHost(serviceProvider)
     {
         protected override string HostType => "TestHost";
 
         protected override bool RunTestApplicationLifeCycleCallbacks => runTestApplicationLifeCycleCallbacks;
+
+        public static Task DisposeServiceProviderForTestingAsync(ServiceProvider serviceProvider)
+            => DisposeServiceProviderAsync(serviceProvider);
 
         public static Task ExecuteRequestForTestingAsync(
             ProxyOutputDevice outputDevice,


### PR DESCRIPTION
Azure DevOps live result publishing can complete successfully and then crash during host teardown because its composite publisher is disposed twice.

`CommonHost` disposed data consumers owned by the message bus but accidentally recorded the message bus itself in the disposed-instance list. This change records the actual consumer, preventing a composite extension that is also registered as a session service from being disposed again. A regression test covers that shared-registration teardown path.

Tests: `CommonHostTests` on `net8.0`

Fixes #10191