### PR TITLE
Simplify array initialization in TestDependencyGraph

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.ChunkBuilding.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.ChunkBuilding.cs
@@ -25,7 +25,7 @@ internal sealed partial class TestDependencyGraph
     {
         projectionCycleTests = null;
 
-        // -1 marks "not scheduled in the parallel phase", which is what the edge projection below tests for.
+        // Tests not scheduled in the parallel phase keep -1: the edge projection below relies on that to skip them.
         int[] chunkOfTest = new int[tests.Length];
         chunkOfTest.AsSpan().Fill(-1);
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.ChunkBuilding.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.ChunkBuilding.cs
@@ -24,11 +24,10 @@ internal sealed partial class TestDependencyGraph
         out List<int>? projectionCycleTests)
     {
         projectionCycleTests = null;
+
+        // -1 marks "not scheduled in the parallel phase", which is what the edge projection below tests for.
         int[] chunkOfTest = new int[tests.Length];
-        for (int i = 0; i < chunkOfTest.Length; i++)
-        {
-            chunkOfTest[i] = -1;
-        }
+        chunkOfTest.AsSpan().Fill(-1);
 
         var chunkMembers = new List<List<int>>();
         if (scope == ExecutionScope.ClassLevel)

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.SequentialSet.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.SequentialSet.cs
@@ -19,11 +19,7 @@ internal sealed partial class TestDependencyGraph
         bool[] isSequential = new bool[tests.Length];
         if (!parallelizationEnabled)
         {
-            for (int i = 0; i < isSequential.Length; i++)
-            {
-                isSequential[i] = true;
-            }
-
+            isSequential.AsSpan().Fill(true);
             return isSequential;
         }
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.cs
@@ -154,11 +154,7 @@ internal sealed partial class TestDependencyGraph
         (int[][] testPrerequisites, bool[] proceedOnFailure) = ResolveEdges(tests, warnings);
 
         string?[] cycleMessageByTest = FindCycles(testPrerequisites, tests, errors);
-        bool[] isBroken = new bool[tests.Length];
-        for (int i = 0; i < tests.Length; i++)
-        {
-            isBroken[i] = cycleMessageByTest[i] is not null;
-        }
+        bool[] isBroken = Array.ConvertAll(cycleMessageByTest, cycleMessage => cycleMessage is not null);
 
         // A test in a cycle cannot be ordered, so it is dropped from scheduling and reported as failed, with
         // the description of the cycle *it* is in. Its dependents keep the edge: at run time the prerequisite

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/TestDependencyGraph.cs
@@ -154,7 +154,7 @@ internal sealed partial class TestDependencyGraph
         (int[][] testPrerequisites, bool[] proceedOnFailure) = ResolveEdges(tests, warnings);
 
         string?[] cycleMessageByTest = FindCycles(testPrerequisites, tests, errors);
-        bool[] isBroken = Array.ConvertAll(cycleMessageByTest, cycleMessage => cycleMessage is not null);
+        bool[] isBroken = Array.ConvertAll(cycleMessageByTest, static cycleMessage => cycleMessage is not null);
 
         // A test in a cycle cannot be ordered, so it is dropped from scheduling and reported as failed, with
         // the description of the cycle *it* is in. Its dependents keep the edge: at run time the prerequisite

--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -37,7 +37,8 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />
-    <!-- Span/MemoryMarshal used by the linked XxHash code below live in System.Memory on these TFMs.
+    <!-- Span/MemoryMarshal used by the linked XxHash code below, and Span<T>.Fill used by
+         Execution\TestDependencyGraph.*, live in System.Memory on these TFMs.
          Referenced explicitly so the compiled assembly binds the System.Memory assembly version 4.0.5.0
          (see SystemMemoryVersion in Directory.Packages.props) instead of the transitive 4.5.5 (4.0.1.2). -->
     <PackageReference Include="System.Memory" Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == '$(NetFrameworkMinimum)' OR '$(TargetFramework)' == '$(UwpMinimum)' " />


### PR DESCRIPTION
Fixes #10319.

The issue proposed replacing three hand-rolled array-initialization loops in `TestDependencyGraph` with BCL calls. Two of the three suggestions used `Array.Fill`, which **does not compile** in this project:

```
error CS0117: 'Array' does not contain a definition for 'Fill'
  [MSTestAdapter.PlatformServices.csproj::TargetFramework=net462]
```

`MSTestAdapter.PlatformServices` multi-targets `net462`, `net8.0`, `net9.0`, `uap10.0.16299`, `net9.0-windows10.0.17763.0` and `net8.0-windows10.0.18362.0`. `Array.Fill` is .NET Core 2.0 / netstandard2.1 and up, so it is missing on `net462` and `uap10.0.16299`.

## What this does instead

`Span<T>.Fill` is used via `array.AsSpan().Fill(value)`. It resolves on every TFM: modern ones have it in the framework, and the down-level ones get it from the `System.Memory` package reference this project **already** has for exactly those TFMs. On modern TFMs `Array.Fill` itself just delegates to `Span<T>.Fill`, so the codegen is the same — without needing `#if` noise or a new polyfill.

| File | Change |
| --- | --- |
| `TestDependencyGraph.cs` | `Array.ConvertAll` to build `isBroken[]` |
| `TestDependencyGraph.ChunkBuilding.cs` | fill `chunkOfTest[]` with `-1` |
| `TestDependencyGraph.SequentialSet.cs` | fill `isSequential[]` with `true` |
| `MSTestAdapter.PlatformServices.csproj` | comment only — see below |

`Array.ConvertAll` is safe here: `cycleMessageByTest.Length == tests.Length` always holds, since `ResolveEdges` allocates `new int[tests.Length][]` and `FindCycles` allocates `new string?[prerequisites.Length]`.

The csproj change is comment-only. The existing comment named the linked XxHash code as the sole reason for the `System.Memory` reference. That code is a cross-project `<Compile Include>` of another component's source, so if it were ever un-linked, someone could reasonably drop the now-"unused" package reference and break the `net462`/`uap` builds. The comment now also names the new first-party usage.

## Validation

- Full 6-TFM build of `MSTestAdapter.PlatformServices`: **succeeded, 0 warnings, 0 errors**.
- `MSTestAdapter.PlatformServices.UnitTests` on `net9.0`: **1054/1054 passed**.
- `MSTestAdapter.PlatformServices.UnitTests` on `net462`: **1096/1096 passed** — this one matters, because it exercises the `System.Memory` 4.0.5.0 assembly binding at runtime on .NET Framework, not just at compile time.
- Confirmed the `Array.Fill` variant genuinely fails to build on `net462` before settling on `Span<T>.Fill`.

No behavior change, no public API change.