### PR TITLE
Add missing 4.3.3 changelog entries (#10145, #10195)

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -30,6 +30,7 @@ See full log [of v4.3.2...v4.3.3](https://github.com/microsoft/testfx/compare/v4
 * Prevent diagnostic file-logger shutdown from crashing an otherwise successful test run under thread-pool starvation by @Evangelink in [#9802](https://github.com/microsoft/testfx/pull/9802)
 * Fix VSTestBridge interpreting a GUID-shaped fully-qualified test name as a test ID by @Evangelink in [#9794](https://github.com/microsoft/testfx/pull/9794)
 * Support comments in `testconfig.json` on .NET Framework by @Evangelink in [#10144](https://github.com/microsoft/testfx/pull/10144)
+* Fix `Microsoft.Testing.Extensions.AzureDevOpsReport` crashing during teardown from duplicate data-consumer disposal after a successful test run by @Evangelink in [#10195](https://github.com/microsoft/testfx/pull/10195)
 
 ## <a name="2.3.2" />[2.3.2] - 2026-07-13
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -37,6 +37,7 @@ See full log [of v4.3.2...v4.3.3](https://github.com/microsoft/testfx/compare/v4
 * Regenerate MSTest.Sdk source-generated entry points and extension registrations after the MSBuild task assembly is updated by @Evangelink in [#10082](https://github.com/microsoft/testfx/pull/10082)
 * Fix MSTEST0063 failing to validate constructors on classes using derived `[TestClass]` attributes, including `[STATestClass]` by @Evangelink in [#9851](https://github.com/microsoft/testfx/pull/9851)
 * Keep `[TestProperty]`, test categories and host-provided properties scoped to the individual test lifecycle by @Evangelink in [#10080](https://github.com/microsoft/testfx/pull/10080)
+* Restore bounded string difference indicators in `Assert.AreEqual` failure messages by @Evangelink in [#10145](https://github.com/microsoft/testfx/pull/10145)
 
 ## <a name="4.3.2" />[4.3.2] - 2026-07-13
 


### PR DESCRIPTION
While triaging the `MSTest 4.3.3 / MTP 2.3.3` milestone, I found two backports that shipped to `rel/4.3` for 4.3.3 but were never added to the changelog:

- **#10145** – Restore bounded string difference indicators in `Assert.AreEqual` failure messages (fixes #10045) → `docs/Changelog.md` (4.3.3 → Fixed)
- **#10195** – Fix `Microsoft.Testing.Extensions.AzureDevOpsReport` crashing during teardown from duplicate data-consumer disposal (fixes #10191) → `docs/Changelog-Platform.md` (2.3.3 → Fixed)

Both correspond to the two issues that were already tracked in the 4.3.3 milestone. All other 4.3.3 backports were already documented.

### Related milestone cleanup (done separately, not part of this PR)
The `MSTest 4.3.3 / MTP 2.3.3` milestone was missing 8 closed tickets fixed via `rel/4.3` backports; these were added: #9784, #9836, #9966, #9971, #9972, #10041, #10056, and #10137 (moved from the 4.4 milestone).