### PR TITLE
Consolidate duplicated attribute-query logic into a shared AttributeQueryHelper

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/AttributeQueryHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/AttributeQueryHelper.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
+
+/// <summary>
+/// Attribute filtering logic shared by every <see cref="Interface.IReflectionOperations"/> implementation
+/// and by <c>ReflectHelper</c>.
+/// </summary>
+/// <remarks>
+/// The methods take an already-resolved (and usually cached) attribute array so that each caller keeps
+/// ownership of how attributes are obtained, while the filtering semantics — including the localized error
+/// message raised for duplicated attributes — live in a single place and cannot diverge between the
+/// reflection-based and source-generated implementations.
+/// </remarks>
+internal static class AttributeQueryHelper
+{
+    private const string NullAttributeMessage = "AttributeQueryHelper: internal error: null entry in the attributes array.";
+
+    /// <summary>
+    /// Checks whether <paramref name="attributes"/> contains an attribute of the given type, or an attribute that
+    /// derives from it. e.g. <c>[MyTestClass]</c> deriving from <c>[TestClass]</c> matches when looking for <c>[TestClass]</c>.
+    /// </summary>
+    /// <typeparam name="TAttribute">Attribute to search for.</typeparam>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <returns>True if an attribute of the specified type is present.</returns>
+    public static bool IsAttributeDefined<TAttribute>(Attribute[] attributes)
+        where TAttribute : Attribute
+    {
+        foreach (Attribute attribute in attributes)
+        {
+            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+
+            if (attribute is TAttribute)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the first attribute that matches the type.
+    /// Use this together with an attribute that does not allow multiple and is sealed. In such case there cannot be
+    /// more attributes, and this will avoid the cost of checking for more than one attribute.
+    /// </summary>
+    /// <typeparam name="TAttribute">Type of the attribute to find.</typeparam>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <returns>The attribute that is found or null.</returns>
+    public static TAttribute? GetFirstAttributeOrDefault<TAttribute>(Attribute[] attributes)
+        where TAttribute : Attribute
+    {
+        // If the attribute is not sealed, then it can allow multiple, even if AllowMultiple is false.
+        // This happens when a derived type is also applied along with the base type.
+        // Or, if the derived type modifies the attribute usage to allow multiple.
+        // So we want to ensure this is only called for sealed attributes.
+        DebugEx.Assert(typeof(TAttribute).IsSealed, $"Expected '{typeof(TAttribute)}' to be sealed, but was not.");
+
+        foreach (Attribute attribute in attributes)
+        {
+            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+
+            if (attribute is TAttribute attributeAsTAttribute)
+            {
+                return attributeAsTAttribute;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the single attribute that matches the type or is derived from it.
+    /// </summary>
+    /// <typeparam name="TAttribute">Type of the attribute to find.</typeparam>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <returns>The attribute that is found or null.</returns>
+    /// <exception cref="InvalidOperationException">Throws when multiple attributes are found (the attribute must allow multiple).</exception>
+    public static TAttribute? GetSingleAttributeOrDefault<TAttribute>(Attribute[] attributes)
+        where TAttribute : Attribute
+    {
+        TAttribute? foundAttribute = null;
+        foreach (Attribute attribute in attributes)
+        {
+            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+
+            if (attribute is TAttribute attributeAsTAttribute)
+            {
+                if (foundAttribute is not null)
+                {
+                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(TAttribute)));
+                }
+
+                foundAttribute = attributeAsTAttribute;
+            }
+        }
+
+        return foundAttribute;
+    }
+
+    /// <summary>
+    /// Gets every attribute which is of the given type or a subtype of it.
+    /// </summary>
+    /// <typeparam name="TAttribute">The attribute type.</typeparam>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <returns>The matching attributes.</returns>
+    public static IEnumerable<TAttribute> GetAttributes<TAttribute>(Attribute[] attributes)
+        where TAttribute : Attribute
+    {
+        foreach (Attribute attribute in attributes)
+        {
+            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+
+            if (attribute is TAttribute attributeAsTAttribute)
+            {
+                yield return attributeAsTAttribute;
+            }
+        }
+    }
+}

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/AttributeQueryHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/AttributeQueryHelper.cs
@@ -17,8 +17,6 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Hel
 /// </remarks>
 internal static class AttributeQueryHelper
 {
-    private const string NullAttributeMessage = "AttributeQueryHelper: internal error: null entry in the attributes array.";
-
     /// <summary>
     /// Checks whether <paramref name="attributes"/> contains an attribute of the given type, or an attribute that
     /// derives from it. e.g. <c>[MyTestClass]</c> deriving from <c>[TestClass]</c> matches when looking for <c>[TestClass]</c>.
@@ -31,7 +29,7 @@ internal static class AttributeQueryHelper
     {
         foreach (Attribute attribute in attributes)
         {
-            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+            AssertNotNull<TAttribute>(attribute);
 
             if (attribute is TAttribute)
             {
@@ -47,6 +45,13 @@ internal static class AttributeQueryHelper
     /// Use this together with an attribute that does not allow multiple and is sealed. In such case there cannot be
     /// more attributes, and this will avoid the cost of checking for more than one attribute.
     /// </summary>
+    /// <remarks>
+    /// <typeparamref name="TAttribute"/> being sealed is a caller contract enforced by a DEBUG-only assert. On .NET
+    /// Framework DEBUG builds <see cref="DebugEx.Assert(bool, string)"/> calls <see cref="Environment.FailFast(string, Exception)"/>,
+    /// so violating it takes down the test host instead of failing a single test. Use
+    /// <see cref="GetSingleAttributeOrDefault{TAttribute}"/> or <see cref="GetAttributes{TAttribute}"/> for non-sealed
+    /// attribute types.
+    /// </remarks>
     /// <typeparam name="TAttribute">Type of the attribute to find.</typeparam>
     /// <param name="attributes">The attributes to inspect.</param>
     /// <returns>The attribute that is found or null.</returns>
@@ -61,7 +66,7 @@ internal static class AttributeQueryHelper
 
         foreach (Attribute attribute in attributes)
         {
-            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+            AssertNotNull<TAttribute>(attribute);
 
             if (attribute is TAttribute attributeAsTAttribute)
             {
@@ -85,7 +90,7 @@ internal static class AttributeQueryHelper
         TAttribute? foundAttribute = null;
         foreach (Attribute attribute in attributes)
         {
-            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+            AssertNotNull<TAttribute>(attribute);
 
             if (attribute is TAttribute attributeAsTAttribute)
             {
@@ -104,15 +109,19 @@ internal static class AttributeQueryHelper
     /// <summary>
     /// Gets every attribute which is of the given type or a subtype of it.
     /// </summary>
+    /// <remarks>
+    /// Filtering is lazy, but <paramref name="attributes"/> is captured eagerly by the caller, so any argument
+    /// validation performed while resolving the attribute array happens before enumeration starts.
+    /// </remarks>
     /// <typeparam name="TAttribute">The attribute type.</typeparam>
     /// <param name="attributes">The attributes to inspect.</param>
-    /// <returns>The matching attributes.</returns>
+    /// <returns>The matching attributes, in declaration order.</returns>
     public static IEnumerable<TAttribute> GetAttributes<TAttribute>(Attribute[] attributes)
         where TAttribute : Attribute
     {
         foreach (Attribute attribute in attributes)
         {
-            DebugEx.Assert(attribute is not null, NullAttributeMessage);
+            AssertNotNull<TAttribute>(attribute);
 
             if (attribute is TAttribute attributeAsTAttribute)
             {
@@ -120,4 +129,35 @@ internal static class AttributeQueryHelper
             }
         }
     }
+
+    /// <summary>
+    /// Invokes <paramref name="action"/> for every attribute which is of the given type or a subtype of it.
+    /// </summary>
+    /// <remarks>
+    /// This is the allocation-free counterpart of <see cref="GetAttributes{TAttribute}"/>: it avoids the iterator
+    /// state machine that enumerating the returned sequence would allocate.
+    /// </remarks>
+    /// <typeparam name="TAttribute">The attribute type.</typeparam>
+    /// <typeparam name="TState">The type of state to be passed to <paramref name="action"/>.</typeparam>
+    /// <param name="attributes">The attributes to inspect.</param>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="state">The state to pass to <paramref name="action"/>.</param>
+    public static void PerformActionOnAttribute<TAttribute, TState>(Attribute[] attributes, Action<TAttribute, TState?> action, TState? state)
+        where TAttribute : Attribute
+    {
+        foreach (Attribute attribute in attributes)
+        {
+            AssertNotNull<TAttribute>(attribute);
+
+            if (attribute is TAttribute attributeAsTAttribute)
+            {
+                action(attributeAsTAttribute, state);
+            }
+        }
+    }
+
+    [Conditional("DEBUG")]
+    private static void AssertNotNull<TAttribute>(Attribute attribute)
+        where TAttribute : Attribute
+        => DebugEx.Assert(attribute is not null, $"{nameof(AttributeQueryHelper)}: internal error: null entry in the attributes array while looking for '{typeof(TAttribute)}'.");
 }

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -164,18 +164,7 @@ internal class ReflectHelper
     /// <param name="state">The state to pass to action.</param>
     internal static void PerformActionOnAttribute<TAttributeType, TState>(ICustomAttributeProvider attributeProvider, Action<TAttributeType, TState?> action, TState? state)
         where TAttributeType : Attribute
-    {
-        Attribute[] attributes = GetCustomAttributesCached(attributeProvider);
-        foreach (Attribute attribute in attributes)
-        {
-            DebugEx.Assert(attribute != null, "ReflectHelper.DefinesAttributeDerivedFrom: internal error: wrong value in the attributes dictionary.");
-
-            if (attribute is TAttributeType attributeAsAttributeType)
-            {
-                action(attributeAsAttributeType, state);
-            }
-        }
-    }
+        => AttributeQueryHelper.PerformActionOnAttribute(GetCustomAttributesCached(attributeProvider), action, state);
 
     /// <summary>
     /// Gets and caches the attributes for the given type, or method.

--- a/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Helpers/ReflectHelper.cs
@@ -35,28 +35,7 @@ internal class ReflectHelper
     /// <returns>True if the attribute of the specified type is defined.</returns>
     public virtual /* for testing */ bool IsAttributeDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        if (attributeProvider is null)
-        {
-            throw new ArgumentNullException(nameof(attributeProvider));
-        }
-
-        // Get all attributes on the member.
-        Attribute[] attributes = GetCustomAttributesCached(attributeProvider);
-
-        // Try to find the attribute that is derived from baseAttrType.
-        foreach (Attribute attribute in attributes)
-        {
-            DebugEx.Assert(attribute != null, $"{nameof(ReflectHelper)}.{nameof(GetCustomAttributesCached)}: internal error: wrong value in the attributes dictionary.");
-
-            if (attribute is TAttribute)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => AttributeQueryHelper.IsAttributeDefined<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
 #if NETFRAMEWORK
     /// <summary>
@@ -79,25 +58,7 @@ internal class ReflectHelper
     /// <returns>The attribute that is found or null.</returns>
     public virtual /* for tests, for moq */ TAttribute? GetFirstAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        // If the attribute is not sealed, then it can allow multiple, even if AllowMultiple is false.
-        // This happens when a derived type is also applied along with the base type.
-        // Or, if the derived type modifies the attribute usage to allow multiple.
-        // So we want to ensure this is only called for sealed attributes.
-        DebugEx.Assert(typeof(TAttribute).IsSealed, $"Expected '{typeof(TAttribute)}' to be sealed, but was not.");
-
-        Attribute[] cachedAttributes = GetCustomAttributesCached(attributeProvider);
-
-        foreach (Attribute cachedAttribute in cachedAttributes)
-        {
-            if (cachedAttribute is TAttribute cachedAttributeAsTAttribute)
-            {
-                return cachedAttributeAsTAttribute;
-            }
-        }
-
-        return null;
-    }
+        => AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Gets first attribute that matches the type or is derived from it.
@@ -110,25 +71,7 @@ internal class ReflectHelper
     /// <exception cref="InvalidOperationException">Throws when multiple attributes are found (the attribute must allow multiple).</exception>
     public virtual /* for tests, for moq */ TAttribute? GetSingleAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        Attribute[] cachedAttributes = GetCustomAttributesCached(attributeProvider);
-
-        TAttribute? foundAttribute = null;
-        foreach (Attribute cachedAttribute in cachedAttributes)
-        {
-            if (cachedAttribute is TAttribute cachedAttributeAsTAttribute)
-            {
-                if (foundAttribute is not null)
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(TAttribute)));
-                }
-
-                foundAttribute = cachedAttributeAsTAttribute;
-            }
-        }
-
-        return foundAttribute;
-    }
+        => AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Match return type of method.
@@ -209,20 +152,7 @@ internal class ReflectHelper
     /// <returns>An instance of the attribute.</returns>
     internal virtual /* for tests, for moq */ IEnumerable<TAttributeType> GetAttributes<TAttributeType>(ICustomAttributeProvider attributeProvider)
         where TAttributeType : Attribute
-    {
-        Attribute[] attributes = GetCustomAttributesCached(attributeProvider);
-
-        // Try to find the attribute that is derived from baseAttrType.
-        foreach (Attribute attribute in attributes)
-        {
-            DebugEx.Assert(attribute != null, "ReflectHelper.DefinesAttributeDerivedFrom: internal error: wrong value in the attributes dictionary.");
-
-            if (attribute is TAttributeType attributeAsAttributeType)
-            {
-                yield return attributeAsAttributeType;
-            }
-        }
-    }
+        => AttributeQueryHelper.GetAttributes<TAttributeType>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Get attribute defined on a method which is of given type of subtype of given type.

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -104,5 +104,6 @@ static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helper
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(System.Attribute![]! attributes) -> TAttribute?
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(System.Attribute![]! attributes) -> TAttribute?
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.IsAttributeDefined<TAttribute>(System.Attribute![]! attributes) -> bool
+static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.PerformActionOnAttribute<TAttribute, TState>(System.Attribute![]! attributes, System.Action<TAttribute!, TState?>! action, TState? state) -> void
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.ConfigureLiveOutputWriter(System.IO.TextWriter! liveOutputWriter) -> void
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SetLiveOutputWriterForTesting(System.IO.TextWriter! liveOutputWriter) -> System.IDisposable!

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -80,6 +80,7 @@ Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Liv
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.None = 0 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode.Result = 1 -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestOutputCaptureMode
 Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.TestRunCancellationToken.CancellationToken.get -> System.Threading.CancellationToken
+Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.SourceGeneratedReflectionDataProvider.Assembly.get -> System.Reflection.Assembly?
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardErrorBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
 Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.StandardOutputBuilder.get -> Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SynchronizedStringBuilder!
@@ -99,5 +100,9 @@ static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.Resour
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.ResourceLockInfo.Encode(Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.ResourceLockInfo! info) -> string!
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestDependencyInfo.Decode(string! encoded) -> Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestDependencyInfo!
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestDependencyInfo.Encode(Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestDependencyInfo! info) -> string!
+static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.GetAttributes<TAttribute>(System.Attribute![]! attributes) -> System.Collections.Generic.IEnumerable<TAttribute!>!
+static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(System.Attribute![]! attributes) -> TAttribute?
+static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(System.Attribute![]! attributes) -> TAttribute?
+static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers.AttributeQueryHelper.IsAttributeDefined<TAttribute>(System.Attribute![]! attributes) -> bool
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.ConfigureLiveOutputWriter(System.IO.TextWriter! liveOutputWriter) -> void
 static Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.TestContextImplementation.SetLiveOutputWriterForTesting(System.IO.TextWriter! liveOutputWriter) -> System.IDisposable!

--- a/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Services/ReflectionOperations.cs
@@ -4,8 +4,8 @@
 using System.Security;
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices;
 
@@ -108,28 +108,7 @@ internal sealed class ReflectionOperations : MarshalByRefObject, IReflectionOper
     /// <returns>True if the attribute of the specified type is defined.</returns>
     public bool IsAttributeDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        if (attributeProvider is null)
-        {
-            throw new ArgumentNullException(nameof(attributeProvider));
-        }
-
-        // Get all attributes on the member.
-        Attribute[] attributes = GetCustomAttributesCached(attributeProvider);
-
-        // Try to find the attribute that is derived from baseAttrType.
-        foreach (Attribute attribute in attributes)
-        {
-            DebugEx.Assert(attribute != null, $"{nameof(ReflectionOperations)}.{nameof(GetCustomAttributesCached)}: internal error: wrong value in the attributes dictionary.");
-
-            if (attribute is TAttribute)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => AttributeQueryHelper.IsAttributeDefined<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Returns object to be used for controlling lifetime, null means infinite lifetime.
@@ -153,25 +132,7 @@ internal sealed class ReflectionOperations : MarshalByRefObject, IReflectionOper
     /// <returns>The attribute that is found or null.</returns>
     public TAttribute? GetFirstAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        // If the attribute is not sealed, then it can allow multiple, even if AllowMultiple is false.
-        // This happens when a derived type is also applied along with the base type.
-        // Or, if the derived type modifies the attribute usage to allow multiple.
-        // So we want to ensure this is only called for sealed attributes.
-        DebugEx.Assert(typeof(TAttribute).IsSealed, $"Expected '{typeof(TAttribute)}' to be sealed, but was not.");
-
-        Attribute[] cachedAttributes = GetCustomAttributesCached(attributeProvider);
-
-        foreach (Attribute cachedAttribute in cachedAttributes)
-        {
-            if (cachedAttribute is TAttribute cachedAttributeAsTAttribute)
-            {
-                return cachedAttributeAsTAttribute;
-            }
-        }
-
-        return null;
-    }
+        => AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Gets first attribute that matches the type or is derived from it.
@@ -184,25 +145,7 @@ internal sealed class ReflectionOperations : MarshalByRefObject, IReflectionOper
     /// <exception cref="InvalidOperationException">Throws when multiple attributes are found (the attribute must allow multiple).</exception>
     public TAttribute? GetSingleAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        Attribute[] cachedAttributes = GetCustomAttributesCached(attributeProvider);
-
-        TAttribute? foundAttribute = null;
-        foreach (Attribute cachedAttribute in cachedAttributes)
-        {
-            if (cachedAttribute is TAttribute cachedAttributeAsTAttribute)
-            {
-                if (foundAttribute is not null)
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(TAttribute)));
-                }
-
-                foundAttribute = cachedAttributeAsTAttribute;
-            }
-        }
-
-        return foundAttribute;
-    }
+        => AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Get attribute defined on a method which is of given type of subtype of given type.
@@ -212,20 +155,7 @@ internal sealed class ReflectionOperations : MarshalByRefObject, IReflectionOper
     /// <returns>An instance of the attribute.</returns>
     public IEnumerable<TAttributeType> GetAttributes<TAttributeType>(ICustomAttributeProvider attributeProvider)
         where TAttributeType : Attribute
-    {
-        Attribute[] attributes = GetCustomAttributesCached(attributeProvider);
-
-        // Try to find the attribute that is derived from baseAttrType.
-        foreach (Attribute attribute in attributes)
-        {
-            DebugEx.Assert(attribute != null, "ReflectionOperations.DefinesAttributeDerivedFrom: internal error: wrong value in the attributes dictionary.");
-
-            if (attribute is TAttributeType attributeAsAttributeType)
-            {
-                yield return attributeAsAttributeType;
-            }
-        }
-    }
+        => AttributeQueryHelper.GetAttributes<TAttributeType>(GetCustomAttributesCached(attributeProvider));
 
     /// <summary>
     /// Gets and caches the attributes for the given type, or method.

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
 
 namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration;
@@ -293,55 +294,19 @@ internal sealed class SourceGeneratedReflectionOperations : IReflectionOperation
 
     public bool IsAttributeDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        foreach (Attribute attr in GetCustomAttributesCached(attributeProvider))
-        {
-            if (attr is TAttribute)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => AttributeQueryHelper.IsAttributeDefined<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public TAttribute? GetFirstAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        foreach (Attribute attr in GetCustomAttributesCached(attributeProvider))
-        {
-            if (attr is TAttribute match)
-            {
-                return match;
-            }
-        }
-
-        return null;
-    }
+        => AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public TAttribute? GetSingleAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        TAttribute? first = null;
-        foreach (Attribute attr in GetCustomAttributesCached(attributeProvider))
-        {
-            if (attr is TAttribute match)
-            {
-                if (first is not null)
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Found multiple attributes of type '{0}' when only one was expected.", typeof(TAttribute)));
-                }
-
-                first = match;
-            }
-        }
-
-        return first;
-    }
+        => AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public IEnumerable<TAttributeType> GetAttributes<TAttributeType>(ICustomAttributeProvider attributeProvider)
         where TAttributeType : Attribute
