### PR TITLE
Centralize TestNodeStateProperty.ToString formatting

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeStateProperties.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/TestNodeStateProperties.cs
@@ -26,11 +26,14 @@ public abstract class TestNodeStateProperty : IProperty, IEquatable<TestNodeStat
         builder.Append(Explanation);
     }
 
+    // Note: the derived types keep an explicit ToString() override that simply forwards here. They are
+    // redundant behavior-wise but are part of the shipped public API, so they cannot be removed.
+
     /// <inheritdoc />
     public override string ToString()
     {
         var builder = new StringBuilder();
-        builder.Append(nameof(TestNodeStateProperty));
+        builder.Append(GetType().Name);
         builder.Append(" { ");
         PrintMembers(builder);
         builder.Append(" }");
@@ -71,14 +74,7 @@ public sealed class DiscoveredTestNodeStateProperty : TestNodeStateProperty, IEq
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(DiscoveredTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
@@ -114,14 +110,7 @@ public sealed class InProgressTestNodeStateProperty : TestNodeStateProperty, IEq
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(InProgressTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
@@ -157,14 +146,7 @@ public sealed class PassedTestNodeStateProperty : TestNodeStateProperty, IEquata
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(PassedTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
@@ -200,14 +182,7 @@ public sealed class SkippedTestNodeStateProperty : TestNodeStateProperty, IEquat
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(SkippedTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     /// <inheritdoc />
     public override bool Equals(object? obj)
@@ -259,14 +234,7 @@ public sealed class FailedTestNodeStateProperty : TestNodeStateProperty, IEquata
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(FailedTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     private protected override void PrintMembers(StringBuilder builder)
     {
@@ -326,14 +294,7 @@ public sealed class ErrorTestNodeStateProperty : TestNodeStateProperty, IEquatab
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(ErrorTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     private protected override void PrintMembers(StringBuilder builder)
     {
@@ -398,14 +359,7 @@ public sealed class TimeoutTestNodeStateProperty : TestNodeStateProperty, IEquat
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(TimeoutTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     private protected override void PrintMembers(StringBuilder builder)
     {
@@ -471,14 +425,7 @@ public sealed class CancelledTestNodeStateProperty : TestNodeStateProperty, IEqu
 
     /// <inheritdoc />
     public override string ToString()
-    {
-        var builder = new StringBuilder();
-        builder.Append(nameof(CancelledTestNodeStateProperty));
-        builder.Append(" { ");
-        PrintMembers(builder);
-        builder.Append(" }");
-        return builder.ToString();
-    }
+        => base.ToString();
 
     private protected override void PrintMembers(StringBuilder builder)
     {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/TestNodePropertiesTests.cs
@@ -153,6 +153,12 @@ public sealed class TestNodePropertiesTests
             new CancelledTestNodeStateProperty(new Exception("some message")).ToString());
 
     [TestMethod]
+    public void CustomTestNodeStateProperty_ToStringUsesRuntimeTypeName()
+        => Assert.AreEqual(
+            "CustomTestNodeStateProperty { Explanation = some explanation }",
+            new CustomTestNodeStateProperty("some explanation").ToString());
+
+    [TestMethod]
     public void TimingProperty_ToStringIsCorrect()
     {
         DateTimeOffset startTime = new(2021, 9, 1, 0, 0, 0, default);
@@ -191,4 +197,12 @@ public sealed class TestNodePropertiesTests
         => Assert.AreEqual(
             "TestMetadataProperty { Key = some name, Value = some value }",
             new TestMetadataProperty("some name", "some value").ToString());
+
+    private sealed class CustomTestNodeStateProperty : TestNodeStateProperty
+    {
+        public CustomTestNodeStateProperty(string? explanation)
+            : base(explanation)
+        {
+        }
+    }
 }


### PR DESCRIPTION
Fixes #10226

## Problem

`TestNodeStateProperty.ToString()` hard-coded `nameof(TestNodeStateProperty)`, so every one of the 8 sealed subclasses had to repeat the exact same 9-line formatting block purely to substitute its own type name (~72 lines of duplication). Any change to the format has to be made in 9 places today.

It also means a subclass that *doesn't* override `ToString()` — e.g. one defined outside this assembly — renders as `TestNodeStateProperty { ... }` instead of its own name.

## Change

- `TestNodeStateProperty.ToString()` now uses `GetType().Name`, so the formatting lives in exactly one place and the runtime type name is always used.
- The 8 subclass `ToString()` overrides now simply forward to `base.ToString()`.

Output is byte-for-byte identical for all existing types (covered by the existing `TestNodePropertiesTests` assertions), and a new test verifies a custom subclass now renders its own type name.

## What I intentionally did *not* do

The issue also suggested deleting the `ToString()`/`Equals`/`GetHashCode` members from the subclasses entirely. Two reasons not to:

1. **Public API.** All 8 `ToString()` overrides (and the `Equals`/`GetHashCode` ones) are listed in `PublicAPI.Shipped.txt`. Deleting them would require `*REMOVED*` entries and is a public API break for a shipped MTP surface — hence keeping them as thin forwarders.
2. **Behavior.** Removing `Equals(object?)` from the "state-only" subclasses is *not* a no-op: the base implementation compares against `TestNodeStateProperty`, so `new PassedTestNodeStateProperty("x").Equals(new SkippedTestNodeStateProperty("x"))` would start returning `true`. The narrower per-type overrides are what keep equality type-discriminating.

## Validation

- `build.cmd -c Debug` on `Microsoft.Testing.Platform.UnitTests` — 0 warnings, 0 errors (public API analyzers clean).
- Full `Microsoft.Testing.Platform.UnitTests` suite: 1653/1653 passing.