### PR TITLE
Replace nullable suppressions with proper annotations

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -3,6 +3,7 @@
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleOutRouter.ConsoleOutRouter(System.IO.TextWriter! originalConsoleOut) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.ConsoleRouter.ConsoleRouter(System.IO.TextWriter! originalConsole) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TraceTextWriter.TraceTextWriter() -> void
+*REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.SourceGeneratedReflectionDataProvider.Assembly.get -> System.Reflection.Assembly!
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(char value) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(char[]! buffer, int index, int count) -> void
 *REMOVED*Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.WriteConsoleErr(string? value) -> void
@@ -29,6 +30,7 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Live = 2 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.None = 0 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Result = 1 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.SourceGeneratedReflectionDataProvider.Assembly.get -> System.Reflection.Assembly?
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardErrorBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardOutputBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.TraceBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
@@ -17,9 +17,11 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Sou
 internal class SourceGeneratedReflectionDataProvider
 {
     /// <summary>
-    /// Gets the test assembly described by this metadata snapshot.
+    /// Gets the test assembly described by this metadata snapshot, or <see langword="null"/> for a snapshot that
+    /// is not tied to a single assembly (for example the merged snapshot built by
+    /// <see cref="CompositeSourceGeneratedReflectionDataProvider"/>).
     /// </summary>
-    public Assembly Assembly { get; init; } = null!;
+    public Assembly? Assembly { get; init; }
 
     /// <summary>
     /// Gets the file-name (without extension) of the test assembly.
@@ -212,6 +214,6 @@ internal class SourceGeneratedReflectionDataProvider
     {
         public Type[] Parameters { get; init; } = [];
 
-        public Func<object?[]?, object> Invoker { get; init; } = null!;
+        public required Func<object?[]?, object> Invoker { get; init; }
     }
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration;

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/ConfigurationFileTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/ConfigurationFileTask.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#pragma warning disable CS8618 // Properties below are set by MSBuild.
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -32,31 +30,32 @@ public sealed class ConfigurationFileTask : Build.Utilities.Task
     /// Gets or sets the Microsoft Testing Platform configuration file source.
     /// </summary>
     [Required]
-    public ITaskItem TestingPlatformConfigurationFileSource { get; set; }
+    public required ITaskItem TestingPlatformConfigurationFileSource { get; set; }
 
     /// <summary>
     /// Gets or sets the MSBuild project directory.
     /// </summary>
     [Required]
-    public ITaskItem MSBuildProjectDirectory { get; set; }
+    public required ITaskItem MSBuildProjectDirectory { get; set; }
 
     /// <summary>
     /// Gets or sets the assembly name.
     /// </summary>
     [Required]
-    public ITaskItem AssemblyName { get; set; }
+    public required ITaskItem AssemblyName { get; set; }
 
     /// <summary>
     /// Gets or sets the output path.
     /// </summary>
     [Required]
-    public ITaskItem OutputPath { get; set; }
+    public required ITaskItem OutputPath { get; set; }
 
     /// <summary>
-    /// Gets or sets the final Microsoft Testing Platform configuration file.
+    /// Gets or sets the final Microsoft Testing Platform configuration file. It stays <see langword="null"/> when
+    /// no configuration file was found, in which case the task produces no output item.
     /// </summary>
     [Output]
-    public ITaskItem FinalTestingPlatformConfigurationFile { get; set; }
+    public ITaskItem? FinalTestingPlatformConfigurationFile { get; set; }
 
     /// <inheritdoc/>
     public override bool Execute()

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -1,7 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-#pragma warning disable CS8618 // Properties below are set by MSBuild.
 
 using Microsoft.Build.Framework;
 using Microsoft.Testing.Extensions.MSBuild.Serializers;
@@ -52,17 +50,19 @@ public partial class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisp
         {
             Debugger.Launch();
         }
-
-        _pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
     }
 
