### PR TITLE
Record upstream tracking and the concrete follow-up for the Copilot CLI install failure

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -261,9 +261,12 @@ cannot do.
 3. Verify a run logs `Exact version match found:` instead of `No compatible toolcache entry found`
    followed by `-> Downloading ...`.
 
-Re-check *both* the `compat.json` `max-agent` value and the version the runner image actually caches
-before choosing the pin — if they diverge, follow the toolcache, not the matrix, since only an exact
-match avoids the download.
+Re-check *both* the `compat.json` window and the version the runner image actually caches before
+choosing the pin, and only pin a version that satisfies both: it must sit inside
+`min-agent`..`max-agent` *and* exist in the toolcache (`1.0.56` is both today). If they diverge —
+the image caches something outside the compat window — stay on a compat-sanctioned version and keep
+paying for the download. `max-agent` is the supported ceiling; pinning past it to chase a cache hit
+would run every agentic workflow on an unsupported CLI.
 
 ## Catalog
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -190,13 +190,16 @@ already ships. Every agentic workflow run therefore downloads the CLI twice — 
 job, once in the `detection` job — and each download is a chance to hit a transient GitHub CDN 5xx.
 The gap is structural, not a stale-image problem: `github/gh-aw-actions`'s `compat.json` caps
 `max-agent` at `1.0.56` (exactly what the runner image caches), while `DefaultCopilotVersion` is
-already `1.0.73` on gh-aw v0.83.1 and `1.0.75` on `main` — so bumping gh-aw *widens* the gap.
+`1.0.73` on the gh-aw v0.83.1 compiler this repo's lock files are pinned to, and `1.0.75` as of
+gh-aw v0.83.4 — so bumping gh-aw *widens* the gap.
 
-**There is no repo-side fix.** All of the following were evaluated and rejected:
+**There is no repo-side fix *today*.** All of the following were evaluated and rejected:
 
 - `engine.version` is silently ignored for the Copilot engine — gh-aw overwrites it with
