### PR TITLE
Add edge-case tests for PreferTestInitialize/CleanupOverDispose analyzers

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestCleanupOverDisposeAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestCleanupOverDisposeAnalyzerTests.cs
@@ -259,4 +259,41 @@ public sealed class PreferTestCleanupOverDisposeAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenDerivedTestClassAttributeAndDispose_Diagnostic()
+    {
+        // Custom attributes that inherit from [TestClass] should also trigger the diagnostic.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestClassAttribute : TestClassAttribute { }
+
+            [CustomTestClass]
+            public class MyTestClass : IDisposable
+            {
+                public void [|Dispose|]()
+                {
+                }
+            }
+            """;
+        string fixedCode = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestClassAttribute : TestClassAttribute { }
+
+            [CustomTestClass]
+            public class MyTestClass
+            {
+                [TestCleanup]
+                public void TestCleanup()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestInitializeOverConstructorAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestInitializeOverConstructorAnalyzerTests.cs
@@ -252,4 +252,56 @@ public sealed class PreferTestInitializeOverConstructorAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenNonTestClassHasExplicitParameterlessCtor_NoDiagnostic()
+    {
+        // The analyzer only fires for classes with [TestClass]; a plain class with
+        // an explicit parameterless constructor should never be flagged.
+        string code = """
+            public class MyPlainClass
+            {
+                public MyPlainClass()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenDerivedTestClassAttributeAndExplicitParameterlessCtor_Diagnostic()
+    {
+        // Custom attributes that inherit from [TestClass] should also trigger the diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestClassAttribute : TestClassAttribute { }
+
+            [CustomTestClass]
+            public class MyTestClass
+            {
+                public [|MyTestClass|]()
+                {
+                }
+            }
+            """;
+        string fixedCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class CustomTestClassAttribute : TestClassAttribute { }
+
+            [CustomTestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                public void TestInitialize()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
+    }
 }


### PR DESCRIPTION
Fixes #10209

Adds the missing edge-case tests for two closely related `[TestClass]` analyzers:

- **MSTEST0019** (`PreferTestInitializeOverConstructorAnalyzer`)
- **MSTEST0022** (`PreferTestCleanupOverDisposeAnalyzer`)

### New tests

`PreferTestInitializeOverConstructorAnalyzerTests`
- `WhenNonTestClassHasExplicitParameterlessCtor_NoDiagnostic` — a plain class (no `[TestClass]`) with an explicit parameterless ctor must not trigger the diagnostic.
- `WhenDerivedTestClassAttributeAndExplicitParameterlessCtor_Diagnostic` — a class annotated with a custom attribute derived from `[TestClass]` still fires the diagnostic and produces the expected code fix.

`PreferTestCleanupOverDisposeAnalyzerTests`
- `WhenDerivedTestClassAttributeAndDispose_Diagnostic` — a class annotated with a custom attribute derived from `[TestClass]` that implements `IDisposable` still fires the diagnostic and code fix.

These exercise the `Inherits()` walk in both analyzers' `AnalyzeSymbol` methods, confirming the attribute inheritance chain is checked (not just exact type equality) and that non-test-class types are never flagged.

### Validation

`MSTest.Analyzers.UnitTests` (net8.0): **1463/1463 passed**, including the 3 new tests.

Test-only change; no product code touched.