### PR TITLE
Add fixture-method edge-case tests for MSTEST0076

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CultureMutationUnderParallelizationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CultureMutationUnderParallelizationAnalyzerTests.cs
@@ -291,4 +291,69 @@ public sealed class CultureMutationUnderParallelizationAnalyzerTests
                 .WithLocation(0)
                 .WithArguments("CultureInfo.DefaultThreadCurrentCulture"));
     }
+
+    [TestMethod]
+    public async Task WhenTestInitializeSetsDefaultThreadCurrentCulture_Diagnostic()
+    {
+        // [TestInitialize] is a class-scoped fixture included in GetFixtureAttributeSymbols, so mutations inside
+        // it must be reported just like mutations inside a test method.
+        string code = """
+            using System.Globalization;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                public void Setup()
+                {
+                    {|#0:CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(CultureMutationUnderParallelizationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("CultureInfo.DefaultThreadCurrentCulture"));
+    }
+
+    [TestMethod]
+    public async Task WhenAssemblyInitializeSetsDefaultThreadCurrentCulture_NoDiagnostic()
+    {
+        // [AssemblyInitialize] is deliberately excluded from GetFixtureAttributeSymbols: it is serialized and
+        // every worker awaits it before running any test, so a process-global mutation there cannot race a
+        // concurrent test. Flagging it would be a false positive.
+        string code = """
+            using System.Globalization;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblySetup(TestContext context)
+                {
+                    CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
 }


### PR DESCRIPTION
Fixes #10334

`CultureMutationUnderParallelizationAnalyzer` (MSTEST0076) resolves fixture methods through `ParallelSafetyHelper.GetFixtureAttributeSymbols`, which deliberately **includes** `[TestInitialize]`/`[TestCleanup]`/`[ClassInitialize]`/`[ClassCleanup]`/`[GlobalTestInitialize]`/`[GlobalTestCleanup]` but **excludes** `[AssemblyInitialize]`/`[AssemblyCleanup]` (those are serialized behind `TestAssemblyInfo`'s `SemaphoreSlim(1, 1)` and every worker awaits them, so a process-global mutation there cannot race a concurrent test).

Neither side of that distinction had test coverage, so a refactor could silently flip it — either losing a real diagnostic or introducing a false positive.

## Changes

Two tests added to `CultureMutationUnderParallelizationAnalyzerTests`:

| Test | Asserts |
| --- | --- |
| `WhenTestInitializeSetsDefaultThreadCurrentCulture_Diagnostic` | Mutating `CultureInfo.DefaultThreadCurrentCulture` inside `[TestInitialize]` **fires** MSTEST0076 |
| `WhenAssemblyInitializeSetsDefaultThreadCurrentCulture_NoDiagnostic` | The same mutation inside `[AssemblyInitialize]` fires **nothing** |

No product code changed.

## Validation

Both tests were mutation-checked against the analyzer to confirm they are not vacuous:

- Adding `AssemblyInitializeAttribute` to `GetFixtureAttributeSymbols` → `WhenAssemblyInitializeSetsDefaultThreadCurrentCulture_NoDiagnostic` fails.
- Removing `TestInitializeAttribute` from `GetFixtureAttributeSymbols` → `WhenTestInitializeSetsDefaultThreadCurrentCulture_Diagnostic` fails.

The analyzer was restored afterwards; the full `MSTest.Analyzers.UnitTests` suite passes on `net8.0` (1685 / 1685).