### PR TITLE
Move OneLocBuild into its own stage so loc failures don't block publishing

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -271,7 +271,21 @@ extends:
                   ArtifactName: TestResults_Linux_Attempt$(System.JobAttempt)
                 condition: always()
 
-      - ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
+    # Localization runs in its own stage rather than as a job of `build`.
+    # OneLocBuild hands the resource strings off to the loc service and then opens a PR back into
+    # microsoft/testfx using the shared dnceng `BotAccount-dotnet-bot-repo-PAT` secret. That check-in
+    # step can fail for reasons unrelated to the product (for example the "Microsoft Open Source"
+    # GitHub enterprise rejecting the shared classic PAT). While it was a job of `build`, such a
+    # failure failed the whole stage, which skipped the post-build `Validate Build Assets` and
+    # `Publish using Darc` stages (both depend on `build`) and silently stopped official publishing.
+    # Nothing that ships depends on the loc PR, so the stage stands alone: a break still turns the
+    # build red, but it no longer blocks publishing. Mirrors the dotnet/runtime layout.
+    # See https://github.com/microsoft/testfx/issues/10322 for the current PAT policy breakage.
+    - ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
+      - stage: Localization
+        # OneLocBuild only needs the sources, so it can run in parallel with `build`.
+        dependsOn: []
+        jobs:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self
           parameters:
             GitHubOrg: microsoft


### PR DESCRIPTION
Fixes the fallout of the broken loc build in [Run 20260729.6](https://dnceng.visualstudio.com/internal/_build/results?buildId=3034270&view=results). Tracked by #10322.

## What's broken

Every `main` run of the official pipeline has failed since **20260728.11** (2026-07-28 ~16:23 UTC). Windows, Linux, SDL and Publish Assets all pass — the only red leg is `OneLocBuild`. The localization build itself succeeds (`LocPayload.json` is generated); it dies at the first GitHub API call of the check-in step:

```
Octokit.ForbiddenException: The 'Microsoft Open Source' enterprise forbids access via a personal
access tokens (classic) if the token's lifetime is greater than 8 days.
```

The credential is `$(BotAccount-dotnet-bot-repo-PAT)`, the default `GithubPat` for `eng/common/core-templates/job/onelocbuild.yml`. It is a Key Vault backed secret exposed through the dnceng-owned `OneLocBuildVariables` group, so **this repo cannot fix the auth**. `dotnet`-org repos using the same secret are still green (`dotnet-roslyn-official` 20260729.1/.2, `dotnet-sdk-official-ci` 20260728.12) — we target `GitHubOrg: microsoft`, and the `microsoft` org is in the *Microsoft Open Source* enterprise whose token policy now rejects long-lived classic PATs.

## Why it matters more than it should

`OneLocBuild` was a job of the `build` stage, so its failure failed the stage. The post-build `Validate Build Assets` and `Publish using Darc` stages both depend on `build`, so both have been **skipped on every run since 2026-07-28**. Official asset publishing has been stopped by a job that only opens a translation PR.

## The change

Move the job into a standalone `Localization` stage with `dependsOn: []` — the same layout [dotnet/runtime](https://github.com/dotnet/runtime/blob/main/eng/pipelines/runtime-official.yml) uses. It still runs on `main` only, still runs in parallel so the pipeline is no slower, and a loc break still surfaces as a red stage. It just no longer gates validation and publishing.

This does not make the check-in work again; that needs dnceng to replace the shared PAT with something the enterprise policy accepts (a classic PAT with a lifetime of 8 days or less, a fine-grained PAT, or a GitHub App token). See #10322.

## Validation

- YAML parses and the stage graph is as intended: `build` (implicit first), `Localization` (`dependsOn: []`), post-build `Validate` (`dependsOn: [build]`) then `publish_using_darc`. The loc stage sits outside the publish chain.
- An Azure DevOps dry run with modified YAML was attempted but requires `EditBuild` on definition 1218, which I don't have.