-        => GetCustomAttributesCached(attributeProvider).OfType<TAttributeType>();
+        => AttributeQueryHelper.GetAttributes<TAttributeType>(GetCustomAttributesCached(attributeProvider));
 
     public Attribute[] GetCustomAttributesCached(ICustomAttributeProvider attributeProvider)
         => attributeProvider is null

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/AttributeQueryHelperTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Helpers/AttributeQueryHelperTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
+
+using TestFramework.ForTestingMSTest;
+
+namespace MSTestAdapter.PlatformServices.UnitTests.Helpers;
+
+/// <summary>
+/// Direct tests for <see cref="AttributeQueryHelper"/>, the single source of truth for the attribute-query
+/// semantics shared by every <c>IReflectionOperations</c> implementation and by <c>ReflectHelper</c>.
+/// </summary>
+public sealed class AttributeQueryHelperTests : TestContainer
+{
+    private static readonly Attribute[] EmptyAttributes = [];
+
+    public void IsAttributeDefinedReturnsFalseForEmptyAttributes()
+        => AttributeQueryHelper.IsAttributeDefined<BaseAttribute>(EmptyAttributes).Should().BeFalse();
+
+    public void IsAttributeDefinedMatchesDerivedAttribute()
+    {
+        Attribute[] attributes = [new UnrelatedAttribute(), new DerivedAttribute()];
+
+        AttributeQueryHelper.IsAttributeDefined<BaseAttribute>(attributes).Should().BeTrue();
+    }
+
+    public void IsAttributeDefinedReturnsFalseWhenNoAttributeMatches()
+    {
+        Attribute[] attributes = [new UnrelatedAttribute()];
+
+        AttributeQueryHelper.IsAttributeDefined<BaseAttribute>(attributes).Should().BeFalse();
+    }
+
+    public void GetFirstAttributeOrDefaultReturnsNullForEmptyAttributes()
+        => AttributeQueryHelper.GetFirstAttributeOrDefault<DerivedAttribute>(EmptyAttributes).Should().BeNull();
+
+    public void GetFirstAttributeOrDefaultReturnsFirstMatchInDeclarationOrder()
+    {
+        var first = new DerivedAttribute();
+        var second = new DerivedAttribute();
+        Attribute[] attributes = [new UnrelatedAttribute(), first, second];
+
+        AttributeQueryHelper.GetFirstAttributeOrDefault<DerivedAttribute>(attributes).Should().BeSameAs(first);
+    }
+
+    public void GetSingleAttributeOrDefaultReturnsNullForEmptyAttributes()
+        => AttributeQueryHelper.GetSingleAttributeOrDefault<BaseAttribute>(EmptyAttributes).Should().BeNull();
+
+    public void GetSingleAttributeOrDefaultMatchesDerivedAttribute()
+    {
+        var derived = new DerivedAttribute();
+        Attribute[] attributes = [new UnrelatedAttribute(), derived];
+
+        AttributeQueryHelper.GetSingleAttributeOrDefault<BaseAttribute>(attributes).Should().BeSameAs(derived);
+    }
+
+    public void GetSingleAttributeOrDefaultThrowsLocalizedErrorWhenMultipleAttributesMatch()
+    {
+        Attribute[] attributes = [new DerivedAttribute(), new DerivedAttribute()];
+
+        Action action = () => AttributeQueryHelper.GetSingleAttributeOrDefault<BaseAttribute>(attributes);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage(string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(BaseAttribute)));
+    }
+
+    public void GetSingleAttributeOrDefaultThrowsOnSecondMatchEvenWhenMoreFollow()
+    {
+        Attribute[] attributes = [new DerivedAttribute(), new DerivedAttribute(), new DerivedAttribute()];
+
+        Action action = () => AttributeQueryHelper.GetSingleAttributeOrDefault<BaseAttribute>(attributes);
+
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    public void GetAttributesReturnsEmptyForEmptyAttributes()
+        => AttributeQueryHelper.GetAttributes<BaseAttribute>(EmptyAttributes).Should().BeEmpty();
+
+    public void GetAttributesReturnsMatchesInDeclarationOrderIncludingDerived()
+    {
+        var derived = new DerivedAttribute();
+        var @base = new BaseAttribute();
+        Attribute[] attributes = [new UnrelatedAttribute(), derived, new UnrelatedAttribute(), @base];
+
+        AttributeQueryHelper.GetAttributes<BaseAttribute>(attributes).Should().Equal(derived, @base);
+    }
+
+    public void PerformActionOnAttributeInvokesActionForEachMatchWithState()
+    {
+        var derived = new DerivedAttribute();
+        var @base = new BaseAttribute();
+        Attribute[] attributes = [new UnrelatedAttribute(), derived, @base];
+        List<BaseAttribute> seen = [];
+
+        AttributeQueryHelper.PerformActionOnAttribute<BaseAttribute, List<BaseAttribute>>(
+            attributes,
+            static (attribute, state) => state!.Add(attribute),
+            seen);
+
+        seen.Should().Equal(derived, @base);
+    }
+
+    public void PerformActionOnAttributeDoesNotInvokeActionWhenNoAttributeMatches()
+    {
+        Attribute[] attributes = [new UnrelatedAttribute()];
+        int callCount = 0;
+
+        AttributeQueryHelper.PerformActionOnAttribute<BaseAttribute, object>(
+            attributes,
+            (_, _) => callCount++,
+            null);
+
+        callCount.Should().Be(0);
+    }
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    private class BaseAttribute : Attribute;
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    private sealed class DerivedAttribute : BaseAttribute;
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    private sealed class UnrelatedAttribute : Attribute;
+}

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/ReflectionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Services/ReflectionOperationsTests.cs
@@ -511,6 +511,15 @@ public class ReflectionOperationsTests : TestContainer
         action.Should().Throw<ArgumentNullException>().WithParameterName("attributeProvider");
     }
 
