### PR TITLE
Do not redefine centrally managed PackageVersion items in MSTest.Sdk

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -204,6 +204,8 @@ Instead, split version specification based on CPM:
 
 This supports both values of `CentralPackageVersionOverrideEnabled` without producing `NU1009`.
 
+Teams migrating to MSTest.Sdk commonly keep declaring MSTest and `Microsoft.Testing.*` packages in their own `Directory.Packages.props` because only part of their repository is on the SDK. To avoid defining a version twice (which NuGet reports as `NU1506`, frequently escalated to an error), `Sdk.targets` snapshots the user's `PackageVersion` items before importing the engine targets and, once all implicit `PackageVersion` items have been added, drops the ones the SDK injected for packages that are already centrally managed. In other words, a version declared by the user always wins and the SDK only supplies versions for packages the user does not manage centrally.
+
 ### Layering MSTest.Sdk on another base SDK
 
 `MSTest.Sdk` implicitly imports `Microsoft.NET.Sdk`. To combine it with another base SDK, such as `Microsoft.NET.Sdk.Web`, import both SDKs manually and list the other SDK first:

--- a/src/Package/MSTest.Sdk/Sdk/Sdk.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Sdk.targets
@@ -7,11 +7,40 @@
     <IsTestApplication Condition=" '$(IsTestApplication)' == '' ">true</IsTestApplication>
   </PropertyGroup>
 
+  <!--
+    Snapshot the 'PackageVersion' items the user manages centrally (typically from
+    'Directory.Packages.props') before the engine/feature targets inject their own ones.
+    See the de-duplication item group below for the rationale.
+  -->
+  <ItemGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
+    <_MSTestSdkUserPackageVersion Include="@(PackageVersion)" />
+  </ItemGroup>
+
   <!-- Import Runner.targets -->
   <Import Project="$(MSBuildThisFileDirectory)Runner/Runner.targets" Condition=" '$(UseVSTest)' == 'false' " />
 
   <!-- Import VSTest.targets -->
   <Import Project="$(MSBuildThisFileDirectory)VSTest/VSTest.targets" Condition=" '$(UseVSTest)' == 'true' " />
+
+  <!--
+    When Central Package Management is enabled, the engine and feature targets add a
+    'PackageVersion' item for each package they implicitly reference so that NuGet can resolve a
+    version without relying on 'VersionOverride' (see docs/dev-guide.md for why we cannot use
+    'VersionOverride' nor 'IsImplicitlyDefined').
+
+    Teams migrating to MSTest.Sdk usually keep declaring MSTest and Microsoft.Testing.* packages in
+    their central package management file (some projects are on the SDK, some are not yet). In that
+    case both the user and MSTest.Sdk define a 'PackageVersion' for the same package id, which
+    NuGet reports as NU1506 (and which many repositories escalate to an error).
+
+    So we drop the versions we injected for packages that are already centrally managed: the
+    version declared by the user always wins.
+  -->
+  <ItemGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
+    <PackageVersion Remove="@(_MSTestSdkUserPackageVersion)" />
+    <PackageVersion Include="@(_MSTestSdkUserPackageVersion)" />
+    <_MSTestSdkUserPackageVersion Remove="@(_MSTestSdkUserPackageVersion)" />
+  </ItemGroup>
 
   <!--
     Implicit bottom import.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -167,6 +167,46 @@ namespace MSTestSdkTest
         }
     }
 
