### PR TITLE
perf: cache progress summary text in TestNodeResultsState

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
@@ -27,15 +27,19 @@ internal sealed class TestNodeResultsState
     // every renderer tick (500ms for the cursor renderer, 1s for the heartbeat one), and the cursor
     // renderer additionally repaints its frame on every write to the terminal, while the running-test
     // count only changes when a test starts or completes. Formatting on every render therefore allocates
-    // a string identical to the previous one. -1 is a sentinel that never matches a real count, so the
-    // first call always formats.
+    // a string identical to the previous one. The key is the count plus both cultures that can change the
+    // result — CurrentUICulture selects the localized resource, CurrentCulture formats the number — so a
+    // hit is always byte-identical to formatting right now. The cultures start null, so the first call for
+    // each shape always formats.
     // Like _runningTasksBuffer, these fields are not synchronized: every caller is reached through
     // IProgressRenderer.OnTick/OnWrite, which TestProgressStateAwareTerminal serializes under its lock.
-    // They also assume the culture does not change mid-run, since the text cached for a given count
-    // otherwise stays pinned to the culture of the call that produced it.
-    private int _cachedFullTestsCount = -1;
+    private int _cachedFullTestsCount;
+    private CultureInfo? _cachedFullTestsCulture;
+    private CultureInfo? _cachedFullTestsUICulture;
     private string _cachedFullTestsText = string.Empty;
-    private int _cachedMoreTestsCount = -1;
+    private int _cachedMoreTestsCount;
+    private CultureInfo? _cachedMoreTestsCulture;
+    private CultureInfo? _cachedMoreTestsUICulture;
     private string _cachedMoreTestsText = string.Empty;
 
     public int Count => _testNodeProgressStates.Count;
@@ -147,14 +151,20 @@ internal sealed class TestNodeResultsState
 
     /// <summary>
     /// Returns the "N tests running" text for <paramref name="count"/>, reusing the previously
-    /// formatted string when the count is unchanged since the last call.
+    /// formatted string when the count and effective cultures are unchanged since the last call.
     /// </summary>
     private string GetFullTestsCountText(int count)
     {
-        if (_cachedFullTestsCount != count)
+        CultureInfo culture = CultureInfo.CurrentCulture;
+        CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+        if (_cachedFullTestsCount != count
+            || !ReferenceEquals(_cachedFullTestsCulture, culture)
+            || !ReferenceEquals(_cachedFullTestsUICulture, uiCulture))
         {
-            _cachedFullTestsText = string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_FullTestsCount, count);
+            _cachedFullTestsText = string.Format(culture, TerminalResources.ActiveTestsRunning_FullTestsCount, count);
             _cachedFullTestsCount = count;
+            _cachedFullTestsCulture = culture;
+            _cachedFullTestsUICulture = uiCulture;
         }
 
         return _cachedFullTestsText;
@@ -162,14 +172,20 @@ internal sealed class TestNodeResultsState
 
     /// <summary>
     /// Returns the "... N more running" text for <paramref name="count"/>, reusing the previously
-    /// formatted string when the count is unchanged since the last call.
+    /// formatted string when the count and effective cultures are unchanged since the last call.
     /// </summary>
     private string GetMoreTestsCountText(int count)
     {
-        if (_cachedMoreTestsCount != count)
+        CultureInfo culture = CultureInfo.CurrentCulture;
+        CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+        if (_cachedMoreTestsCount != count
+            || !ReferenceEquals(_cachedMoreTestsCulture, culture)
+            || !ReferenceEquals(_cachedMoreTestsUICulture, uiCulture))
         {
-            _cachedMoreTestsText = $"... {string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_MoreTestsCount, count)}";
+            _cachedMoreTestsText = $"... {string.Format(culture, TerminalResources.ActiveTestsRunning_MoreTestsCount, count)}";
             _cachedMoreTestsCount = count;
+            _cachedMoreTestsCulture = culture;
+            _cachedMoreTestsUICulture = uiCulture;
         }
 
         return _cachedMoreTestsText;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TestNodeResultsState.cs
@@ -23,6 +23,21 @@ internal sealed class TestNodeResultsState
     // Reusable buffer for GetRunningTasks — cleared and rebuilt each call to avoid per-tick list allocation.
     private readonly List<TestDetailState> _runningTasksBuffer = [];
 
+    // Caches for the two summary messages rendered on the progress row. The summaries are re-rendered on
+    // every renderer tick (500ms for the cursor renderer, 1s for the heartbeat one), and the cursor
+    // renderer additionally repaints its frame on every write to the terminal, while the running-test
+    // count only changes when a test starts or completes. Formatting on every render therefore allocates
+    // a string identical to the previous one. -1 is a sentinel that never matches a real count, so the
+    // first call always formats.
+    // Like _runningTasksBuffer, these fields are not synchronized: every caller is reached through
+    // IProgressRenderer.OnTick/OnWrite, which TestProgressStateAwareTerminal serializes under its lock.
+    // They also assume the culture does not change mid-run, since the text cached for a given count
+    // otherwise stays pinned to the culture of the call that produced it.
+    private int _cachedFullTestsCount = -1;
+    private string _cachedFullTestsText = string.Empty;
+    private int _cachedMoreTestsCount = -1;
+    private string _cachedMoreTestsText = string.Empty;
+
     public int Count => _testNodeProgressStates.Count;
 
     public void AddRunningTestNode(int id, string uid, string name, IStopwatch stopwatch) => _testNodeProgressStates[uid] = new TestDetailState(id, stopwatch, name);
@@ -62,7 +77,7 @@ internal sealed class TestNodeResultsState
             return first;
         }
 
