### PR TITLE
Add MSTEST0078 and [DependsOn]/[ResourceLock] telemetry

### DIFF
--- a/docs/RFCs/022-Test-Dependencies.md
+++ b/docs/RFCs/022-Test-Dependencies.md
@@ -319,14 +319,18 @@ dependency that matches no test as a warning rather than a failure, so that `--f
 keep working; that decision is only safe because build time catches the genuinely broken references. The
 analyzer reports a named method that does not exist on the target type, a target that is not a test method
 or not a test class, a target type from another assembly (dependencies are resolved within a single test
-source, so such a reference matches nothing), a test that depends on itself, a cycle visible within one
-compilation, and an attribute applied where it has no effect (a non-test method, or a class without
-`[TestClass]` — the attribute is not inherited, so an application on a shared base class produces no edge).
+source, so such a reference matches nothing), a target that is an abstract test class (discovery enumerates
+its tests under each concrete derived class, never under the abstract class's own name), a test that depends
+on itself, a cycle visible within one compilation, and an attribute applied where it has no effect (a
+non-test method, or a class discovery runs no test for — the attribute is not inherited, so an application
+on a shared base class produces no edge).
 
 It stays quiet whenever the answer depends on something the compilation does not know. The important case
-is a test method declared on a *non-test* base class: its implicit references (`[DependsOn(nameof(X))]`
-with no `typeof`) are resolved against each derived test class at run time, so the analyzer cannot decide
-them and leaves them alone.
+is a test method declared on a class that discovery does not run directly — an unannotated base, or an
+abstract `[TestClass]`: its implicit references (`[DependsOn(nameof(X))]` with no `typeof`) are resolved
+against each concrete derived test class at run time, so the analyzer cannot decide them and leaves them
+alone. It also models the *effective* method set, dropping base declarations that an override replaces,
+because neither `[TestMethod]` nor `[DependsOn]` is inherited across an override chain.
 
 ## Future work
 

--- a/docs/RFCs/022-Test-Dependencies.md
+++ b/docs/RFCs/022-Test-Dependencies.md
@@ -318,9 +318,10 @@ in every test is impractical, and prefer, in order:
 dependency that matches no test as a warning rather than a failure, so that `--filter` and single-test runs
 keep working; that decision is only safe because build time catches the genuinely broken references. The
 analyzer reports a named method that does not exist on the target type, a target that is not a test method
-or not a test class, a test that depends on itself, a cycle visible within one compilation, and an
-attribute applied where it has no effect (a non-test method, or a class without `[TestClass]` — the
-attribute is not inherited, so an application on a shared base class produces no edge).
+or not a test class, a target type from another assembly (dependencies are resolved within a single test
+source, so such a reference matches nothing), a test that depends on itself, a cycle visible within one
+compilation, and an attribute applied where it has no effect (a non-test method, or a class without
+`[TestClass]` — the attribute is not inherited, so an application on a shared base class produces no edge).
 
 It stays quiet whenever the answer depends on something the compilation does not know. The important case
 is a test method declared on a *non-test* base class: its implicit references (`[DependsOn(nameof(X))]`

--- a/docs/RFCs/022-Test-Dependencies.md
+++ b/docs/RFCs/022-Test-Dependencies.md
@@ -140,8 +140,8 @@ special case.
 consequential trade-off in the design. Skipping the dependent instead would be "safer" in the abstract,
 but it would make `--filter`, and running one test from an IDE, useless the moment that test has a
 prerequisite — a well-known complaint about `pytest-dependency`. Debuggability wins; the warning keeps a
-typo from being silent. A build-time analyzer (see [Future work](#future-work)) is the right place to
-catch genuinely misspelled references.
+typo from being silent. `MSTEST0078` (see [Build-time validation](#build-time-validation)) catches the
+genuinely misspelled references before the run.
 
 **References are resolved at discovery.** `[DependsOn(typeof(X))]` is stored as `X.FullName`, because the
 graph is rebuilt at execution time — possibly in another app domain — where the `Type` is gone. The
@@ -312,13 +312,23 @@ in every test is impractical, and prefer, in order:
 
 `RandomizeTestOrder` remains the tool for finding dependencies you did not declare.
 
+## Build-time validation
+
+**`MSTEST0078` reports the references that are statically decidable.** The runtime deliberately treats a
+dependency that matches no test as a warning rather than a failure, so that `--filter` and single-test runs
+keep working; that decision is only safe because build time catches the genuinely broken references. The
+analyzer reports a named method that does not exist on the target type, a target that is not a test method
+or not a test class, a test that depends on itself, a cycle visible within one compilation, and an
+attribute applied where it has no effect (a non-test method, or a class without `[TestClass]` — the
+attribute is not inherited, so an application on a shared base class produces no edge).
+
+It stays quiet whenever the answer depends on something the compilation does not know. The important case
+is a test method declared on a *non-test* base class: its implicit references (`[DependsOn(nameof(X))]`
+with no `typeof`) are resolved against each derived test class at run time, so the analyzer cannot decide
+them and leaves them alone.
+
 ## Future work
 
-- **A `MSTEST0xxx` analyzer** for references that resolve to no method, self-references, and cycles that
-  are statically visible. This is the natural complement to the "ignore unmatched references" decision
-  and would make renames safe at build time. Tracked by
-  [#10259](https://github.com/microsoft/testfx/issues/10259), which also covers the missing
-  `WellKnownTypeNames` registration, usage telemetry, and NativeAOT source-generation support.
 - **Per-data-row dependencies.** Naming a data-driven test currently creates an edge to *all* of its
   cases: the dependent waits for every row and is skipped if any row fails. Matching row *i* of B to row
   *i* of A is the hardest open problem in this space — even TUnit's mature implementation requires manual

--- a/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Telemetry/MSTestTelemetryDataCollector.cs
@@ -130,6 +130,8 @@ internal sealed class MSTestTelemetryDataCollector
                 TimeoutAttribute => nameof(TimeoutAttribute),
                 IgnoreAttribute => nameof(IgnoreAttribute),
                 DoNotParallelizeAttribute => nameof(DoNotParallelizeAttribute),
+                ResourceLockAttribute => nameof(ResourceLockAttribute),
+                DependsOnAttribute => nameof(DependsOnAttribute),
                 RetryBaseAttribute => nameof(RetryBaseAttribute),
                 ConditionBaseAttribute => nameof(ConditionBaseAttribute),
                 TestCategoryAttribute => nameof(TestCategoryAttribute),
@@ -169,6 +171,8 @@ internal sealed class MSTestTelemetryDataCollector
                 TestClassAttribute => nameof(TestClassAttribute),
                 ParallelizeAttribute => nameof(ParallelizeAttribute),
                 DoNotParallelizeAttribute => nameof(DoNotParallelizeAttribute),
+                ResourceLockAttribute => nameof(ResourceLockAttribute),
+                DependsOnAttribute => nameof(DependsOnAttribute),
                 _ => null,
             };
 

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ MSTEST0074 | Usage | Info | UndeclaredProcessGlobalStateMutationAnalyzer, [Docum
 MSTEST0075 | Usage | Info | CurrentDirectoryMutationUnderParallelizationAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0075)
 MSTEST0076 | Usage | Info | CultureMutationUnderParallelizationAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0076)
 MSTEST0077 | Usage | Info | SharedFileSystemPathInTestAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0077)
+MSTEST0078 | Usage | Warning | DependsOnShouldBeValidAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0078)

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -1,0 +1,548 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0078: <inheritdoc cref="Resources.DependsOnShouldBeValidTitle"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The runtime deliberately treats a dependency that matches no test as a non-fatal warning, so that
+/// <c>--filter</c> and single-test runs keep working (see RFC 022). That makes build time the right place
+/// to catch the references that are statically decidable - a typo, a rename, a target that is not a test -
+/// which is what the <c>nameof</c>/<c>typeof</c> shape of the attribute is for.
+/// </para>
+/// <para>
+/// Every check bails out when the answer depends on information the compilation does not have. The most
+/// important case is a test method declared on a non-test base class: its dependencies are resolved against
+/// each <em>derived</em> test class at run time, so a reference that names no member of the base class is
+/// not necessarily broken and is left alone.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// Caps the dependency walk so that a pathological graph cannot make the analyzer quadratic. Real
+    /// dependency graphs are tiny; a graph larger than this simply does not get its cycles reported at
+    /// build time, and the runtime still reports them.
+    /// </summary>
+    private const int MaxVisitedNodes = 512;
+
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.DependsOnShouldBeValidTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.DependsOnShouldBeValidDescription), Resources.ResourceManager, typeof(Resources));
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_MethodNotFound"/>
+    public static readonly DiagnosticDescriptor MethodNotFoundRule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.DependsOnShouldBeValidRuleId,
+        Title,
+        new LocalizableResourceString(nameof(Resources.DependsOnShouldBeValidMessageFormat_MethodNotFound), Resources.ResourceManager, typeof(Resources)),
+        Description,
+        Category.Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_NotATestMethod"/>
+    public static readonly DiagnosticDescriptor NotATestMethodRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NotATestMethod), Resources.ResourceManager, typeof(Resources)));
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_NotATestClass"/>
+    public static readonly DiagnosticDescriptor NotATestClassRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NotATestClass), Resources.ResourceManager, typeof(Resources)));
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_SelfReference"/>
+    public static readonly DiagnosticDescriptor SelfReferenceRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_SelfReference), Resources.ResourceManager, typeof(Resources)));
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_Cycle"/>
+    public static readonly DiagnosticDescriptor CycleRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_Cycle), Resources.ResourceManager, typeof(Resources)));
+
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_NoEffect"/>
+    public static readonly DiagnosticDescriptor NoEffectRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NoEffect), Resources.ResourceManager, typeof(Resources)));
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        MethodNotFoundRule,
+        NotATestMethodRule,
+        NotATestClassRule,
+        SelfReferenceRule,
+        CycleRule,
+        NoEffectRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingDependsOnAttribute, out INamedTypeSymbol? dependsOnAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol))
+            {
+                return;
+            }
+
+            var symbols = new AnalysisSymbols(dependsOnAttributeSymbol, testMethodAttributeSymbol, testClassAttributeSymbol);
+            context.RegisterSymbolAction(context => AnalyzeMethod(context, symbols), SymbolKind.Method);
+            context.RegisterSymbolAction(context => AnalyzeNamedType(context, symbols), SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context, AnalysisSymbols symbols)
+    {
+        var typeSymbol = (INamedTypeSymbol)context.Symbol;
+        List<AttributeData> attributes = GetDependsOnAttributes(typeSymbol, symbols);
+        if (attributes.Count == 0)
+        {
+            return;
+        }
+
+        // '[DependsOn]' is not inherited (AttributeUsage(Inherited = false)) and is only read off the test
+        // class itself, so an application on a type that is not a test class - including a shared base class
+        // whose derived types are the test classes - never produces an edge.
+        if (!typeSymbol.IsTestClass(symbols.TestClassAttribute))
+        {
+            ReportNoEffect(context, attributes, typeSymbol.Name);
+            return;
+        }
+
+        foreach (AttributeData attribute in attributes)
+        {
+            AnalyzeTarget(context, attribute, symbols, declaringClass: typeSymbol, declaringMethod: null);
+        }
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context, AnalysisSymbols symbols)
+    {
+        var methodSymbol = (IMethodSymbol)context.Symbol;
+        List<AttributeData> attributes = GetDependsOnAttributes(methodSymbol, symbols);
+
+        bool isTestMethod = methodSymbol.IsTestMethod(symbols.TestMethodAttribute);
+        if (!isTestMethod)
+        {
+            ReportNoEffect(context, attributes, methodSymbol.Name);
+            return;
+        }
+
+        INamedTypeSymbol declaringClass = methodSymbol.ContainingType;
+        List<AttributeData> classAttributes = GetDependsOnAttributes(declaringClass, symbols);
+        if (attributes.Count == 0 && classAttributes.Count == 0)
+        {
+            return;
+        }
+
+        bool selfReferenceReported = false;
+        foreach (AttributeData attribute in attributes)
+        {
+            selfReferenceReported |= AnalyzeTarget(context, attribute, symbols, declaringClass, methodSymbol);
+        }
+
+        // A self reference is the one-node cycle; reporting it again as a cycle would be noise. Cycles are
+        // only modelled for tests of a test class, because for any other declaring type the class the edge
+        // resolves against is not known at compile time.
+        if (selfReferenceReported || !declaringClass.IsTestClass(symbols.TestClassAttribute))
+        {
+            return;
+        }
+
+        AnalyzeCycle(context, symbols, new TestNode(declaringClass, methodSymbol.Name));
+    }
+
+    /// <summary>
+    /// Validates one <c>[DependsOn]</c> application against the members it names.
+    /// </summary>
+    /// <returns><see langword="true"/> when the application was reported as a self reference.</returns>
+    private static bool AnalyzeTarget(
+        SymbolAnalysisContext context,
+        AttributeData attribute,
+        AnalysisSymbols symbols,
+        INamedTypeSymbol declaringClass,
+        IMethodSymbol? declaringMethod)
+    {
+        if (attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not { } attributeSyntax)
+        {
+            return false;
+        }
+
+        (INamedTypeSymbol? explicitTargetClass, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
+        if (isMalformed)
+        {
+            return false;
+        }
+
+        // An implicit target ("a method of my own class") is resolved against the class the test runs under.
+        // For a test method declared on a non-test base class that class is each derived test class, which is
+        // not knowable from this declaration, so only explicit 'typeof' targets are validated there.
+        INamedTypeSymbol? targetClass = explicitTargetClass;
+        if (targetClass is null)
+        {
+            if (!declaringClass.IsTestClass(symbols.TestClassAttribute))
+            {
+                return false;
+            }
+
+            targetClass = declaringClass;
+        }
+
+        if (targetClass.TypeKind == TypeKind.Error)
+        {
+            return false;
+        }
+
+        if (!targetClass.IsTestClass(symbols.TestClassAttribute))
+        {
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestClassRule, targetClass.Name));
+            return false;
+        }
+
+        if (targetMethodName is null)
+        {
+            // A whole-class target on a test class always matches something (or the class has no test at
+            // all, which MSTEST0016 already reports).
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(targetMethodName))
+        {
+            // The attribute constructor throws for these, so there is nothing useful to add.
+            return false;
+        }
+
+        MethodLookup lookup = LookupMethods(targetClass, targetMethodName, symbols);
+        if (!lookup.Exists)
+        {
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(MethodNotFoundRule, targetClass.Name, targetMethodName));
+            return false;
+        }
+
+        if (!lookup.IsTestMethod)
+        {
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestMethodRule, targetClass.Name, targetMethodName));
+            return false;
+        }
+
+        // Only a reference written directly on the method is a self reference. The same reference written on
+        // the class means "every *other* test waits for this one", and discovery drops the generated
+        // self-edge.
+        if (declaringMethod is not null
+            && string.Equals(targetMethodName, declaringMethod.Name, StringComparison.Ordinal)
+            && SymbolEqualityComparer.Default.Equals(targetClass, declaringClass))
+        {
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(SelfReferenceRule, declaringMethod.Name));
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void AnalyzeCycle(SymbolAnalysisContext context, AnalysisSymbols symbols, TestNode start)
+    {
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var path = new List<TestNode>();
+        if (!TryFindCycle(context, symbols, start, start, visited, path, out AttributeData? firstEdge)
+            || firstEdge?.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not { } attributeSyntax)
+        {
+            return;
+        }
+
+        var builder = new StringBuilder();
+        builder.Append(start.Describe());
+        foreach (TestNode node in path)
+        {
+            builder.Append(" > ").Append(node.Describe());
+        }
+
+        context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(CycleRule, builder.ToString()));
+    }
+
+    /// <summary>
+    /// Depth-first search for a path from <paramref name="current"/> back to <paramref name="start"/>.
+    /// <paramref name="path"/> ends up holding that path (excluding the start node, including the closing
+    /// return to it) and <paramref name="firstEdge"/> the attribute application that begins it, so the
+    /// diagnostic can be reported where the cycle is declared rather than on the test symbol.
+    /// </summary>
+    private static bool TryFindCycle(
+        SymbolAnalysisContext context,
+        AnalysisSymbols symbols,
+        TestNode start,
+        TestNode current,
+        HashSet<string> visited,
+        List<TestNode> path,
+        out AttributeData? firstEdge)
+    {
+        firstEdge = null;
+        if (visited.Count >= MaxVisitedNodes)
+        {
+            return false;
+        }
+
+        foreach ((TestNode target, AttributeData source) in GetPrerequisites(context, symbols, current))
+        {
+            path.Add(target);
+            if (target.Equals(start))
+            {
+                firstEdge = source;
+                return true;
+            }
+
+            if (visited.Add(target.Key) && TryFindCycle(context, symbols, start, target, visited, path, out _))
+            {
+                firstEdge = source;
+                return true;
+            }
+
+            path.RemoveAt(path.Count - 1);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Expands the <c>[DependsOn]</c> applications that apply to <paramref name="node"/> - those on its test
+    /// class and those on the test methods that carry its name - into the nodes they point at, mirroring what
+    /// discovery does: a class-wide target covers every test of that class except the dependent itself, and a
+    /// class-level declaration never makes a test depend on itself.
+    /// </summary>
+    private static IEnumerable<(TestNode Target, AttributeData Source)> GetPrerequisites(SymbolAnalysisContext context, AnalysisSymbols symbols, TestNode node)
+    {
+        foreach (AttributeData attribute in GetDependsOnAttributes(node.TestClass, symbols))
+        {
+            foreach ((TestNode target, AttributeData source) in ExpandTarget(context, symbols, node, attribute, isClassLevel: true))
+            {
+                yield return (target, source);
+            }
+        }
+
+        foreach (IMethodSymbol method in EnumerateMethods(node.TestClass, node.MethodName))
+        {
+            if (!method.IsTestMethod(symbols.TestMethodAttribute))
+            {
+                continue;
+            }
+
+            foreach (AttributeData attribute in GetDependsOnAttributes(method, symbols))
+            {
+                foreach ((TestNode target, AttributeData source) in ExpandTarget(context, symbols, node, attribute, isClassLevel: false))
+                {
+                    yield return (target, source);
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<(TestNode Target, AttributeData Source)> ExpandTarget(
+        SymbolAnalysisContext context,
+        AnalysisSymbols symbols,
+        TestNode node,
+        AttributeData attribute,
+        bool isClassLevel)
+    {
+        context.CancellationToken.ThrowIfCancellationRequested();
+
+        (INamedTypeSymbol? explicitTargetClass, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
+        if (isMalformed)
+        {
+            yield break;
+        }
+
+        INamedTypeSymbol targetClass = explicitTargetClass ?? node.TestClass;
+        if (targetClass.TypeKind == TypeKind.Error || !targetClass.IsTestClass(symbols.TestClassAttribute))
+        {
+            yield break;
+        }
+
+        if (targetMethodName is null)
+        {
+            foreach (string testMethodName in EnumerateTestMethodNames(targetClass, symbols))
+            {
+                var target = new TestNode(targetClass, testMethodName);
+
+                // Discovery drops the self-edge a whole-class target generates, whether the declaration is on
+                // the class or on the method.
+                if (!target.Equals(node))
+                {
+                    yield return (target, attribute);
+                }
+            }
+
+            yield break;
+        }
+
+        if (string.IsNullOrWhiteSpace(targetMethodName) || !LookupMethods(targetClass, targetMethodName, symbols).IsTestMethod)
+        {
+            yield break;
+        }
+
+        var namedTarget = new TestNode(targetClass, targetMethodName);
+
+        // A class-level '[DependsOn(nameof(Setup))]' means "every *other* test waits for Setup", so the edge
+        // it would generate for Setup itself is dropped. Written on the method, the same reference is a real
+        // (and reported) self reference.
+        if (isClassLevel && namedTarget.Equals(node))
+        {
+            yield break;
+        }
+
+        yield return (namedTarget, attribute);
+    }
+
+    /// <summary>
+    /// Reads the target of one <c>[DependsOn]</c> application: the three constructors are
+    /// <c>(string)</c>, <c>(Type)</c> and <c>(Type, string)</c>, so the target class and method name can be
+    /// told apart by argument kind.
+    /// </summary>
+    private static (INamedTypeSymbol? TargetClass, string? TargetMethodName, bool IsMalformed) ReadTarget(AttributeData attribute)
+    {
+        INamedTypeSymbol? targetClass = null;
+        string? targetMethodName = null;
+        foreach (TypedConstant argument in attribute.ConstructorArguments)
+        {
+            switch (argument)
+            {
+                case { Kind: TypedConstantKind.Type, Value: INamedTypeSymbol type }:
+                    targetClass = type;
+                    break;
+
+                case { Kind: TypedConstantKind.Type }:
+                    // typeof(int[]), typeof(T), ... - not something that can carry tests, and not something
+                    // this analyzer models.
+                    return (null, null, true);
+
+                case { Kind: TypedConstantKind.Primitive, Value: string name }:
+                    targetMethodName = name;
+                    break;
+            }
+        }
+
+        return (targetClass, targetMethodName, targetClass is null && targetMethodName is null);
+    }
+
+    private static MethodLookup LookupMethods(INamedTypeSymbol targetClass, string methodName, AnalysisSymbols symbols)
+    {
+        bool exists = false;
+        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName))
+        {
+            exists = true;
+
+            // The name is what the run-time graph matches on, so any overload (or any declaration of that
+            // name in the hierarchy) being a test is enough for the reference to resolve.
+            if (method.IsTestMethod(symbols.TestMethodAttribute))
+            {
+                return new MethodLookup(Exists: true, IsTestMethod: true);
+            }
+        }
+
+        return new MethodLookup(exists, IsTestMethod: false);
+    }
+
+    /// <summary>
+    /// Enumerates the methods named <paramref name="methodName"/> declared by <paramref name="type"/> or any
+    /// of its base types: a test method declared on a base class runs as a test of the derived test class, so
+    /// the hierarchy is part of the lookup.
+    /// </summary>
+    private static IEnumerable<IMethodSymbol> EnumerateMethods(INamedTypeSymbol type, string methodName)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers(methodName))
+            {
+                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method)
+                {
+                    yield return method;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateTestMethodNames(INamedTypeSymbol type, AnalysisSymbols symbols)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers())
+            {
+                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method
+                    && method.IsTestMethod(symbols.TestMethodAttribute)
+                    && seen.Add(method.Name))
+                {
+                    yield return method.Name;
+                }
+            }
+        }
+    }
+
+    private static List<AttributeData> GetDependsOnAttributes(ISymbol symbol, AnalysisSymbols symbols)
+    {
+        List<AttributeData> attributes = [];
+        foreach (AttributeData attribute in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, symbols.DependsOnAttribute))
+            {
+                attributes.Add(attribute);
+            }
+        }
+
+        return attributes;
+    }
+
+    private static void ReportNoEffect(SymbolAnalysisContext context, List<AttributeData> attributes, string memberName)
+    {
+        foreach (AttributeData attribute in attributes)
+        {
+            if (attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is { } attributeSyntax)
+            {
+                context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NoEffectRule, memberName));
+            }
+        }
+    }
+
+    private readonly record struct MethodLookup(bool Exists, bool IsTestMethod);
+
+    private sealed record AnalysisSymbols(
+        INamedTypeSymbol DependsOnAttribute,
+        INamedTypeSymbol TestMethodAttribute,
+        INamedTypeSymbol TestClassAttribute);
+
+    /// <summary>
+    /// One node of the dependency graph. The run-time graph keys tests by class name and method name - an
+    /// overloaded or data-driven test contributes several tests under one name - so the analyzer models a
+    /// node the same way rather than by method symbol.
+    /// </summary>
+    private readonly struct TestNode : IEquatable<TestNode>
+    {
+        public TestNode(INamedTypeSymbol testClass, string methodName)
+        {
+            TestClass = testClass;
+            MethodName = methodName;
+            Key = testClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + "." + methodName;
+        }
+
+        public INamedTypeSymbol TestClass { get; }
+
+        public string MethodName { get; }
+
+        public string Key { get; }
+
+        public string Describe() => TestClass.Name + "." + MethodName;
+
+        public bool Equals(TestNode other) => string.Equals(Key, other.Key, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is TestNode other && Equals(other);
+
+        public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(Key);
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -60,6 +60,10 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor NotATestClassRule = MethodNotFoundRule
         .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NotATestClass), Resources.ResourceManager, typeof(Resources)));
 
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_OtherAssembly"/>
+    public static readonly DiagnosticDescriptor OtherAssemblyRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_OtherAssembly), Resources.ResourceManager, typeof(Resources)));
+
     /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_SelfReference"/>
     public static readonly DiagnosticDescriptor SelfReferenceRule = MethodNotFoundRule
         .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_SelfReference), Resources.ResourceManager, typeof(Resources)));
@@ -77,6 +81,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         MethodNotFoundRule,
         NotATestMethodRule,
         NotATestClassRule,
+        OtherAssemblyRule,
         SelfReferenceRule,
         CycleRule,
         NoEffectRule);
@@ -200,6 +205,15 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         if (targetClass.TypeKind == TypeKind.Error)
         {
+            return false;
+        }
+
+        // Discovery resolves a dependency against the tests of one test source, and stores a 'typeof' target
+        // as its CLR full name. A type from another assembly therefore matches nothing, however well-formed
+        // the reference is - so this is reported before the "is it a test class" question, which is moot.
+        if (!IsFromCurrentAssembly(context, targetClass))
+        {
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(OtherAssemblyRule, targetClass.Name));
             return false;
         }
 
@@ -360,8 +374,12 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         }
 
         INamedTypeSymbol targetClass = explicitTargetClass ?? node.TestClass;
-        if (targetClass.TypeKind == TypeKind.Error || !targetClass.IsTestClass(symbols.TestClassAttribute))
+        if (targetClass.TypeKind == TypeKind.Error
+            || !IsFromCurrentAssembly(context, targetClass)
+            || !targetClass.IsTestClass(symbols.TestClassAttribute))
         {
+            // A target in another assembly produces no edge at run time, so the walk must not follow it -
+            // otherwise a "cycle" could be reported through a link that does not exist.
             yield break;
         }
 
@@ -430,6 +448,9 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         return (targetClass, targetMethodName, targetClass is null && targetMethodName is null);
     }
+
+    private static bool IsFromCurrentAssembly(SymbolAnalysisContext context, INamedTypeSymbol type)
+        => SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, context.Compilation.Assembly);
 
     private static MethodLookup LookupMethods(INamedTypeSymbol targetClass, string methodName, AnalysisSymbols symbols)
     {

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -183,7 +183,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        (INamedTypeSymbol? explicitTargetClass, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
+        (ITypeSymbol? explicitTarget, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
         if (isMalformed)
         {
             return false;
@@ -192,8 +192,8 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         // An implicit target ("a method of my own class") is resolved against the class the test runs under.
         // For a test method declared on a non-test base class that class is each derived test class, which is
         // not knowable from this declaration, so only explicit 'typeof' targets are validated there.
-        INamedTypeSymbol? targetClass = explicitTargetClass;
-        if (targetClass is null)
+        INamedTypeSymbol targetClass;
+        if (explicitTarget is null)
         {
             if (!declaringClass.IsTestClass(symbols.TestClassAttribute))
             {
@@ -201,6 +201,18 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             }
 
             targetClass = declaringClass;
+        }
+        else if (explicitTarget is INamedTypeSymbol namedTarget)
+        {
+            targetClass = namedTarget;
+        }
+        else
+        {
+            // typeof(int[]), typeof(int*), ... - the attribute accepts them, but an array or pointer can
+            // never carry a '[TestClass]', so the reference is decidably dead. Reported before the
+            // assembly check below, which has no answer for a type with no containing assembly.
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestClassRule, DescribeType(explicitTarget)));
+            return false;
         }
 
         if (targetClass.TypeKind == TypeKind.Error)
@@ -375,13 +387,20 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.CancellationToken.ThrowIfCancellationRequested();
 
-        (INamedTypeSymbol? explicitTargetClass, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
+        (ITypeSymbol? explicitTarget, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
         if (isMalformed)
         {
             yield break;
         }
 
-        INamedTypeSymbol targetClass = explicitTargetClass ?? node.TestClass;
+        // Only a named type can contribute graph nodes; an array or pointer target is reported by
+        // AnalyzeTarget and contributes no edge.
+        if (explicitTarget is not null and not INamedTypeSymbol)
+        {
+            yield break;
+        }
+
+        INamedTypeSymbol targetClass = explicitTarget as INamedTypeSymbol ?? node.TestClass;
         if (targetClass.TypeKind == TypeKind.Error
             || !IsFromCurrentAssembly(context, targetClass)
             || !targetClass.IsTestClass(symbols.TestClassAttribute))
@@ -431,22 +450,17 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// <c>(string)</c>, <c>(Type)</c> and <c>(Type, string)</c>, so the target class and method name can be
     /// told apart by argument kind.
     /// </summary>
-    private static (INamedTypeSymbol? TargetClass, string? TargetMethodName, bool IsMalformed) ReadTarget(AttributeData attribute)
+    private static (ITypeSymbol? TargetClass, string? TargetMethodName, bool IsMalformed) ReadTarget(AttributeData attribute)
     {
-        INamedTypeSymbol? targetClass = null;
+        ITypeSymbol? targetClass = null;
         string? targetMethodName = null;
         foreach (TypedConstant argument in attribute.ConstructorArguments)
         {
             switch (argument)
             {
-                case { Kind: TypedConstantKind.Type, Value: INamedTypeSymbol type }:
+                case { Kind: TypedConstantKind.Type, Value: ITypeSymbol type }:
                     targetClass = type;
                     break;
-
-                case { Kind: TypedConstantKind.Type }:
-                    // typeof(int[]), typeof(T), ... - not something that can carry tests, and not something
-                    // this analyzer models.
-                    return (null, null, true);
 
                 case { Kind: TypedConstantKind.Primitive, Value: string name }:
                     targetMethodName = name;
@@ -456,6 +470,15 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         return (targetClass, targetMethodName, targetClass is null && targetMethodName is null);
     }
+
+    /// <summary>
+    /// Names a type for a diagnostic message. <see cref="ISymbol.Name"/> is empty for an array or pointer,
+    /// so those fall back to the display form (<c>int[]</c>).
+    /// </summary>
+    private static string DescribeType(ITypeSymbol type)
+        => string.IsNullOrEmpty(type.Name)
+            ? type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
+            : type.Name;
 
     private static bool IsFromCurrentAssembly(SymbolAnalysisContext context, INamedTypeSymbol type)
         => SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, context.Compilation.Assembly);

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -162,10 +162,43 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         // inherits. Starting them from AnalyzeMethod instead would key the node off the class that *declares*
         // the method, which is not the class the edge resolves against, and would need a de-duplication rule
         // that no name-based check can get right in the presence of overloads.
+        //
+        // A class with a duplicated method signature in its hierarchy is skipped: discovery's duplicate
+        // fallback then collapses *every* same-named test to the declaration closest to the class, including
+        // genuine overloads, and modelling that here would mean baking a run-time quirk into the analyzer.
+        // Going quiet is the safe answer, and MSTEST0036 already reports the shadowing that triggers it.
+        if (HasDuplicateSignature(typeSymbol))
+        {
+            return;
+        }
+
         foreach (string testMethodName in EnumerateTestMethodNames(typeSymbol, symbols))
         {
             AnalyzeCycle(context, symbols, new TestNode(typeSymbol, testMethodName));
         }
+    }
+
+    /// <summary>
+    /// Whether the type's hierarchy declares the same method signature twice, which is what makes
+    /// <c>TypeEnumerator.GetTests</c> fall back to collapsing tests by name.
+    /// </summary>
+    private static bool HasDuplicateSignature(INamedTypeSymbol type)
+    {
+        var signatures = new HashSet<string>(StringComparer.Ordinal);
+        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            foreach (ISymbol member in current.GetMembers())
+            {
+                // An override is not a duplicate: reflection surfaces only the most-derived declaration.
+                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary, OverriddenMethod: null } method
+                    && !signatures.Add(BuildSignatureKey(method)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static void AnalyzeMethod(SymbolAnalysisContext context, AnalysisSymbols symbols)
@@ -297,6 +330,40 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    /// <summary>
+    /// Whether <see cref="AnalyzeTarget"/> already reported <paramref name="node"/> as a self reference.
+    /// That happens only for a declaration on the node's own class, because that is the one case where the
+    /// class a reference resolves against is the same as the class declaring it.
+    /// </summary>
+    private static bool IsSelfReferenceReported(TestNode node, AnalysisSymbols symbols)
+    {
+        foreach (ISymbol member in node.TestClass.GetMembers(node.MethodName))
+        {
+            if (member is not IMethodSymbol method || !method.IsTestMethod(symbols.TestMethodAttribute))
+            {
+                continue;
+            }
+
+            foreach (AttributeData attribute in GetDependsOnAttributes(method, symbols))
+            {
+                (ITypeSymbol? explicitTarget, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
+                if (isMalformed || !string.Equals(targetMethodName, node.MethodName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // An implicit target resolves to the declaring class, which is this node's class here.
+                if (explicitTarget is null
+                    || SymbolEqualityComparer.Default.Equals(explicitTarget, node.TestClass))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     private static void AnalyzeCycle(SymbolAnalysisContext context, AnalysisSymbols symbols, TestNode start)
     {
         var visited = new HashSet<string>(StringComparer.Ordinal);
@@ -307,9 +374,11 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // A one-node cycle is a test naming itself, which AnalyzeTarget already reports as a self reference
-        // against the very same declaration; reporting it again as a cycle would just be noise.
-        if (path.Count == 1)
+        // A one-node cycle is a test naming itself. AnalyzeTarget reports that as a self reference, but only
+        // when it can see it: it compares the target against the class that *declares* the method, so an
+        // inherited test pointing at its own derived class (`[DependsOn(typeof(Derived), nameof(Run))]` on a
+        // base method) is not reported there. Suppress only the cycles that really were.
+        if (path.Count == 1 && IsSelfReferenceReported(start, symbols))
         {
             return;
         }

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -111,10 +111,6 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         var typeSymbol = (INamedTypeSymbol)context.Symbol;
         List<AttributeData> attributes = GetDependsOnAttributes(typeSymbol, symbols);
-        if (attributes.Count == 0)
-        {
-            return;
-        }
 
         // '[DependsOn]' is not inherited (AttributeUsage(Inherited = false)) and is only read off the test
         // class itself, so an application on a type that is not a test class - including a shared base class
@@ -129,6 +125,31 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         {
             AnalyzeTarget(context, attribute, symbols, declaringClass: typeSymbol, declaringMethod: null);
         }
+
+        // A test method inherited from another class runs as a test of *this* class, but AnalyzeMethod only
+        // ever starts a walk for the class that declares the method. Without a start node here, a cycle
+        // between two test classes whose tests are all inherited would be invisible. Names this type declares
+        // itself are skipped: AnalyzeMethod starts exactly the same node for those.
+        foreach (string testMethodName in EnumerateTestMethodNames(typeSymbol, symbols))
+        {
+            if (!DeclaresMethod(typeSymbol, testMethodName))
+            {
+                AnalyzeCycle(context, symbols, new TestNode(typeSymbol, testMethodName));
+            }
+        }
+    }
+
+    private static bool DeclaresMethod(INamedTypeSymbol type, string methodName)
+    {
+        foreach (ISymbol member in type.GetMembers(methodName))
+        {
+            if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary })
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void AnalyzeMethod(SymbolAnalysisContext context, AnalysisSymbols symbols)
@@ -490,8 +511,8 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         {
             exists = true;
 
-            // The name is what the run-time graph matches on, so any overload (or any declaration of that
-            // name in the hierarchy) being a test is enough for the reference to resolve.
+            // The name is what the run-time graph matches on, so any overload in the type's effective method
+            // set being a test is enough for the reference to resolve.
             if (method.IsTestMethod(symbols.TestMethodAttribute))
             {
                 return new MethodLookup(Exists: true, IsTestMethod: true);
@@ -502,37 +523,63 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Enumerates the methods named <paramref name="methodName"/> declared by <paramref name="type"/> or any
-    /// of its base types: a test method declared on a base class runs as a test of the derived test class, so
-    /// the hierarchy is part of the lookup.
+    /// Enumerates the methods named <paramref name="methodName"/> that <paramref name="type"/> effectively
+    /// has: its own declarations plus the inherited ones, excluding base declarations that an override
+    /// replaces.
     /// </summary>
     private static IEnumerable<IMethodSymbol> EnumerateMethods(INamedTypeSymbol type, string methodName)
-    {
-        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
-        {
-            foreach (ISymbol member in current.GetMembers(methodName))
-            {
-                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method)
-                {
-                    yield return method;
-                }
-            }
-        }
-    }
+        => EnumerateEffectiveMethods(type, methodName);
 
     private static IEnumerable<string> EnumerateTestMethodNames(INamedTypeSymbol type, AnalysisSymbols symbols)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (IMethodSymbol method in EnumerateEffectiveMethods(type, methodName: null))
+        {
+            if (method.IsTestMethod(symbols.TestMethodAttribute) && seen.Add(method.Name))
+            {
+                yield return method.Name;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks <paramref name="type"/> and its base types most-derived first, yielding the ordinary methods
+    /// that make up the type's effective method set - optionally only those named
+    /// <paramref name="methodName"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A base declaration that an override replaces is dropped, because reflection surfaces only the
+    /// most-derived declaration and both <c>[TestMethod]</c> and <c>[DependsOn]</c> are declared
+    /// <c>Inherited = false</c>. Keeping the base declaration would let its attributes travel to the
+    /// override: an overridden test whose override does not re-declare <c>[TestMethod]</c> would still count
+    /// as a test, and - worse - a <c>[DependsOn]</c> the author deliberately dropped by overriding would
+    /// still contribute an edge, which can close a cycle that does not exist at run time.
+    /// </para>
+    /// <para>
+    /// <c>new</c>-shadowing is deliberately not modelled. Reflection surfaces both declarations there, so the
+    /// effective set genuinely contains both, and MSTEST0036 already tells authors not to shadow.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<IMethodSymbol> EnumerateEffectiveMethods(INamedTypeSymbol type, string? methodName)
+    {
+        var overridden = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
         {
-            foreach (ISymbol member in current.GetMembers())
+            foreach (ISymbol member in methodName is null ? current.GetMembers() : current.GetMembers(methodName))
             {
-                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method
-                    && method.IsTestMethod(symbols.TestMethodAttribute)
-                    && seen.Add(method.Name))
+                if (member is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method
+                    || overridden.Contains(method))
                 {
-                    yield return method.Name;
+                    continue;
                 }
+
+                for (IMethodSymbol? baseMethod = method.OverriddenMethod; baseMethod is not null; baseMethod = baseMethod.OverriddenMethod)
+                {
+                    overridden.Add(baseMethod);
+                }
+
+                yield return method;
             }
         }
     }

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -106,10 +106,36 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var symbols = new AnalysisSymbols(dependsOnAttributeSymbol, testMethodAttributeSymbol, testClassAttributeSymbol);
+            var symbols = new AnalysisSymbols(
+                dependsOnAttributeSymbol,
+                testMethodAttributeSymbol,
+                testClassAttributeSymbol,
+                DiscoversInternals(context.Compilation));
             context.RegisterSymbolAction(context => AnalyzeMethod(context, symbols), SymbolKind.Method);
             context.RegisterSymbolAction(context => AnalyzeNamedType(context, symbols), SymbolKind.NamedType);
         });
+    }
+
+    /// <summary>
+    /// Whether the assembly opts internal members into discovery, which decides whether an internal
+    /// <c>[TestMethod]</c> is a runnable test (<c>TestMethodValidator.IsValidTestMethod</c>).
+    /// </summary>
+    private static bool DiscoversInternals(Compilation compilation)
+    {
+        if (!compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingDiscoverInternalsAttribute, out INamedTypeSymbol? discoverInternalsAttributeSymbol))
+        {
+            return false;
+        }
+
+        foreach (AttributeData attribute in compilation.Assembly.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, discoverInternalsAttributeSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void AnalyzeNamedType(SymbolAnalysisContext context, AnalysisSymbols symbols)
@@ -397,7 +423,10 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         foreach (IMethodSymbol method in EnumerateMethods(node.TestClass, node.MethodName))
         {
-            if (!method.IsTestMethod(symbols.TestMethodAttribute))
+            // Graph nodes use the stricter "does discovery run this" predicate: reading the attributes of a
+            // method discovery never turns into a test would invent edges, and an invented edge can close a
+            // cycle that does not exist at run time.
+            if (!IsRunnableTestMethod(method, symbols))
             {
                 continue;
             }
@@ -461,7 +490,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             yield break;
         }
 
-        if (string.IsNullOrWhiteSpace(targetMethodName) || !LookupMethods(targetClass, targetMethodName, symbols).IsTestMethod)
+        if (string.IsNullOrWhiteSpace(targetMethodName) || !HasRunnableTestMethod(targetClass, targetMethodName, symbols))
         {
             yield break;
         }
@@ -490,6 +519,14 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         string? targetMethodName = null;
         foreach (TypedConstant argument in attribute.ConstructorArguments)
         {
+            // A null argument means the constructor throws and no dependency is ever recorded. Reading the
+            // remaining arguments would misread '[DependsOn((Type)null!, nameof(A))]' as an implicit
+            // same-class target and could report a self reference against code that never builds a graph.
+            if (argument.IsNull)
+            {
+                return (null, null, true);
+            }
+
             switch (argument)
             {
                 case { Kind: TypedConstantKind.Type, Value: ITypeSymbol type }:
@@ -516,13 +553,36 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// Whether discovery runs tests under <paramref name="type"/>'s own name. Mirrors
-    /// <c>TypeValidator.IsValidTestClass</c> on the two points that decide whether a
-    /// <c>[DependsOn]</c> reference can ever match: the <c>[TestClass]</c> attribute, and the fact that an
-    /// abstract test class is skipped so that its tests are enumerated under each concrete derived class
-    /// instead.
+    /// <c>TypeValidator.IsValidTestClass</c> on the points that decide whether a <c>[DependsOn]</c> reference
+    /// can ever match: the <c>[TestClass]</c> attribute, the fact that an abstract test class is skipped so
+    /// its tests are enumerated under each concrete derived class, and the fact that a non-abstract generic
+    /// test class is rejected outright.
     /// </summary>
     private static bool IsRunnableTestClass(INamedTypeSymbol type, AnalysisSymbols symbols)
-        => !type.IsAbstract && type.IsTestClass(symbols.TestClassAttribute);
+        => !type.IsAbstract
+            && !IsGenericTypeDefinition(type)
+            && type.IsTestClass(symbols.TestClassAttribute);
+
+    private static bool IsGenericTypeDefinition(INamedTypeSymbol type)
+        => type.IsGenericType && SymbolEqualityComparer.Default.Equals(type, type.OriginalDefinition);
+
+    /// <summary>
+    /// Whether discovery turns <paramref name="method"/> into a test. Mirrors the parts of
+    /// <c>TestMethodValidator.IsValidTestMethod</c> that are decidable here: the <c>[TestMethod]</c>
+    /// attribute, accessibility (public, or internal when the assembly opts in with
+    /// <c>[DiscoverInternals]</c>), and the rejection of static and abstract methods.
+    /// </summary>
+    /// <remarks>
+    /// The return-type rule is deliberately not mirrored. MSTEST0003 already reports a test method with an
+    /// invalid signature, so the only thing this omission costs is a graph node for a method that is
+    /// reported as broken anyway - whereas getting <c>async void</c> and <c>ValueTask&lt;T&gt;</c> subtly
+    /// wrong would drop nodes for methods that really do run.
+    /// </remarks>
+    private static bool IsRunnableTestMethod(IMethodSymbol method, AnalysisSymbols symbols)
+        => method is { IsStatic: false, IsAbstract: false }
+            && (method.DeclaredAccessibility == Accessibility.Public
+                || (symbols.DiscoverInternals && method.DeclaredAccessibility == Accessibility.Internal))
+            && method.IsTestMethod(symbols.TestMethodAttribute);
 
     private static bool IsFromCurrentAssembly(SymbolAnalysisContext context, INamedTypeSymbol type)
         => SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, context.Compilation.Assembly);
@@ -553,12 +613,25 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     private static IEnumerable<IMethodSymbol> EnumerateMethods(INamedTypeSymbol type, string methodName)
         => EnumerateEffectiveMethods(type, methodName);
 
+    private static bool HasRunnableTestMethod(INamedTypeSymbol targetClass, string methodName, AnalysisSymbols symbols)
+    {
+        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName))
+        {
+            if (IsRunnableTestMethod(method, symbols))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static IEnumerable<string> EnumerateTestMethodNames(INamedTypeSymbol type, AnalysisSymbols symbols)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (IMethodSymbol method in EnumerateEffectiveMethods(type, methodName: null))
         {
-            if (method.IsTestMethod(symbols.TestMethodAttribute) && seen.Add(method.Name))
+            if (IsRunnableTestMethod(method, symbols) && seen.Add(method.Name))
             {
                 yield return method.Name;
             }
@@ -580,19 +653,22 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// still contribute an edge, which can close a cycle that does not exist at run time.
     /// </para>
     /// <para>
-    /// <c>new</c>-shadowing is deliberately not modelled. Reflection surfaces both declarations there, so the
-    /// effective set genuinely contains both, and MSTEST0036 already tells authors not to shadow.
+    /// A base declaration that a <c>new</c> member hides with the <em>same signature</em> is dropped for the
+    /// same reason: <c>TypeEnumerator.GetTests</c> detects the duplicate and keeps the declaration closest to
+    /// the test class. Genuine overloads (a different signature) are kept, since those are distinct tests.
     /// </para>
     /// </remarks>
     private static IEnumerable<IMethodSymbol> EnumerateEffectiveMethods(INamedTypeSymbol type, string? methodName)
     {
         var overridden = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var signatures = new HashSet<string>(StringComparer.Ordinal);
         for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
         {
             foreach (ISymbol member in methodName is null ? current.GetMembers() : current.GetMembers(methodName))
             {
                 if (member is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method
-                    || overridden.Contains(method))
+                    || overridden.Contains(method)
+                    || !signatures.Add(BuildSignatureKey(method)))
                 {
                     continue;
                 }
@@ -605,6 +681,24 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
                 yield return method;
             }
         }
+    }
+
+    private static string BuildSignatureKey(IMethodSymbol method)
+    {
+        var builder = new StringBuilder(method.Name);
+        builder.Append('`').Append(method.Arity).Append('(');
+        for (int i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            IParameterSymbol parameter = method.Parameters[i];
+            builder.Append(parameter.RefKind).Append(':').Append(parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+        }
+
+        return builder.Append(')').ToString();
     }
 
     private static List<AttributeData> GetDependsOnAttributes(ISymbol symbol, AnalysisSymbols symbols)
@@ -637,7 +731,8 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     private sealed record AnalysisSymbols(
         INamedTypeSymbol DependsOnAttribute,
         INamedTypeSymbol TestMethodAttribute,
-        INamedTypeSymbol TestClassAttribute);
+        INamedTypeSymbol TestClassAttribute,
+        bool DiscoverInternals);
 
     /// <summary>
     /// One node of the dependency graph. The run-time graph keys tests by class name and method name - an

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -167,7 +167,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         // fallback then collapses *every* same-named test to the declaration closest to the class, including
         // genuine overloads, and modelling that here would mean baking a run-time quirk into the analyzer.
         // Going quiet is the safe answer, and MSTEST0036 already reports the shadowing that triggers it.
