### PR TITLE
Add MSTEST0077 tests for File/Directory delete and Directory.Move

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -526,7 +526,8 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     [TestMethod]
     public async Task WhenTestMethodDeletesDirectoryWithConstantPath_Diagnostic()
     {
-        // Directory.Delete mutates its single 'path' argument, including through the recursive overload.
+        // Directory.Delete mutates the entry named by 'path'; the recursive overload adds only a bool, which the
+        // string-typed parameter filter skips, so the constant directory path is still the reported argument.
         string code = """
             using System.IO;
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -585,7 +586,7 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     public async Task WhenTestMethodMovesDirectoryToConstantDestination_Diagnostic()
     {
         // Directory.Move also creates its destination directory, so a constant 'destDirName' is a mutation on its
-        // own - unlike File.Copy, where only the destination role is flagged and the source is merely read.
+        // own, even when the source is per-test unique.
         string code = """
             using System.IO;
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -609,5 +610,61 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
             VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
                 .WithLocation(0)
                 .WithArguments("dest-dir"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodMovesDirectoryBetweenConstantPaths_SingleDiagnosticForSource()
+    {
+        // Both Directory.Move positions are mutations, but the analyzer reports the first constant mutated path it
+        // finds rather than one diagnostic per position, so this invocation yields a single diagnostic naming the
+        // source. Pinning that keeps the "report once per invocation" contract observable.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    {|#0:Directory.Move("source-dir", "dest-dir")|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("source-dir"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodReadsConstantDirectoryPath_NoDiagnostic()
+    {
+        // The Directory.* allowlist must stay as narrow as the File.* one: enumerating or probing a shared directory
+        // at a fixed path does not mutate it, so the delete/move coverage above is pinned from both directions.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    bool exists = Directory.Exists("shared-dir");
+                    string[] files = Directory.GetFiles("shared-dir");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -493,4 +493,121 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
                 .WithLocation(0)
                 .WithArguments("setup.txt"));
     }
+
+    [TestMethod]
+    public async Task WhenTestMethodDeletesFileWithConstantPath_Diagnostic()
+    {
+        // File.Delete removes the entry named by its single 'path' argument, so a constant path is a mutation
+        // that races with any other test touching the same file.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    {|#0:File.Delete("shared.txt")|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("shared.txt"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodDeletesDirectoryWithConstantPath_Diagnostic()
+    {
+        // Directory.Delete mutates its single 'path' argument, including through the recursive overload.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    {|#0:Directory.Delete("shared-dir", recursive: true)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("shared-dir"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodMovesDirectoryFromConstantSource_Diagnostic()
+    {
+        // Directory.Move deletes its source directory, so a constant 'sourceDirName' is a mutation and must be
+        // flagged even when the destination is per-test unique.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string destination = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    {|#0:Directory.Move("source-dir", destination)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("source-dir"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodMovesDirectoryToConstantDestination_Diagnostic()
+    {
+        // Directory.Move also creates its destination directory, so a constant 'destDirName' is a mutation on its
+        // own - unlike File.Copy, where only the destination role is flagged and the source is merely read.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string source = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    {|#0:Directory.Move(source, "dest-dir")|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("dest-dir"));
+    }
 }


### PR DESCRIPTION
Fixes #10299

## What

Adds 6 tests to `SharedFileSystemPathInTestAnalyzerTests` covering MSTEST0077 mutation operations that had no coverage.

`SharedFileSystemPathInTestAnalyzer` has per-method path-role logic (`IsMutatedPathParameter`): `File.Copy` flags only its destination, `File.Move` flags both positions, `File.Replace` flags the destination and the backup, `Directory.Move` flags both positions, and everything else flags `path`. The `Delete` entries in both allowlist arms and the whole `Directory.Move` case were untested — the suite only exercised `CreateDirectory`, `Copy`, `Move` (file), `Replace`, `OpenWrite`, and the `WriteAllText` variants.

| Test | Pins |
| --- | --- |
| `WhenTestMethodDeletesFileWithConstantPath_Diagnostic` | `"Delete"` in the `File` allowlist arm |
| `WhenTestMethodDeletesDirectoryWithConstantPath_Diagnostic` | `"Delete"` in the `Directory` arm; also that the recursive overload's `bool` is skipped by the string-typed parameter filter |
| `WhenTestMethodMovesDirectoryFromConstantSource_Diagnostic` | `sourceDirName` role |
| `WhenTestMethodMovesDirectoryToConstantDestination_Diagnostic` | `destDirName` role |
| `WhenTestMethodMovesDirectoryBetweenConstantPaths_SingleDiagnosticForSource` | One diagnostic per invocation, reporting the *first* constant mutated path |
| `WhenTestMethodReadsConstantDirectoryPath_NoDiagnostic` | The `Directory` allowlist stays narrow (`Exists`/`GetFiles` must not fire) |

The last two came out of review: without the "both constant" test the early `return` in `TryGetConstantMutatedPathArgument` is never exercised with two candidates in play, and without the negative test the `Directory` arm could be widened to `=> true` with the whole file still green.

No production code changes.

## Verification

24/24 tests pass in `SharedFileSystemPathInTestAnalyzerTests` on `net8.0`.

Each new test was mutation-checked against the analyzer (mutations reverted; the analyzer is untouched on this branch), and the failure sets are disjoint, so the tests pin distinct behaviors rather than overlapping on one code path:

| Mutation to `SharedFileSystemPathInTestAnalyzer` | Failures |
| --- | --- |
| `Directory` arm of `IsMutatingFileSystemMethod` widened with `Exists`/`GetFiles` | 1 — the new negative test |
| `Directory.Move` case in `IsMutatedPathParameter` neutered | 3 — the three `Directory.Move` tests |
| `"Delete"` removed from both arms of `IsMutatingFileSystemMethod` | 2 — the two `Delete` tests |

## Follow-up

#10305 tracks two adjacent gaps left out to keep this PR scoped: the missing `[DoNotParallelize]` opt-out test, and the untested `Directory.CreateSymbolicLink` / `Directory.Set*Time*` allowlist entries.