-        _summaryDetail.Text = string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_FullTestsCount, count);
+        _summaryDetail.Text = GetFullTestsCountText(count);
         return _summaryDetail;
     }
 
@@ -114,9 +129,9 @@ internal sealed class TestNodeResultsState
             _summaryDetail.Text =
                 itemsToTake == 0
                     // Note: If itemsToTake is 0, then we only show two lines, the project summary and the number of running tests.
-                    ? string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_FullTestsCount, _runningTasksBuffer.Count)
+                    ? GetFullTestsCountText(_runningTasksBuffer.Count)
                     // If itemsToTake is larger, then we show the project summary, active tests, and the number of active tests that are not shown.
-                    : $"... {string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_MoreTestsCount, _runningTasksBuffer.Count - itemsToTake)}";
+                    : GetMoreTestsCountText(_runningTasksBuffer.Count - itemsToTake);
 
             // Truncate in-place to avoid allocating a second list/array.
             if (itemsToTake < _runningTasksBuffer.Count)
@@ -128,5 +143,35 @@ internal sealed class TestNodeResultsState
         }
 
         return _runningTasksBuffer;
+    }
+
+    /// <summary>
+    /// Returns the "N tests running" text for <paramref name="count"/>, reusing the previously
+    /// formatted string when the count is unchanged since the last call.
+    /// </summary>
+    private string GetFullTestsCountText(int count)
+    {
+        if (_cachedFullTestsCount != count)
+        {
+            _cachedFullTestsText = string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_FullTestsCount, count);
+            _cachedFullTestsCount = count;
+        }
+
+        return _cachedFullTestsText;
+    }
+
+    /// <summary>
+    /// Returns the "... N more running" text for <paramref name="count"/>, reusing the previously
+    /// formatted string when the count is unchanged since the last call.
+    /// </summary>
+    private string GetMoreTestsCountText(int count)
+    {
+        if (_cachedMoreTestsCount != count)
+        {
+            _cachedMoreTestsText = $"... {string.Format(CultureInfo.CurrentCulture, TerminalResources.ActiveTestsRunning_MoreTestsCount, count)}";
+            _cachedMoreTestsCount = count;
+        }
+
+        return _cachedMoreTestsText;
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1854,27 +1854,34 @@ public sealed class TerminalTestReporterTests
                 stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
             }
 
-            string first = state.GetSingleActiveOrSummaryTask()!.Text;
+            // Each culture is changed on its own so that both halves of the key are covered
+            // independently: changing them together would let either comparison be dropped without
+            // failing this test. The count stays at 5 throughout.
+            string enUS = state.GetSingleActiveOrSummaryTask()!.Text;
 
             // Do NOT remove these interleaved calls. TestDetailState.Text's setter ignores writes that are
             // ordinally equal to the current value, so two back-to-back calls could return the previous
             // instance even without the cache. Flipping the shared summary detail to the other message
             // shape forces the setter to assign on the next call, which is what makes the reference
             // assertions below meaningful.
-            Assert.AreNotEqual(first, state.GetRunningTasks(maxCount: 3)[2].Text);
+            FlipToMoreRunningShape(state);
 
+            // CurrentCulture alone governs how the count is formatted.
             CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            string frenchNumbers = state.GetSingleActiveOrSummaryTask()!.Text;
+            Assert.AreNotSame(enUS, frenchNumbers);
+
+            FlipToMoreRunningShape(state);
+
+            // CurrentUICulture alone governs which localized resource is loaded.
             CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+            string frFR = state.GetSingleActiveOrSummaryTask()!.Text;