-        if (HasDuplicateSignature(typeSymbol))
+        if (HasDuplicateSignature(typeSymbol, symbols))
         {
             return;
         }
@@ -179,10 +179,12 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// Whether the type's hierarchy declares the same method signature twice, which is what makes
-    /// <c>TypeEnumerator.GetTests</c> fall back to collapsing tests by name.
+    /// Whether the type's hierarchy declares the same method signature twice <em>among the methods discovery
+    /// turns into tests</em>, which is what makes <c>TypeEnumerator.GetTests</c> fall back to collapsing tests
+    /// by name. Methods discovery never looks at - private helpers and the like - cannot trigger it, so they
+    /// must not disable cycle analysis here either.
     /// </summary>
-    private static bool HasDuplicateSignature(INamedTypeSymbol type)
+    private static bool HasDuplicateSignature(INamedTypeSymbol type, AnalysisSymbols symbols)
     {
         var signatures = new HashSet<string>(StringComparer.Ordinal);
         for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
@@ -191,6 +193,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             {
                 // An override is not a duplicate: reflection surfaces only the most-derived declaration.
                 if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary, OverriddenMethod: null } method
+                    && IsRunnableTestMethod(method, symbols)
                     && !signatures.Add(BuildSignatureKey(method)))
                 {
                     return true;
@@ -459,7 +462,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        foreach (IMethodSymbol method in EnumerateMethods(node.TestClass, node.MethodName))
+        foreach (IMethodSymbol method in EnumerateMethods(node.TestClass, node.MethodName, symbols))
         {
             // Graph nodes use the stricter "does discovery run this" predicate: reading the attributes of a
             // method discovery never turns into a test would invent edges, and an invented edge can close a
@@ -675,7 +678,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     private static MethodLookup LookupMethods(INamedTypeSymbol targetClass, string methodName, AnalysisSymbols symbols)
     {
         bool exists = false;
-        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName))
+        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName, symbols))
         {
             exists = true;
 
@@ -695,12 +698,12 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// has: its own declarations plus the inherited ones, excluding base declarations that an override
     /// replaces.
     /// </summary>
-    private static IEnumerable<IMethodSymbol> EnumerateMethods(INamedTypeSymbol type, string methodName)
-        => EnumerateEffectiveMethods(type, methodName);
+    private static IEnumerable<IMethodSymbol> EnumerateMethods(INamedTypeSymbol type, string methodName, AnalysisSymbols symbols)
+        => EnumerateEffectiveMethods(type, methodName, symbols);
 
     private static bool HasRunnableTestMethod(INamedTypeSymbol targetClass, string methodName, AnalysisSymbols symbols)
     {
-        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName))
+        foreach (IMethodSymbol method in EnumerateMethods(targetClass, methodName, symbols))
         {
             if (IsRunnableTestMethod(method, symbols))
             {
@@ -714,7 +717,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     private static IEnumerable<string> EnumerateTestMethodNames(INamedTypeSymbol type, AnalysisSymbols symbols)
     {
         var seen = new HashSet<string>(StringComparer.Ordinal);
-        foreach (IMethodSymbol method in EnumerateEffectiveMethods(type, methodName: null))
+        foreach (IMethodSymbol method in EnumerateEffectiveMethods(type, methodName: null, symbols))
         {
             if (IsRunnableTestMethod(method, symbols) && seen.Add(method.Name))
             {
@@ -741,9 +744,11 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// A base declaration that a <c>new</c> member hides with the <em>same signature</em> is dropped for the
     /// same reason: <c>TypeEnumerator.GetTests</c> detects the duplicate and keeps the declaration closest to
     /// the test class. Genuine overloads (a different signature) are kept, since those are distinct tests.
+    /// That duplicate detection only looks at the methods discovery turns into tests, so a hiding declaration
+    /// discovery ignores - a private helper, say - must not displace the base test it happens to shadow.
     /// </para>
     /// </remarks>
-    private static IEnumerable<IMethodSymbol> EnumerateEffectiveMethods(INamedTypeSymbol type, string? methodName)
+    private static IEnumerable<IMethodSymbol> EnumerateEffectiveMethods(INamedTypeSymbol type, string? methodName, AnalysisSymbols symbols)
     {
         var overridden = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
         var signatures = new HashSet<string>(StringComparer.Ordinal);
@@ -752,8 +757,12 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             foreach (ISymbol member in methodName is null ? current.GetMembers() : current.GetMembers(methodName))
             {
                 if (member is not IMethodSymbol { MethodKind: MethodKind.Ordinary } method
-                    || overridden.Contains(method)
-                    || !signatures.Add(BuildSignatureKey(method)))
+                    || overridden.Contains(method))
+                {
+                    continue;
+                }
+
+                if (IsRunnableTestMethod(method, symbols) && !signatures.Add(BuildSignatureKey(method)))
                 {
                     continue;
                 }

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -250,8 +250,10 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         {
             // An abstract '[TestClass]' is skipped by discovery - its tests are enumerated under each
             // concrete derived class - so the reference matches nothing even though the attribute is there.
-            // That needs its own message: "add [TestClass]" is not the fix.
-            DiagnosticDescriptor rule = targetClass.IsAbstract && targetClass.IsTestClass(symbols.TestClassAttribute)
+            // That needs its own message: "add [TestClass]" is not the fix. A static class is rejected by
+            // discovery too (reflection sees it as abstract), but nothing derives from it, so it gets the
+            // plain message instead.
+            DiagnosticDescriptor rule = targetClass is { IsAbstract: true, IsStatic: false } && targetClass.IsTestClass(symbols.TestClassAttribute)
                 ? AbstractTargetRule
                 : NotATestClassRule;
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(rule, targetClass.Name));
@@ -525,11 +527,37 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// is skipped so its tests are enumerated under each concrete derived class, and the fact that a
     /// non-abstract generic test class is rejected outright.
     /// </summary>
+    /// <remarks>
+    /// A static class is checked separately from an abstract one. Reflection sees a static class as
+    /// <c>abstract sealed</c>, so <c>IsValidTestClass</c> rejects it through its <c>IsAbstract</c> test, but
+    /// Roslyn models the two independently and reports <c>IsAbstract == false</c> for it.
+    /// </remarks>
     private static bool IsRunnableTestClass(INamedTypeSymbol type, AnalysisSymbols symbols)
         => !type.IsAbstract
-            && !IsGenericTypeDefinition(type)
+            && !type.IsStatic
+            && !IsGenericOrNestedInGeneric(type)
             && HasValidAccessibility(type, symbols)
             && type.IsTestClass(symbols.TestClassAttribute);
+
+    /// <summary>
+    /// Whether any generic type is involved. Discovery enumerates the assembly's type <em>definitions</em>,
+    /// and <c>TypeValidator.IsValidTestClass</c> rejects a non-abstract generic definition - so no test ever
+    /// exists under a generic class's name, whether it is written open (<c>typeof(Tests&lt;&gt;)</c>) or
+    /// constructed (<c>typeof(Tests&lt;int&gt;)</c>). A type nested in a generic container is itself a generic
+    /// definition at run time, so it is covered too.
+    /// </summary>
+    private static bool IsGenericOrNestedInGeneric(INamedTypeSymbol type)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.ContainingType)
+        {
+            if (current.IsGenericType)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Mirrors <c>TypeValidator.TypeHasValidAccessibility</c>: the type and every type it is nested in must be
@@ -553,9 +581,6 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         return true;
     }
-
-    private static bool IsGenericTypeDefinition(INamedTypeSymbol type)
-        => type.IsGenericType && SymbolEqualityComparer.Default.Equals(type, type.OriginalDefinition);
 
     /// <summary>
     /// Whether discovery turns <paramref name="method"/> into a test. Mirrors the parts of

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -106,10 +106,15 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
+            // Optional: without it the TestContext property rule simply does not apply, which leaves the
+            // analyzer where it was before that rule existed rather than mis-classifying anything.
+            context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestContext, out INamedTypeSymbol? testContextSymbol);
+
             var symbols = new AnalysisSymbols(
                 dependsOnAttributeSymbol,
                 testMethodAttributeSymbol,
                 testClassAttributeSymbol,
+                testContextSymbol,
                 DiscoversInternals(context.Compilation));
             context.RegisterSymbolAction(context => AnalyzeMethod(context, symbols), SymbolKind.Method);
             context.RegisterSymbolAction(context => AnalyzeNamedType(context, symbols), SymbolKind.NamedType);
@@ -609,7 +614,42 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             && !type.IsStatic
             && !IsGenericOrNestedInGeneric(type)
             && HasValidAccessibility(type, symbols)
+            && HasCorrectTestContextSignature(type, symbols)
             && type.IsTestClass(symbols.TestClassAttribute);
+
+    /// <summary>
+    /// Mirrors <c>TypeValidator.HasCorrectTestContextSignature</c>: a class that declares a
+    /// <c>TestContext</c>-typed property whose getter is missing, private, static or abstract is rejected
+    /// outright, so none of its tests are discovered.
+    /// </summary>
+    private static bool HasCorrectTestContextSignature(INamedTypeSymbol type, AnalysisSymbols symbols)
+    {
+        if (symbols.TestContext is null)
+        {
+            return true;
+        }
+
+        // Declared properties only, matching the reflection call the runtime uses.
+        foreach (ISymbol member in type.GetMembers())
+        {
+            if (member is not IPropertySymbol property
+                || !SymbolEqualityComparer.Default.Equals(property.Type, symbols.TestContext))
+            {
+                continue;
+            }
+
+            // A missing setter is fine - the property can be assigned from the constructor.
+            if (property.GetMethod is not { } getter
+                || getter.DeclaredAccessibility == Accessibility.Private
+                || getter.IsStatic
+                || getter.IsAbstract)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Whether any generic type is involved. Discovery enumerates the assembly's type <em>definitions</em>,
@@ -884,6 +924,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol DependsOnAttribute,
         INamedTypeSymbol TestMethodAttribute,
         INamedTypeSymbol TestClassAttribute,
+        INamedTypeSymbol? TestContext,
         bool DiscoverInternals);
 
     /// <summary>

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -80,6 +80,10 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor NoEffectRule = MethodNotFoundRule
         .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NoEffect), Resources.ResourceManager, typeof(Resources)));
 
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_NoEffectOnClass"/>
+    public static readonly DiagnosticDescriptor NoEffectOnClassRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_NoEffectOnClass), Resources.ResourceManager, typeof(Resources)));
+
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
         MethodNotFoundRule,
