### PR TITLE
[perf-improver] perf: eliminate per-test closure allocations in IPC deserializers

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/Serializers/BaseSerializer.cs
@@ -333,9 +333,8 @@ internal abstract class BaseSerializer
     /// Matches the two leading collection-envelope fields (<c>ExecutionId</c> id 1 / <c>InstanceId</c> id 2) shared by
     /// the four 'dotnet test' list-carrying messages payloads, assigning the value into <paramref name="executionId"/>
     /// or <paramref name="instanceId"/> and returning <see langword="true"/> when the field is one of them. The caller
-    /// invokes this from its own single <see cref="ReadFields"/> callback and handles its type-specific message-list
-    /// field ids when this returns <see langword="false"/>. Kept as a <see langword="ref"/>-based matcher (rather than a
-    /// wrapping callback) so it adds no closure/delegate allocation on the hot per-test IPC read path.
+    /// handles its type-specific message-list field ids when this returns <see langword="false"/>. Kept as a
+    /// <see langword="ref"/>-based matcher so it adds no allocation on the hot per-test IPC read path.
     /// </summary>
     protected static bool TryReadExecutionScopedField(Stream stream, ushort fieldId, int fieldSize, ref string? executionId, ref string? instanceId)
     {

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/DiscoveredTestMessagesSerializer.cs
@@ -85,21 +85,27 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
         string? instanceId = null;
         DiscoveredTestMessage[]? discoveredTestMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        // Inline ReadFields to avoid per-message closure allocation on the hot IPC deserialization path.
+        ushort fieldCount = ReadUShort(stream);
+        for (int f = 0; f < fieldCount; f++)
         {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
             if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
             {
-                return true;
+                continue;
             }
 
             if (fieldId == DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList)
             {
                 discoveredTestMessages = ReadDiscoveredTestMessagesPayload(stream);
-                return true;
             }
-
-            return false;
-        });
+            else
+            {
+                SetPosition(stream, stream.Position + fieldSize);
+            }
+        }
 
         return new(executionId, instanceId, discoveredTestMessages);
     }
@@ -120,50 +126,56 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
             TraitMessage[] traits = [];
             string[] parameterTypeFullNames = [];
 
-            ReadFields(stream, (fieldId, fieldSize) =>
+            // Inline ReadFields to avoid per-test closure allocation on the hot IPC deserialization path.
+            ushort msgFieldCount = ReadUShort(stream);
+            for (int f = 0; f < msgFieldCount; f++)
             {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
                 switch (fieldId)
                 {
                     case DiscoveredTestMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.FilePath:
                         filePath = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.LineNumber:
                         lineNumber = ReadInt(stream);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.Namespace:
                         @namespace = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.TypeName:
                         typeName = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.MethodName:
                         methodName = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.Traits:
                         traits = ReadTraitsPayload(stream);
-                        return true;
+                        break;
 
                     case DiscoveredTestMessageFieldsId.ParameterTypeFullNames:
                         parameterTypeFullNames = ReadParameterTypeFullNamesPayload(stream);
-                        return true;
+                        break;
 
                     default:
-                        return false;
+                        SetPosition(stream, stream.Position + fieldSize);
+                        break;
                 }
-            });
+            }
 
             discoveredTestMessages[i] = new DiscoveredTestMessage(uid, displayName, filePath, lineNumber, @namespace, typeName, methodName, parameterTypeFullNames, traits);
         }
@@ -193,22 +205,28 @@ internal sealed class DiscoveredTestMessagesSerializer : NamedPipeSerializer<Dis
             string? key = null;
             string? value = null;
 