+    public void GetAttributesShouldValidateProviderEagerlyWithoutEnumerating()
+    {
+        // GetAttributes resolves the attribute array eagerly and only defers the filtering, so
+        // argument validation surfaces at call time rather than on the first MoveNext.
+        var rh = new ReflectionOperations();
+        Action action = () => _ = rh.GetAttributes<DummyAAttribute>(null!);
+        action.Should().Throw<ArgumentNullException>().WithParameterName("attributeProvider");
+    }
+
     public void GetCustomAttributesCachedShouldThrowWhenProviderIsNull()
     {
         var rh = new ReflectionOperations();

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration;
 
 using TestFramework.ForTestingMSTest;
@@ -214,6 +215,25 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
         operations.GetFirstAttributeOrDefault<DerivedMarkerAttribute>(method).Should().BeSameAs(generated);
         operations.GetSingleAttributeOrDefault<MarkerAttribute>(method).Should().BeSameAs(generated);
         operations.GetAttributes<MarkerAttribute>(method).Should().ContainSingle().Which.Should().BeSameAs(generated);
+    }
+
+    public void MethodAttributeHelpers_GetSingleAttributeOrDefault_ThrowsLocalizedErrorOnDuplicates()
+    {
+        MethodInfo method = typeof(AttributedSample).GetMethod(nameof(AttributedSample.AttributedMethod))!;
+        var provider = new SourceGeneratedReflectionDataProvider
+        {
+            TypeMethodAttributes = new Dictionary<MethodInfo, Attribute[]>
+            {
+                [method] = [new MarkerAttribute("first"), new DerivedMarkerAttribute("second")],
+            },
+        };
+        var operations = new SourceGeneratedReflectionOperations(provider);
+
+        Action action = () => operations.GetSingleAttributeOrDefault<MarkerAttribute>(method);
+
+        // Regression test for #10302: this path used to throw a hardcoded, non-localizable English message.
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage(string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(MarkerAttribute)));
     }
 
     public void CompositeProvider_MergesMethodAttributesFromMultipleProviders()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
