### PR TITLE
Exclude repo-local .dotnet from Component Governance detection

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -88,6 +88,13 @@ extends:
         enabled: true
       tsa:
         enabled: true
+      componentgovernance:
+        # .dotnet/ is the repo-local .NET SDK bootstrapped by eng/common/tools.ps1 from global.json,
+        # plus the workloads installed by eng/restore-toolset.ps1. It is not checked in (see .gitignore)
+        # and nothing in it ships. Scanning it surfaces alerts for components we cannot service, such as
+        # the npm packages vendored inside Microsoft.NET.Runtime.Emscripten.*.Sdk/tools/emscripten/node_modules,
+        # which are owned by dotnet/runtime and pinned by the SDK pack.
+        ignoreDirectories: $(Build.SourcesDirectory)/.dotnet
     featureFlags:
       autoBaseline: true
     pool:


### PR DESCRIPTION
## What

Adds `sdl.componentgovernance.ignoreDirectories: $(Build.SourcesDirectory)/.dotnet` to the official pipeline.

## Why

Component Governance currently reports 6 active alerts on `main` - all npm, all resolving to a single location:

```
.dotnet/packs/Microsoft.NET.Runtime.Emscripten.3.1.56.Sdk.win-x64/10.0.9/tools/emscripten/node_modules/
    brace-expansion 1.1.12
    @babel/plugin-transform-modules-systemjs 7.23.3
    @babel/core 7.23.7
    string_decoder 1.1.1
```

`.dotnet/` is the repo-local SDK bootstrapped by `eng/common/tools.ps1` from `global.json`, plus the `wasi-experimental-net10` workload installed by `eng/restore-toolset.ps1`. It is gitignored and nothing in it ships.

These versions are baked into a `Microsoft.NET.Runtime.Emscripten.*.Sdk` pack authored by dotnet/runtime, so there is nothing to bump here - testfx has no `package.json`, no lockfile, and ships no JavaScript. Without this exclusion every SDK/workload bump keeps re-introducing a fresh batch of unactionable alerts.

There are 0 active NuGet alerts on `main`.

## Notes

- Pipeline-level `sdl:` setting, so it applies to both the Windows and Linux jobs.
- Follows the same pattern already used in `dotnet/dotnet-docker`, `Azure/azure-sdk-for-net`, and the Arcade source-build templates.