-            ReadFields(stream, (fieldId, fieldSize) =>
+            // Inline ReadFields to avoid per-trait closure allocation.
+            ushort traitFieldCount = ReadUShort(stream);
+            for (int f = 0; f < traitFieldCount; f++)
             {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
                 switch (fieldId)
                 {
                     case TraitMessageFieldsId.Key:
                         key = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case TraitMessageFieldsId.Value:
                         value = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     default:
-                        return false;
+                        SetPosition(stream, stream.Position + fieldSize);
+                        break;
                 }
-            });
+            }
 
             _ = key ?? throw new InvalidOperationException("Trait key is required.");
             _ = value ?? throw new InvalidOperationException("Trait value is required.");

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestInProgressMessagesSerializer.cs
@@ -42,21 +42,27 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
         string? instanceId = null;
         TestInProgressMessage[]? inProgressMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        // Inline ReadFields to avoid per-message closure allocation on the hot IPC deserialization path.
+        ushort fieldCount = ReadUShort(stream);
+        for (int f = 0; f < fieldCount; f++)
         {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
             if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
             {
-                return true;
+                continue;
             }
 
             if (fieldId == TestInProgressMessagesFieldsId.TestInProgressMessageList)
             {
                 inProgressMessages = ReadInProgressMessagesPayload(stream);
-                return true;
             }
-
-            return false;
-        });
+            else
+            {
+                SetPosition(stream, stream.Position + fieldSize);
+            }
+        }
 
         return new(executionId, instanceId, inProgressMessages);
     }
@@ -70,22 +76,28 @@ internal sealed class TestInProgressMessagesSerializer : NamedPipeSerializer<Tes
             string? uid = null;
             string? displayName = null;
 
-            ReadFields(stream, (fieldId, fieldSize) =>
+            // Inline ReadFields to avoid per-message closure allocation on the hot IPC deserialization path.
+            ushort fieldCount = ReadUShort(stream);
+            for (int f = 0; f < fieldCount; f++)
             {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
                 switch (fieldId)
                 {
                     case TestInProgressMessageFieldsId.Uid:
                         uid = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case TestInProgressMessageFieldsId.DisplayName:
                         displayName = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     default:
-                        return false;
+                        SetPosition(stream, stream.Position + fieldSize);
+                        break;
                 }
-            });
+            }
 
             inProgressMessages[i] = new TestInProgressMessage(uid, displayName);
         }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/TestResultMessagesSerializer.cs
@@ -122,27 +122,33 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
         SuccessfulTestResultMessage[]? successfulTestResultMessages = [];
         FailedTestResultMessage[]? failedTestResultMessages = [];
 