-    internal InvokeTestingPlatformTask(IFileSystem fileSystem) => _fileSystem = fileSystem;
+    internal InvokeTestingPlatformTask(IFileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+        _pipeNameDescription = NamedPipeServer.GetPipeName(Guid.NewGuid().ToString("N"));
+    }
 
     /// <summary>
     /// Gets or sets the target path.
     /// </summary>
     [Required]
-    public ITaskItem TargetPath { get; set; }
+    public required ITaskItem TargetPath { get; set; }
 
     // -------- BEGIN the following properties shouldn't be used. See https://github.com/microsoft/testfx/issues/5091 --------
 
@@ -97,37 +97,37 @@ public partial class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisp
     /// Gets or sets the target framework.
     /// </summary>
     [Required]
-    public ITaskItem TargetFramework { get; set; }
+    public required ITaskItem TargetFramework { get; set; }
 
     /// <summary>
     /// Gets or sets the test architecture.
     /// </summary>
     [Required]
-    public ITaskItem TestArchitecture { get; set; }
+    public required ITaskItem TestArchitecture { get; set; }
 
     /// <summary>
     /// Gets or sets the target framework identifier.
     /// </summary>
     [Required]
-    public ITaskItem TargetFrameworkIdentifier { get; set; }
+    public required ITaskItem TargetFrameworkIdentifier { get; set; }
 
     /// <summary>
     /// Gets or sets the testing platform show tests failure.
     /// </summary>
     [Required]
-    public ITaskItem TestingPlatformShowTestsFailure { get; set; }
+    public required ITaskItem TestingPlatformShowTestsFailure { get; set; }
 
     /// <summary>
     /// Gets or sets the testing platform capture output.
     /// </summary>
     [Required]
-    public ITaskItem TestingPlatformCaptureOutput { get; set; }
+    public required ITaskItem TestingPlatformCaptureOutput { get; set; }
 
     /// <summary>
     /// Gets or sets the project full path.
     /// </summary>
     [Required]
-    public ITaskItem ProjectFullPath { get; set; }
+    public required ITaskItem ProjectFullPath { get; set; }
 
     /// <summary>
     /// Gets or sets the dotnet host path.

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/MSBuildCompatibilityHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/MSBuildCompatibilityHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#pragma warning disable CS8618 // Properties below are set by MSBuild.
-
 using Microsoft.Build.Framework;
 
 namespace Microsoft.Testing.Platform.MSBuild;

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformAutoRegisteredExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#pragma warning disable CS8618 // Properties below are set by MSBuild.
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Testing.Platform.Helpers;
@@ -53,19 +51,19 @@ public sealed class TestingPlatformSelfRegisteredExtensions : Build.Utilities.Ta
     /// Gets or sets the path to the source file.
     /// </summary>
     [Required]
-    public ITaskItem SelfRegisteredExtensionsSourcePath { get; set; }
+    public required ITaskItem SelfRegisteredExtensionsSourcePath { get; set; }
 
     /// <summary>
     /// Gets or sets the language of the source file.
     /// </summary>
     [Required]
-    public ITaskItem Language { get; set; }
+    public required ITaskItem Language { get; set; }
 
     /// <summary>
     /// Gets or sets the builder hooks.
     /// </summary>
     [Required]
-    public ITaskItem[] SelfRegisteredExtensionsBuilderHook { get; set; }
+    public required ITaskItem[] SelfRegisteredExtensionsBuilderHook { get; set; }
 
     /// <summary>
     /// Gets or sets the root namespace.
@@ -73,10 +71,11 @@ public sealed class TestingPlatformSelfRegisteredExtensions : Build.Utilities.Ta
     public string? RootNamespace { get; set; }
 
     /// <summary>
-    /// Gets or sets the path to the generated file.
+    /// Gets or sets the path to the generated file. It stays <see langword="null"/> when the project language is
+    /// not supported, in which case the task produces no output item.
     /// </summary>
     [Output]