+            Assert.AreNotSame(frenchNumbers, frFR);
 
-            // Same count, different culture: the cache must not serve the text formatted under en-US.
-            string second = state.GetSingleActiveOrSummaryTask()!.Text;
-            Assert.AreNotSame(first, second);
+            FlipToMoreRunningShape(state);
 
-            Assert.AreNotEqual(second, state.GetRunningTasks(maxCount: 3)[2].Text);
-
-            // ...and it must re-arm for the new culture rather than formatting on every call from now on.
-            string third = state.GetSingleActiveOrSummaryTask()!.Text;
-            Assert.AreSame(second, third);
+            // ...and the cache must re-arm for the new culture rather than formatting on every call.
+            Assert.AreSame(frFR, state.GetSingleActiveOrSummaryTask()!.Text);
         }
         finally
         {
@@ -1882,6 +1889,72 @@ public sealed class TerminalTestReporterTests
             CultureInfo.CurrentUICulture = originalUICulture;
         }
     }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void TestNodeResultsState_GetRunningTasks_WhenCultureChanges_ReformatsSummary()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+
+            var stopwatchFactory = new StopwatchFactory();
+            var state = new TestNodeResultsState(1);
+            for (int i = 0; i < 5; i++)
+            {
+                state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+                stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+            }
+
+            // The "... N more running" cache is independent of the "N tests running" one, so it needs its
+            // own coverage for each half of the key. The interleaved calls flip the shared summary detail
+            // to the other shape for the same reason as in the GetSingleActiveOrSummaryTask counterpart.
+            string enUS = GetMoreRunningText(state);
+
+            FlipToTestsRunningShape(state);
+
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            string frenchNumbers = GetMoreRunningText(state);
+            Assert.AreNotSame(enUS, frenchNumbers);
+
+            FlipToTestsRunningShape(state);
+
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+            string frFR = GetMoreRunningText(state);
+            Assert.AreNotSame(frenchNumbers, frFR);
+
+            FlipToTestsRunningShape(state);
+
+            Assert.AreSame(frFR, GetMoreRunningText(state));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    }
+
+    /// <summary>
+    /// Returns the trailing "... N more running" summary, which <see cref="TestNodeResultsState.GetRunningTasks"/>
+    /// appends when there are more running tests than <c>maxCount</c> allows it to list.
+    /// </summary>
+    private static string GetMoreRunningText(TestNodeResultsState state) => state.GetRunningTasks(maxCount: 3)[2].Text;
+
+    /// <summary>
+    /// Rewrites the shared summary detail to the "... N more running" shape so that the next write of the
+    /// "N tests running" shape is not swallowed by <c>TestDetailState.Text</c>'s ordinal-equality guard.
+    /// </summary>
+    private static void FlipToMoreRunningShape(TestNodeResultsState state) => state.GetRunningTasks(maxCount: 3);
+
+    /// <summary>
+    /// Rewrites the shared summary detail to the "N tests running" shape, the mirror of
+    /// <see cref="FlipToMoreRunningShape"/>.
+    /// </summary>
+    private static void FlipToTestsRunningShape(TestNodeResultsState state) => state.GetSingleActiveOrSummaryTask();
 
     [TestMethod]
     public void TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenCountChanges_ReformatsSummary()

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1835,6 +1835,55 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    [DoNotParallelize]
+    public void TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenCultureChanges_ReformatsSummary()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUICulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
+
+            var stopwatchFactory = new StopwatchFactory();
+            var state = new TestNodeResultsState(1);
+            for (int i = 0; i < 5; i++)
+            {
+                state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+                stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+            }
+
+            string first = state.GetSingleActiveOrSummaryTask()!.Text;
+
+            // Do NOT remove these interleaved calls. TestDetailState.Text's setter ignores writes that are
+            // ordinally equal to the current value, so two back-to-back calls could return the previous
+            // instance even without the cache. Flipping the shared summary detail to the other message
+            // shape forces the setter to assign on the next call, which is what makes the reference
+            // assertions below meaningful.
+            Assert.AreNotEqual(first, state.GetRunningTasks(maxCount: 3)[2].Text);
+
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            // Same count, different culture: the cache must not serve the text formatted under en-US.
+            string second = state.GetSingleActiveOrSummaryTask()!.Text;
+            Assert.AreNotSame(first, second);
+
+            Assert.AreNotEqual(second, state.GetRunningTasks(maxCount: 3)[2].Text);
+
+            // ...and it must re-arm for the new culture rather than formatting on every call from now on.
+            string third = state.GetSingleActiveOrSummaryTask()!.Text;
+            Assert.AreSame(second, third);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUICulture;
+        }
+    }
+
+    [TestMethod]
     public void TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenCountChanges_ReformatsSummary()
     {
         var stopwatchFactory = new StopwatchFactory();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1808,6 +1808,147 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenCountUnchanged_ReusesFormattedSummaryString()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        for (int i = 0; i < 5; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        string first = state.GetSingleActiveOrSummaryTask()!.Text;
+
+        // Do NOT remove this interleaved call. TestDetailState.Text's setter ignores writes that are
+        // ordinally equal to the current value, so two back-to-back calls would return the very first
+        // instance even without the cache, making the AreSame assertion below vacuous. Flipping the
+        // shared summary detail to the other message shape forces the setter to assign on the next call,
+        // so only the count-keyed cache can hand back the same instance.
+        string interleaved = state.GetRunningTasks(maxCount: 3)[2].Text;
+        Assert.AreNotEqual(first, interleaved);
+
+        string second = state.GetSingleActiveOrSummaryTask()!.Text;
+
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 5), first);
+        Assert.AreSame(first, second);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetSingleActiveOrSummaryTask_WhenCountChanges_ReformatsSummary()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        state.AddRunningTestNode(id: 10, uid: "uid-1", name: "T1", stopwatchFactory.CreateStopwatch());
+        state.AddRunningTestNode(id: 11, uid: "uid-2", name: "T2", stopwatchFactory.CreateStopwatch());
+
+        string? twoRunning = state.GetSingleActiveOrSummaryTask()?.Text;
+        state.AddRunningTestNode(id: 12, uid: "uid-3", name: "T3", stopwatchFactory.CreateStopwatch());
+        string? threeRunning = state.GetSingleActiveOrSummaryTask()?.Text;
+
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 2), twoRunning);
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 3), threeRunning);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenCountUnchanged_ReusesFormattedSummaryString()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        for (int i = 0; i < 5; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        // maxCount 3 truncates, so the trailing entry is the "... N more running" summary.
+        string first = state.GetRunningTasks(maxCount: 3)[2].Text;
+
+        // See the note in the GetSingleActiveOrSummaryTask counterpart: this interleaved call flips the
+        // shared summary detail to the other message shape so the AreSame assertion below is meaningful.
+        string interleaved = state.GetSingleActiveOrSummaryTask()!.Text;
+        Assert.AreNotEqual(first, interleaved);
+
+        string second = state.GetRunningTasks(maxCount: 3)[2].Text;
+
+        Assert.AreEqual($"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, 3)}", first);
+        Assert.AreSame(first, second);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_GetRunningTasks_WhenCountChanges_ReformatsSummary()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        for (int i = 0; i < 5; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        // 5 running, maxCount 3 => 2 shown + "... 3 more running".
+        string fiveRunning = state.GetRunningTasks(maxCount: 3)[2].Text;
+
+        // 4 running, maxCount 3 => 2 shown + "... 2 more running".
+        state.RemoveRunningTestNode("uid-0");
+        string fourRunning = state.GetRunningTasks(maxCount: 3)[2].Text;
+
+        Assert.AreEqual($"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, 3)}", fiveRunning);
+        Assert.AreEqual($"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, 2)}", fourRunning);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_FullCountSummary_IsSharedBetweenGetRunningTasksAndGetSingleActiveOrSummaryTask()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        for (int i = 0; i < 3; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        // maxCount 1 leaves no room for individual tests, so GetRunningTasks emits the same
+        // "N tests running" message that GetSingleActiveOrSummaryTask produces.
+        string fromGetRunningTasks = state.GetRunningTasks(maxCount: 1)[0].Text;
+
+        // Flip to the "... N more running" shape so the Text setter is forced to assign again below.
+        string interleaved = state.GetRunningTasks(maxCount: 2)[1].Text;
+        Assert.AreNotEqual(fromGetRunningTasks, interleaved);
+
+        string fromGetSingleActive = state.GetSingleActiveOrSummaryTask()!.Text;
+
+        Assert.AreEqual(string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 3), fromGetRunningTasks);
+        Assert.AreSame(fromGetRunningTasks, fromGetSingleActive);
+    }
+
+    [TestMethod]
+    public void TestNodeResultsState_SummaryCaches_DoNotLeakBetweenTheTwoMessageShapes()
+    {
+        var stopwatchFactory = new StopwatchFactory();
+        var state = new TestNodeResultsState(1);
+        for (int i = 0; i < 5; i++)
+        {
+            state.AddRunningTestNode(id: 10 + i, uid: $"uid-{i}", name: $"Test{i}", stopwatchFactory.CreateStopwatch());
+            stopwatchFactory.AddTime(TimeSpan.FromSeconds(1));
+        }
+
+        // 5 running, maxCount 3 => 2 shown + "... 3 more running". This caches the "more" message for the number 3.
+        Assert.AreEqual(
+            $"... {string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_MoreTestsCount, 3)}",
+            state.GetRunningTasks(maxCount: 3)[2].Text);
+
+        // Drop to 3 running. The count now collides with the number cached above, so a cache keyed only
+        // on the count would wrongly serve the "... 3 more running" text as the "3 tests running" summary.
+        state.RemoveRunningTestNode("uid-0");
+        state.RemoveRunningTestNode("uid-1");
+
+        Assert.AreEqual(
+            string.Format(CultureInfo.CurrentCulture, PlatformResources.ActiveTestsRunning_FullTestsCount, 3),
+            state.GetSingleActiveOrSummaryTask()?.Text);
+    }
+
+    [TestMethod]
     public void TerminalTestReporter_WhenInDiscoveryMode_ShouldIncrementDiscoveredTests()
     {
         // Arrange


### PR DESCRIPTION
Fixes #10320.

## Problem

`TestNodeResultsState` builds the two progress-row summary labels — `"N tests running"` and `"... N more running"` — with `string.Format` every time the progress row is rendered, once per test assembly:

- `GetSingleActiveOrSummaryTask()` — used by `SimpleTerminalBase` and `SilenceDrivenHeartbeatRenderer`.
- `GetRunningTasks(int)` — used by `AnsiTerminalTestProgressFrame`.

`CursorProgressRenderer` re-renders every 500 ms **and again on every write to the terminal** (`OnWrite` does `EraseProgress` → `write` → `RenderProgress`), so on a chatty run this fires far more often than the tick interval alone. The running-test count, meanwhile, only changes when a test starts or completes — so the overwhelming majority of those calls allocated a string byte-identical to the one produced by the previous render, which `TestDetailState.Text`'s ordinal-comparing setter then immediately discarded.

## Change

Cache the last formatted text per message shape, keyed on the count, and reuse it while the count is unchanged.

- Both producers of the `"N tests running"` message — `GetSingleActiveOrSummaryTask` and the `itemsToTake == 0` branch of `GetRunningTasks` — share a single cache, since the value means the same thing in both.
- `"... N more running"` gets its own cache, so the two shapes can never collide when their counts happen to match (e.g. `"... 3 more running"` vs `"3 tests running"`).

The issue's original patch only covered `GetSingleActiveOrSummaryTask`; this also covers `GetRunningTasks`, which is the hotter path (it's the one the ANSI progress frame drives).

**No behavior change.** The cached string is always exactly what `string.Format` would have returned, and `TestDetailState.Text` compares ordinally, so `Version` bookkeeping and the renderer's repaint decisions are bit-for-bit identical.

## Notes on safety

- **Threading:** the new fields are unsynchronized, matching the existing `_runningTasksBuffer`. Every caller is reached through `IProgressRenderer.OnTick`/`OnWrite`, both of which `TestProgressStateAwareTerminal` invokes under its `_lock`, so access is serialized. `AddRunningTestNode`/`RemoveRunningTestNode` — the genuinely concurrent callers — don't touch the cache.
- **`-1` sentinel** is unreachable as a real count: `GetFullTestsCountText` is only entered with count ≥ 2, and `GetMoreTestsCountText` only when `Count > maxCount`, so its argument is ≥ 2.

## Tests

Six new tests in `TerminalTestReporterTests`, covering cache reuse, cache invalidation on count change, cache sharing between the two full-count producers, and non-collision between the two message shapes.

One subtlety worth calling out for reviewers: `TestDetailState.Text`'s setter ignores writes that are ordinally equal to the current value, so a naive "call it twice, `Assert.AreSame` the text" test passes even *without* the cache — the setter hands back the first instance either way. The reuse tests therefore interleave the *other* message shape between the two calls to force the setter to assign, and there's a comment on each explaining why that call must not be "cleaned up".

Verified by mutation testing rather than assumption:

| Mutation | Result |
|---|---|
| Cache disabled (always format) | the 3 `Assert.AreSame` reuse tests **fail** |
| Cache never invalidated | the 2 `WhenCountChanges_ReformatsSummary` tests **fail** |
| Unmodified | all pass |

Build of `Microsoft.Testing.Platform.UnitTests` → 0 warnings, 0 errors; full suite → **1914/1914 passing**.

No public or internal API surface change — both new members are `private`, so `InternalAPI.Shipped.txt`/`.Unshipped.txt` are untouched.