### PR TITLE
perf: cache FullyQualifiedName (FullClassName.Name) in TestMethod

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
+++ b/src/Adapter/MSTest.TestAdapter/Extensions/UnitTestElementExtensions.cs
@@ -50,7 +50,7 @@ internal static class UnitTestElementExtensions
         // string testFullName = this.TestMethod.HasManagedMethodAndTypeProperties
         //     ? $"{TestMethod.ManagedTypeName}.{TestMethod.ManagedMethodName}"
         //     : $"{TestMethod.FullClassName}.{TestMethod.Name}";
-        string testFullName = $"{testMethod.FullClassName}.{testMethod.Name}";
+        string testFullName = testMethod.FullyQualifiedName;
 
         TestCase testCase = new(testFullName, EngineConstants.ExecutorUri, testMethod.AssemblyName)
         {
@@ -158,7 +158,7 @@ internal static class UnitTestElementExtensions
         }
 
         TestMethod testMethod = element.TestMethod;
-        string testFullName = $"{testMethod.FullClassName}.{testMethod.Name}";
+        string testFullName = testMethod.FullyQualifiedName;
         Guid testId = GenerateSerializedDataStrategyTestId(element, testFullName);
         element.CachedTestNodeUid = testId;
         return testId;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestElementFilter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MtpTestElementFilter.cs
@@ -122,7 +122,7 @@ internal sealed class MtpTestElementFilterProvider : ITestElementFilterProvider
 
             if (propertyName.Equals(FullyQualifiedNameLabel, StringComparison.OrdinalIgnoreCase))
             {
-                return $"{testMethod.FullClassName}.{testMethod.Name}";
+                return testMethod.FullyQualifiedName;
             }
 
             if (propertyName.Equals(DisplayNameLabel, StringComparison.OrdinalIgnoreCase))

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.TestFilter.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.TestFilter.cs
@@ -123,7 +123,7 @@ internal sealed partial class UnitTestRunner
 
         return new TestFilterContext
         {
-            FullyQualifiedName = $"{testMethod.FullClassName}.{testMethod.Name}",
+            FullyQualifiedName = testMethod.FullyQualifiedName,
             DisplayName = testMethod.DisplayName,
             MethodName = testMethod.Name,
             Source = testMethod.AssemblyName,

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -23,6 +23,7 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.GlobalTest
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.GlobalTestInitializeTimeout.get -> int
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestSettings.OutputCaptureMode.get -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.AdapterSettingsException.AdapterSettingsException(string? message, System.Exception? innerException) -> void
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestMethod.FullyQualifiedName.get -> string!
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.get -> System.Guid?
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.UnitTestElement.CachedTestNodeUid.set -> void
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -68,6 +68,21 @@ internal sealed class TestMethod : ITestMethod
     /// <inheritdoc />
     public string FullClassName { get; }
 
+    /// <summary>
+    /// Gets the <c>FullClassName.Name</c> pair used as the test's fully qualified name by both the VSTest and the
+    /// Microsoft.Testing.Platform paths (discovery, test id hashing and filtering).
+    /// </summary>
+    /// <remarks>
+    /// Computed on first access and cached, as <see cref="FullClassName"/> and <see cref="Name"/> are immutable for
+    /// the lifetime of the instance. Concurrent first accesses may each compute the string, but they all produce an
+    /// equal value, so the race is benign. The cache is a pure function of two already-serialized fields, so it is
+    /// excluded from serialization on .NET Framework and simply re-derived after deserialization.
+    /// </remarks>
+#if NETFRAMEWORK
+    [field: NonSerialized]
+#endif
+    public string FullyQualifiedName => field ??= $"{FullClassName}.{Name}";
+
     public string? ParameterTypes { get; }
 
     /// <inheritdoc />

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -72,6 +72,22 @@ public class UnitTestElementTests : TestContainer
 
     #endregion
 
+    #region TestMethod.FullyQualifiedName tests
+
+    public void FullyQualifiedNameShouldCombineFullClassNameAndMethodName()
+        => _testMethod.FullyQualifiedName.Should().Be("C.M");
+
+    public void FullyQualifiedNameShouldBeComputedOnceAndCached()
+    {
+        string first = _testMethod.FullyQualifiedName;
+
+        // The string is built by interpolation, so a recomputed value would be a distinct (non-interned)
+        // instance. Reference identity is what proves the hot paths reuse a single allocation per test method.
+        _testMethod.FullyQualifiedName.Should().BeSameAs(first);
+    }
+
+    #endregion
+
     #region ToTestCase tests
 
     public void ToTestCaseShouldSetFullyQualifiedName()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/ObjectModel/UnitTestElementTests.cs
@@ -80,6 +80,7 @@ public class UnitTestElementTests : TestContainer
     public void FullyQualifiedNameShouldBeComputedOnceAndCached()
     {
         string first = _testMethod.FullyQualifiedName;
+        first.Should().Be("C.M");
 
         // The string is built by interpolation, so a recomputed value would be a distinct (non-interned)
         // instance. Reference identity is what proves the hot paths reuse a single allocation per test method.


### PR DESCRIPTION
Fixes #10223

## What

`$"{FullClassName}.{Name}"` was built by string interpolation in four separate places on the discovery / execution / filtering hot paths. Since both `FullClassName` and `Name` are immutable for the lifetime of a `TestMethod`, the value is now computed once per instance and cached behind a new `TestMethod.FullyQualifiedName` property.

Updated call sites:

| File | Context |
|------|---------|
| `UnitTestElementExtensions.ToTestCase` | VSTest discovery (once per test) |
| `UnitTestElementExtensions.GetTestId` | MTP uid hashing (once per test) |
| `MtpTestElementFilter.GetPropertyValue` | MTP filter evaluation (once per test during run) |
| `UnitTestRunner.TestFilter.CreateFilterContext` | VSTest filter context (once per test during run) |

## Notes

- The property uses the `field` keyword (`=> field ??= ...`), matching the lazy-cache pattern already used elsewhere in the adapter (`PlatformServiceProvider`, `MSTestSettings`, `TestMethodInfo.ParameterTypes`, …).
- On the .NET Framework serialization path the backing field is `[field: NonSerialized]`: it is a pure cache of two already-serialized fields and is trivially re-derived on first access after deserialization.
- Concurrent first accesses may each compute the string, but they all produce an equal value, so the race is benign.
- `Clone` / `CloneWithSource` / `CloneWithUpdatedSource` use `MemberwiseClone` and neither `FullClassName` nor `Name` changes, so carrying the cache over is correct.
- No behavior change — the produced string is byte-for-byte identical at every call site.

## Validation

- `build.cmd -projects src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj` — succeeded, 0 warnings / 0 errors (all TFMs incl. `net462` and `uap10.0.16299`).
- `build.cmd -test` for `MSTestAdapter.UnitTests` and `MSTestAdapter.PlatformServices.UnitTests` — all green on `net462`, `net48`, `net8.0`, `net9.0`, `net8.0-windows`.