-        ReadFields(stream, (fieldId, fieldSize) =>
+        // Inline ReadFields to avoid per-message closure allocation on the hot IPC deserialization path.
+        ushort fieldCount = ReadUShort(stream);
+        for (int f = 0; f < fieldCount; f++)
         {
+            ushort fieldId = ReadUShort(stream);
+            int fieldSize = ReadInt(stream);
+
             if (TryReadExecutionScopedField(stream, fieldId, fieldSize, ref executionId, ref instanceId))
             {
-                return true;
+                continue;
             }
 
             switch (fieldId)
             {
                 case TestResultMessagesFieldsId.SuccessfulTestMessageList:
                     successfulTestResultMessages = ReadSuccessfulTestMessagesPayload(stream);
-                    return true;
+                    break;
 
                 case TestResultMessagesFieldsId.FailedTestMessageList:
                     failedTestResultMessages = ReadFailedTestMessagesPayload(stream);
-                    return true;
+                    break;
 
                 default:
-                    return false;
+                    SetPosition(stream, stream.Position + fieldSize);
+                    break;
             }
-        });
+        }
 
         return new(
             executionId,
@@ -159,14 +165,24 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
         {
             CommonTestResultFields fields = default;
 
-            ReadFields(stream, (fieldId, fieldSize) => TryReadCommonTestResultField(
-                stream,
-                fieldId,
-                fieldSize,
-                ref fields,
-                SuccessfulTestResultMessageFieldsId.StandardOutput,
-                SuccessfulTestResultMessageFieldsId.ErrorOutput,
-                SuccessfulTestResultMessageFieldsId.SessionUid));
+            // Inline ReadFields to avoid per-test closure allocation on the hot IPC deserialization path.
+            ushort fieldCount = ReadUShort(stream);
+            for (int f = 0; f < fieldCount; f++)
+            {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+                if (!TryReadCommonTestResultField(
+                    stream,
+                    fieldId,
+                    fieldSize,
+                    ref fields,
+                    SuccessfulTestResultMessageFieldsId.StandardOutput,
+                    SuccessfulTestResultMessageFieldsId.ErrorOutput,
+                    SuccessfulTestResultMessageFieldsId.SessionUid))
+                {
+                    SetPosition(stream, stream.Position + fieldSize);
+                }
+            }
 
             successfulTestResultMessages[i] = new SuccessfulTestResultMessage(fields.Uid, fields.DisplayName, fields.State, fields.Duration, fields.Reason, fields.StandardOutput, fields.ErrorOutput, fields.SessionUid);
         }
@@ -187,32 +203,43 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
             // of the shared CommonTestResultFields, so they are read alongside the exception list.
             string? expected = null, actual = null;
 
-            ReadFields(stream, (fieldId, fieldSize) =>
+            // Inline ReadFields to avoid per-test closure allocation on the hot IPC deserialization path.
+            ushort fieldCount = ReadUShort(stream);
+            for (int f = 0; f < fieldCount; f++)
             {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
                 switch (fieldId)
                 {
                     case FailedTestResultMessageFieldsId.ExceptionMessageList:
                         exceptionMessages = ReadExceptionMessagesPayload(stream);
-                        return true;
+                        break;
 
                     case FailedTestResultMessageFieldsId.Expected:
                         expected = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case FailedTestResultMessageFieldsId.Actual:
                         actual = ReadStringValue(stream, fieldSize);
-                        return true;
-                }
+                        break;
 
-                return TryReadCommonTestResultField(
-                    stream,
-                    fieldId,
-                    fieldSize,
-                    ref fields,
-                    FailedTestResultMessageFieldsId.StandardOutput,
-                    FailedTestResultMessageFieldsId.ErrorOutput,
-                    FailedTestResultMessageFieldsId.SessionUid);
-            });
+                    default:
+                        if (!TryReadCommonTestResultField(
+                            stream,
+                            fieldId,
+                            fieldSize,
+                            ref fields,
+                            FailedTestResultMessageFieldsId.StandardOutput,
+                            FailedTestResultMessageFieldsId.ErrorOutput,
+                            FailedTestResultMessageFieldsId.SessionUid))
+                        {
+                            SetPosition(stream, stream.Position + fieldSize);
+                        }
+
+                        break;
+                }
+            }
 
             failedTestResultMessages[i] = new FailedTestResultMessage(fields.Uid, fields.DisplayName, fields.State, fields.Duration, fields.Reason, exceptionMessages, fields.StandardOutput, fields.ErrorOutput, fields.SessionUid, expected, actual);
         }
@@ -281,26 +308,32 @@ internal sealed class TestResultMessagesSerializer : NamedPipeSerializer<TestRes
             string? errorType = null;
             string? stackTrace = null;
 
-            ReadFields(stream, (fieldId, fieldSize) =>
+            // Inline ReadFields to avoid per-exception closure allocation.
+            ushort fieldCount = ReadUShort(stream);
+            for (int f = 0; f < fieldCount; f++)
             {
+                ushort fieldId = ReadUShort(stream);
+                int fieldSize = ReadInt(stream);
+
                 switch (fieldId)
                 {
                     case ExceptionMessageFieldsId.ErrorMessage:
                         errorMessage = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case ExceptionMessageFieldsId.ErrorType:
                         errorType = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     case ExceptionMessageFieldsId.StackTrace:
                         stackTrace = ReadStringValue(stream, fieldSize);
-                        return true;
+                        break;
 
                     default:
-                        return false;
+                        SetPosition(stream, stream.Position + fieldSize);
+                        break;
                 }
-            });
+            }
 
             exceptionMessages[i] = new ExceptionMessage(errorMessage, errorType, stackTrace);
         }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolEdgeCaseTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolEdgeCaseTests.cs