-    public ITaskItem SelfRegisteredExtensionsGeneratedFilePath { get; set; }
+    public ITaskItem? SelfRegisteredExtensionsGeneratedFilePath { get; set; }
 
     private readonly string _expectedItemSpec = """
 Expected item spec:
@@ -130,7 +129,7 @@ static Contoso.BuilderHook.AddExtensions(Microsoft.Testing.Platform.Builder.Test
                 !Language.ItemSpec.Equals(VBLanguageSymbol, StringComparison.OrdinalIgnoreCase) &&
                 !Language.ItemSpec.Equals(FSharpLanguageSymbol, StringComparison.OrdinalIgnoreCase))
             {
-                SelfRegisteredExtensionsGeneratedFilePath = default!;
+                SelfRegisteredExtensionsGeneratedFilePath = null;
                 Log.LogError($"Language '{Language.ItemSpec}' is not supported.");
             }
             else

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/TestingPlatformEntryPointTask.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#pragma warning disable CS8618 // Properties below are set by MSBuild.
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -41,13 +39,13 @@ public sealed class TestingPlatformEntryPointTask : Build.Utilities.Task
     /// Gets or sets the path to the Testing Platform entry point source file.
     /// </summary>
     [Required]
-    public ITaskItem TestingPlatformEntryPointSourcePath { get; set; }
+    public required ITaskItem TestingPlatformEntryPointSourcePath { get; set; }
 
     /// <summary>
     /// Gets or sets the language of the project.
     /// </summary>
     [Required]
-    public ITaskItem Language { get; set; }
+    public required ITaskItem Language { get; set; }
 
     /// <summary>
     /// Gets or sets the root namespace of the project.
@@ -55,10 +53,11 @@ public sealed class TestingPlatformEntryPointTask : Build.Utilities.Task
     public string? RootNamespace { get; set; }
 
     /// <summary>
-    /// Gets or sets the path to the generated Testing Platform entry point file.
+    /// Gets or sets the path to the generated Testing Platform entry point file. It stays <see langword="null"/>
+    /// when the project language is not supported, in which case the task produces no output item.
     /// </summary>
     [Output]
-    public ITaskItem TestingPlatformEntryPointGeneratedFilePath { get; set; }
+    public ITaskItem? TestingPlatformEntryPointGeneratedFilePath { get; set; }
 
     /// <inheritdoc />
     public override bool Execute()
@@ -70,7 +69,7 @@ public sealed class TestingPlatformEntryPointTask : Build.Utilities.Task
             !Language.ItemSpec.Equals(VBLanguageSymbol, StringComparison.OrdinalIgnoreCase) &&
             !Language.ItemSpec.Equals(FSharpLanguageSymbol, StringComparison.OrdinalIgnoreCase))
         {
-            TestingPlatformEntryPointGeneratedFilePath = default!;
+            TestingPlatformEntryPointGeneratedFilePath = null;
             Log.LogError($"Language '{Language.ItemSpec}' is not supported.");
         }
         else

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/JsonValueSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/JsonValueSerializer.cs
@@ -5,9 +5,7 @@ using System.Text.Json;
 
 namespace Microsoft.Testing.Platform.ServerMode.Json;
 
-internal abstract class JsonValueSerializer : JsonSerializer
+internal abstract class JsonValueSerializer(Action<Utf8JsonWriter, object> serialize) : JsonSerializer
 {
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    public Action<Utf8JsonWriter, object> Serialize { get; protected set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    public Action<Utf8JsonWriter, object> Serialize { get; } = serialize;
 }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/JsonValueSerializer1.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/JsonValueSerializer1.cs
@@ -5,7 +5,5 @@ using System.Text.Json;
 
 namespace Microsoft.Testing.Platform.ServerMode.Json;
 
-internal sealed class JsonValueSerializer<T> : JsonValueSerializer
-{
-    public JsonValueSerializer(Action<Utf8JsonWriter, T> value) => Serialize = (w, o) => value(w, (T)o);
-}
+internal sealed class JsonValueSerializer<T>(Action<Utf8JsonWriter, T> value)
+    : JsonValueSerializer((w, o) => value(w, (T)o));

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 using Microsoft.Testing.Platform.Helpers;
 
 using Moq;
@@ -69,9 +70,19 @@ public sealed class InvokeTestingPlatformTaskTests
 
     private sealed class TestableInvokeTestingPlatformTask : InvokeTestingPlatformTask
     {
+        // MSBuild is the one that normally supplies the [Required] inputs; stub them out here so the test can focus
+        // on the output-logging behavior.
+        [SetsRequiredMembers]
         public TestableInvokeTestingPlatformTask()
             : base(new StubFileSystem())
         {
+            TargetPath = new TaskItem("MyAssembly.dll");
+            TargetFramework = new TaskItem("net9.0");
+            TestArchitecture = new TaskItem("x64");
+            TargetFrameworkIdentifier = new TaskItem(".NETCoreApp");
+            TestingPlatformShowTestsFailure = new TaskItem("false");
+            TestingPlatformCaptureOutput = new TaskItem("true");
+            ProjectFullPath = new TaskItem("MyProject.csproj");
         }
 
         public void InvokeLogEventsFromTextOutput(string singleLine)

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Framework;


### PR DESCRIPTION
Fixes part of #10208.

Per the issue triage, this covers Task 1, Task 3, and the `SourceGeneratedReflectionDataProvider` half of Task 2. Task 2's main suggestion (`required` on `TestHostBuilder`'s internal build-state type) doesn't apply — those properties are assigned sequentially during the build pipeline rather than in an object initializer, so `required` can't express it. Tasks 4 and 5 are left out.

### MSBuild tasks (Task 1)

The five files under `src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/` shared a file-level `#pragma warning disable CS8618 // Properties below are set by MSBuild.`, which suppressed the warning for the *whole file* rather than just the task properties.

- `[Required]` inputs now use the C# `required` modifier. `required` is enforced by the compiler only — MSBuild instantiates tasks via `Activator.CreateInstance`, which does not enforce it — so there is no runtime behavior change.
- `[Output]` results are now `ITaskItem?`. They genuinely stay null on the error paths that previously assigned `default!`, so this removes two null-forgiving operators as well.
- `MSBuildCompatibilityHelper.cs` had the pragma but no properties at all; it's just removed.

Removing the blanket pragma surfaced a real latent bug: `InvokeTestingPlatformTask._pipeNameDescription` was only assigned in the public parameterless constructor, so the internal `InvokeTestingPlatformTask(IFileSystem)` constructor left the non-nullable field null. The assignment moved to the internal constructor that the public one chains to.

### `JsonValueSerializer` (Task 3)

`Serialize` was a `{ get; protected set; }` property with CS8618 suppressed because the only subclass set it from its own constructor. It's now passed through a base constructor and exposed get-only.

### `SourceGeneratedReflectionDataProvider` (Task 2, partial)

- `Assembly` was `= null!` but is genuinely optional: `CompositeSourceGeneratedReflectionDataProvider` already guards it with `is { } addedAssembly` and deliberately leaves it unset on merged snapshots. It's now `Assembly?`, with the `InternalAPI` baseline updated accordingly.
- `ConstructorInvoker.Invoker` is always set at every construction site, so it uses `required` instead of `= null!`.

### Notes

- `InvokeTestingPlatformTask.cs` was missing its UTF-8 BOM, which `.editorconfig` requires; that's why line 1 shows as changed.
- The MSBuild unit test's task subclass now stubs the required inputs (with `[SetsRequiredMembers]`) the way MSBuild would supply them.

### Validation

Full solution build is clean (0 warnings, 0 errors — warnings are errors in this repo). All tests pass in the three affected projects: `Microsoft.Testing.Platform.MSBuild.UnitTests` (20), `MSTestAdapter.PlatformServices.UnitTests` (939), `Microsoft.Testing.Platform.UnitTests` (1652).

Acceptance tests were not run locally: `-pack` fails in a git worktree because SourceLink can't resolve `RepositoryCommit`, which is unrelated to these changes. CI should cover `MSBuildTests.GenerateEntryPoint`, `MSBuildTests.ConfigurationFile`, and `MSBuild.KnownExtensionRegistration`, which exercise the changed tasks end to end.