### PR TITLE
Avoid LogLevel.ToString().ToUpper() allocations in FileLogger

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -259,7 +259,25 @@ internal sealed class FileLogger : IDisposable
     }
 
     private string BuildLogEntry<TState>(LogLevel logLevel, TState state, Exception? exception, Func<TState, Exception?, string> formatter, string category)
-        => $"{_clock.UtcNow:O} {category} {logLevel.ToString().ToUpper(CultureInfo.InvariantCulture)} {formatter(state, exception)}";
+        => $"{_clock.UtcNow:O} {category} {GetUpperCaseName(logLevel)} {formatter(state, exception)}";
+
+    /// <summary>
+    /// Returns the upper-case name of <paramref name="logLevel"/>. Logging is on the hot path of a test run, so we
+    /// return interned literals instead of calling <c>logLevel.ToString().ToUpper(...)</c>, which boxes the enum and
+    /// allocates a new upper-cased copy of its (cached) name for every single log entry.
+    /// </summary>
+    private static string GetUpperCaseName(LogLevel logLevel)
+        => logLevel switch
+        {
+            LogLevel.Trace => "TRACE",
+            LogLevel.Debug => "DEBUG",
+            LogLevel.Information => "INFORMATION",
+            LogLevel.Warning => "WARNING",
+            LogLevel.Error => "ERROR",
+            LogLevel.Critical => "CRITICAL",
+            LogLevel.None => "NONE",
+            _ => logLevel.ToString().ToUpper(CultureInfo.InvariantCulture),
+        };
 
 #if NETCOREAPP
     private async Task WriteLogToFileAsync()

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -22,6 +22,10 @@ public sealed class FileLoggerTests : IDisposable
     private const string Category = "Test";
     private const string Message = "Message";
 
+    // Moq returns default(DateTimeOffset) from IClock.UtcNow, which the "O" format renders with an explicit +00:00
+    // offset, so this is stable across machines, time zones and cultures.
+    private const string DefaultClockTimestamp = "0001-01-01T00:00:00.0000000+00:00";
+
     private static readonly Func<string, Exception?, string> Formatter =
         (state, exception) =>
             string.Format(CultureInfo.InvariantCulture, "{0}{1}", state, exception is not null ? $" -- {exception}" : string.Empty);
@@ -238,12 +242,81 @@ public sealed class FileLoggerTests : IDisposable
 
         if (LogTestHelpers.IsLogEnabled(defaultLogLevel, currentLogLevel))
         {
-            Assert.AreEqual($"0001-01-01T00:00:00.0000000+00:00 Test {currentLogLevel.ToString().ToUpperInvariant()} Message{Environment.NewLine}", Encoding.Default.GetString(_memoryStream.ToArray()));
+            Assert.AreEqual($"{DefaultClockTimestamp} Test {currentLogLevel.ToString().ToUpperInvariant()} Message{Environment.NewLine}", Encoding.Default.GetString(_memoryStream.ToArray()));
         }
         else
         {
             Assert.AreEqual(0, _memoryStream.Length);
         }