@@ -89,7 +93,8 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         AbstractTargetRule,
         SelfReferenceRule,
         CycleRule,
-        NoEffectRule);
+        NoEffectRule,
+        NoEffectOnClassRule);
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -154,7 +159,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         // tests are enumerated under each concrete derived class - never produces an edge.
         if (!IsRunnableTestClass(typeSymbol, symbols))
         {
-            ReportNoEffect(context, attributes, typeSymbol.Name);
+            ReportNoEffect(context, attributes, typeSymbol.Name, NoEffectOnClassRule);
             return;
         }
 
@@ -215,7 +220,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         List<AttributeData> attributes = GetDependsOnAttributes(methodSymbol, symbols);
         if (!methodSymbol.IsTestMethod(symbols.TestMethodAttribute))
         {
-            ReportNoEffect(context, attributes, methodSymbol.Name);
+            ReportNoEffect(context, attributes, methodSymbol.Name, NoEffectRule);
             return;
         }
 
@@ -459,6 +464,14 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// </summary>
     private static IEnumerable<(TestNode Target, AttributeData Source)> GetPrerequisites(SymbolAnalysisContext context, AnalysisSymbols symbols, TestNode node)
     {
+        // The duplicate-signature bail-out has to be per node, not just per walk start: a walk beginning in
+        // another class can still traverse *into* a class whose tests discovery collapsed by name, and
+        // expanding this node's declarations would then invent edges discovery removed.
+        if (HasDuplicateSignature(node.TestClass, symbols))
+        {
+            yield break;
+        }
+
         foreach (AttributeData attribute in GetDependsOnAttributes(node.TestClass, symbols))
         {
             foreach ((TestNode target, AttributeData source) in ExpandTarget(context, symbols, node, attribute, isClassLevel: true))
@@ -907,13 +920,13 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         return attributes;
     }
 
-    private static void ReportNoEffect(SymbolAnalysisContext context, List<AttributeData> attributes, string memberName)
+    private static void ReportNoEffect(SymbolAnalysisContext context, List<AttributeData> attributes, string memberName, DiagnosticDescriptor rule)
     {
         foreach (AttributeData attribute in attributes)
         {
             if (attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is { } attributeSyntax)
             {
-                context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NoEffectRule, memberName));
+                context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(rule, memberName));
             }
         }
     }

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -306,6 +306,14 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
 
         foreach ((TestNode target, AttributeData source) in GetPrerequisites(context, symbols, current))
         {
+            // Re-checked per target, not just on entry: a single high fan-out node would otherwise push
+            // 'visited' past the budget wholesale, since the entry check only stops the *next* call.
+            // Bailing before 'path.Add' keeps the path balanced for the caller's own RemoveAt.
+            if (visited.Count >= MaxVisitedNodes)
+            {
+                return false;
+            }
+
             path.Add(target);
             if (target.Equals(start))
             {

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -683,6 +683,16 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         }
     }
 
