### PR TITLE
Complete MSTEST0077 test coverage: [DoNotParallelize] opt-out and remaining Directory.* allowlist entries

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -737,7 +737,9 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     public async Task WhenTestMethodSetsDirectoryTimestampWithConstantPath_Diagnostic(string methodName)
     {
         // The Directory.Set*Time* family rewrites the metadata of the entry named by 'path'. That is a mutation two
-        // parallel tests can interleave on, so every member of the allowlist arm must fire on a constant path.
+        // parallel tests can interleave on, so every member of the allowlist arm must fire on a constant path. The
+        // timestamp value is irrelevant here - only string-typed parameters are inspected - so 'default' keeps the
+        // snippet neutral between the local-time and the *Utc members.
         string code = $$"""
             using System;
             using System.IO;
@@ -751,7 +753,7 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
                 [TestMethod]
                 public void MyTestMethod()
                 {
-                    {|#0:Directory.{{methodName}}("shared-dir", DateTime.Now)|};
+                    {|#0:Directory.{{methodName}}("shared-dir", default(DateTime))|};
                 }
             }
             """;

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -647,7 +647,9 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     {
         // The Directory.* allowlist must stay as narrow as the File.* one: enumerating or probing a shared directory
         // at a fixed path does not mutate it, so the delete/move coverage above is pinned from both directions.
+        // 'Directory.GetLastWriteTime' additionally pins the Get*/Set* asymmetry: only the Set*Time* family mutates.
         string code = """
+            using System;
             using System.IO;
             using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -661,10 +663,189 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
                 {
                     bool exists = Directory.Exists("shared-dir");
                     string[] files = Directory.GetFiles("shared-dir");
+                    DateTime lastWrite = Directory.GetLastWriteTime("shared-dir");
                 }
             }
             """;
 
         await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodCreatesDirectorySymbolicLinkWithConstantPath_Diagnostic()
+    {
+        // Directory.CreateSymbolicLink creates the entry named by 'path', so a constant link path collides with any
+        // other test creating the same link.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string target = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    {|#0:Directory.CreateSymbolicLink("shared-link", target)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("shared-link"));
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodCreatesDirectorySymbolicLinkToConstantTarget_NoDiagnostic()
+    {
+        // Only 'path' is created by Directory.CreateSymbolicLink; 'pathToTarget' merely names an existing directory
+        // the link points at, so a constant target - like a shared fixture directory - must not be flagged.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string link = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    Directory.CreateSymbolicLink(link, "shared-fixture-dir");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    [DataRow("SetCreationTime")]
+    [DataRow("SetCreationTimeUtc")]
+    [DataRow("SetLastAccessTime")]
+    [DataRow("SetLastAccessTimeUtc")]
+    [DataRow("SetLastWriteTime")]
+    [DataRow("SetLastWriteTimeUtc")]
+    public async Task WhenTestMethodSetsDirectoryTimestampWithConstantPath_Diagnostic(string methodName)
+    {
+        // The Directory.Set*Time* family rewrites the metadata of the entry named by 'path'. That is a mutation two
+        // parallel tests can interleave on, so every member of the allowlist arm must fire on a constant path.
+        string code = $$"""
+            using System;
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    {|#0:Directory.{{methodName}}("shared-dir", DateTime.Now)|};
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("shared-dir"));
+    }
+
+    [TestMethod]
+    public async Task WhenDoNotParallelizeDeclared_NoDiagnostic()
+    {
+        // A class-level [DoNotParallelize] runs every test of the class in the sequential phase, so no other test can
+        // be touching the same path at the same time and the collision risk the rule reports about disappears.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            [DoNotParallelize]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    File.WriteAllText("shared.txt", "data");
+                    File.Delete("shared.txt");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenTestMethodHasMethodLevelDoNotParallelize_NoDiagnostic()
+    {
+        // A method-level [DoNotParallelize] is honored by discovery for real test methods, so it opts the mutation out
+        // of the parallel phase just as the class-level attribute does.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [DoNotParallelize]
+                public void MyTestMethod()
+                {
+                    File.Delete("shared.txt");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenFixtureMethodHasMethodLevelDoNotParallelize_Diagnostic()
+    {
+        // [DoNotParallelize] on a fixture method is ignored at runtime - only test methods carry the flag through
+        // discovery - so it must not silence a constant-path mutation inside [TestInitialize].
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                [DoNotParallelize]
+                public void Setup()
+                {
+                    {|#0:File.WriteAllText("setup.txt", "data")|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("setup.txt"));
     }
 }


### PR DESCRIPTION
Fixes #10305.

Closes the two coverage gaps `SharedFileSystemPathInTestAnalyzerTests` had left after the delete/move path-role PR. Test-only change; no production code touched.

### 1. `[DoNotParallelize]` opt-out

`SharedFileSystemPathInTestAnalyzer` bails out via `ParallelSafetyHelper.IsOptedOutOfParallelization` before reporting, and that branch was entirely untested for MSTEST0077. Three tests now pin it, matching the naming convention already used by `CurrentDirectoryMutation…` / `CultureMutation…` / `UndeclaredProcessGlobalStateMutation…`:

- `WhenDoNotParallelizeDeclared_NoDiagnostic` — class-level attribute, exercising the containing/base-type walk.
- `WhenTestMethodHasMethodLevelDoNotParallelize_NoDiagnostic` — method-level attribute on a real test method.
- `WhenFixtureMethodHasMethodLevelDoNotParallelize_Diagnostic` — pins the same conjunction from the other side: `[DoNotParallelize]` on a `[TestInitialize]` is ignored at runtime (only test methods carry the flag through discovery), so it must **not** silence a constant-path mutation.

Together these pin `IsTestMethod(...) && MethodHasInheritedAttribute(...)` from both directions — dropping the `IsTestMethod` guard breaks the third test, dropping the whole method-level check breaks the second.

Per the note on the issue, **no `[ResourceLock]` test was added**: MSTEST0077 never calls `HasResourceLockFor`/`HasAnyResourceLock`, so such a test would assert behavior this rule does not have.

### 2. Remaining `Directory.*` allowlist entries

- `Directory.CreateSymbolicLink` — a positive test for the created `path`, plus a negative test proving a constant `pathToTarget` is **not** flagged (the link target is only read, so pointing at a shared fixture directory is safe). The negative test is discriminating: adding `pathToTarget` to `IsMutatedPathParameter` would fail it.
- The six-member `Directory.Set*Time*` family — one `[DataRow]`-driven test covering `SetCreationTime(Utc)`, `SetLastAccessTime(Utc)`, and `SetLastWriteTime(Utc)`, an exact match for the directory arm of `IsMutatingFileSystemMethod`.
- `Directory.GetLastWriteTime` added to the existing `WhenTestMethodReadsConstantDirectoryPath_NoDiagnostic` to pin the `Get*`/`Set*` asymmetry from the other direction.

The `Directory.*` arm is now fully pinned: `CreateDirectory`, `CreateSymbolicLink`, `Delete`, `Move`, and all six `Set*Time*` members.

### Follow-up

The `File.*` arm still has unpinned entries — including the exact mirrors of what this PR adds (`File.CreateSymbolicLink`, the `File.Set*Time*` family) plus the write/append/attribute members. That is outside #10305's stated scope, so it is tracked separately in #10316 rather than silently inherited.

### Validation

Reviewed by three independent passes (diff review, gap analysis, MSTest expert review); the one actionable nit — passing `DateTime.Now` to the `*Utc` members in the shared snippet — is fixed in the second commit by using a neutral `default(DateTime)`.

`MSTest.Analyzers.UnitTests --filter FullyQualifiedName~SharedFileSystemPathInTestAnalyzerTests`: **35/35 pass on both `net8.0` and `net472`**, build clean with 0 warnings.

Note that `Directory.CreateSymbolicLink` is .NET 6+ but needs no `#if` guard: the analyzer test harness resolves snippets against `ReferenceAssemblies.Net.Net80` on both TFM legs (the verifier's `#if NET462` branch never activates, since the project targets `net472`). Confirmed empirically by the passing `net472` run.