### PR TITLE
Fix MSTEST0024 not flagging coalesce and deconstruction assignments

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -19,6 +19,7 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 ### Fixed
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
+* Fix MSTEST0024 not reporting coalesce (`s_testContext ??= tc`) and deconstruction (`(s_testContext, _) = (tc, 0)`) assignments of a `TestContext` parameter to a static member. Projects treating warnings as errors may see new MSTEST0024 diagnostics on code that previously went unreported by @Evangelink in [#10232](https://github.com/microsoft/testfx/issues/10232)
 
 ## <a name="4.3.3" />[4.3.3] - UNRELEASED
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -19,7 +19,7 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 ### Fixed
 
 * Fix `CloneWithUpdatedSource` mutating `this` instead of the clone by @Evangelink in [#9581](https://github.com/microsoft/testfx/pull/9581)
-* Fix MSTEST0024 not reporting coalesce (`s_testContext ??= tc`) and deconstruction (`(s_testContext, _) = (tc, 0)`) assignments of a `TestContext` parameter to a static member. Projects treating warnings as errors may see new MSTEST0024 diagnostics on code that previously went unreported by @Evangelink in [#10232](https://github.com/microsoft/testfx/issues/10232)
+* Fix MSTEST0024 not reporting coalesce (`s_testContext ??= tc`) and deconstruction (`(s_testContext, _) = (tc, 0)`) assignments of a `TestContext` parameter to a static member. Projects treating warnings as errors may see new MSTEST0024 diagnostics on code that previously went unreported by @Evangelink in [#10244](https://github.com/microsoft/testfx/pull/10244)
 
 ## <a name="4.3.3" />[4.3.3] - UNRELEASED
 

--- a/src/Analyzers/MSTest.Analyzers/DoNotStoreStaticTestContextAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DoNotStoreStaticTestContextAnalyzer.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
 using MSTest.Analyzers.Helpers;
+using MSTest.Analyzers.RoslynAnalyzerHelpers;
 
 namespace MSTest.Analyzers;
 
@@ -45,19 +46,47 @@ public sealed class DoNotStoreStaticTestContextAnalyzer : DiagnosticAnalyzer
         {
             if (context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext, out INamedTypeSymbol? testContextSymbol))
             {
-                context.RegisterOperationAction(context => AnalyzeOperation(context, testContextSymbol), OperationKind.SimpleAssignment);
+                // Note that compound assignments (for example '+=') are intentionally not handled: they store the
+                // result of the underlying operator, not the TestContext parameter itself.
+                context.RegisterOperationAction(
+                    context => AnalyzeOperation(context, testContextSymbol),
+                    OperationKind.SimpleAssignment,
+                    OperationKind.CoalesceAssignment,
+                    OperationKind.DeconstructionAssignment);
             }
         });
     }
 
     private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol testContextSymbol)
     {
-        var assignmentOperation = (ISimpleAssignmentOperation)context.Operation;
+        var assignmentOperation = (IAssignmentOperation)context.Operation;
 
-        if (assignmentOperation is { Target: IMemberReferenceOperation { Instance: null }, Value: IParameterReferenceOperation parameterReferenceOperation }
-            && SymbolEqualityComparer.Default.Equals(parameterReferenceOperation.Type, testContextSymbol))
+        if (IsStoringTestContextParameterInStaticMember(assignmentOperation.Target, assignmentOperation.Value, testContextSymbol))
         {
             context.ReportDiagnostic(assignmentOperation.CreateDiagnostic(Rule));
         }
+    }
+
+    private static bool IsStoringTestContextParameterInStaticMember(IOperation target, IOperation value, INamedTypeSymbol testContextSymbol)
+    {
+        // Deconstruction assignments, for example '(s_testContext, _) = (tc, 0);', pair the elements of both tuples.
+        if (target.WalkDownConversion() is ITupleOperation targetTuple
+            && value.WalkDownConversion() is ITupleOperation valueTuple
+            && targetTuple.Elements.Length == valueTuple.Elements.Length)
+        {
+            for (int i = 0; i < targetTuple.Elements.Length; i++)
+            {
+                if (IsStoringTestContextParameterInStaticMember(targetTuple.Elements[i], valueTuple.Elements[i], testContextSymbol))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return target is IMemberReferenceOperation { Instance: null }
+            && value is IParameterReferenceOperation parameterReferenceOperation
+            && SymbolEqualityComparer.Default.Equals(parameterReferenceOperation.Type, testContextSymbol);
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -297,4 +297,162 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenCoalesceAssigningTestContextParameterToStaticMember_Diagnostic()
+    {
+        // 's_testContext ??= tc' produces an ICoalesceAssignmentOperation rather than an
+        // ISimpleAssignmentOperation, but it still stores the TestContext parameter in a static member.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_testContext;
+                private static TestContext StaticContext { get; set; }
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    [|s_testContext ??= tc|];
+                    [|StaticContext ??= tc|];
+                }
+
+                [ClassInitialize]
+                public static void ClassInit(TestContext tc)
+                {
+                    [|s_testContext ??= tc|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCoalesceAssigningTestContextParameterToInstanceMemberOrLocal_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private TestContext _testContext;
+                public TestContext TestContextProperty { get; set; }
+
+                public void Store(TestContext tc)
+                {
+                    _testContext ??= tc;
+                    TestContextProperty ??= tc;
+
+                    TestContext local = null;
+                    local ??= tc;
+                    local.WriteLine("");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCoalesceAssigningNonParameterValueToStaticMember_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_source;
+                private static TestContext s_target;
+                private static string s_name;
+
+                public static void CopyContext(TestContext tc)
+                {
+                    s_target ??= s_source;
+                    s_name ??= "value";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenDeconstructionAssigningTestContextParameterToStaticMember_Diagnostic()
+    {
+        // A deconstruction assignment produces an IDeconstructionAssignmentOperation whose target and value
+        // are tuples, so each pair of elements must be inspected individually.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static TestContext s_testContext;
+                private static int s_counter;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    [|(s_testContext, s_counter) = (tc, 1)|];
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenDeconstructionAssigningTestContextParameterToLocalsOrInstanceMembers_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private TestContext _testContext;
+                private static int s_counter;
+
+                public void Store(TestContext tc)
+                {
+                    TestContext local;
+                    int count;
+                    (local, count) = (tc, 1);
+                    (_testContext, s_counter) = (tc, 2);
+                    local.WriteLine(count.ToString());
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenCompoundAssigningToStaticMember_NoDiagnostic()
+    {
+        // Compound assignments store the result of the underlying operator rather than the TestContext
+        // parameter itself, so they are never reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                private static string s_names;
+
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext tc)
+                {
+                    s_names += tc.TestName;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DoNotStoreStaticTestContextAnalyzerTests.cs
@@ -433,22 +433,29 @@ public sealed class DoNotStoreStaticTestContextAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenCompoundAssigningToStaticMember_NoDiagnostic()
+    public async Task WhenCompoundAssigningTestContextParameterToStaticMember_NoDiagnostic()
     {
         // Compound assignments store the result of the underlying operator rather than the TestContext
-        // parameter itself, so they are never reported.
+        // parameter itself, so they are never reported. A user-defined operator is used so that the
+        // right operand is the TestContext parameter *directly*: this way the test would start failing
+        // if OperationKind.CompoundAssignment were ever registered.
         string code = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Accumulator
+            {
+                public static Accumulator operator +(Accumulator left, TestContext right) => left;
+            }
 
             [TestClass]
             public class MyTestClass
             {
-                private static string s_names;
+                private static Accumulator s_accumulator = new Accumulator();
 
                 [AssemblyInitialize]
                 public static void AssemblyInit(TestContext tc)
                 {
-                    s_names += tc.TestName;
+                    s_accumulator += tc;
                 }
             }
             """;


### PR DESCRIPTION
Fixes #10232

## Problem

`DoNotStoreStaticTestContextAnalyzer` only registered `OperationKind.SimpleAssignment`. A coalesce assignment produces an `ICoalesceAssignmentOperation`, a different operation kind, so this was silently **not** reported even though it stores the `TestContext` parameter in a static member — exactly what MSTEST0024 exists to prevent:

```csharp
[AssemblyInitialize]
public static void AssemblyInit(TestContext tc)
{
    s_testContext ??= tc; // MSTEST0024 expected, but not reported
}
```

## Fix

- Register `OperationKind.CoalesceAssignment` and `OperationKind.DeconstructionAssignment` in addition to `OperationKind.SimpleAssignment`, and cast to the shared `IAssignmentOperation` base (which exposes both `Target` and `Value`) instead of `ISimpleAssignmentOperation`.
- Deconstruction assignments have tuples on both sides, so the target/value elements are paired and inspected individually. This closes a second (rarer) hole: `(s_testContext, s_counter) = (tc, 1);`.

### On the other assignment forms

Per the "worth checking compound/deconstruction assignment forms" note in the issue:

- **Deconstruction** — genuine hole, now handled (see above).
- **Compound assignment** (`+=`, `|=`, …) — intentionally *not* handled, and a comment in the analyzer records why: a compound assignment stores the result of the underlying operator, not the `TestContext` parameter itself. A regression test documents the expectation.

The value-side match is deliberately left strict (`Value is IParameterReferenceOperation` with an exact `TestContext` type match), so no additional conversion-based widening is introduced beyond the two new operation kinds.

## Tests

Added to `DoNotStoreStaticTestContextAnalyzerTests`:

- `WhenCoalesceAssigningTestContextParameterToStaticMember_Diagnostic` (static field + static property, in both `[AssemblyInitialize]` and `[ClassInitialize]`)
- `WhenCoalesceAssigningTestContextParameterToInstanceMemberOrLocal_NoDiagnostic`
- `WhenCoalesceAssigningNonParameterValueToStaticMember_NoDiagnostic`
- `WhenDeconstructionAssigningTestContextParameterToStaticMember_Diagnostic`
- `WhenDeconstructionAssigningTestContextParameterToLocalsOrInstanceMembers_NoDiagnostic`
- `WhenCompoundAssigningToStaticMember_NoDiagnostic`

Full `MSTest.Analyzers.UnitTests` suite passes (1480 tests).

## Breaking change note

This widens the set of code that produces MSTEST0024, so consumers building with warnings-as-errors may see new diagnostics. Called out in `docs/Changelog.md` under 4.4.0.