+    /// <summary>
+    /// Builds a key identifying a method's CLR signature. Method type parameters are normalized to their
+    /// ordinal, and the walk is structural, because two declarations that hide each other can spell their
+    /// type parameters differently (<c>Run&lt;T&gt;(T)</c> and <c>Run&lt;U&gt;(U)</c> are the same signature).
+    /// Rendering the parameter types as source text would miss that and keep the hidden declaration.
+    /// </summary>
+    /// <remarks>
+    /// Erring toward collision is safe here: the walk yields most-derived first, so a key collision only ever
+    /// drops a <em>base</em> declaration, which removes edges rather than inventing them.
+    /// </remarks>
     private static string BuildSignatureKey(IMethodSymbol method)
     {
         var builder = new StringBuilder(method.Name);
@@ -695,10 +705,58 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             }
 
             IParameterSymbol parameter = method.Parameters[i];
-            builder.Append(parameter.RefKind).Append(':').Append(parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            builder.Append(parameter.RefKind).Append(':');
+            AppendTypeKey(builder, parameter.Type);
         }
 
         return builder.Append(')').ToString();
+    }
+
+    private static void AppendTypeKey(StringBuilder builder, ITypeSymbol type)
+    {
+        switch (type)
+        {
+            // The name a method type parameter is given is not part of the signature; its position is.
+            case ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } methodTypeParameter:
+                builder.Append("!!").Append(methodTypeParameter.Ordinal);
+                return;
+
+            // 'dynamic' and 'object' are the same type to the CLR.
+            case IDynamicTypeSymbol:
+                builder.Append("object");
+                return;
+
+            case IArrayTypeSymbol array:
+                AppendTypeKey(builder, array.ElementType);
+                builder.Append('[').Append(array.Rank).Append(']');
+                return;
+
+            case IPointerTypeSymbol pointer:
+                AppendTypeKey(builder, pointer.PointedAtType);
+                builder.Append('*');
+                return;
+
+            // A constructed generic has to be compared argument by argument, so that 'List<T>' and 'List<U>'
+            // are recognized as the same signature.
+            case INamedTypeSymbol { IsGenericType: true } named:
+                builder.Append(named.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)).Append('<');
+                for (int i = 0; i < named.TypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendTypeKey(builder, named.TypeArguments[i]);
+                }
+
+                builder.Append('>');
+                return;
+
+            default:
+                builder.Append(type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                return;
+        }
     }
 
     private static List<AttributeData> GetDependsOnAttributes(ISymbol symbol, AnalysisSymbols symbols)

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -64,6 +64,10 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     public static readonly DiagnosticDescriptor OtherAssemblyRule = MethodNotFoundRule
         .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_OtherAssembly), Resources.ResourceManager, typeof(Resources)));
 
