### PR TITLE
Split SimplifiedConsoleOutputDeviceBase into partial class files

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.Session.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.Session.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// Session lifecycle display logic: banner, before/after session output and session start/stop handling.
+/// </summary>
+internal abstract partial class SimplifiedConsoleOutputDeviceBase
+{
+    public async Task DisplayBannerAsync(string? bannerMessage, CancellationToken cancellationToken)
+    {
+        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
+        {
+            if (_bannerDisplayed)
+            {
+                return;
+            }
+
+            // skip the banner for the children processes
+            _environment.SetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
+
+            _bannerDisplayed = true;
+
+            if (bannerMessage is not null)
+            {
+                ConsoleLog(bannerMessage);
+                return;
+            }
+
+            ConsoleLog(OutputDeviceBannerHelper.BuildBannerText(_platformInformation, _runtimeFeature, _longArchitecture, _runtimeFramework));
+        }
+    }
+
+    public Task DisplayBeforeSessionStartAsync(CancellationToken cancellationToken)
+    {
+        AppendAssemblyLinkTargetFrameworkAndArchitecture(_console, _assemblyName, _targetFramework, _longArchitecture);
+        return Task.CompletedTask;
+    }
+
+    private static void AppendAssemblyLinkTargetFrameworkAndArchitecture(IConsole console, string assembly, string? targetFramework, string? architecture)
+    {
+        var builder = new StringBuilder();
+        builder.Append(assembly);
+        if (targetFramework == null && architecture == null)
+        {
+            console.WriteLine(builder.ToString());
+            return;
+        }
+
+        builder.Append(" (");
+        if (targetFramework != null)
+        {
+            builder.Append(targetFramework);
+            builder.Append('|');
+        }
+
+        if (architecture != null)
+        {
+            builder.Append(architecture);
+        }
+
+        builder.Append(')');
+
+        console.WriteLine(builder.ToString());
+    }
+
+    public async Task DisplayAfterSessionEndRunAsync(CancellationToken cancellationToken)
+    {
+        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
+        {
+            if (_firstCallTo_OnSessionStartingAsync)
+            {
+                return;
+            }
+
+            int total = _skippedTests + _passedTests + _failedTests;
+
+            // The abort callback sets _wasCancelled, but it does not cover every cancellation path
+            // (e.g. cancellations that request the session token without going through the abort
+            // callback). Fold in the token state so the verdict and routing also reflect those.
+            bool wasCancelled = _wasCancelled || cancellationToken.IsCancellationRequested;
+
+            // minimumExpectedTests is always 0 here because SimplifiedConsoleOutputDeviceBase does not
+            // receive ICommandLineOptions. The --minimum-expected-tests policy is still enforced via
+            // TestApplicationResult (exit code), but it is not surfaced in this summary.
+            string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0);
+
+            if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0))
+            {
+                ConsoleError(text);
+            }
+            else
+            {
+                ConsoleLog(text);
+            }
+        }
+    }
+
+    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
+    {
+        SlowTestReporterState? reporterState = Interlocked.Exchange(ref _slowTestReporterState, null);
+
+#if NET
+        if (reporterState is not null)
+        {
+            await reporterState.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
+        }
+#else
+#pragma warning disable VSTHRD103 // CancellationTokenSource.CancelAsync is not available on this target framework.
+        reporterState?.CancellationTokenSource.Cancel();
+#pragma warning restore VSTHRD103
+#endif
+
+        if (reporterState is not null)
+        {
+            await reporterState.Task.ConfigureAwait(false);
+            reporterState.CancellationTokenSource.Dispose();
+        }
+
+        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
+        {
+            _progressMessages.Clear();
+            _activeTestTracker.Clear();
+        }
+    }
+
+    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
+    {
+        CancellationToken cancellationToken = testSessionContext.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // We implement IDataConsumerService and IOutputDisplayService.
+        // So the engine is calling us before as IDataConsumerService and after as IOutputDisplayService.
+        // The engine look for the ITestSessionLifetimeHandler in both case and call it.
+        if (_firstCallTo_OnSessionStartingAsync)
+        {
+            _firstCallTo_OnSessionStartingAsync = false;
+            if (_activeTestTracker.IsEnabled)
+            {
+                var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                _slowTestReporterState = new(cancellationTokenSource, ReportSlowTestsAsync(cancellationTokenSource.Token));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.SlowTests.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.SlowTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// Background slow-test detection and periodic reporting.
+/// </summary>
+internal abstract partial class SimplifiedConsoleOutputDeviceBase
+{
+    /// <summary>
+    /// Reports tests that have crossed their next slow-test threshold.
+    /// </summary>
+    /// <remarks>
+    /// Browser WebAssembly runs this cooperatively. Delay continuations can run while a test is asynchronously
+    /// suspended, but no managed diagnostic can execute while a test synchronously blocks the sole WebAssembly thread.
+    /// </remarks>
+    internal async Task ReportSlowTestsOnceAsync(CancellationToken cancellationToken)
+    {
+        SlowTestDiagnostic[] diagnostics = _activeTestTracker.GetDueDiagnostics();
+        if (diagnostics.Length == 0)
+        {
+            return;
+        }
+
+        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            foreach (SlowTestDiagnostic diagnostic in diagnostics)
+            {
+                if (!_activeTestTracker.IsActive(diagnostic))
+                {
+                    continue;
+                }
+
+                string duration = HumanReadableDurationFormatter.Render(diagnostic.Elapsed, wrapInParentheses: false);
+                ConsoleLog(string.Format(
+                    CultureInfo.CurrentCulture,
+                    TerminalResources.TerminalProgressSlowTest,
+                    duration,
+                    diagnostic.DisplayName));
+            }
+        }
+    }
+
+    private async Task ReportSlowTestsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (true)
+            {
+                await Task.Delay(_slowTestPollInterval, cancellationToken).ConfigureAwait(false);
+                await ReportSlowTestsOnceAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+    }
+
+    private sealed class SlowTestReporterState(CancellationTokenSource cancellationTokenSource, Task task)
+    {
+        internal CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
+
+        internal Task Task { get; } = task;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.TestEvents.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.TestEvents.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+namespace Microsoft.Testing.Platform.OutputDevice;
+
+/// <summary>
+/// Consumption and display of test node updates and output device messages.
+/// </summary>
+internal abstract partial class SimplifiedConsoleOutputDeviceBase
+{
+    public Type[] DataTypesConsumed { get; } =
+    [
+        typeof(TestNodeUpdateMessage),
+        typeof(SessionFileArtifact),
+        typeof(FileArtifact),
+    ];
+
+    /// <summary>
+    /// Displays provided data through IConsole, which is typically System.Console.
+    /// </summary>
+    /// <param name="producer">The producer that sent the data.</param>
+    /// <param name="data">The data to be displayed.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public async Task DisplayAsync(IOutputDeviceDataProducer producer, IOutputDeviceData data, CancellationToken cancellationToken)
+    {
+        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
+        {
+            switch (data)
+            {
+                case SessionMessageOutputDeviceData sessionMessageData:
+                    ConsoleLog(sessionMessageData.Message);
+                    break;
+
+                case ProgressMessageOutputDeviceData progressMessageData:
+                    var identity = new ProgressMessageIdentity(producer.Uid, progressMessageData.Key);
+                    if (progressMessageData.Message is null)
+                    {
+                        _progressMessages.Remove(identity);
+                    }
+                    else if (!_progressMessages.TryGetValue(identity, out string? existingMessage)
+                        || existingMessage != progressMessageData.Message)
+                    {
+                        ConsoleLog(progressMessageData.Message);
+                        _progressMessages[identity] = progressMessageData.Message;
+                    }
+
+                    break;
+
+                case FormattedTextOutputDeviceData formattedTextData:
+                    ConsoleLog(formattedTextData.Text);
+                    break;
+
+                case TextOutputDeviceData textData:
+                    ConsoleLog(textData.Text);
+                    break;
+
+                case WarningMessageOutputDeviceData warningData:
+                    ConsoleWarn(warningData.Message);
+                    break;
+
+                case ErrorMessageOutputDeviceData errorData:
+                    ConsoleError(errorData.Message);
+                    break;
+
+                case ExceptionOutputDeviceData exceptionOutputDeviceData:
+                    ConsoleError(exceptionOutputDeviceData.Exception.ToString());
+                    break;
+            }
+        }
+    }
+
+    private readonly record struct ProgressMessageIdentity(string ProducerUid, string Key);
+
+    private void OnFailedTest(TestNodeUpdateMessage testNodeStateChanged, TestNodeStateProperty state, Exception? exception, TimeSpan? duration)
+    {
+        _failedTests++;
+        var builder = new StringBuilder();
+        builder.Append("failed ");
+        builder.Append(testNodeStateChanged.TestNode.DisplayName);
+
+        if (duration.HasValue)
+        {
+            builder.Append(' ');
+            HumanReadableDurationFormatter.Append(builder, static (builder, s) => builder!.Append(s), duration.Value);
+        }
+
+        if (state.Explanation is not null)
+        {
+            builder.AppendLine();
+            builder.Append("  ");
+            builder.Append(state.Explanation);
+        }
+
+        if (exception is not null)
+        {
+            builder.AppendLine();
+            builder.Append("  ");
+            builder.Append(exception.ToString());
+        }
+
+        ConsoleError(builder.ToString());
+    }
+
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.CompletedTask;
+        }
+
+        switch (value)
+        {
+            case TestNodeUpdateMessage testNodeStateChanged:
+
+                // Single-pass collection: replaces SingleOrDefault<TimingProperty>() + SingleOrDefault<TestNodeStateProperty>()
+                // with one zero-allocation GetStructEnumerator() walk. Note: TestNodeStateProperty was already O(1) via direct
+                // field access, so the win here is code-path simplification and consistency with the established single-pass pattern.
+                TimingProperty? timingProp = null;
+                TestNodeStateProperty? nodeStateProp = null;
+                bool executionCompleted = false;
+                PropertyBag.PropertyBagEnumerator enumerator = testNodeStateChanged.TestNode.Properties.GetStructEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    switch (enumerator.Current)
+                    {
+                        case TimingProperty t: timingProp = t; break;
+                        case TestNodeStateProperty s: nodeStateProp = s; break;
+                        case TestNodeExecutionCompletedProperty: executionCompleted = true; break;
+                    }
+                }
+
+                TimeSpan? duration = timingProp?.GlobalTiming.Duration;
+                bool testCompleted = executionCompleted;
+
+                if (nodeStateProp is InProgressTestNodeStateProperty)
+                {
+                    _activeTestTracker.Start(testNodeStateChanged.TestNode.Uid, testNodeStateChanged.TestNode.DisplayName);
+                }
+#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
+                else if (executionCompleted
+                    || nodeStateProp is PassedTestNodeStateProperty or ErrorTestNodeStateProperty or CancelledTestNodeStateProperty
+#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
+                    or FailedTestNodeStateProperty or TimeoutTestNodeStateProperty or SkippedTestNodeStateProperty)
+                {
+                    _activeTestTracker.Complete(testNodeStateChanged.TestNode.Uid);
+                }
+
+                switch (nodeStateProp)
+                {
+                    case InProgressTestNodeStateProperty:
+                        if (DisplayActiveTestProgress)
+                        {
+                            return DisplayAsync(
+                                this,
+                                new ProgressMessageOutputDeviceData(
+                                    testNodeStateChanged.TestNode.Uid.Value,
+                                    $"running {testNodeStateChanged.TestNode.DisplayName}"),
+                                cancellationToken);
+                        }
+
+                        break;
+
+                    case ErrorTestNodeStateProperty errorState:
+                        OnFailedTest(testNodeStateChanged, errorState, errorState.Exception, duration);
+                        testCompleted = true;
+                        break;
+
+                    case FailedTestNodeStateProperty failedState:
+                        OnFailedTest(testNodeStateChanged, failedState, failedState.Exception, duration);
+                        testCompleted = true;
+                        break;
+
+                    case TimeoutTestNodeStateProperty timeoutState:
+                        OnFailedTest(testNodeStateChanged, timeoutState, timeoutState.Exception, duration);
+                        testCompleted = true;
+                        break;
+
+#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
+                    case CancelledTestNodeStateProperty cancelledState:
+#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
+                        OnFailedTest(testNodeStateChanged, cancelledState, cancelledState.Exception, duration);
+                        testCompleted = true;
+                        break;
+
+                    case PassedTestNodeStateProperty:
+                        _passedTests++;
+                        testCompleted = true;
+                        break;
+
+                    case SkippedTestNodeStateProperty:
+                        _skippedTests++;
+                        testCompleted = true;
+                        break;
+                }
+
+                if (testCompleted && DisplayActiveTestProgress)
+                {
+                    return DisplayAsync(
+                        this,
+                        new ProgressMessageOutputDeviceData(testNodeStateChanged.TestNode.Uid.Value, message: null),
+                        cancellationToken);
+                }
+
+                // Tracked by https://github.com/microsoft/testfx/issues/8086:
+                // surface per-test file artifacts in the simplified console output once the format is defined.
+                break;
+
+            case SessionFileArtifact:
+                {
+                    // Tracked by https://github.com/microsoft/testfx/issues/8086:
+                    // session-level artifacts are currently ignored by this output device.
+                }
+
+                break;
+            case FileArtifact:
+                {
+                    // Tracked by https://github.com/microsoft/testfx/issues/8086:
+                    // file artifacts are currently ignored by this output device.
+                }
+
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Extensions;
-using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.OutputDevice.Terminal;
 using Microsoft.Testing.Platform.Resources;
 using Microsoft.Testing.Platform.Services;
 
@@ -15,7 +13,7 @@ namespace Microsoft.Testing.Platform.OutputDevice;
 /// <summary>
 /// Base class for browser and WASI output devices that provides common functionality.
 /// </summary>
-internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevice,
+internal abstract partial class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevice,
     IDataConsumer,
     IOutputDeviceDataProducer,
     ITestSessionLifetimeHandler,
@@ -106,23 +104,6 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
         }
     }
 
-    public async Task InitializeAsync()
-        => await _policiesService.RegisterOnAbortCallbackAsync(
-            () =>
-            {
-                _wasCancelled = true;
-                ConsoleLog(PlatformResources.CancellingTestSession);
-                ConsoleLog(PlatformResources.PressCtrlCAgainToForceExit);
-                return Task.CompletedTask;
-            }).ConfigureAwait(false);
-
-    public Type[] DataTypesConsumed { get; } =
-    [
-        typeof(TestNodeUpdateMessage),
-        typeof(SessionFileArtifact),
-        typeof(FileArtifact),
-    ];
-
     /// <inheritdoc />
     public string Uid => GetType().Name;
 
@@ -135,6 +116,18 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
     /// <inheritdoc />
     public abstract string Description { get; }
 
+    protected virtual bool DisplayActiveTestProgress => false;
+
+    public async Task InitializeAsync()
+        => await _policiesService.RegisterOnAbortCallbackAsync(
+            () =>
+            {
+                _wasCancelled = true;
+                ConsoleLog(PlatformResources.CancellingTestSession);
+                ConsoleLog(PlatformResources.PressCtrlCAgainToForceExit);
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
+
     /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
@@ -143,413 +136,6 @@ internal abstract class SimplifiedConsoleOutputDeviceBase : IPlatformOutputDevic
     protected abstract void ConsoleError(string? message);
 
     protected abstract void ConsoleLog(string? message);
-
-    protected virtual bool DisplayActiveTestProgress => false;
-
-    public async Task DisplayBannerAsync(string? bannerMessage, CancellationToken cancellationToken)
-    {
-        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
-        {
-            if (_bannerDisplayed)
-            {
-                return;
-            }
-
-            // skip the banner for the children processes
-            _environment.SetEnvironmentVariable(OutputDeviceBannerHelper.TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER, "1");
-
-            _bannerDisplayed = true;
-
-            if (bannerMessage is not null)
-            {
-                ConsoleLog(bannerMessage);
-                return;
-            }
-
-            ConsoleLog(OutputDeviceBannerHelper.BuildBannerText(_platformInformation, _runtimeFeature, _longArchitecture, _runtimeFramework));
-        }
-    }
-
-    public Task DisplayBeforeSessionStartAsync(CancellationToken cancellationToken)
-    {
-        AppendAssemblyLinkTargetFrameworkAndArchitecture(_console, _assemblyName, _targetFramework, _longArchitecture);
-        return Task.CompletedTask;
-    }
-
-    private static void AppendAssemblyLinkTargetFrameworkAndArchitecture(IConsole console, string assembly, string? targetFramework, string? architecture)
-    {
-        var builder = new StringBuilder();
-        builder.Append(assembly);
-        if (targetFramework == null && architecture == null)
-        {
-            console.WriteLine(builder.ToString());
-            return;
-        }
-
-        builder.Append(" (");
-        if (targetFramework != null)
-        {
-            builder.Append(targetFramework);
-            builder.Append('|');
-        }
-
-        if (architecture != null)
-        {
-            builder.Append(architecture);
-        }
-
-        builder.Append(')');
-
-        console.WriteLine(builder.ToString());
-    }
-
-    public async Task DisplayAfterSessionEndRunAsync(CancellationToken cancellationToken)
-    {
-        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
-        {
-            if (_firstCallTo_OnSessionStartingAsync)
-            {
-                return;
-            }
-
-            int total = _skippedTests + _passedTests + _failedTests;
-
-            // The abort callback sets _wasCancelled, but it does not cover every cancellation path
-            // (e.g. cancellations that request the session token without going through the abort
-            // callback). Fold in the token state so the verdict and routing also reflect those.
-            bool wasCancelled = _wasCancelled || cancellationToken.IsCancellationRequested;
-
-            // minimumExpectedTests is always 0 here because SimplifiedConsoleOutputDeviceBase does not
-            // receive ICommandLineOptions. The --minimum-expected-tests policy is still enforced via
-            // TestApplicationResult (exit code), but it is not surfaced in this summary.
-            string text = TestRunSummaryHelper.FormatSummaryText(total, _failedTests, _passedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0);
-
-            if (TestRunSummaryHelper.IsRunFailed(total, _failedTests, _skippedTests, wasCancelled, minimumExpectedTests: 0))
-            {
-                ConsoleError(text);
-            }
-            else
-            {
-                ConsoleLog(text);
-            }
-        }
-    }
-
-    public async Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
-    {
-        SlowTestReporterState? reporterState = Interlocked.Exchange(ref _slowTestReporterState, null);
-
-#if NET
-        if (reporterState is not null)
-        {
-            await reporterState.CancellationTokenSource.CancelAsync().ConfigureAwait(false);
-        }
-#else
-#pragma warning disable VSTHRD103 // CancellationTokenSource.CancelAsync is not available on this target framework.
-        reporterState?.CancellationTokenSource.Cancel();
-#pragma warning restore VSTHRD103
-#endif
-
-        if (reporterState is not null)
-        {
-            await reporterState.Task.ConfigureAwait(false);
-            reporterState.CancellationTokenSource.Dispose();
-        }
-
-        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
-        {
-            _progressMessages.Clear();
-            _activeTestTracker.Clear();
-        }
-    }
-
-    public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
-    {
-        CancellationToken cancellationToken = testSessionContext.CancellationToken;
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // We implement IDataConsumerService and IOutputDisplayService.
-        // So the engine is calling us before as IDataConsumerService and after as IOutputDisplayService.
-        // The engine look for the ITestSessionLifetimeHandler in both case and call it.
-        if (_firstCallTo_OnSessionStartingAsync)
-        {
-            _firstCallTo_OnSessionStartingAsync = false;
-            if (_activeTestTracker.IsEnabled)
-            {
-                var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                _slowTestReporterState = new(cancellationTokenSource, ReportSlowTestsAsync(cancellationTokenSource.Token));
-            }
-        }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Displays provided data through IConsole, which is typically System.Console.
-    /// </summary>
-    /// <param name="producer">The producer that sent the data.</param>
-    /// <param name="data">The data to be displayed.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    public async Task DisplayAsync(IOutputDeviceDataProducer producer, IOutputDeviceData data, CancellationToken cancellationToken)
-    {
-        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
-        {
-            switch (data)
-            {
-                case SessionMessageOutputDeviceData sessionMessageData:
-                    ConsoleLog(sessionMessageData.Message);
-                    break;
-
-                case ProgressMessageOutputDeviceData progressMessageData:
-                    var identity = new ProgressMessageIdentity(producer.Uid, progressMessageData.Key);
-                    if (progressMessageData.Message is null)
-                    {
-                        _progressMessages.Remove(identity);
-                    }
-                    else if (!_progressMessages.TryGetValue(identity, out string? existingMessage)
-                        || existingMessage != progressMessageData.Message)
-                    {
-                        ConsoleLog(progressMessageData.Message);
-                        _progressMessages[identity] = progressMessageData.Message;
-                    }
-
-                    break;
-
-                case FormattedTextOutputDeviceData formattedTextData:
-                    ConsoleLog(formattedTextData.Text);
-                    break;
-
-                case TextOutputDeviceData textData:
-                    ConsoleLog(textData.Text);
-                    break;
-
-                case WarningMessageOutputDeviceData warningData:
-                    ConsoleWarn(warningData.Message);
-                    break;
-
-                case ErrorMessageOutputDeviceData errorData:
-                    ConsoleError(errorData.Message);
-                    break;
-
-                case ExceptionOutputDeviceData exceptionOutputDeviceData:
-                    ConsoleError(exceptionOutputDeviceData.Exception.ToString());
-                    break;
-            }
-        }
-    }
-
-    private readonly record struct ProgressMessageIdentity(string ProducerUid, string Key);
-
-    private void OnFailedTest(TestNodeUpdateMessage testNodeStateChanged, TestNodeStateProperty state, Exception? exception, TimeSpan? duration)
-    {
-        _failedTests++;
-        var builder = new StringBuilder();
-        builder.Append("failed ");
-        builder.Append(testNodeStateChanged.TestNode.DisplayName);
-
-        if (duration.HasValue)
-        {
-            builder.Append(' ');
-            HumanReadableDurationFormatter.Append(builder, static (builder, s) => builder!.Append(s), duration.Value);
-        }
-
-        if (state.Explanation is not null)
-        {
-            builder.AppendLine();
-            builder.Append("  ");
-            builder.Append(state.Explanation);
-        }
-
-        if (exception is not null)
-        {
-            builder.AppendLine();
-            builder.Append("  ");
-            builder.Append(exception.ToString());
-        }
-
-        ConsoleError(builder.ToString());
-    }
-
-    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
-    {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return Task.CompletedTask;
-        }
-
-        switch (value)
-        {
-            case TestNodeUpdateMessage testNodeStateChanged:
-
-                // Single-pass collection: replaces SingleOrDefault<TimingProperty>() + SingleOrDefault<TestNodeStateProperty>()
-                // with one zero-allocation GetStructEnumerator() walk. Note: TestNodeStateProperty was already O(1) via direct
-                // field access, so the win here is code-path simplification and consistency with the established single-pass pattern.
-                TimingProperty? timingProp = null;
-                TestNodeStateProperty? nodeStateProp = null;
-                bool executionCompleted = false;
-                PropertyBag.PropertyBagEnumerator enumerator = testNodeStateChanged.TestNode.Properties.GetStructEnumerator();
-                while (enumerator.MoveNext())
-                {
-                    switch (enumerator.Current)
-                    {
-                        case TimingProperty t: timingProp = t; break;
-                        case TestNodeStateProperty s: nodeStateProp = s; break;
-                        case TestNodeExecutionCompletedProperty: executionCompleted = true; break;
-                    }
-                }
-
-                TimeSpan? duration = timingProp?.GlobalTiming.Duration;
-                bool testCompleted = executionCompleted;
-
-                if (nodeStateProp is InProgressTestNodeStateProperty)
-                {
-                    _activeTestTracker.Start(testNodeStateChanged.TestNode.Uid, testNodeStateChanged.TestNode.DisplayName);
-                }
-#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
-                else if (executionCompleted
-                    || nodeStateProp is PassedTestNodeStateProperty or ErrorTestNodeStateProperty or CancelledTestNodeStateProperty
-#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
-                    or FailedTestNodeStateProperty or TimeoutTestNodeStateProperty or SkippedTestNodeStateProperty)
-                {
-                    _activeTestTracker.Complete(testNodeStateChanged.TestNode.Uid);
-                }
-
-                switch (nodeStateProp)
-                {
-                    case InProgressTestNodeStateProperty:
-                        if (DisplayActiveTestProgress)
-                        {
-                            return DisplayAsync(
-                                this,
-                                new ProgressMessageOutputDeviceData(
-                                    testNodeStateChanged.TestNode.Uid.Value,
-                                    $"running {testNodeStateChanged.TestNode.DisplayName}"),
-                                cancellationToken);
-                        }
-
-                        break;
-
-                    case ErrorTestNodeStateProperty errorState:
-                        OnFailedTest(testNodeStateChanged, errorState, errorState.Exception, duration);
-                        testCompleted = true;
-                        break;
-
-                    case FailedTestNodeStateProperty failedState:
-                        OnFailedTest(testNodeStateChanged, failedState, failedState.Exception, duration);
-                        testCompleted = true;
-                        break;
-
-                    case TimeoutTestNodeStateProperty timeoutState:
-                        OnFailedTest(testNodeStateChanged, timeoutState, timeoutState.Exception, duration);
-                        testCompleted = true;
-                        break;
-
-#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
-                    case CancelledTestNodeStateProperty cancelledState:
-#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
-                        OnFailedTest(testNodeStateChanged, cancelledState, cancelledState.Exception, duration);
-                        testCompleted = true;
-                        break;
-
-                    case PassedTestNodeStateProperty:
-                        _passedTests++;
-                        testCompleted = true;
-                        break;
-
-                    case SkippedTestNodeStateProperty:
-                        _skippedTests++;
-                        testCompleted = true;
-                        break;
-                }
-
-                if (testCompleted && DisplayActiveTestProgress)
-                {
-                    return DisplayAsync(
-                        this,
-                        new ProgressMessageOutputDeviceData(testNodeStateChanged.TestNode.Uid.Value, message: null),
-                        cancellationToken);
-                }
-
-                // Tracked by https://github.com/microsoft/testfx/issues/8086:
-                // surface per-test file artifacts in the simplified console output once the format is defined.
-                break;
-
-            case SessionFileArtifact:
-                {
-                    // Tracked by https://github.com/microsoft/testfx/issues/8086:
-                    // session-level artifacts are currently ignored by this output device.
-                }
-
-                break;
-            case FileArtifact:
-                {
-                    // Tracked by https://github.com/microsoft/testfx/issues/8086:
-                    // file artifacts are currently ignored by this output device.
-                }
-
-                break;
-        }
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Reports tests that have crossed their next slow-test threshold.
-    /// </summary>
-    /// <remarks>
-    /// Browser WebAssembly runs this cooperatively. Delay continuations can run while a test is asynchronously
-    /// suspended, but no managed diagnostic can execute while a test synchronously blocks the sole WebAssembly thread.
-    /// </remarks>
-    internal async Task ReportSlowTestsOnceAsync(CancellationToken cancellationToken)
-    {
-        SlowTestDiagnostic[] diagnostics = _activeTestTracker.GetDueDiagnostics();
-        if (diagnostics.Length == 0)
-        {
-            return;
-        }
-
-        using (await _asyncMonitor.LockAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            foreach (SlowTestDiagnostic diagnostic in diagnostics)
-            {
-                if (!_activeTestTracker.IsActive(diagnostic))
-                {
-                    continue;
-                }
-
-                string duration = HumanReadableDurationFormatter.Render(diagnostic.Elapsed, wrapInParentheses: false);
-                ConsoleLog(string.Format(
-                    CultureInfo.CurrentCulture,
-                    TerminalResources.TerminalProgressSlowTest,
-                    duration,
-                    diagnostic.DisplayName));
-            }
-        }
-    }
-
-    private async Task ReportSlowTestsAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            while (true)
-            {
-                await Task.Delay(_slowTestPollInterval, cancellationToken).ConfigureAwait(false);
-                await ReportSlowTestsOnceAsync(cancellationToken).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-    }
-
-    private sealed class SlowTestReporterState(CancellationTokenSource cancellationTokenSource, Task task)
-    {
-        internal CancellationTokenSource CancellationTokenSource { get; } = cancellationTokenSource;
-
-        internal Task Task { get; } = task;
-    }
 
     public async Task HandleProcessRoleAsync(TestProcessRole processRole, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Fixes #10206

`src/Platform/Microsoft.Testing.Platform/OutputDevice/SimplifiedConsoleOutputDeviceBase.cs` had grown to 563 lines while covering four distinct concerns. It is now split into `partial class` files, each well under the 300-line threshold:

| File | Lines | Responsibility |
| --- | --- | --- |
| `SimplifiedConsoleOutputDeviceBase.cs` | 149 | Fields, constructors, extension identity (`Uid`/`Version`/`DisplayName`/`Description`), `InitializeAsync`, `IsEnabledAsync`, abstract console members, `HandleProcessRoleAsync` |
| `SimplifiedConsoleOutputDeviceBase.Session.cs` | 151 | Session lifecycle display: `DisplayBannerAsync`, `DisplayBeforeSessionStartAsync`, `AppendAssemblyLinkTargetFrameworkAndArchitecture`, `DisplayAfterSessionEndRunAsync`, `OnTestSessionStartingAsync`, `OnTestSessionFinishingAsync` |
| `SimplifiedConsoleOutputDeviceBase.TestEvents.cs` | 231 | `DataTypesConsumed`, `ConsumeAsync`, `DisplayAsync`, `OnFailedTest`, `ProgressMessageIdentity` |
| `SimplifiedConsoleOutputDeviceBase.SlowTests.cs` | 71 | `ReportSlowTestsOnceAsync`, `ReportSlowTestsAsync`, `SlowTestReporterState` |

`HandleProcessRoleAsync` was kept in the core file rather than grouped with the slow-test reporter (as the issue sketched), since it is a process-role/initialization concern rather than slow-test reporting.

## Notes

- Pure code move — no behavior, API surface, or member accessibility changes. Consumers reference the type name, so no `using` directives changed elsewhere.
- File-scoped namespaces, UTF-8 with BOM, and `.editorconfig` conventions applied to all new files.

## Validation

- `.\build.cmd` — succeeds with 0 warnings, 0 errors (including `IDE0005` unused-using enforcement).
- `Microsoft.Testing.Platform.UnitTests` (net9.0) — 1652/1652 passing, including the 16 `SimplifiedConsoleOutputDeviceTests`.