@@ -111,6 +111,36 @@ public sealed class ProtocolEdgeCaseTests
     }
 
     [TestMethod]
+    public void TestResultMessages_WhenUnknownFieldsPrecedeKnownFields_DeserializesRemainingFields()
+    {
+        byte[] successfulResult = WriteFields(
+            (ushort.MaxValue, [0x99]),
+            (SuccessfulTestResultMessageFieldsId.DisplayName, WriteString("passed test")));
+        byte[] exception = WriteFields(
+            (ushort.MaxValue, [0xAA, 0xBB]),
+            (ExceptionMessageFieldsId.ErrorMessage, WriteString("boom")));
+        byte[] failedResult = WriteFields(
+            (ushort.MaxValue, [0xCC]),
+            (FailedTestResultMessageFieldsId.DisplayName, WriteString("failed test")),
+            (FailedTestResultMessageFieldsId.ExceptionMessageList, WriteList(exception)));
+        byte[] payload = WriteFields(
+            (ushort.MaxValue, [0xDD, 0xEE]),
+            (TestResultMessagesFieldsId.InstanceId, WriteString("instance")),
+            (TestResultMessagesFieldsId.SuccessfulTestMessageList, WriteList(successfulResult)),
+            (TestResultMessagesFieldsId.FailedTestMessageList, WriteList(failedResult)));
+
+        TestResultMessages actual = DeserializePayload<TestResultMessages>(new TestResultMessagesSerializer(), payload);
+
+        Assert.AreEqual("instance", actual.InstanceId);
+        Assert.HasCount(1, actual.SuccessfulTestMessages);
+        Assert.AreEqual("passed test", actual.SuccessfulTestMessages[0].DisplayName);
+        Assert.HasCount(1, actual.FailedTestMessages);
+        Assert.AreEqual("failed test", actual.FailedTestMessages[0].DisplayName);
+        Assert.HasCount(1, actual.FailedTestMessages[0].Exceptions!);
+        Assert.AreEqual("boom", actual.FailedTestMessages[0].Exceptions![0].ErrorMessage);
+    }
+
+    [TestMethod]
     public void DiscoveredTestMessages_WhenEmptyList_RoundTrips()
     {
         var message = new DiscoveredTestMessages("exec", "inst", []);
@@ -120,6 +150,32 @@ public sealed class ProtocolEdgeCaseTests
         Assert.AreEqual("exec", actual.ExecutionId);
         Assert.AreEqual("inst", actual.InstanceId);
         Assert.IsEmpty(actual.DiscoveredMessages);
+    }
+
+    [TestMethod]
+    public void DiscoveredTestMessages_WhenUnknownFieldsPrecedeKnownFields_DeserializesRemainingFields()
+    {
+        byte[] trait = WriteFields(
+            (ushort.MaxValue, [0xAA]),
+            (TraitMessageFieldsId.Key, WriteString("category")),
+            (TraitMessageFieldsId.Value, WriteString("unit")));
+        byte[] discoveredTest = WriteFields(
+            (ushort.MaxValue, [0xBB, 0xCC]),
+            (DiscoveredTestMessageFieldsId.DisplayName, WriteString("discovered test")),
+            (DiscoveredTestMessageFieldsId.Traits, WriteList(trait)));
+        byte[] payload = WriteFields(
+            (ushort.MaxValue, [0xDD]),
+            (DiscoveredTestMessagesFieldsId.InstanceId, WriteString("instance")),
+            (DiscoveredTestMessagesFieldsId.DiscoveredTestMessageList, WriteList(discoveredTest)));
+
+        DiscoveredTestMessages actual = DeserializePayload<DiscoveredTestMessages>(new DiscoveredTestMessagesSerializer(), payload);
+
+        Assert.AreEqual("instance", actual.InstanceId);
+        Assert.HasCount(1, actual.DiscoveredMessages);
+        Assert.AreEqual("discovered test", actual.DiscoveredMessages[0].DisplayName);
+        Assert.HasCount(1, actual.DiscoveredMessages[0].Traits);
+        Assert.AreEqual("category", actual.DiscoveredMessages[0].Traits[0].Key);
+        Assert.AreEqual("unit", actual.DiscoveredMessages[0].Traits[0].Value);
     }
 
     [TestMethod]