+    /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_AbstractTarget"/>
+    public static readonly DiagnosticDescriptor AbstractTargetRule = MethodNotFoundRule
+        .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_AbstractTarget), Resources.ResourceManager, typeof(Resources)));
+
     /// <inheritdoc cref="Resources.DependsOnShouldBeValidMessageFormat_SelfReference"/>
     public static readonly DiagnosticDescriptor SelfReferenceRule = MethodNotFoundRule
         .WithMessage(new(nameof(Resources.DependsOnShouldBeValidMessageFormat_SelfReference), Resources.ResourceManager, typeof(Resources)));
@@ -82,6 +86,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         NotATestMethodRule,
         NotATestClassRule,
         OtherAssemblyRule,
+        AbstractTargetRule,
         SelfReferenceRule,
         CycleRule,
         NoEffectRule);
@@ -112,10 +117,11 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         var typeSymbol = (INamedTypeSymbol)context.Symbol;
         List<AttributeData> attributes = GetDependsOnAttributes(typeSymbol, symbols);
 
-        // '[DependsOn]' is not inherited (AttributeUsage(Inherited = false)) and is only read off the test
-        // class itself, so an application on a type that is not a test class - including a shared base class
-        // whose derived types are the test classes - never produces an edge.
-        if (!typeSymbol.IsTestClass(symbols.TestClassAttribute))
+        // '[DependsOn]' is not inherited (AttributeUsage(Inherited = false)) and is only read off a class
+        // discovery actually runs tests for, so an application on a type that is not a runnable test class -
+        // a shared base class whose derived types are the test classes, or an abstract '[TestClass]' whose
+        // tests are enumerated under each concrete derived class - never produces an edge.
+        if (!IsRunnableTestClass(typeSymbol, symbols))
         {
             ReportNoEffect(context, attributes, typeSymbol.Name);
             return;
@@ -178,9 +184,9 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         }
 
         // A self reference is the one-node cycle; reporting it again as a cycle would be noise. Cycles are
-        // only modelled for tests of a test class, because for any other declaring type the class the edge
-        // resolves against is not known at compile time.
-        if (selfReferenceReported || !declaringClass.IsTestClass(symbols.TestClassAttribute))
+        // only modelled for tests of a runnable test class, because for any other declaring type the class
+        // the edge resolves against is not known at compile time.
+        if (selfReferenceReported || !IsRunnableTestClass(declaringClass, symbols))
         {
             return;
         }
@@ -211,12 +217,13 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         }
 
         // An implicit target ("a method of my own class") is resolved against the class the test runs under.
-        // For a test method declared on a non-test base class that class is each derived test class, which is
-        // not knowable from this declaration, so only explicit 'typeof' targets are validated there.
+        // For a test method declared on a class discovery does not run directly - an unannotated base, or an
+        // abstract '[TestClass]' - that class is each concrete derived test class, which is not knowable from
+        // this declaration, so only explicit 'typeof' targets are validated there.
         INamedTypeSymbol targetClass;
         if (explicitTarget is null)
         {
-            if (!declaringClass.IsTestClass(symbols.TestClassAttribute))
+            if (!IsRunnableTestClass(declaringClass, symbols))
             {
                 return false;
             }
@@ -250,9 +257,15 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (!targetClass.IsTestClass(symbols.TestClassAttribute))
+        if (!IsRunnableTestClass(targetClass, symbols))
         {
-            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestClassRule, targetClass.Name));
+            // An abstract '[TestClass]' is skipped by discovery - its tests are enumerated under each
+            // concrete derived class - so the reference matches nothing even though the attribute is there.
+            // That needs its own message: "add [TestClass]" is not the fix.
+            DiagnosticDescriptor rule = targetClass.IsAbstract && targetClass.IsTestClass(symbols.TestClassAttribute)
+                ? AbstractTargetRule
+                : NotATestClassRule;
+            context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(rule, targetClass.Name));
             return false;
         }
 
@@ -424,7 +437,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol targetClass = explicitTarget as INamedTypeSymbol ?? node.TestClass;
         if (targetClass.TypeKind == TypeKind.Error
             || !IsFromCurrentAssembly(context, targetClass)
-            || !targetClass.IsTestClass(symbols.TestClassAttribute))
+            || !IsRunnableTestClass(targetClass, symbols))
         {
             // A target in another assembly produces no edge at run time, so the walk must not follow it -
             // otherwise a "cycle" could be reported through a link that does not exist.
@@ -500,6 +513,16 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         => string.IsNullOrEmpty(type.Name)
             ? type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)
             : type.Name;
+
+    /// <summary>
+    /// Whether discovery runs tests under <paramref name="type"/>'s own name. Mirrors
+    /// <c>TypeValidator.IsValidTestClass</c> on the two points that decide whether a
+    /// <c>[DependsOn]</c> reference can ever match: the <c>[TestClass]</c> attribute, and the fact that an
+    /// abstract test class is skipped so that its tests are enumerated under each concrete derived class
+    /// instead.
+    /// </summary>
+    private static bool IsRunnableTestClass(INamedTypeSymbol type, AnalysisSymbols symbols)
+        => !type.IsAbstract && type.IsTestClass(symbols.TestClassAttribute);
 
     private static bool IsFromCurrentAssembly(SymbolAnalysisContext context, INamedTypeSymbol type)
         => SymbolEqualityComparer.Default.Equals(type.ContainingAssembly, context.Compilation.Assembly);

--- a/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DependsOnShouldBeValidAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -158,73 +158,36 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             AnalyzeTarget(context, attribute, symbols, declaringClass: typeSymbol, declaringMethod: null);
         }
 
-        // A test method inherited from another class runs as a test of *this* class, but AnalyzeMethod only
-        // ever starts a walk for the class that declares the method. Without a start node here, a cycle
-        // between two test classes whose tests are all inherited would be invisible. Names this type declares
-        // itself are skipped: AnalyzeMethod starts exactly the same node for those.
+        // Every cycle walk starts here, once per test the class effectively runs - including the ones it only
+        // inherits. Starting them from AnalyzeMethod instead would key the node off the class that *declares*
+        // the method, which is not the class the edge resolves against, and would need a de-duplication rule
+        // that no name-based check can get right in the presence of overloads.
         foreach (string testMethodName in EnumerateTestMethodNames(typeSymbol, symbols))
         {
-            if (!DeclaresMethod(typeSymbol, testMethodName))
-            {
-                AnalyzeCycle(context, symbols, new TestNode(typeSymbol, testMethodName));
-            }
+            AnalyzeCycle(context, symbols, new TestNode(typeSymbol, testMethodName));
         }
-    }
-
-    private static bool DeclaresMethod(INamedTypeSymbol type, string methodName)
-    {
-        foreach (ISymbol member in type.GetMembers(methodName))
-        {
-            if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary })
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static void AnalyzeMethod(SymbolAnalysisContext context, AnalysisSymbols symbols)
     {
         var methodSymbol = (IMethodSymbol)context.Symbol;
         List<AttributeData> attributes = GetDependsOnAttributes(methodSymbol, symbols);
-
-        bool isTestMethod = methodSymbol.IsTestMethod(symbols.TestMethodAttribute);
-        if (!isTestMethod)
+        if (!methodSymbol.IsTestMethod(symbols.TestMethodAttribute))
         {
             ReportNoEffect(context, attributes, methodSymbol.Name);
             return;
         }
 
-        INamedTypeSymbol declaringClass = methodSymbol.ContainingType;
-        List<AttributeData> classAttributes = GetDependsOnAttributes(declaringClass, symbols);
-        if (attributes.Count == 0 && classAttributes.Count == 0)
-        {
-            return;
-        }
-
-        bool selfReferenceReported = false;
         foreach (AttributeData attribute in attributes)
         {
-            selfReferenceReported |= AnalyzeTarget(context, attribute, symbols, declaringClass, methodSymbol);
+            AnalyzeTarget(context, attribute, symbols, methodSymbol.ContainingType, methodSymbol);
         }
-
-        // A self reference is the one-node cycle; reporting it again as a cycle would be noise. Cycles are
-        // only modelled for tests of a runnable test class, because for any other declaring type the class
-        // the edge resolves against is not known at compile time.
-        if (selfReferenceReported || !IsRunnableTestClass(declaringClass, symbols))
-        {
-            return;
-        }
-
-        AnalyzeCycle(context, symbols, new TestNode(declaringClass, methodSymbol.Name));
     }
 
     /// <summary>
     /// Validates one <c>[DependsOn]</c> application against the members it names.
     /// </summary>
-    /// <returns><see langword="true"/> when the application was reported as a self reference.</returns>
-    private static bool AnalyzeTarget(
+    private static void AnalyzeTarget(
         SymbolAnalysisContext context,
         AttributeData attribute,
         AnalysisSymbols symbols,
@@ -233,13 +196,13 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         if (attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not { } attributeSyntax)
         {
-            return false;
+            return;
         }
 
         (ITypeSymbol? explicitTarget, string? targetMethodName, bool isMalformed) = ReadTarget(attribute);
         if (isMalformed)
         {
-            return false;
+            return;
         }
 
         // An implicit target ("a method of my own class") is resolved against the class the test runs under.
@@ -251,7 +214,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         {
             if (!IsRunnableTestClass(declaringClass, symbols))
             {
-                return false;
+                return;
             }
 
             targetClass = declaringClass;
@@ -266,12 +229,12 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             // never carry a '[TestClass]', so the reference is decidably dead. Reported before the
             // assembly check below, which has no answer for a type with no containing assembly.
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestClassRule, DescribeType(explicitTarget)));
-            return false;
+            return;
         }
 
         if (targetClass.TypeKind == TypeKind.Error)
         {
-            return false;
+            return;
         }
 
         // Discovery resolves a dependency against the tests of one test source, and stores a 'typeof' target
@@ -280,7 +243,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         if (!IsFromCurrentAssembly(context, targetClass))
         {
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(OtherAssemblyRule, targetClass.Name));
-            return false;
+            return;
         }
 
         if (!IsRunnableTestClass(targetClass, symbols))
@@ -292,33 +255,33 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
                 ? AbstractTargetRule
                 : NotATestClassRule;
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(rule, targetClass.Name));
-            return false;
+            return;
         }
 
         if (targetMethodName is null)
         {
             // A whole-class target on a test class always matches something (or the class has no test at
             // all, which MSTEST0016 already reports).
-            return false;
+            return;
         }
 
         if (string.IsNullOrWhiteSpace(targetMethodName))
         {
             // The attribute constructor throws for these, so there is nothing useful to add.
-            return false;
+            return;
         }
 
         MethodLookup lookup = LookupMethods(targetClass, targetMethodName, symbols);
         if (!lookup.Exists)
         {
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(MethodNotFoundRule, targetClass.Name, targetMethodName));
-            return false;
+            return;
         }
 
         if (!lookup.IsTestMethod)
         {
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(NotATestMethodRule, targetClass.Name, targetMethodName));
-            return false;
+            return;
         }
 
         // Only a reference written directly on the method is a self reference. The same reference written on
@@ -329,10 +292,7 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
             && SymbolEqualityComparer.Default.Equals(targetClass, declaringClass))
         {
             context.ReportDiagnostic(attributeSyntax.CreateDiagnostic(SelfReferenceRule, declaringMethod.Name));
-            return true;
         }
-
-        return false;
     }
 
     private static void AnalyzeCycle(SymbolAnalysisContext context, AnalysisSymbols symbols, TestNode start)
@@ -341,6 +301,13 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
         var path = new List<TestNode>();
         if (!TryFindCycle(context, symbols, start, start, visited, path, out AttributeData? firstEdge)
             || firstEdge?.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken) is not { } attributeSyntax)
+        {
+            return;
+        }
+
+        // A one-node cycle is a test naming itself, which AnalyzeTarget already reports as a self reference
+        // against the very same declaration; reporting it again as a cycle would just be noise.
+        if (path.Count == 1)
         {
             return;
         }
@@ -554,14 +521,38 @@ public sealed class DependsOnShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// Whether discovery runs tests under <paramref name="type"/>'s own name. Mirrors
     /// <c>TypeValidator.IsValidTestClass</c> on the points that decide whether a <c>[DependsOn]</c> reference