+    }
+
+    // Explicit expected names, deliberately not derived from logLevel.ToString().ToUpperInvariant(): a level missing
+    // from FileLogger's switch silently falls back to that very expression, so an oracle built from it could never
+    // fail. ExpectedUpperCaseNames_CoverEveryLogLevel keeps this table exhaustive.
+    private static readonly Dictionary<LogLevel, string> ExpectedUpperCaseNames = new()
+    {
+        [LogLevel.Trace] = "TRACE",
+        [LogLevel.Debug] = "DEBUG",
+        [LogLevel.Information] = "INFORMATION",
+        [LogLevel.Warning] = "WARNING",
+        [LogLevel.Error] = "ERROR",
+        [LogLevel.Critical] = "CRITICAL",
+        [LogLevel.None] = "NONE",
+    };
+
+    [TestMethod]
+    [DynamicData(nameof(GetExpectedUpperCaseNames))]
+    public void Log_WhenAsyncFlush_LogLevelIsWrittenInUpperCase(LogLevel currentLogLevel, string expectedLevelName)
+    {
+        LogSingleEntryWithAsyncFlush(currentLogLevel);
+
+        _mockConsole.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+        Assert.AreEqual(
+            $"{DefaultClockTimestamp} {Category} {expectedLevelName} {Message}{Environment.NewLine}",
+            Encoding.Default.GetString(_memoryStream.ToArray()));
+    }
+
+    // Comparing the keys, rather than counting them, also catches a duplicated entry in the table above silently
+    // overwriting another level. Both sides are ordered because Dictionary key order is an implementation detail.
+    [TestMethod]
+    public void ExpectedUpperCaseNames_CoverEveryLogLevel()
+        => Assert.AreSequenceEqual(
+            LogTestHelpers.GetLogLevels().OrderBy(logLevel => logLevel),
+            ExpectedUpperCaseNames.Keys.OrderBy(logLevel => logLevel));
+
+    // LogLevel is a public enum and IsEnabled is a plain '>=' comparison, so a value outside the enum reaches
+    // BuildLogEntry from user code. It must not throw; it renders as the numeric value, like ToString() always did.
+    [TestMethod]
+    public void Log_WhenAsyncFlush_UndefinedLogLevelIsWrittenAsItsNumericValue()
+    {
+        LogSingleEntryWithAsyncFlush((LogLevel)999);
+
+        _mockConsole.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+        Assert.AreEqual(
+            $"{DefaultClockTimestamp} {Category} 999 {Message}{Environment.NewLine}",
+            Encoding.Default.GetString(_memoryStream.ToArray()));
+    }
+
+    public static IEnumerable<object[]> GetExpectedUpperCaseNames()
+        => ExpectedUpperCaseNames.Select(pair => new object[] { pair.Key, pair.Value });
+
+    private void LogSingleEntryWithAsyncFlush(LogLevel logLevel)
+    {
+        _mockFileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);
+        _mockFileStreamFactory
+            .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Returns(_mockStream.Object);
+
+        // Disposing the logger drains the channel, so the stream is complete once this method returns.
+        using FileLogger fileLogger = new(
+            new(LogFolder, LogPrefix, fileName: FileName, syncFlush: false),
+            LogLevel.Trace,
+            _mockClock.Object,
+            new SystemTask(),
+            _mockConsole.Object,
+            _mockFileSystem.Object,
+            _mockFileStreamFactory.Object);
+        fileLogger.Log(logLevel, Message, null, Formatter, Category);
     }
 
     // Chaos test for https://github.com/dotnet/sdk/issues/55215.

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LogTestHelpers.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/LogTestHelpers.cs
@@ -26,7 +26,7 @@ internal static class LogTestHelpers
 
         for (int i = 0; i < logLevels.Length; i++)
         {
-            for (int j = 0; i < logLevels.Length; i++)
+            for (int j = 0; j < logLevels.Length; j++)
             {
                 logLevelCombinations.Add((logLevels[i], logLevels[j]));
             }


### PR DESCRIPTION
Fixes #10222.

`FileLogger.BuildLogEntry` runs for every enqueued or async-flushed log entry and rendered the level name with:

```csharp
logLevel.ToString().ToUpper(CultureInfo.InvariantCulture)
```

That boxes the enum (the `ToString` override lives on `System.Enum`) and allocates a new upper-cased copy of its name, to produce one of seven fixed strings. Measured at **72 B/op → 0 B/op** for `LogLevel.Information` on x64. The enum name itself is *not* allocated — `Enum.ToString()` returns the runtime's cached instance — so the win is the box plus the upper-cased copy, not "two strings".

## Change

A `switch` expression over `LogLevel` returning interned literals. The previous expression is kept as the fallback arm: `LogLevel` is a **public** enum and `IsEnabled` is a plain `>=` comparison, so an undefined value reaches `BuildLogEntry` from user code and must still render rather than throw on a logging path.

Written output is byte-for-byte unchanged. `InternalSyncLog` uses a different, title-case format and is intentionally untouched.

## Two commits, please review separately

**1. `Fix GetLogLevelCombinations producing 7 combinations instead of 49`** — a pre-existing bug in the shared test helper, found while validating the coverage of this change:

```csharp
for (int j = 0; i < logLevels.Length; i++)   // condition and increment both use `i`
```

`j` never leaves `0`, so the helper returned only `(level, Trace)` pairs. Since `IsLogEnabled(default, Trace)` holds only when `default == Trace`, the level-name assertion in `Log_WhenAsyncFlush_StreamWriterIsCalledOnlyWhenLogLevelAllowsIt` ran for **1 of 7** rows — i.e. the existing suite could not have caught a regression in the code this PR touches. Three `LoggerTests` cases were under-covered the same way.

Heads-up on scope: this takes those five tests from 35 to 245 cases (all passing, ~1s). Isolated in its own commit so it can be reviewed — or dropped — independently.

**2. `Avoid LogLevel.ToString().ToUpper() allocations in FileLogger`** — the perf fix and its tests.

## On the new tests

The expected names are **explicit literals**, not `logLevel.ToString().ToUpperInvariant()`. That distinction matters: a level missing from the switch falls back to exactly that expression, so an oracle built from it would pass while the optimization silently regressed. `ExpectedUpperCaseNames_CoverEveryLogLevel` fails if a level is added without a table entry; a duplicated entry is caught at compile time by CA2244.

I verified this empirically rather than by inspection — mutating `"WARNING"` to `"WARN"` fails 5 tests, and dropping a table row fails the coverage guard.

Also added a case pinning the undefined-level fallback (`(LogLevel)999` → `999`), which was previously unexercised.

## Verification

- `Microsoft.Testing.Platform.UnitTests`: **1871/1871** on `net8.0`, **1830/1830** on `net462` (the netstandard2.0 code path). Up from 1652 on `main`, mostly from the restored combinations.
- Build: 0 warnings, 0 errors across all TFMs.
