### PR TITLE
Add edge-case tests for DoNotStoreStaticTestContextAnalyzer (MSTEST0024)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -266,4 +266,54 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
 #endif
+
+    [TestMethod]
+    public async Task WhenCoalesceAssigningTestContextParameterToStaticField_NoDiagnostic()
+    {
+        // Coalesce assignment (??=) produces an ICoalesceAssignmentOperation, not an
+        // ISimpleAssignmentOperation. The analyzer only registers OperationKind.SimpleAssignment,
+        // so ??= must not trigger the diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_testContext;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    s_testContext ??= tc;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssigningTestContextFieldToStaticField_NoDiagnostic()
+    {
+        // The right-hand side is a field reference (IFieldReferenceOperation), not a parameter
+        // reference (IParameterReferenceOperation), so the analyzer must not fire even though the
+        // target is a static member and the value type is TestContext.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_source;
+                private static TestContext s_target;
+
+                public static void CopyContext()
+                {
+                    s_target = s_source;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -268,11 +268,12 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
 #endif
 
     [TestMethod]
-    public async Task WhenAssigningTestContextFieldToStaticField_NoDiagnostic()
+    public async Task WhenAssigningTestContextToStaticField_DiagnosticOnlyForParameterReference()
     {
         // The right-hand side is a field reference (IFieldReferenceOperation), not a parameter
         // reference (IParameterReferenceOperation), so the analyzer must not fire even though the
-        // target is a static member and the value type is TestContext.
+        // target is a static member and the value type is TestContext. The paired assignment from a
+        // parameter is expected to fire, so the snippet demonstrates the boundary on its own.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -285,6 +286,11 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
                 public static void CopyContext()
                 {
                     s_target = s_source;
+                }
+
+                public static void StoreContext(TestContext tc)
+                {
+                    [|s_target = tc|];
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -268,31 +268,6 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
 #endif
 
     [TestMethod]
-    public async Task WhenCoalesceAssigningTestContextParameterToStaticField_NoDiagnostic()
-    {
-        // Coalesce assignment (??=) produces an ICoalesceAssignmentOperation, not an
-        // ISimpleAssignmentOperation. The analyzer only registers OperationKind.SimpleAssignment,
-        // so ??= must not trigger the diagnostic.
-        string code = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            [TestClass]
-            public class MyTestClass
-            {
-                private static TestContext s_testContext;
-
-                [AssemblyInitialize]
-                public static void AssemblyInit(TestContext tc)
-                {
-                    s_testContext ??= tc;
-                }
-            }
-            """;
-
-        await VerifyCS.VerifyAnalyzerAsync(code);
-    }
-
-    [TestMethod]
     public async Task WhenAssigningTestContextFieldToStaticField_NoDiagnostic()
     {
         // The right-hand side is a field reference (IFieldReferenceOperation), not a parameter


### PR DESCRIPTION
Fixes #10224

Adds a targeted test for `DoNotStoreStaticTestContextAnalyzer` (MSTEST0024) covering a boundary of its pattern that was previously untested.

The analyzer registers `OperationKind.SimpleAssignment` and only fires when the target is `IMemberReferenceOperation { Instance: null }` and the value is an `IParameterReferenceOperation` of type `TestContext`.

- `WhenAssigningTestContextToStaticField_DiagnosticOnlyForParameterReference` — a static-field-to-static-field copy has an `IFieldReferenceOperation` value rather than a parameter reference, so it must stay silent; the adjacent assignment from a `TestContext` parameter in the same snippet is expected to report. Pairing both halves means the test can't pass merely because the analyzer is inert.

The originally proposed coalesce-assignment test (`s_testContext ??= tc` asserting no diagnostic) was dropped during review: that case *should* be reported by MSTEST0024, and asserting no-diagnostic would have locked in the analyzer gap as expected behavior. The gap is tracked separately in #10232.

### Validation

`MSTest.Analyzers.UnitTests` filtered to `DoNotStoreStaticTestContextAnalyzerTests`: net8.0 8/8 passed, net472 6/6 passed.

Original changes authored by the `test-improver` agentic workflow on branch `test-assist/donotstorestatictestcontext-edge-cases-8ba07c0324e826af`; commit cherry-picked here to preserve attribution.