+    [TestMethod]
+    [DynamicData(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
+    public async Task RunTests_With_CentralPackageManagement_AndPackagesAlreadyDeclaredCentrally_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
+    {
+        // Teams migrating to MSTest.Sdk keep declaring MSTest and Microsoft.Testing.* packages in
+        // their central package management file. MSTest.Sdk must not redefine a version for those
+        // packages, otherwise NuGet reports NU1506 (duplicate 'PackageVersion' items), which many
+        // repositories escalate to an error.
+        const string CpmSourceCode = SingleTestSourceCode + """
+
+#file Directory.Packages.props
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+  </ItemGroup>
+</Project>
+""";
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+               AssetName,
+               CpmSourceCode
+               .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+               .PatchCodeWithReplace("$TargetFramework$", multiTfm)
+               .PatchCodeWithReplace("$ExtraProperties$", string.Empty));
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"build -c {buildConfiguration} {testAsset.TargetAssetPath}", cancellationToken: TestContext.CancellationToken);
+        compilationResult.AssertExitCodeIs(0);
+        compilationResult.AssertOutputDoesNotContain("NU1506");
+        foreach (string tfm in multiTfm.Split(";"))
+        {
+            var testHost = TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, tfm, buildConfiguration: buildConfiguration);
+            TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+            testHostResult.AssertOutputContainsSummary(0, 1, 0);
+        }
+    }
+
     public static IEnumerable<TestDataRow<(string MultiTfm, BuildConfiguration BuildConfiguration, string MSBuildExtensionEnableFragment, string EnableCommandLineArg, string InvalidCommandLineArg)>> RunTests_With_MSTestRunner_Standalone_Plus_Extensions_Data()
     {
         foreach ((string MultiTfm, BuildConfiguration BuildConfiguration) buildConfig in GetBuildMatrixMultiTfmFoldedBuildConfiguration())


### PR DESCRIPTION
## Problem

Commit f9e01d19d6ff7a6afbcd2b51f593f1af9949131a replaced `VersionOverride` with **unconditional** `PackageVersion` injection whenever `ManagePackageVersionsCentrally == true`.

That regresses the exact scenario the original design note called out: teams progressively adopting `MSTest.Sdk` keep declaring MSTest and `Microsoft.Testing.*` packages in their own `Directory.Packages.props`, because only part of their repository is on the SDK.

When they do, the package id ends up with **two** `PackageVersion` items — one from the user, one from `MSTest.Sdk` — and NuGet reports:

```
error NU1506: Warning As Error: Duplicate 'PackageVersion' items found. Remove the duplicate items or
use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageVersion'
items are: MSTest.TestFramework 4.4.0-dev, MSTest.TestFramework 4.4.0-dev;
MSTest.TestAdapter 4.4.0-dev, MSTest.TestAdapter 4.4.0-dev.
```

NuGet silently keeps the *first* item, so the SDK-injected version is dropped anyway. In repositories that treat warnings as errors (very common in 1ES / Azure repos) this is a hard build break, and repositories with governance targets asserting "`PackageVersion` may only be declared in the central file" see an outright policy violation.

This was reported by an internal partner whose Guardian automation bumped them to `4.4.0-preview.26372.14`.

## Fix

`src/Package/MSTest.Sdk/Sdk/Sdk.targets` now:

1. Snapshots the user's `@(PackageVersion)` items **before** importing the engine/feature targets.
2. After those targets have injected their own `PackageVersion` items, removes the ones whose identity was already centrally managed and re-adds the user's original items.

```xml
<ItemGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
  <PackageVersion Remove="@(_MSTestSdkUserPackageVersion)" />
  <PackageVersion Include="@(_MSTestSdkUserPackageVersion)" />
  <_MSTestSdkUserPackageVersion Remove="@(_MSTestSdkUserPackageVersion)" />
</ItemGroup>
```

Resulting behavior:

- **Package already declared centrally** → the user's version wins, a single `PackageVersion` item survives, no `NU1506`, and `MSTest.Sdk` contributes no `PackageVersion` item at all (so strict governance targets stay happy).
- **Package not declared centrally** → `MSTest.Sdk` still supplies the version, and it keeps working with `CentralPackageVersionOverrideEnabled=false` (the scenario the original commit was fixing).

## Validation

- Added `RunTests_With_CentralPackageManagement_AndPackagesAlreadyDeclaredCentrally_Standalone`, which declares `MSTest.TestFramework` / `MSTest.TestAdapter` in `Directory.Packages.props` and asserts the build succeeds without `NU1506`.
- Verified the new test **fails** against the pre-fix targets with the `NU1506` error quoted above, and **passes** with the fix — so it is a genuine regression test.
- Full `SdkTests` suite: 62/63 pass. The only failure is `NativeAot_Smoke_Test`, unrelated to this change (ILC linking cannot find `vswhere.exe` / the MSVC linker on the local machine).
- `build.cmd -pack`: clean, 0 warnings.

The existing `RunTests_With_CentralPackageManagement_Standalone` test (which covers `CentralPackageVersionOverrideEnabled=false`) still passes, so both CPM shapes are now covered.

## Docs

`docs/dev-guide.md` gains a paragraph explaining the de-duplication so future changes to the `.targets` files don't reintroduce the problem.