### PR TITLE
perf: avoid list copy in TestContextImplementation.GetResultFiles

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/TestContextImplementation.cs
@@ -381,10 +381,11 @@ internal sealed partial class TestContextImplementation : TestContext, ITestCont
             return null;
         }
 
-        var results = _testResultFiles.ToList();
-
-        // clear the result files to handle data driven tests
-        _testResultFiles.Clear();
+        // Hand over the existing list to the caller (callers only enumerate it) and reset the field
+        // so data driven tests start with a fresh list on the next AddResultFile call.
+        // This avoids the copy that ToList() would do.
+        List<string> results = _testResultFiles;
+        _testResultFiles = null;
 
         return results;
     }


### PR DESCRIPTION
Fixes #10207

`TestContextImplementation.GetResultFiles()` copied `_testResultFiles` with `.ToList()` and then immediately `.Clear()`ed the original. The copy is unnecessary — every caller (`TestMethodInfo`, `TestResultExtensions`, `MSTestTestNodeConverter`) only enumerates the returned list.

This replaces the copy-then-clear with a swap-and-null: the existing `List<string>` is handed to the caller and the field is reset to `null`, so the next `AddResultFile()` (e.g. for the next data-driven iteration) lazily allocates a fresh list — same observable behavior as before, minus one `List<string>` + backing array allocation per test that attaches result files.

### Validation

- `.\build.cmd -c Debug -projects test\UnitTests\MSTestAdapter.PlatformServices.UnitTests\...` — build succeeded, 0 warnings / 0 errors.
- `MSTestAdapter.PlatformServices.UnitTests` (net9.0): **939/939 passing**, including `GetResultFilesShouldReturnNullIfNoAddedResultFiles`, `GetResultFilesShouldReturnListOfAddedResultFiles`, and `CloneForDataDrivenIterationShouldStartWithFreshResultFiles`.