-  `DefaultCopilotVersion` (`pkg/workflow/copilot_engine_installation.go`, still the case on `main`).
-  `gh aw compile --strict` reports no error, and the regenerated lock keeps the pinned version.
+  `DefaultCopilotVersion` (`pkg/workflow/copilot_engine_installation.go`, still the case in
+  v0.83.4). `gh aw compile --strict` reports no error, and the regenerated lock keeps the pinned
+  version. This is the one rejected option upstream is actively changing — see
+  [Tracking the upstream fix](#tracking-the-upstream-fix).
 - Hand-editing a `.lock.yml` (older pin, extra retries) is overwritten on the next `gh aw compile`.
 - `engine.command:` pointed at `/opt/hostedtoolcache/copilot-cli/<version>/x64/bin/copilot` bypasses
   the install step, but hardcodes a path that rotates with runner images and skips the `.copilot`
@@ -214,6 +217,53 @@ version the hosted runner toolcache is expected to contain (in practice the `com
 `max-agent`, with a CI guard against drift), or pass the compat range to the toolcache lookup even
 when a version is pinned. Merely choosing a default somewhere inside the compat window still
 downloads unless that exact version is cached.
+
+#### Tracking the upstream fix
+
+The drift is filed upstream as [github/gh-aw#48358][gh-aw-48358] — *"DefaultCopilotVersion drifts
+past compat.json max-agent, forcing a network install on every job and disabling the toolcache
+path"*. It is still open, and nothing in gh-aw v0.83.2 – v0.83.4 touches the install path:
+v0.83.4 only bumps `DefaultCopilotVersion` to `1.0.75`, and `install_copilot_cli.sh` is byte-for-byte
+unchanged since v0.83.1 (both curls already carry `--retry 3 --retry-delay 5`, which is the retry
+budget the failing run exhausted).
+
+The unblocking change is [github/gh-aw#48519][gh-aw-48519] — *"honor `engine.version` for
+copilot"*, open against `main`. It makes the compiler emit `install_copilot_cli.sh <engine.version>`
+instead of always substituting `DefaultCopilotVersion`. That alone does **not** restore compat-matrix
+resolution — an explicit version still skips it — but it hands us the lever we currently lack,
+because `find_cached_copilot_bin` already short-circuits on an exact match:
+
+```text
+Found candidate: /opt/hostedtoolcache/copilot-cli/1.0.56/x64/bin/copilot (version: 1.0.56, arch: x64)
+Exact version match found: /opt/hostedtoolcache/copilot-cli/1.0.56/x64/bin/copilot
+```
+
+That branch returns *before* the cache-TTL check, so pinning the version the runner image already
+caches skips both downloads outright — which is precisely what today's `range: none..none` lookup
+cannot do.
+
+**Once #48519 ships in a gh-aw release**, the repo-side follow-up is:
+
+1. Bump the pinned gh-aw toolchain, recompile with `gh aw compile --strict`, review the `.lock.yml`
+   diff, and run `python .github/scripts/check_action_pins.py` (see
+   [Compile on the pinned toolchain](#compile-on-the-pinned-toolchain-and-check-the-pins-afterwards)).
+2. Pin the engine to the version the hosted runner caches:
+
+   ```yaml
+   engine:
+     id: copilot
+     version: "1.0.56"   # == compat.json max-agent == hosted-runner toolcache entry
+   ```
+
+   No workflow here declares `engine:` today, so this is new frontmatter. Check whether gh-aw's
+   frontmatter merging lets a `shared/` import carry it before adding the block to all ~30
+   workflows individually.
+3. Verify a run logs `Exact version match found:` instead of `No compatible toolcache entry found`
+   followed by `-> Downloading ...`.
+
+Re-check *both* the `compat.json` `max-agent` value and the version the runner image actually caches
+before choosing the pin — if they diverge, follow the toolcache, not the matrix, since only an exact
+match avoids the download.
 
 ## Catalog
 
@@ -312,3 +362,5 @@ Reusable agentic-workflow snippets imported via `imports:` in workflow frontmatt
 - **Minimal permissions.** Workflows declare the least privilege they need; write capabilities flow through gh-aw `safe-outputs:` rather than direct `permissions: write-all`.
 
 [gh-aw]: https://github.com/github/gh-aw
+[gh-aw-48358]: https://github.com/github/gh-aw/issues/48358
+[gh-aw-48519]: https://github.com/github/gh-aw/pull/48519


### PR DESCRIPTION
Refs #10203.

## What this is (and isn't)

#10203 is the bot-managed `[aw] Detection Runs` tracker. Its single recorded entry (run [30106781448](https://github.com/microsoft/testfx/actions/runs/30106781448), *Grade Tests on PR*, `parse_error`) was investigated in the issue comments and documented in #10267: the `detection` job died at `Install GitHub Copilot CLI` on a transient `curl: (22) … 504`, so `safe_outputs` was skipped and the grading comment never posted.

That investigation concluded **there is no repo-side fix**, and I re-verified that against upstream today — it still holds. So this PR does **not** eliminate the failure; it can't be eliminated from this repo. What it does is close the loop the previous write-up left open: it records *where* the fix lives, *what* unblocks it, and *what we do here* when it ships.

Docs-only change to `.github/workflows/README.md`. No workflow source or `.lock.yml` is touched, so no `gh aw compile` is required.

## Upstream state, verified 2026-07-28

| | |
| --- | --- |
| Latest gh-aw release | **v0.83.4** (2026-07-27) — this repo's locks are compiled on v0.83.1 |
| `DefaultCopilotVersion` | `1.0.73` on v0.83.1, **`1.0.75`** on v0.83.4 and `main` |
| `gh-aw-actions` `compat.json` `max-agent` | still **`1.0.56`** for gh-aw ≥ 0.72.0 |
| `install_copilot_cli.sh` | byte-for-byte unchanged since v0.83.1 (both curls already carry `--retry 3 --retry-delay 5` — the budget the failing run exhausted) |

Nothing in v0.83.2 – v0.83.4 touches the install path, so the drift has only widened.

## The two upstream items now recorded

- **[github/gh-aw#48358](https://github.com/github/gh-aw/issues/48358)** (open) — *"DefaultCopilotVersion drifts past compat.json max-agent, forcing a network install on every job and disabling the toolcache path"*. This is the tracking issue promised in the #10203 investigation comment.
- **[github/gh-aw#48519](https://github.com/github/gh-aw/pull/48519)** (open) — *"honor `engine.version` for copilot"*. This is the unblocking change.

## Why #48519 matters more than it looks

Its own description notes it does **not** restore compat-matrix resolution — an explicit version still skips it. That reads like it doesn't help, but it does, because `find_cached_copilot_bin` already short-circuits on an *exact* match:

```text
Found candidate: /opt/hostedtoolcache/copilot-cli/1.0.56/x64/bin/copilot (version: 1.0.56, arch: x64)
Exact version match found: /opt/hostedtoolcache/copilot-cli/1.0.56/x64/bin/copilot
```

That branch returns *before* the cache-TTL check. So once `engine.version` is actually honored, pinning it to `1.0.56` — the version the hosted runner image caches, which is also the `compat.json` ceiling — turns today's `range: none..none` miss into a hit and removes **both** downloads (`agent` + `detection`), not just makes them rarer.

The README now spells out that follow-up: bump + recompile, add the `engine:` block (noting no workflow declares one today, so check whether a `shared/` import can carry it before touching ~30 files), and verify the log flips from `No compatible toolcache entry found` / `-> Downloading ...` to `Exact version match found:`.

## Not closing #10203

`Refs`, not `Fixes` — the tracker is bot-managed, says *"Do not close this issue manually"*, and auto-expires via its `gh-aw-expires` marker (2026-08-23).

## Validation

- `.github/workflows/README.md` is inside markdownlint's `ignores` (`.github/workflows/**/*.md`) and outside the link-checker's scope (`docs/` + root `README.md`), so neither gates this — checked anyway: no trailing whitespace, single trailing newline, both new anchors (`#tracking-the-upstream-fix`, `#compile-on-the-pinned-toolchain-and-check-the-pins-afterwards`) resolve to real headings, and the new `[gh-aw-48358]` / `[gh-aw-48519]` reference definitions sit with the existing `[gh-aw]` one.
- Every upstream claim above was read from source at the pinned tag (`v0.83.4`) rather than inferred: `pkg/constants/version_constants.go`, `pkg/workflow/copilot_engine_installation.go`, `pkg/workflow/copilot_installer.go`, `actions/setup/sh/install_copilot_cli.sh`, and `gh-aw-actions`' `compat.json`.