-    /// can ever match: the <c>[TestClass]</c> attribute, the fact that an abstract test class is skipped so
-    /// its tests are enumerated under each concrete derived class, and the fact that a non-abstract generic
-    /// test class is rejected outright.
+    /// can ever match: the <c>[TestClass]</c> attribute, accessibility, the fact that an abstract test class
+    /// is skipped so its tests are enumerated under each concrete derived class, and the fact that a
+    /// non-abstract generic test class is rejected outright.
     /// </summary>
     private static bool IsRunnableTestClass(INamedTypeSymbol type, AnalysisSymbols symbols)
         => !type.IsAbstract
             && !IsGenericTypeDefinition(type)
+            && HasValidAccessibility(type, symbols)
             && type.IsTestClass(symbols.TestClassAttribute);
+
+    /// <summary>
+    /// Mirrors <c>TypeValidator.TypeHasValidAccessibility</c>: the type and every type it is nested in must be
+    /// public, or internal when the assembly opts in with <c>[DiscoverInternals]</c>. Anything else - a
+    /// private, protected or protected-internal nested class - is skipped by discovery.
+    /// </summary>
+    private static bool HasValidAccessibility(INamedTypeSymbol type, AnalysisSymbols symbols)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.ContainingType)
+        {
+            if (current.DeclaredAccessibility == Accessibility.Public)
+            {
+                continue;
+            }
+
+            if (!symbols.DiscoverInternals || current.DeclaredAccessibility != Accessibility.Internal)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     private static bool IsGenericTypeDefinition(INamedTypeSymbol type)
         => type.IsGenericType && SymbolEqualityComparer.Default.Equals(type, type.OriginalDefinition);

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -82,4 +82,5 @@ internal static class DiagnosticIds
     public const string CurrentDirectoryMutationUnderParallelizationRuleId = "MSTEST0075";
     public const string CultureMutationUnderParallelizationRuleId = "MSTEST0076";
     public const string SharedFileSystemPathInTestRuleId = "MSTEST0077";
+    public const string DependsOnShouldBeValidRuleId = "MSTEST0078";
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -20,6 +20,7 @@ internal static class WellKnownTypeNames
     public const string MicrosoftVisualStudioTestToolsUnitTestingConditionBaseAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.ConditionBaseAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingDataRowAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingDataTestMethodAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute";
+    public const string MicrosoftVisualStudioTestToolsUnitTestingDependsOnAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DependsOnAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingDeploymentItemAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DeploymentItemAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingDescriptionAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute";
     public const string MicrosoftVisualStudioTestToolsUnitTestingDiscoverInternalsAttribute = "Microsoft.VisualStudio.TestTools.UnitTesting.DiscoverInternalsAttribute";

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -990,8 +990,12 @@ The type declaring these methods should also respect the following rules:
     <comment>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</comment>
   </data>
   <data name="DependsOnShouldBeValidMessageFormat_NoEffect" xml:space="preserve">
-    <value>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</value>
-    <comment>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</comment>
+    <value>'[DependsOn]' has no effect because '{0}' is not a test method</value>
+    <comment>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_NoEffectOnClass" xml:space="preserve">
+    <value>'[DependsOn]' has no effect because discovery runs no test under '{0}'</value>
+    <comment>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</comment>
   </data>
   <data name="MemberConditionShouldBeValidDescription" xml:space="preserve">
     <value>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</value>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -977,6 +977,10 @@ The type declaring these methods should also respect the following rules:
     <value>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</value>
     <comment>{0} is the referenced type name. {Locked="[DependsOn]"}</comment>
   </data>
+  <data name="DependsOnShouldBeValidMessageFormat_AbstractTarget" xml:space="preserve">
+    <value>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</value>
+    <comment>{0} is the referenced type name. {Locked="[DependsOn]"}</comment>
+  </data>
   <data name="DependsOnShouldBeValidMessageFormat_SelfReference" xml:space="preserve">
     <value>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</value>
     <comment>{0} is the test method name. {Locked="[DependsOn]"}</comment>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -958,7 +958,7 @@ The type declaring these methods should also respect the following rules:
     <comment>{Locked="[DependsOn]"}</comment>
   </data>
   <data name="DependsOnShouldBeValidDescription" xml:space="preserve">
-    <value>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</value>
+    <value>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</value>
     <comment>{Locked="[DependsOn]"}</comment>
   </data>
   <data name="DependsOnShouldBeValidMessageFormat_MethodNotFound" xml:space="preserve">
@@ -971,6 +971,10 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="DependsOnShouldBeValidMessageFormat_NotATestClass" xml:space="preserve">
     <value>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</value>
+    <comment>{0} is the referenced type name. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_OtherAssembly" xml:space="preserve">
+    <value>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</value>
     <comment>{0} is the referenced type name. {Locked="[DependsOn]"}</comment>
   </data>
   <data name="DependsOnShouldBeValidMessageFormat_SelfReference" xml:space="preserve">

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -953,6 +953,38 @@ The type declaring these methods should also respect the following rules:
     <value>'[MemberCondition]' arguments should be valid</value>
     <comment>{Locked="[MemberCondition]"}</comment>
   </data>
+  <data name="DependsOnShouldBeValidTitle" xml:space="preserve">
+    <value>'[DependsOn]' arguments should be valid</value>
+    <comment>{Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidDescription" xml:space="preserve">
+    <value>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</value>
+    <comment>{Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_MethodNotFound" xml:space="preserve">
+    <value>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</value>
+    <comment>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_NotATestMethod" xml:space="preserve">
+    <value>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</value>
+    <comment>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_NotATestClass" xml:space="preserve">
+    <value>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</value>
+    <comment>{0} is the referenced type name. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_SelfReference" xml:space="preserve">
+    <value>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</value>
+    <comment>{0} is the test method name. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_Cycle" xml:space="preserve">
+    <value>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</value>
+    <comment>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</comment>
+  </data>
+  <data name="DependsOnShouldBeValidMessageFormat_NoEffect" xml:space="preserve">
+    <value>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</value>
+    <comment>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</comment>
+  </data>
   <data name="MemberConditionShouldBeValidDescription" xml:space="preserve">
     <value>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</value>
     <comment>{Locked="[MemberCondition]"}{Locked="public static"}{Locked="bool"}</comment>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -340,6 +340,46 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Členy, na které odkazuje atribut [MemberCondition], musí existovat v odkazovaném typu, musí být public static, vracet bool a v případě metod nesmí mít žádné parametry. Atribut při porušení těchto pravidel vyvolá za běhu výjimku. Tento analyzátor upozorňuje na stejné problémy už při sestavení, aby překlepy a refaktorizace nenarušily řízení testů bez povšimnutí.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -361,9 +361,14 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -341,8 +341,8 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -345,6 +345,11 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -341,6 +341,46 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Die Mitglieder, auf die ein „[MemberCondition]“-Attribut verweist, müssen für den Referenztyp vorhanden sein, „public static“, „bool“ zurückgeben und (für Methoden) parameterlos sein. Das Attribut wird zur Laufzeit ausgelöst, wenn diese Regeln verletzt werden. Dieses Analysetool zeigt die gleichen Probleme zur Buildzeit an, sodass Tippfehler und Refactors die Testgating nicht im Hintergrund unterbrechen.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -342,8 +342,8 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -370,6 +370,11 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -362,9 +362,14 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -346,6 +346,11 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -341,8 +341,8 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -345,6 +345,11 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -340,6 +340,46 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Los miembros a los que hace referencia un atributo "[MemberCondition]" deben existir en el tipo al que se hace referencia, ser "public static", devolver "bool" y (para métodos) no tener parámetros. El atributo se produce en tiempo de ejecución cuando se infringen estas reglas; este analizador muestra los mismos problemas en tiempo de compilación, por lo que los errores tipográficos y las refactorizaciones no interrumpen silenciosamente el acceso a las pruebas.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -361,9 +361,14 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -340,6 +340,46 @@ Le type doit être une classe
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Les membres référencés par un attribut '[MemberCondition]' doivent exister sur le type référencé, être 'public static', renvoyer 'bool' et (pour les méthodes) être sans paramètre. L'attribut est lancé au moment de l'exécution lorsque ces règles sont violées ; cet analyseur présente les mêmes problèmes au moment de la construction, de sorte que les fautes de frappe et les refacteurs ne brisent pas silencieusement le contrôle des tests.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -345,6 +345,11 @@ Le type doit être une classe
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -341,8 +341,8 @@ Le type doit être une classe
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ Le type doit être une classe
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -361,9 +361,14 @@ Le type doit être une classe
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -340,6 +340,46 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">I membri a cui fa riferimento un attributo '[MemberCondition]' devono esistere nel tipo a cui si fa riferimento, essere 'public static', restituire 'bool' e (per i metodi) devono essere senza parametri. L'attributo genera un'eccezione in fase di esecuzione quando tali regole vengono violate; l'analizzatore segnala gli stessi problemi in fase di compilazione, in questo modo refusi e refactoring non interrompono silenziosamente la gating dei test.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -345,6 +345,11 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -341,8 +341,8 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -361,9 +361,14 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -361,9 +361,14 @@ The type declaring these methods should also respect the following rules:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -341,8 +341,8 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ The type declaring these methods should also respect the following rules:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -340,6 +340,46 @@ The type declaring these methods should also respect the following rules:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">'[MemberCondition]' 属性で参照されるメンバーは、参照先の型に存在し、'public static' で、'bool' を返し、(メソッドの場合は) パラメーターなしである必要があります。これらの規則に違反すると、属性は実行時に例外をスローします。このアナライザーは、ビルド時に同じ問題を検出するため、入力ミスやリファクタリングによってテストのゲート処理が気づかないうちに機能しなくなる事態を回避できます。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -345,6 +345,11 @@ The type declaring these methods should also respect the following rules:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -340,6 +340,46 @@ The type declaring these methods should also respect the following rules:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">'[MemberCondition]' 특성이 참조하는 멤버는 참조된 형식에 있어야 합니다. 또한 'public static'이어야 하고, 'bool'을 반환해야 하며, 메서드인 경우 매개 변수가 없어야 합니다. 이러한 규칙을 위반하면 특성은 런타임에 예외를 throw합니다. 이 분석기는 빌드 시점에 같은 문제를 알려 주므로, 오타나 리팩터링 때문에 테스트 게이팅이 조용히 깨지는 일을 막을 수 있습니다.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -361,9 +361,14 @@ The type declaring these methods should also respect the following rules:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -341,8 +341,8 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ The type declaring these methods should also respect the following rules:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -345,6 +345,11 @@ The type declaring these methods should also respect the following rules:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -340,6 +340,46 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Elementy członkowskie,do których odwołuje się atrybut „[MemberCondition]” muszą istnieć w przywoływanym typie, mieć wartość „public static”, zwracać wartość „bool” i (dla metod) być bez parametrów. Atrybut odrzuca w czasie wykonywania, gdy te reguły zostały naruszone; ten analizator ujawnia te same problemy w czasie kompilacji, dzięki czemu literówki i refaktoryzacje nie przerywają dyskretnie kontroli testu.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -361,9 +361,14 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -341,8 +341,8 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -345,6 +345,11 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -361,9 +361,14 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -341,8 +341,8 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -340,6 +340,46 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Os membros referenciados por um atributo '[MemberCondition]' devem existir no tipo referenciado, ser 'public static', devolver 'bool' e, no caso de métodos, não ter parâmetros. O atributo gera uma exceção em runtime quando essas regras são violadas; este analisador expõe os mesmos problemas em tempo de compilação, para que erros de digitação e refatorações não interrompam o bloqueio de testes silenciosamente.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -345,6 +345,11 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -367,9 +367,14 @@ The type declaring these methods should also respect the following rules:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -347,8 +347,8 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -375,6 +375,11 @@ The type declaring these methods should also respect the following rules:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -346,6 +346,46 @@ The type declaring these methods should also respect the following rules:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">Элементы, на которые ссылается атрибут "[MemberCondition]", должны существовать в указанном типе, быть "public static", возвращать "bool" и (для методов) не содержать параметров. Если эти правила нарушены, атрибут вызывает исключение во время выполнения. Этот анализатор выявляет те же проблемы на этапе сборки, поэтому опечатки и выполнения рефакторинга не нарушают автоматически проверку тестов.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -351,6 +351,11 @@ The type declaring these methods should also respect the following rules:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -361,9 +361,14 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -340,6 +340,46 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">'[MemberCondition]' özniteliği tarafından başvurulan üyeler, başvurulan türde mevcut olmalı, 'public static' olmalı, 'bool' döndürmeli ve (yöntemler için) parametresiz olmalıdır. Bu kurallar ihlal edildiğinde öznitelik çalışma zamanında hata oluşturur; bu çözümleyici aynı sorunları derleme zamanında ortaya çıkarır, böylece yazım hataları ve yeniden düzenlemeler test geçişini sessizce bozmaz.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -341,8 +341,8 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -345,6 +345,11 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -361,9 +361,14 @@ The type declaring these methods should also respect the following rules:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -340,6 +340,46 @@ The type declaring these methods should also respect the following rules:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">"[MemberCondition]" 属性引用的成员必须存在于所引用的类型中，必须为 "public static"，返回 "bool"，并且(对于方法)为无参数。如果违反这些规则，则该属性会在运行时引发异常；此分析器在生成时会出现相同的问题，因此拼写错误和重构不会以无提示方式中断测试门控。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -341,8 +341,8 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ The type declaring these methods should also respect the following rules:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -345,6 +345,11 @@ The type declaring these methods should also respect the following rules:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -361,9 +361,14 @@ The type declaring these methods should also respect the following rules:
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
-        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
-        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
-        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+        <source>'[DependsOn]' has no effect because '{0}' is not a test method</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is not a test method</target>
+        <note>{0} is the name of the method the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffectOnClass">
+        <source>'[DependsOn]' has no effect because discovery runs no test under '{0}'</source>
+        <target state="new">'[DependsOn]' has no effect because discovery runs no test under '{0}'</target>
+        <note>{0} is the name of the class the attribute is applied to. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
         <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -341,8 +341,8 @@ The type declaring these methods should also respect the following rules:
         <note />
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidDescription">
-        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
-        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
@@ -369,6 +369,11 @@ The type declaring these methods should also respect the following rules:
         <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
         <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
         <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_OtherAssembly">
+        <source>'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}' from another assembly; dependencies are resolved within a single test source, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
       </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
         <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -340,6 +340,46 @@ The type declaring these methods should also respect the following rules:
         <target state="new">Avoid changing the current directory in a parallelized test</target>
         <note />
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidDescription">
+        <source>A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</source>
+        <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, and an attribute applied where it has no effect.</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
+        <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
+        <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>
+        <note>{0} is the cycle path, for example 'MyTests.A &gt; MyTests.B &gt; MyTests.A'. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_MethodNotFound">
+        <source>'[DependsOn]' references method '{1}', which does not exist on type '{0}'</source>
+        <target state="new">'[DependsOn]' references method '{1}', which does not exist on type '{0}'</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NoEffect">
+        <source>'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</source>
+        <target state="new">'[DependsOn]' has no effect because '{0}' is neither a test method nor a test class</target>
+        <note>{0} is the name of the member the attribute is applied to. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestClass">
+        <source>'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references type '{0}', which is not a test class, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_NotATestMethod">
+        <source>'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references '{0}.{1}', which is not a test method, so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {1} is the referenced method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_SelfReference">
+        <source>'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</source>
+        <target state="new">'[DependsOn]' makes '{0}' depend on itself, which is a dependency cycle and fails the test at run time</target>
+        <note>{0} is the test method name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidTitle">
+        <source>'[DependsOn]' arguments should be valid</source>
+        <target state="new">'[DependsOn]' arguments should be valid</target>
+        <note>{Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="MemberConditionShouldBeValidDescription">
         <source>The members referenced by a '[MemberCondition]' attribute must exist on the referenced type, be 'public static', return 'bool', and (for methods) be parameterless. The attribute throws at runtime when these rules are violated; this analyzer surfaces the same problems at build time so typos and refactors do not silently break test gating.</source>
         <target state="translated">'[MemberCondition]' 屬性所參考的成員必須存在於參考的類型上、為 'public static'、傳回 'bool'，以及 (針對方法) 無參數。違反這些規則時，此屬性會在執行階段擲回；此分析器在建置階段遇到相同的問題，因此錯字和重構不會以無訊息方式中斷測試管制。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -345,6 +345,11 @@ The type declaring these methods should also respect the following rules:
         <target state="new">A '[DependsOn]' attribute references a test by name. A reference that matches no test is deliberately non-fatal at run time, so that running a subset of the suite stays possible, which means a typo or a rename silently drops the declared ordering. This analyzer reports the problems that can be decided at build time: a method that does not exist on the referenced type, a target that is not a test, a test that depends on itself, a dependency cycle visible in the compilation, a reference to a type from another assembly (dependencies are resolved within a single test source), and an attribute applied where it has no effect.</target>
         <note>{Locked="[DependsOn]"}</note>
       </trans-unit>
+      <trans-unit id="DependsOnShouldBeValidMessageFormat_AbstractTarget">
+        <source>'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</source>
+        <target state="new">'[DependsOn]' references abstract type '{0}'; its tests run under each derived test class rather than under '{0}', so the dependency is ignored at run time</target>
+        <note>{0} is the referenced type name. {Locked="[DependsOn]"}</note>
+      </trans-unit>
       <trans-unit id="DependsOnShouldBeValidMessageFormat_Cycle">
         <source>'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</source>
         <target state="new">'[DependsOn]' declares the dependency cycle '{0}', which fails every test in the cycle at run time</target>

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -523,9 +523,47 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(
             code,
-            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectRule)
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectOnClassRule)
                 .WithLocation(0)
                 .WithArguments("BaseTests"));
+    }
+
+    [TestMethod]
+    public async Task WhenWalkEntersAClassWithDuplicateSignatures_NoCycle()
+    {
+        // 'DuplicatedTests' has a duplicated 'Run(int)', so discovery's fallback keeps only the 'Run' closest
+        // to the class and the 'Run(string)' dependency is gone. The walk starts in another class and enters
+        // this node, so the bail-out has to apply per node rather than only where a walk begins.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Run(int value) { }
+
+                [TestMethod]
+                [DependsOn(typeof(OtherTests), nameof(OtherTests.Start))]
+                public void Run(string value) { }
+            }
+
+            [TestClass]
+            public class DuplicatedTests : BaseTests
+            {
+                [TestMethod]
+                public new void Run(int value) { }
+            }
+
+            [TestClass]
+            public class OtherTests
+            {
+                [TestMethod]
+                [DependsOn(typeof(DuplicatedTests), "Run")]
+                public void Start() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
     [TestMethod]
@@ -1301,7 +1339,7 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(
             code,
-            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectRule)
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectOnClassRule)
                 .WithLocation(0)
                 .WithArguments("BaseTests"));
     }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -436,6 +436,99 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenDeclaredOnMethodOfAbstractTestClass_NoDiagnostic()
