### PR TITLE
[rel/v5.0] Fix RunTests_With_PackagedVSTest for per-assembly VSTest summary output

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Utilities/VSTestConsoleLocator.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/Utilities/VSTestConsoleLocator.cs
@@ -149,7 +149,20 @@ public sealed class VSTestConsoleResult(int exitCode, string standardOutput, str
     }
 
     private void AssertCount(string labelPattern, int expected)
-        => Assert.IsTrue(
-            Regex.IsMatch(StandardOutput, $@"{labelPattern}:\s*{expected}(?:\D|$)"),
-            $"Expected '{labelPattern}' count {expected} in packaged VSTest output:{Environment.NewLine}{StandardOutput}");
+    {
+        // Newer VSTest console versions emit a per-assembly summary (one line per test file,
+        // e.g. "Failed: 0, Passed: 1, Skipped: 0, Total: 1 - MSTestSdk.dll (net10.0)") instead of
+        // a single aggregate summary ("Total tests: 2" / "Passed: 2"). Sum the counts across every
+        // matching line so the assertion holds for both output shapes.
+        int actual = 0;
+        foreach (Match match in Regex.Matches(StandardOutput, $@"{labelPattern}:\s*(\d+)"))
+        {
+            actual += int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        }
+
+        Assert.AreEqual(
+            expected,
+            actual,
+            $"Expected '{labelPattern}' total count {expected} in packaged VSTest output:{Environment.NewLine}{StandardOutput}");
+    }
 }


### PR DESCRIPTION
## Problem

The `rel/v5.0` pipeline is red (e.g. [build 20260723.13](https://dnceng.visualstudio.com/internal/_build/results?buildId=3030009&view=results)). The Linux `Tests` leg fails in `MSTest.Acceptance.IntegrationTests` on `RunTests_With_PackagedVSTest` (both Debug and Release, multiTfm `net10.0;net8.0`).

## Root cause

Newer packaged VSTest console (`18.10.0-preview-...`) changed its summary output. Instead of a single aggregate summary:

```
Total tests: 2
     Passed: 2
```

it now prints a **per-assembly** summary line per test file:

```
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 17 ms - MSTestSdk.dll (net10.0)
Passed!  - Failed: 0, Passed: 1, Skipped: 0, Total: 1, Duration: 11 ms - MSTestSdk.dll (net10.0)
```

`VSTestConsoleResult.AssertCount` matched a single line with the exact expected value, so a 2-TFM run (two `Total: 1` lines) no longer matched `Total: 2` and the assertion failed.

## Fix

`AssertCount` now **sums the count across every matching summary line**, so it holds for both the legacy aggregate output and the new per-assembly output. Verified the regex yields `Total=2, Passed=2` for both shapes, and the acceptance test project builds cleanly (all TFMs incl. net11.0).