@@ -184,6 +240,24 @@ public sealed class ProtocolEdgeCaseTests
     }
 
     [TestMethod]
+    public void TestInProgressMessages_WhenUnknownFieldsPrecedeKnownFields_DeserializesRemainingFields()
+    {
+        byte[] inProgressTest = WriteFields(
+            (ushort.MaxValue, [0xAA, 0xBB]),
+            (TestInProgressMessageFieldsId.DisplayName, WriteString("running test")));
+        byte[] payload = WriteFields(
+            (ushort.MaxValue, [0xCC]),
+            (TestInProgressMessagesFieldsId.InstanceId, WriteString("instance")),
+            (TestInProgressMessagesFieldsId.TestInProgressMessageList, WriteList(inProgressTest)));
+
+        TestInProgressMessages actual = DeserializePayload<TestInProgressMessages>(new TestInProgressMessagesSerializer(), payload);
+
+        Assert.AreEqual("instance", actual.InstanceId);
+        Assert.HasCount(1, actual.InProgressMessages);
+        Assert.AreEqual("running test", actual.InProgressMessages[0].DisplayName);
+    }
+
+    [TestMethod]
     public void TestSessionEvent_End_RoundTrips()
     {
         var message = new TestSessionEvent(SessionEventTypes.TestSessionEnd, "session", "exec");
@@ -193,5 +267,52 @@ public sealed class ProtocolEdgeCaseTests
         Assert.AreEqual(SessionEventTypes.TestSessionEnd, actual.SessionType);
         Assert.AreEqual("session", actual.SessionUid);
         Assert.AreEqual("exec", actual.ExecutionId);
+    }
+
+    private static TMessage DeserializePayload<TMessage>(object serializer, byte[] payload)
+    {
+        using var stream = new MemoryStream(payload);
+        return (TMessage)Deserialize(serializer, stream);
+    }
+
+    private static byte[] WriteFields(params (ushort Id, byte[] Payload)[] fields)
+    {
+        using var stream = new MemoryStream();
+        WriteUShort(stream, (ushort)fields.Length);
+
+        foreach ((ushort id, byte[] payload) in fields)
+        {
+            WriteUShort(stream, id);
+            WriteInt(stream, payload.Length);
+            stream.Write(payload, 0, payload.Length);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] WriteList(params byte[][] items)
+    {
+        using var stream = new MemoryStream();
+        WriteInt(stream, items.Length);
+        foreach (byte[] item in items)
+        {
+            stream.Write(item, 0, item.Length);
+        }
+
+        return stream.ToArray();
+    }
+
+    private static byte[] WriteString(string value) => Encoding.UTF8.GetBytes(value);
+
+    private static void WriteInt(Stream stream, int value)
+    {
+        byte[] bytes = BitConverter.GetBytes(value);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    private static void WriteUShort(Stream stream, ushort value)
+    {
+        byte[] bytes = BitConverter.GetBytes(value);
+        stream.Write(bytes, 0, bytes.Length);
     }
 }


### PR DESCRIPTION
Fixes #10200

## Summary

- inline IPC field-reading loops in the discovered-test, in-progress-test, and test-result deserializers
- eliminate capturing delegates and their per-message, per-test, per-trait, and per-exception closure allocations
- preserve unknown-field skipping and forward-compatible wire behavior
- update the shared execution-scoped field helper documentation for the callback-free read path

## Validation

- `Microsoft.Testing.Platform.UnitTests` passed on `net8.0`, `net9.0`, and `net462`
- 39 focused protocol tests passed on `net9.0`