@@ -208,7 +208,10 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
         var operations = new SourceGeneratedReflectionOperations(provider);
 
         operations.IsAttributeDefined<MarkerAttribute>(method).Should().BeTrue();
-        operations.GetFirstAttributeOrDefault<MarkerAttribute>(method).Should().BeSameAs(generated);
+
+        // GetFirstAttributeOrDefault is contractually restricted to sealed attribute types (a non-sealed
+        // type can be matched by several derived attributes), so it is queried with the sealed derived type.
+        operations.GetFirstAttributeOrDefault<DerivedMarkerAttribute>(method).Should().BeSameAs(generated);
         operations.GetSingleAttributeOrDefault<MarkerAttribute>(method).Should().BeSameAs(generated);
         operations.GetAttributes<MarkerAttribute>(method).Should().ContainSingle().Which.Should().BeSameAs(generated);
     }

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/MockableReflectionOperations.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/TestableImplementations/MockableReflectionOperations.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface;
-using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 
 using Moq;
 
@@ -61,41 +61,24 @@ internal sealed class MockableReflectionOperations(Mock<IReflectionOperations> m
     public Action<object?, object?>? GetPropertySetter(PropertyInfo property)
         => mock.Object.GetPropertySetter(property);
 
-    // Higher-level generic methods → filter results from mock's GetCustomAttributes
+    // Higher-level generic methods → filter results from mock's GetCustomAttributes using the
+    // same production logic, so that matching semantics and the error message raised on duplicate
+    // attributes match what callers would see at runtime.
     public bool IsAttributeDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-        => GetCustomAttributesCached(attributeProvider).OfType<TAttribute>().Any();
+        => AttributeQueryHelper.IsAttributeDefined<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public TAttribute? GetFirstAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-        => GetCustomAttributesCached(attributeProvider).OfType<TAttribute>().FirstOrDefault();
+        => AttributeQueryHelper.GetFirstAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public TAttribute? GetSingleAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
         where TAttribute : Attribute
-    {
-        // Mirror the production ReflectionOperations implementation so that the error
-        // message on duplicate attributes matches what callers would see at runtime.
-        TAttribute? found = null;
-        foreach (Attribute attr in GetCustomAttributesCached(attributeProvider))
-        {
-            if (attr is TAttribute match)
-            {
-                if (found is not null)
-                {
-                    throw new InvalidOperationException(
-                        string.Format(CultureInfo.InvariantCulture, Resource.DuplicateAttributeError, typeof(TAttribute)));
-                }
-
-                found = match;
-            }
-        }
-
-        return found;
-    }
+        => AttributeQueryHelper.GetSingleAttributeOrDefault<TAttribute>(GetCustomAttributesCached(attributeProvider));
 
     public IEnumerable<TAttributeType> GetAttributes<TAttributeType>(ICustomAttributeProvider attributeProvider)
         where TAttributeType : Attribute
-        => GetCustomAttributesCached(attributeProvider).OfType<TAttributeType>();
+        => AttributeQueryHelper.GetAttributes<TAttributeType>(GetCustomAttributesCached(attributeProvider));
 
     // Note: no caching by design — each call re-queries the mock so that test setups
     // can change the returned attributes between calls without needing to clear a cache.


### PR DESCRIPTION
Fixes #10302

## Problem

Four attribute-query methods — `IsAttributeDefined<T>`, `GetFirstAttributeOrDefault<T>`, `GetSingleAttributeOrDefault<T>` and `GetAttributes<T>` — were hand-rolled in **four** places: `ReflectionOperations`, `SourceGeneratedReflectionOperations`, `ReflectHelper` and the unit-test double `MockableReflectionOperations`. The copies had already drifted:

- `SourceGeneratedReflectionOperations.GetSingleAttributeOrDefault` threw with a **hardcoded English string** instead of the localized `Resource.DuplicateAttributeError`, so users on the source-generated path got a non-localized message.
- The same method was missing the sealed-attribute precondition assert that `GetFirstAttributeOrDefault` has on the reflection path.
- `ReflectHelper.PerformActionOnAttribute` carried a stale assert message referencing `ReflectHelper.DefinesAttributeDerivedFrom`, a method that does not exist.

## Fix

Extract the filtering policy into a single `internal static AttributeQueryHelper` that operates on an already-resolved `Attribute[]`. Every previous copy becomes a one-line delegation, so acquisition/caching stays per-implementation while the query semantics — including the localized duplicate-attribute error — live in exactly one place.

Both alternatives suggested in the issue are unavailable here:
- **Default interface implementations** — the project multi-targets `netstandard2.0`, `net462` and `uap10.0`, none of which support DIM.
- **Shared abstract base class** — `ReflectionOperations` already derives from `MarshalByRefObject`.

The interface members are deliberately kept so `SourceGeneratedReflectionOperations` retains the ability to specialize these queries (e.g. answering `IsAttributeDefined<T>` from a compile-time type set without materializing the full array, which would close the `AreAttributesComplete == false` gap for async test methods).

## Behavior changes

- **Localized error on the source-generated path.** `GetSingleAttributeOrDefault` now throws `Resource.DuplicateAttributeError` everywhere.
- **`GetAttributes<T>` resolves the attribute array eagerly.** It used to be a `yield return` iterator in `ReflectionOperations` and `ReflectHelper`, so `GetCustomAttributesCached` (and its `ArgumentNullException`) was deferred to the first `MoveNext()`. Filtering is still lazy; only argument validation moves to call time. This matches what `SourceGeneratedReflectionOperations` already did and matches .NET argument-validation guidelines. All existing callers enumerate immediately.
- **The sealed-attribute assert now applies to all paths.** `DebugEx.Assert(typeof(TAttribute).IsSealed, …)` is DEBUG-only, but on .NET Framework DEBUG it calls `Environment.FailFast`. Every existing call site was audited repo-wide — the only type arguments used are `AsyncStateMachineAttribute`, `TimeoutAttribute`, `ClassInitializeAttribute`, `ClassCleanupAttribute`, `DummySealedAttribute` and `DerivedMarkerAttribute`, all sealed. The contract is now documented on the method.
- Redundant `ArgumentNullException` pre-checks were dropped from `IsAttributeDefined`; all four `GetCustomAttributesCached` implementations already throw the same exception with the same parameter name.

No behavior change in Release builds beyond the localized message: `DebugEx.Assert` is `[Conditional("DEBUG")]`, so the asserts and their argument expressions are compiled out.

## Tests

- New `AttributeQueryHelperTests` — 13 tests covering empty input, derived-type matching, declaration order, duplicate detection (including the exact localized message), and the allocation-free `PerformActionOnAttribute` overload.
- New regression test pinning the localized `DuplicateAttributeError` on `SourceGeneratedReflectionOperations.GetSingleAttributeOrDefault`.
- New test pinning the eager argument validation of `GetAttributes`.
- `MethodAttributeHelpers_UseRegisteredAttributes` now queries `GetFirstAttributeOrDefault<DerivedMarkerAttribute>` (sealed) instead of the non-sealed base; the adjacent assertions still cover derived-instance-matches-base for the other three methods.

All green on both .NET and .NET Framework:

| Suite | net9.0 / net8.0 | net462 / net472 |
| --- | --- | --- |
| `MSTestAdapter.PlatformServices.UnitTests` | 1054 ✅ | 1096 ✅ |
| `MSTestAdapter.UnitTests` | 61 ✅ | 61 ✅ |
| `MSTest.Analyzers.UnitTests` (runs on the real Debug adapter) | 1599 ✅ | 1568 ✅ |
| `MSTest.SelfRealExamples.UnitTests` | 9 ✅ | 9 ✅ |

Build is clean (0 warnings) across all six target frameworks, including the internal-API analyzer.