### PR TITLE
Port copilot-app LLM detection rule from dotnet/sdk

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -198,8 +198,8 @@
           "repo": "dotnet/sdk",
           "ref": "main",
           "path": "src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs",
-          "baseline_ref_sha": "bcafbe92a30b1866bd17789759c9941761bf6b49",
-          "baseline_blob_sha": "0682d3bf641c49fe17b4a0de4d48929b36ab87e1",
+          "baseline_ref_sha": "79e9664eb6918a0d6b78d1018e196a468901977f",
+          "baseline_blob_sha": "d8b750e1f8eb0b004a4566f455ce7997f07bfa61",
           "scope": "LLM/agent detection rules"
         }
       ]

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
@@ -26,7 +26,6 @@ internal sealed class LLMEnvironmentDetector
         new EnvironmentDetectionRuleWithResult<string>("copilot-cli", new AnyPresentEnvironmentRule(
             "GITHUB_COPILOT_CLI_MODE", "GH_COPILOT_WORKING_DIRECTORY", "COPILOT_CLI", "COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN")),
         // GitHub Copilot app (the desktop GitHub application running as an AI agent), which sets AI_AGENT=github_copilot_app_agent.
-        // Placed before copilot-vscode so the more specific value match takes precedence when both could apply.
         new EnvironmentDetectionRuleWithResult<string>("copilot-app", new EnvironmentVariableValueRule("AI_AGENT", "github_copilot_app_agent")),
         // GitHub Copilot agent mode in VS Code, which sets AI_AGENT=github_copilot_vscode_agent and COPILOT_AGENT=1 on the terminals it runs commands in.
         new EnvironmentDetectionRuleWithResult<string>("copilot-vscode", new AnyMatchEnvironmentRule(

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Testing.Platform.Helpers;
 
-// Adapted from https://github.com/dotnet/sdk/tree/bcafbe92a30b1866bd17789759c9941761bf6b49/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+// Adapted from https://github.com/dotnet/sdk/tree/79e9664eb6918a0d6b78d1018e196a468901977f/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
 // Diverged from the upstream telemetry-only version so detection results can drive
 // user-facing platform defaults (ANSI mode, banner, --show-stdout/--show-stderr).
 // IMPORTANT: keep the environment-variable list below in sync with
@@ -25,6 +25,9 @@ internal sealed class LLMEnvironmentDetector
         // GitHub Copilot CLI (legacy gh extension: GITHUB_COPILOT_CLI_MODE; new Copilot CLI: GH_COPILOT_WORKING_DIRECTORY, COPILOT_CLI, COPILOT_MODEL, COPILOT_ALLOW_ALL, or COPILOT_GITHUB_TOKEN is set).
         new EnvironmentDetectionRuleWithResult<string>("copilot-cli", new AnyPresentEnvironmentRule(
             "GITHUB_COPILOT_CLI_MODE", "GH_COPILOT_WORKING_DIRECTORY", "COPILOT_CLI", "COPILOT_MODEL", "COPILOT_ALLOW_ALL", "COPILOT_GITHUB_TOKEN")),
+        // GitHub Copilot app (the desktop GitHub application running as an AI agent), which sets AI_AGENT=github_copilot_app_agent.
+        // Placed before copilot-vscode so the more specific value match takes precedence when both could apply.
+        new EnvironmentDetectionRuleWithResult<string>("copilot-app", new EnvironmentVariableValueRule("AI_AGENT", "github_copilot_app_agent")),
         // GitHub Copilot agent mode in VS Code, which sets AI_AGENT=github_copilot_vscode_agent and COPILOT_AGENT=1 on the terminals it runs commands in.
         new EnvironmentDetectionRuleWithResult<string>("copilot-vscode", new AnyMatchEnvironmentRule(
             new EnvironmentVariableValueRule("AI_AGENT", "github_copilot_vscode_agent"),

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Testing.Platform.Helpers;
 
-// Adapted from https://github.com/dotnet/sdk/tree/79e9664eb6918a0d6b78d1018e196a468901977f/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
+// Adapted from https://github.com/dotnet/sdk/blob/79e9664eb6918a0d6b78d1018e196a468901977f/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs
 // Diverged from the upstream telemetry-only version so detection results can drive
 // user-facing platform defaults (ANSI mode, banner, --show-stdout/--show-stderr).
 // IMPORTANT: keep the environment-variable list below in sync with

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/LLMEnvironmentDetectorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/LLMEnvironmentDetectorTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+using Moq;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class LLMEnvironmentDetectorTests
+{
+    [TestMethod]
+    [DataRow("github_copilot_app_agent")]
+    [DataRow("GitHub_Copilot_App_Agent")]
+    [DataRow("github_copilot_vscode_agent")]
+    public void IsLLMEnvironment_WhenAIAgentHoldsAKnownAgentValue_ReturnsTrue(string aiAgentValue)
+        => Assert.IsTrue(CreateDetector(aiAgentValue).IsLLMEnvironment());
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow("github_copilot_app")]
+    [DataRow("some_other_agent")]
+    public void IsLLMEnvironment_WhenAIAgentDoesNotHoldAKnownAgentValue_ReturnsFalse(string? aiAgentValue)
+        => Assert.IsFalse(CreateDetector(aiAgentValue).IsLLMEnvironment());
+
+    private static LLMEnvironmentDetector CreateDetector(string? aiAgentValue)
+    {
+        Mock<IEnvironment> environment = new();
+        _ = environment.Setup(x => x.GetEnvironmentVariable(It.IsAny<string>())).Returns((string?)null);
+        _ = environment.Setup(x => x.GetEnvironmentVariable("AI_AGENT")).Returns(aiAgentValue);
+        return new LLMEnvironmentDetector(environment.Object);
+    }
+}


### PR DESCRIPTION
Reconciles the vendored-file drift reported in #10250 for `src/Platform/Microsoft.Testing.Platform/Helpers/LLMEnvironmentDetector.cs`.

Upstream ([`dotnet/sdk`](https://github.com/dotnet/sdk/blob/79e9664eb6918a0d6b78d1018e196a468901977f/src/Cli/dotnet/Telemetry/LLMEnvironmentDetectorForTelemetry.cs)) added a `copilot-app` rule that detects the GitHub Copilot desktop app via `AI_AGENT=github_copilot_app_agent`. This is a genuine detection improvement, so it is ported as-is:

- Add the `copilot-app` rule ahead of `copilot-vscode`, so the more specific value match takes precedence.
- Bump `baseline_ref_sha` / `baseline_blob_sha` for the `platform-llm-environment-detector` entry in `eng/vendored-files.json` (verified against the GitHub contents API).
- Update the adaptation link in the file header to the new upstream ref SHA.

`AI_AGENT` is already tracked in `WellKnownEnvironmentVariables.LLMEnvironmentVariables`, so no test-infrastructure change is required.

Verified with `.\build.cmd -c Debug -projects src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj` (0 warnings, 0 errors) and `python .github\scripts\check_vendored_files.py validate`.

Fixes #10250