### PR TITLE
Pin gh-aw-actions in Dependabot to prevent recurring lock/action drift (#10203)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,14 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # The github/gh-aw-actions/* actions are pinned by `gh aw compile` and
+      # MUST move in lockstep with the gh-aw CLI version that generated the
+      # `.lock.yml` files (and `.github/aw/actions-lock.json`). Letting
+      # Dependabot bump just the `uses:` SHAs drifts them away from the
+      # generator, which breaks the threat-detection job with
+      # `awf: command not found` -> parse_error (see #10203). These are
+      # updated via `gh aw upgrade` / the Agentic Maintenance workflow instead.
+      - dependency-name: "github/gh-aw-actions/*"
     commit-message:
       prefix: '[main] '


### PR DESCRIPTION
## Problem

The threat-detection job of the `grade-tests-on-pr` agentic workflow has repeatedly failed with `awf: command not found` (exit 127) — no `THREAT_DETECTION_RESULT` is emitted, so the parser reports `parse_error` (the symptom tracked by #10203). The recurring cause is **gh-aw lock/action drift**: Dependabot bumps only the `github/gh-aw-actions/*` `uses:` SHAs, drifting them away from the gh-aw CLI version that generated the `.lock.yml` files.

## What this PR does

Adds a Dependabot `ignore` rule for `github/gh-aw-actions/*` under the `github-actions` ecosystem in `.github/dependabot.yml`. These actions are pinned by `gh aw compile` and must move in lockstep with the CLI version that generated the lock files (their `uses:` SHAs, the embedded `gh-aw-manifest` comment, and `.github/aw/actions-lock.json` all have to agree). They are updated via `gh aw upgrade` / the Agentic Maintenance workflow, which regenerates everything together — not by isolated Dependabot SHA bumps. This is the durable prevention for the recurring drift.

## Correction from the first revision

An earlier revision of this PR also downgraded the rendered `setup` `uses:` lines across the `.lock.yml` files from v0.83.1 to v0.82.8. **That has been reverted.** On inspection, the lock files were generated by gh-aw **v0.83.1** — their `compiler_version`, `gh-aw-manifest` comments, and `.github/aw/actions-lock.json` all already resolve `setup`/`setup-cli` to v0.83.1 and were internally consistent. Editing only the `uses:` lines introduced *reverse* drift rather than removing it (thanks to the Copilot reviewer for catching this). The pins are left at the consistent v0.83.1 state the generator produced.

Any residual fix for the `awf: command not found` behavior belongs in a proper `gh aw upgrade` / regenerate pass (which keeps the `uses:` lines, manifests, and central action lock in sync), not in hand-edited generated lines.

References #10203 (auto-managed tracking issue; not closed by this PR).