### PR TITLE
perf: cache ManagedTypeName on TestMethod

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/TestMethod.cs
@@ -89,7 +89,16 @@ internal sealed class TestMethod : ITestMethod
     public string AssemblyName { get; private set; }
 
     /// <inheritdoc />
-    public string? ManagedTypeName => GetManagedTypeName(FullClassName);
+    /// <remarks>
+    /// Computed on first access and cached, as <see cref="FullClassName"/> is immutable for the lifetime of the
+    /// instance. Concurrent first accesses may each compute the string, but they all produce an equal value, so the
+    /// race is benign. The cache is a pure function of an already-serialized field, so it is excluded from
+    /// serialization on .NET Framework and simply re-derived after deserialization.
+    /// </remarks>
+#if NETFRAMEWORK
+    [field: NonSerialized]
+#endif
+    public string? ManagedTypeName => field ??= GetManagedTypeName(FullClassName);
 
     /// <inheritdoc />
     public string? ManagedMethodName { get; }


### PR DESCRIPTION
Fixes #10236.

`TestMethod.ManagedTypeName` recomputed `GetManagedTypeName(FullClassName)` on every access, scanning the class name for `[` to strip generic arguments. `FullClassName` is immutable for the lifetime of a `TestMethod`, so the result is always identical.

This applies the same field-backed property cache pattern already used for `FullyQualifiedName` (PR #10230):

```csharp
#if NETFRAMEWORK
[field: NonSerialized]
#endif
public string? ManagedTypeName => field ??= GetManagedTypeName(FullClassName);
```

`ManagedTypeName` is read from several paths per test:
- **Discovery** — `TypeEnumerator`, `AssemblyEnumerator`
- **Execution** — `TypeCache.MethodResolution`, `TestRunInfo`, `UnitTestRunner.TestFilter`
- **Conversion** — `MSTestTestNodeConverter`, `UnitTestElementExtensions`
- **Ordering** — `TestExecutionManager.Runner` (`OrderBy`)

`GetManagedTypeName` is a pure function of an immutable field, so concurrent first accesses may each compute the value but all produce an equal string — the race is benign. On .NET Framework the backing field is `[field: NonSerialized]`, matching `FullyQualifiedName`: the cached value is simply re-derived from the already-serialized `FullClassName` after deserialization.

Cost is one extra pointer-sized field per `TestMethod` instance.

## Validation

- `.\build.cmd -c Debug` → Build succeeded, 0 warnings, 0 errors
- `MSTestAdapter.UnitTests` (net8.0) → 56/56 passed
- `MSTestAdapter.PlatformServices.UnitTests` (net8.0) → 985/985 passed
- `MSTestAdapter.PlatformServices.UnitTests` (net462, covers the serialization path) → 1027/1027 passed