+    {
+        // Discovery skips an abstract '[TestClass]' and enumerates its tests under each concrete derived
+        // class, so an implicit target is resolved against the derived class exactly as for an unannotated
+        // base. Validating it against the abstract class would report a method that does exist at run time.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public abstract class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("DeclaredOnlyOnDerived")]
+                public void AddItem() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public void DeclaredOnlyOnDerived() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedTypeIsAbstractTestClass_AbstractTarget()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public abstract class BaseTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(BaseTests))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.AbstractTargetRule)
+                .WithLocation(0)
+                .WithArguments("BaseTests"));
+    }
+
+    [TestMethod]
+    public async Task WhenAppliedToAbstractTestClass_NoEffect()
+    {
+        // The abstract class contributes no test of its own and '[DependsOn]' is not inherited, so the
+        // class-level declaration produces no edge anywhere.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            [{|#0:DependsOn(typeof(SetupTests))|}]
+            public abstract class BaseTests
+            {
+                [TestMethod]
+                public void AddItem() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectRule)
+                .WithLocation(0)
+                .WithArguments("BaseTests"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -783,6 +783,68 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenReferencedTypeIsConstructedGeneric_NotATestClass()
+    {
+        // Discovery enumerates the assembly's type definitions and rejects the non-abstract generic one, so
+        // no test exists under either the open or the constructed name.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class GenericTests<T>
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(GenericTests<int>))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestClassRule)
+                .WithLocation(0)
+                .WithArguments("GenericTests"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedTypeIsStaticTestClass_NotATestClass()
+    {
+        // Roslyn reports a static class as abstract, but nothing derives from it, so the abstract-base
+        // message would be misleading here.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public static class StaticTests
+            {
+                [TestMethod]
+                public static void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(StaticTests))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestClassRule)
+                .WithLocation(0)
+                .WithArguments("StaticTests"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -529,6 +529,136 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestMethodIsNotRunnable_NoCycle()
+    {
+        // Discovery rejects a private '[TestMethod]', so it never becomes a node and the "cycle" between the
+        // two does not exist at run time. MSTEST0003 already reports the invalid method itself.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DependsOn(nameof(AddItem))]
+                private void CreateCart() { }
+
+                [TestMethod]
+                [DependsOn(nameof(CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenInternalTestMethodAndDiscoverInternals_Cycle()
+    {
+        // With '[assembly: DiscoverInternals]' an internal test method *is* discovered, so the cycle is real.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: DiscoverInternals]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(nameof(AddItem))|}]
+                internal void CreateCart() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.CreateCart > MyTestClass.AddItem > MyTestClass.CreateCart"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.AddItem > MyTestClass.CreateCart > MyTestClass.AddItem"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassIsGeneric_NoCycle()
+    {
+        // 'TypeValidator.IsValidTestClass' rejects a non-abstract generic type definition outright, so no
+        // test runs under this class and there is no cycle to report.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass<T>
+            {
+                [TestMethod]
+                [DependsOn(nameof(AddItem))]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [DependsOn(nameof(CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenNewHidesTheBaseDependency_NoDiagnostic()
+    {
+        // Discovery dedupes same-signature declarations and keeps the one closest to the test class, so the
+        // hidden base declaration's dependency is gone at run time and 'Run > Other > Run' is not a cycle.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("Other")]
+                public void Run() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public new void Run() { }
+
+                [TestMethod]
+                [DependsOn(nameof(Run))]
+                public void Other() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTypeArgumentIsNull_NoDiagnostic()
+    {
+        // The constructor throws for a null type, so no dependency is ever recorded; reading past it would
+        // misread this as an implicit same-class self reference.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DependsOn((System.Type)null!, nameof(AddItem))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -874,6 +874,72 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenOnlyPrivateHelpersShareASignature_Cycle()
+    {
+        // A private helper hidden in the derived class is not a test, so discovery's duplicate fallback never
+        // triggers and the real cycle must still be reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                private void Log() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                private void Log() { }
+
+                [TestMethod]
+                [{|#0:DependsOn(nameof(AddItem))|}]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.CreateCart > MyTestClass.AddItem > MyTestClass.CreateCart"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.AddItem > MyTestClass.CreateCart > MyTestClass.AddItem"));
+    }
+
+    [TestMethod]
+    public async Task WhenNonTestMemberHidesABaseTest_NoDiagnostic()
+    {
+        // The hiding declaration is not a test, so discovery still finds the base test and its dependency is
+        // real. 'CreateCart' exists, so nothing is reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("CreateCart")]
+                public void Run() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                private new void Run() { }
+
+                [TestMethod]
+                public void CreateCart() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.DependsOnShouldBeValidAnalyzer,
     Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
@@ -448,6 +451,115 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
             VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
                 .WithLocation(1)
                 .WithArguments("SecondTests.B > FirstTests.A > SecondTests.B"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedTestClassIsInAnotherAssembly_OtherAssembly()
+    {
+        // Discovery resolves dependencies against the tests of one test source and stores a 'typeof' target
+        // as its CLR full name, so a reference to a type from a referenced assembly matches nothing at run
+        // time even though the type and the method both exist.
+        string libraryCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+            """;
+
+        string consumerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(SetupTests))|}]
+                public void AddItem() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(typeof(SetupTests), nameof(SetupTests.CreateCart))|}]
+                public void ApplyCoupon() { }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = consumerCode,
+        };
+
+        AddTestLibraryProject(test, libraryCode);
+
+        test.ExpectedDiagnostics.Add(
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.OtherAssemblyRule)
+                .WithLocation(0)
+                .WithArguments("SetupTests"));
+        test.ExpectedDiagnostics.Add(
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.OtherAssemblyRule)
+                .WithLocation(1)
+                .WithArguments("SetupTests"));
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenClassLevelReferenceIsInAnotherAssembly_OtherAssemblyAndNoCycle()
+    {
+        // The same rule applies to the dependency walk: an edge that crosses the assembly boundary does not
+        // exist at run time, so it must not be traversed and must not contribute to a cycle.
+        string libraryCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [DependsOn(nameof(SetupTests.CreateCart))]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+
+                [TestMethod]
+                public void AddItem() { }
+            }
+            """;
+
+        string consumerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [{|#0:DependsOn(typeof(SetupTests))|}]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void PlaceOrder() { }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = consumerCode,
+        };
+
+        AddTestLibraryProject(test, libraryCode);
+
+        test.ExpectedDiagnostics.Add(
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.OtherAssemblyRule)
+                .WithLocation(0)
+                .WithArguments("SetupTests"));
+
+        await test.RunAsync();
+    }
+
+    private static void AddTestLibraryProject(VerifyCS.Test test, string libraryCode)
+    {
+        var libraryProject = new ProjectState("TestLib", LanguageNames.CSharp, "/TestLib/", "cs");
+        libraryProject.Sources.Add(("Library.cs", libraryCode));
+        libraryProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(ParallelizeAttribute).Assembly.Location));
+        libraryProject.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(TestContext).Assembly.Location));
+        test.TestState.AdditionalProjects.Add("TestLib", libraryProject);
+        test.TestState.AdditionalProjectReferences.Add("TestLib");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -719,6 +719,70 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenInheritedTestIsShadowedByNonTestOverload_Cycle()
+    {
+        // 'MyTestClass' declares an 'A' overload that is not a test, so nothing starts a walk for the
+        // inherited 'A' unless cycle analysis is driven from the test class rather than from the declaring
+        // method. The inherited test still runs under 'MyTestClass', so the cycle is real.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [{|#0:DependsOn("Other")|}]
+                public void A() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                public void A(int value) { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(A))|}]
+                public void Other() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.A > MyTestClass.Other > MyTestClass.A"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.Other > MyTestClass.A > MyTestClass.Other"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestClassIsInaccessible_NoCycle()
+    {
+        // A private nested '[TestClass]' is skipped by discovery, so no test runs under it and there is no
+        // cycle. MSTEST0002 already reports the class itself.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Outer
+            {
+                [TestClass]
+                private class MyTestClass
+                {
+                    [TestMethod]
+                    [DependsOn(nameof(AddItem))]
+                    public void CreateCart() { }
+
+                    [TestMethod]
+                    [DependsOn(nameof(CreateCart))]
+                    public void AddItem() { }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -312,6 +312,30 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenReferencedTypeIsNotANamedType_NotATestClass()
+    {
+        // The attribute constructor takes a 'Type', so 'typeof(int[])' compiles - but an array can never
+        // carry a '[TestClass]', so the reference is decidably dead.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(int[]))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestClassRule)
+                .WithLocation(0)
+                .WithArguments("int[]"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -659,6 +659,66 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenNewHidesTheBaseDependencyWithRenamedTypeParameter_NoDiagnostic()
+    {
+        // 'Run<U>(U)' hides 'Run<T>(T)': the type parameter's name is not part of the signature, so discovery
+        // dedupes them and keeps the derived declaration. Comparing the parameter types as source text would
+        // see 'U' and 'T', keep the hidden base declaration, and invent its dependency back.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("Other")]
+                public void Run<T>(T value) { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public new void Run<U>(U value) { }
+
+                [TestMethod]
+                [DependsOn(nameof(Run))]
+                public void Other() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenBaseDeclaresGenuineOverload_NoDiagnostic()
+    {
+        // A different signature is a distinct test rather than a hidden one, so the base declaration stays in
+        // the effective set and its dependency is real. 'CreateCart' exists, so nothing is reported.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("CreateCart")]
+                public void Run(int value) { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public void Run() { }
+
+                [TestMethod]
+                public void CreateCart() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -845,6 +845,35 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenInheritedTestReferencesItsOwnDerivedClass_Cycle()
+    {
+        // The test runs as 'MyTestClass.Run' and depends on 'MyTestClass.Run', so the run-time graph has a
+        // self-cycle. AnalyzeTarget cannot see it - it compares the target against the *declaring* class -
+        // so the cycle rule has to report it rather than assume a self reference was already flagged.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(MyTestClass), nameof(Run))|}]
+                public void Run() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.Run > MyTestClass.Run"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -1,0 +1,510 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.DependsOnShouldBeValidAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class DependsOnShouldBeValidAnalyzerTests
+{
+    [TestMethod]
+    public async Task WhenReferencingTestMethodOfSameClass_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [DependsOn(nameof(CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenReferencingTestMethodOfAnotherClass_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DependsOn(typeof(SetupTests), nameof(SetupTests.CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenReferencingWholeTestClass_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DependsOn(typeof(SetupTests))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenReferencingInheritedTestMethod_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public abstract class BaseTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                [DependsOn(nameof(CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenClassLevelAttributeNamesMethodOfSameClass_NoDiagnostic()
+    {
+        // The class-level declaration means "every *other* test waits for CreateCart", so the self-edge it
+        // would generate for CreateCart is dropped by discovery and must not be reported as a cycle.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [DependsOn(nameof(MyTestClass.CreateCart))]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void CreateCart() { }
+
+                [TestMethod]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodNameIsEmpty_NoDiagnostic()
+    {
+        // The attribute constructor already throws for these, so the analyzer stays quiet.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DependsOn("")]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenDeclaredOnMethodOfNonTestBaseClass_NoDiagnostic()
+    {
+        // The implicit target is resolved against each derived test class at run time, so a name that is not
+        // a member of the base class is not necessarily broken.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public abstract class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("DeclaredOnlyOnDerived")]
+                public void AddItem() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public void DeclaredOnlyOnDerived() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedMethodDoesNotExist_MethodNotFound()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn("CreateCat")|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.MethodNotFoundRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass", "CreateCat"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedMethodDoesNotExistOnOtherClass_MethodNotFound()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(SetupTests), "CreateCat")|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.MethodNotFoundRule)
+                .WithLocation(0)
+                .WithArguments("SetupTests", "CreateCat"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedMethodIsNotATestMethod_NotATestMethod()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public void CreateCart() { }
+
+                [TestMethod]
+                [{|#0:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestMethodRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass", "CreateCart"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedMethodIsAFixtureMethod_NotATestMethod()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [{|#0:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestMethodRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass", "CreateCart"));
+    }
+
+    [TestMethod]
+    public async Task WhenReferencedTypeIsNotATestClass_NotATestClass()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Helpers
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(Helpers))|}]
+                public void AddItem() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(typeof(Helpers), nameof(Helpers.CreateCart))|}]
+                public void ApplyCoupon() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestClassRule)
+                .WithLocation(0)
+                .WithArguments("Helpers"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestClassRule)
+                .WithLocation(1)
+                .WithArguments("Helpers"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestReferencesItself_SelfReference()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(nameof(AddItem))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.SelfReferenceRule)
+                .WithLocation(0)
+                .WithArguments("AddItem"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestReferencesItselfThroughItsOwnType_SelfReference()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(typeof(MyTestClass), nameof(AddItem))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.SelfReferenceRule)
+                .WithLocation(0)
+                .WithArguments("AddItem"));
+    }
+
+    [TestMethod]
+    public async Task WhenTwoTestsDependOnEachOther_Cycle()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(nameof(AddItem))|}]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.CreateCart > MyTestClass.AddItem > MyTestClass.CreateCart"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.AddItem > MyTestClass.CreateCart > MyTestClass.AddItem"));
+    }
+
+    [TestMethod]
+    public async Task WhenThreeTestsFormACycle_Cycle()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:DependsOn(nameof(C))|}]
+                public void A() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(A))|}]
+                public void B() { }
+
+                [TestMethod]
+                [{|#2:DependsOn(nameof(B))|}]
+                public void C() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.A > MyTestClass.C > MyTestClass.B > MyTestClass.A"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.B > MyTestClass.A > MyTestClass.C > MyTestClass.B"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(2)
+                .WithArguments("MyTestClass.C > MyTestClass.B > MyTestClass.A > MyTestClass.C"));
+    }
+
+    [TestMethod]
+    public async Task WhenTwoTestClassesDependOnEachOther_Cycle()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [{|#0:DependsOn(typeof(SecondTests))|}]
+            public class FirstTests
+            {
+                [TestMethod]
+                public void A() { }
+            }
+
+            [TestClass]
+            [{|#1:DependsOn(typeof(FirstTests))|}]
+            public class SecondTests
+            {
+                [TestMethod]
+                public void B() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("FirstTests.A > SecondTests.B > FirstTests.A"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("SecondTests.B > FirstTests.A > SecondTests.B"));
+    }
+
+    [TestMethod]
+    public async Task WhenAppliedToNonTestMethod_NoEffect()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void CreateCart() { }
+
+                [{|#0:DependsOn(nameof(CreateCart))|}]
+                public void Helper() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectRule)
+                .WithLocation(0)
+                .WithArguments("Helper"));
+    }
+
+    [TestMethod]
+    public async Task WhenAppliedToNonTestClass_NoEffect()
+    {
+        // '[DependsOn]' is not inherited, so an application on a shared base class never produces an edge.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class SetupTests
+            {
+                [TestMethod]
+                public void CreateCart() { }
+            }
+
+            [{|#0:DependsOn(typeof(SetupTests))|}]
+            public abstract class BaseTests
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NoEffectRule)
+                .WithLocation(0)
+                .WithArguments("BaseTests"));
+    }
+}

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -940,6 +940,64 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestContextPropertyIsInvalid_NoCycle()
+    {
+        // Discovery rejects the whole class when a declared 'TestContext' property has a static getter, so no
+        // test runs under it and there is no cycle. MSTEST0005 already reports the property itself.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public static TestContext TestContext { get; set; }
+
+                [TestMethod]
+                [DependsOn(nameof(AddItem))]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [DependsOn(nameof(CreateCart))]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestContextPropertyIsValid_Cycle()
+    {
+        // The ordinary instance 'TestContext' property must not disturb anything.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                [{|#0:DependsOn(nameof(AddItem))|}]
+                public void CreateCart() { }
+
+                [TestMethod]
+                [{|#1:DependsOn(nameof(CreateCart))|}]
+                public void AddItem() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass.CreateCart > MyTestClass.AddItem > MyTestClass.CreateCart"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("MyTestClass.AddItem > MyTestClass.CreateCart > MyTestClass.AddItem"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/DependsOnShouldBeValidAnalyzerTests.cs
@@ -336,6 +336,106 @@ public sealed class DependsOnShouldBeValidAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenOverrideDropsTheBaseDependency_NoDiagnostic()
+    {
+        // '[DependsOn]' is not inherited across an override chain, so at run time 'Run' carries no
+        // dependency and 'Run > Other > Run' is not a cycle. Reading the overridden base declaration's
+        // attribute here would invent one and report a cycle against correct code.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                [DependsOn("Other")]
+                public virtual void Run() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                [TestMethod]
+                public override void Run() { }
+
+                [TestMethod]
+                [DependsOn(nameof(Run))]
+                public void Other() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenOverrideDropsTestMethodAttribute_NotATestMethod()
+    {
+        // The override is the declaration reflection surfaces, and '[TestMethod]' is not inherited across
+        // overrides, so the base declaration no longer makes this name a test.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public virtual void Run() { }
+            }
+
+            [TestClass]
+            public class MyTestClass : BaseTests
+            {
+                public override void Run() { }
+
+                [TestMethod]
+                [{|#0:DependsOn(nameof(Run))|}]
+                public void PlaceOrder() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.NotATestMethodRule)
+                .WithLocation(0)
+                .WithArguments("MyTestClass", "Run"));
+    }
+
+    [TestMethod]
+    public async Task WhenTwoClassesWithOnlyInheritedTestsDependOnEachOther_Cycle()
+    {
+        // Both classes run the inherited test as their own, so this is a real run-time cycle even though
+        // neither class declares a test method of its own.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Run() { }
+            }
+
+            [TestClass]
+            [{|#0:DependsOn(typeof(SecondTests))|}]
+            public class FirstTests : BaseTests
+            {
+            }
+
+            [TestClass]
+            [{|#1:DependsOn(typeof(FirstTests))|}]
+            public class SecondTests : BaseTests
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(0)
+                .WithArguments("FirstTests.Run > SecondTests.Run > FirstTests.Run"),
+            VerifyCS.Diagnostic(DependsOnShouldBeValidAnalyzer.CycleRule)
+                .WithLocation(1)
+                .WithArguments("SecondTests.Run > FirstTests.Run > SecondTests.Run"));
+    }
+
+    [TestMethod]
     public async Task WhenTestReferencesItself_SelfReference()
     {
         string code = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1329,6 +1329,60 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_MaterializesSchedulingAttributes_OnMethodAndClass()
+    {
+        // '[DependsOn]' and '[ResourceLock]' are not part of the generator's small set of specially
+        // understood attributes; they ride the generic attribute-materialization path, which is what
+        // makes them work under Native AOT. This pins that so the generic path is not narrowed to an
+        // allow-list by accident.
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Microsoft.VisualStudio.TestTools.UnitTesting
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+                public sealed class DependsOnAttribute : System.Attribute
+                {
+                    public DependsOnAttribute(string testMethodName) { }
+                    public DependsOnAttribute(System.Type testClass) { }
+                    public bool ProceedOnFailure { get; set; }
+                }
+
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+                public sealed class ResourceLockAttribute : System.Attribute
+                {
+                    public ResourceLockAttribute(string resource) { }
+                }
+            }
+
+            namespace Sample
+            {
+                [TestClass]
+                [DependsOn(typeof(Tests))]
+                public class Tests
+                {
+                    [TestMethod]
+                    public void CreateCart() { }
+
+                    [TestMethod]
+                    [DependsOn(nameof(CreateCart), ProceedOnFailure = true)]
+                    [ResourceLock("database")]
+                    public void AddItem() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registry = GetRegistry(result);
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.DependsOnAttribute(\"CreateCart\")");
+        registry.Should().Contain("ProceedOnFailure = true");
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.DependsOnAttribute(typeof(global::Sample.Tests))");
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.ResourceLockAttribute(\"database\")");
+    }
+
+    [TestMethod]
     public void Generator_CapturesAssemblyLevelAttribute()
     {
         const string userCode = """

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Telemetry/MSTestTelemetryDataCollectorTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Telemetry/MSTestTelemetryDataCollectorTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if !WINDOWS_UWP && !WIN_UI
+using AwesomeAssertions;
+
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestFramework.ForTestingMSTest;
+
+namespace MSTestAdapter.PlatformServices.UnitTests.Telemetry;
+
+public sealed class MSTestTelemetryDataCollectorTests : TestContainer
+{
+    public void TrackDiscoveredMethod_CountsSchedulingAttributes()
+    {
+        var collector = new MSTestTelemetryDataCollector();
+
+        collector.TrackDiscoveredMethod([
+            new TestMethodAttribute(),
+            new DependsOnAttribute("CreateCart"),
+            new ResourceLockAttribute("database"),
+        ]);
+
+        Dictionary<string, object> metrics = collector.BuildDiscoveryMetrics();
+
+        metrics["mstest.attribute_usage"].Should()
+            .Be("""{"DependsOnAttribute":1,"ResourceLockAttribute":1,"TestMethodAttribute":1}""");
+    }
+
+    public void TrackDiscoveredMethod_AggregatesRepeatedDependsOnDeclarations()
+    {
+        var collector = new MSTestTelemetryDataCollector();
+
+        // '[DependsOn]' allows multiple applications: fan-in is declared by repeating it.
+        collector.TrackDiscoveredMethod([
+            new TestMethodAttribute(),
+            new DependsOnAttribute("AddItem"),
+            new DependsOnAttribute("ApplyCoupon"),
+        ]);
+
+        Dictionary<string, object> metrics = collector.BuildDiscoveryMetrics();
+
+        metrics["mstest.attribute_usage"].Should()
+            .Be("""{"DependsOnAttribute":2,"TestMethodAttribute":1}""");
+    }
+
+    public void TrackDiscoveredClass_CountsSchedulingAttributes()
+    {
+        var collector = new MSTestTelemetryDataCollector();
+
+        collector.TrackDiscoveredClass([
+            new TestClassAttribute(),
+            new DependsOnAttribute(typeof(MSTestTelemetryDataCollectorTests)),
+            new ResourceLockAttribute("database"),
+        ]);
+
+        Dictionary<string, object> metrics = collector.BuildDiscoveryMetrics();
+
+        metrics["mstest.attribute_usage"].Should()
+            .Be("""{"DependsOnAttribute":1,"ResourceLockAttribute":1,"TestClassAttribute":1}""");
+    }
+}
+#endif


### PR DESCRIPTION
Closes #10259.

`[DependsOn]` (RFC 022) shipped without any analyzer or telemetry support. Nothing here was a correctness problem — the runtime already reports unresolvable references and cycles — these were build-time and observability gaps.

## 1 & 2 — `MSTEST0078`, `DependsOnShouldBeValidAnalyzer`

The runtime deliberately treats a dependency that matches no test as a *warning* rather than a failure, so that `--filter` and single-test runs keep working. That trade-off is only safe if the genuinely broken references are caught before the run — which is what makes the `nameof`/`typeof` shape of the API pay off.

One rule ID, six message formats (the `MemberConditionShouldBeValidAnalyzer` shape):

| Message | Reported when |
| --- | --- |
| `MethodNotFoundRule` | the named method does not exist on the target type (base types included) |
| `NotATestMethodRule` | the named method exists but no declaration of that name is a test method |
| `NotATestClassRule` | the target type has no `[TestClass]`, so it contributes no test |
| `SelfReferenceRule` | a self reference written directly on the method |
| `CycleRule` | a cycle visible within one compilation, with the path (`A > B > A`) |
| `NoEffectRule` | applied to a non-test method, or a class without `[TestClass]` |

The analyzer models the graph the way discovery does — keyed by class name + method name, since an overloaded or data-driven test contributes several tests under one name — and reproduces discovery's rule that a **class-level** `[DependsOn(nameof(Setup))]` means "every *other* test waits for Setup" and so never makes `Setup` depend on itself. Written on the method, the same reference is a real self reference and is reported.

`Warning`/enabled-by-default per `docs/AddingAnalyzerCodeFix.md`: each case is a run-time defect (a cycle *fails* every test in it; an unmatched reference silently drops the declared ordering and the runtime warns). `[DependsOn]` is new in this release, so no existing code is affected.

**Every check bails out when the answer is not statically decidable.** The important case is a test method declared on a *non-test* base class: its implicit references (`[DependsOn(nameof(X))]` with no `typeof`) are resolved against each *derived* test class at run time, so the analyzer cannot decide them and leaves them alone. Cycle detection is likewise skipped there, and capped at 512 visited nodes so a pathological graph cannot make analysis quadratic.

### On item 2 (the "family of scheduling attributes" question)

`UseAttributeOnTestMethodAnalyzer` (MSTEST0007) has a closed `RuleTuples` set that also excludes `[DoNotParallelize]`, `[Parallelize]` and `[ResourceLock]`. I did **not** add `[DependsOn]` there: the dedicated rule can say *why* the attribute is inert (no edge is produced) and can cover the class-level application too, which MSTEST0007 does not analyze. Extending MSTEST0007 to the rest of that family is left alone as a separate decision.

## 3 — `WellKnownTypeNames`

`DependsOnAttribute` registered, now that an analyzer consumes it.

## 4 — Telemetry

`MSTestTelemetryDataCollector` now counts `[DependsOn]` **and** `[ResourceLock]` (which had the same gap) at both method and class level.

## 5 — NativeAOT source generation

This one turned out not to be a real gap. `MSTestAttributeNames` is not an allow-list for attribute emission — it holds constants for the few attributes the generator makes *decisions* about (`TestClass`, `TestMethod`, `DataRow`, `DynamicData`); `Timeout`, `Ignore` and `DoNotParallelize` are already unused constants there. Attributes are materialized **generically** by `AttributeMaterializationHelper`, so `[DependsOn]` and `[ResourceLock]` already flow through the Native AOT path. Adding constants would have been dead code, so instead there is a generator test pinning the generic behaviour so it is not narrowed to an allow-list by accident.

## Tests

- `DependsOnShouldBeValidAnalyzerTests` — 19 tests: one per message, plus the no-diagnostic cases that matter (inherited test method, class-level reference to a method of the same class, empty name, and the non-test-base-class bail-out).
- `MSTestTelemetryDataCollectorTests` — new, covering the method/class tracking and repeated `[DependsOn]` aggregation.
- `Generator_MaterializesSchedulingAttributes_OnMethodAndClass` — the Native AOT regression pin.

Full suites green: MSTest.Analyzers.UnitTests (1573), MSTestAdapter.PlatformServices.UnitTests (1039), MSTest.SourceGeneration.UnitTests (125). `MSTest.SelfRealExamples.UnitTests` (which dogfoods the analyzers) builds with 0 warnings.

Docs: RFC 022's "Future work" entry for the analyzer is replaced by a "Build-time validation" section describing what ships and, importantly, what the analyzer deliberately does not decide.