### PR TITLE
Align CTRF retry reporting and runId with ctrf-io/ctrf#58

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfMergeMode.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfMergeMode.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.CtrfReport;
+
+/// <summary>
+/// Controls how <see cref="CtrfReportMerger"/> combines the <c>tests[]</c> arrays of its inputs.
+/// </summary>
+internal enum CtrfMergeMode
+{
+    /// <summary>
+    /// Concatenates the inputs, which is correct when they describe disjoint sets of tests (the shard or
+    /// per-module case). This is the default: MTP test UIDs are only unique WITHIN an assembly, so collapsing
+    /// by identity across modules would fuse same-named tests from different assemblies.
+    /// </summary>
+    Concatenate,
+
+    /// <summary>
+    /// Folds rows describing the same logical test into one, which is correct when the inputs are successive
+    /// attempts of the same test module (<c>--retry-failed-tests</c>): the last attempt wins and earlier ones
+    /// become its <c>retryAttempts[]</c>. Inputs MUST be supplied in attempt order, and MUST come from the same
+    /// module for identities to be comparable.
+    /// </summary>
+    CollapseRetryAttempts,
+}

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 
 using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
@@ -68,6 +69,12 @@ internal sealed partial class CtrfReportEngine
             // Bump this constant whenever we update against a newer schema revision.
             writer.WriteString("specVersion", CtrfSpecVersion);
             writer.WriteString("reportId", Guid.NewGuid().ToString("D"));
+            // CTRF 5.4 (`runId`): identifies the logical run this document belongs to. A logical run can span
+            // several documents — the modules of one `dotnet test` invocation, or the successive processes of
+            // `--retry-failed-tests`, where each attempt writes its own document. ctrf-io/ctrf#58 confirmed that
+            // those per-execution documents (and any document merged from them) SHOULD share a `runId` while each
+            // keeps its own `reportId`. When nothing correlated this process, it is the whole logical run.
+            writer.WriteString("runId", ResolveRunId());
             writer.WriteString("timestamp", finishTime.ToString("O", CultureInfo.InvariantCulture));
             writer.WriteString(
                 "generatedBy",
@@ -151,5 +158,25 @@ internal sealed partial class CtrfReportEngine
         }
 
         return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Resolves the CTRF <c>runId</c>: the id of the logical run this document belongs to.
+    /// </summary>
+    /// <remarks>
+    /// The retry orchestrator seeds <c>TESTINGPLATFORM_LOGICAL_RUN_ID</c> before launching its attempts, so every
+    /// attempt process stamps the same value; <c>dotnet test</c> already correlates the modules of one invocation
+    /// through its execution id, which serves the same purpose when no orchestrator is involved. Falling back to a
+    /// fresh id keeps the field a valid non-empty string for a standalone run, which is its own logical run.
+    /// </remarks>
+    private string ResolveRunId()
+    {
+        string? runId = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID);
+        if (RoslynString.IsNullOrEmpty(runId))
+        {
+            runId = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
+        }
+
+        return RoslynString.IsNullOrEmpty(runId) ? Guid.NewGuid().ToString("D") : runId;
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
@@ -70,10 +70,9 @@ internal sealed partial class CtrfReportEngine
             writer.WriteString("specVersion", CtrfSpecVersion);
             writer.WriteString("reportId", Guid.NewGuid().ToString("D"));
             // CTRF 5.4 (`runId`): identifies the logical run this document belongs to. A logical run can span
-            // several documents — the modules of one `dotnet test` invocation, or the successive processes of
-            // `--retry-failed-tests`, where each attempt writes its own document. ctrf-io/ctrf#58 confirmed that
-            // those per-execution documents (and any document merged from them) SHOULD share a `runId` while each
-            // keeps its own `reportId`. When nothing correlated this process, it is the whole logical run.
+            // several documents — most notably the successive processes of `--retry-failed-tests`, where each
+            // attempt writes its own document. ctrf-io/ctrf#58 confirmed that those per-execution documents (and
+            // any document merged from them) SHOULD share a `runId` while each keeps its own `reportId`.
             writer.WriteString("runId", ResolveRunId());
             writer.WriteString("timestamp", finishTime.ToString("O", CultureInfo.InvariantCulture));
             writer.WriteString(
@@ -164,10 +163,13 @@ internal sealed partial class CtrfReportEngine
     /// Resolves the CTRF <c>runId</c>: the id of the logical run this document belongs to.
     /// </summary>
     /// <remarks>
-    /// The retry orchestrator seeds <c>TESTINGPLATFORM_LOGICAL_RUN_ID</c> before launching its attempts, so every
-    /// attempt process stamps the same value; <c>dotnet test</c> already correlates the modules of one invocation
-    /// through its execution id, which serves the same purpose when no orchestrator is involved. Falling back to a
-    /// fresh id keeps the field a valid non-empty string for a standalone run, which is its own logical run.
+    /// The retry orchestrator sets <c>TESTINGPLATFORM_LOGICAL_RUN_ID</c> before launching its attempts, so every
+    /// attempt process stamps the same value; a CI job can set it too, to correlate documents this process cannot
+    /// know about (the modules of a multi-project run, or shards on different machines). Failing that, the
+    /// <c>dotnet test</c> execution id identifies this test application's own process tree — note it is per root
+    /// test application, NOT per <c>dotnet test</c> invocation, so sibling modules legitimately get distinct ids
+    /// (see <c>docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md</c>). A fresh id is the last resort:
+    /// an uncorrelated run is a logical run of its own, and CTRF requires the field to be a non-empty string.
     /// </remarks>
     private string ResolveRunId()
     {
@@ -177,6 +179,6 @@ internal sealed partial class CtrfReportEngine
             runId = _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
         }
 
-        return RoslynString.IsNullOrEmpty(runId) ? Guid.NewGuid().ToString("D") : runId;
+        return RoslynString.IsNullOrEmpty(runId) ? Guid.NewGuid().ToString("D") : runId!;
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonTestWriter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonTestWriter.cs
@@ -77,6 +77,9 @@ internal sealed partial class CtrfReportEngine
 
         if (c.PriorAttempts.Count > 0)
         {
+            // CTRF 9.20/9.21 as clarified by ctrf-io/ctrf#58: `retries` is the number of
+            // re-executions, which equals `retryAttempts.length` because the array holds
+            // attempts 1..N-1 only — so the final attempt's number is `retries + 1`.
             writer.WriteNumber("retries", c.PriorAttempts.Count);
             writer.WritePropertyName("retryAttempts");
             writer.WriteStartArray();

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.TestCollapsing.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.TestCollapsing.cs
@@ -56,6 +56,11 @@ internal sealed partial class CtrfReportEngine
         // For each UID, group all captures in arrival order: the latest entry becomes the
         // final test record, earlier entries become `retryAttempts[]`. Preserves the
         // insertion order of first-seen UIDs in the output (stable across runs).
+        //
+        // ctrf-io/ctrf#58 confirmed this is the intended CTRF model: `retryAttempts[]`
+        // is the attempt history PRECEDING the final attempt (attempts 1..N-1, initial
+        // execution included), and the final attempt is excluded because its outcome and
+        // diagnostics are carried by the test object itself.
         var byUid = new Dictionary<string, int>(StringComparer.Ordinal);
         var collapsed = new List<CollapsedTestResult>(results.Length);
         foreach (CapturedTestResult r in results)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 /// <list type="bullet">
 ///   <item><description><c>results.tests[]</c> arrays are concatenated as-is, unless <see cref="CtrfMergeMode.CollapseRetryAttempts"/> asks for successive attempts of the same test to be folded into one row.</description></item>
 ///   <item><description><c>results.summary</c> counters are re-derived by counting the merged <c>tests[]</c> (so <c>summary.tests</c> always matches the array length); <c>start</c>/<c>stop</c> use the earliest/latest across inputs, <c>duration</c> is the resulting span.</description></item>
-///   <item><description><c>reportFormat</c> and <c>specVersion</c> are taken from the first report; <c>reportId</c> is derived deterministically from the inputs, so identical inputs reproduce the same id (RFC 018 idempotency).</description></item>
+///   <item><description><c>reportFormat</c> and <c>specVersion</c> are taken from the first report; <c>reportId</c> is derived deterministically from the inputs AND the merge mode, so identical inputs reproduce the same id (RFC 018 idempotency) while the two modes — which produce materially different documents — get distinct ids.</description></item>
 ///   <item><description><c>runId</c> is carried over when every input agrees on one, because the merged document describes the same logical run as its inputs while remaining a distinct artifact with its own <c>reportId</c> (see ctrf-io/ctrf#58).</description></item>
 ///   <item><description><c>tool</c> keeps a concrete identity only when every input reported the exact same tool object; otherwise (inputs disagree or any input omits it) a neutral merger identity is used, so one framework is not attributed to another's tests.</description></item>
 ///   <item><description><c>environment</c> keeps the first report's shared fields, but module-specific values under <c>extra</c> (<c>testApplication</c>, <c>exitCode</c>) are dropped rather than presented as describing all merged modules.</description></item>
@@ -269,7 +269,7 @@ internal static class CtrfReportMerger
         {
             ["reportFormat"] = first["reportFormat"]?.DeepClone() ?? "CTRF",
             ["specVersion"] = first["specVersion"]?.DeepClone() ?? "0.0.0",
-            ["reportId"] = CreateDeterministicReportId(acceptedReports),
+            ["reportId"] = CreateDeterministicReportId(acceptedReports, mode),
         };
 
         // A merged document is a new artifact (hence its own reportId) but it still describes the same logical
@@ -664,18 +664,24 @@ internal static class CtrfReportMerger
     }
 
     /// <summary>
-    /// Derives a stable <c>reportId</c> from the accepted CTRF input reports so identical inputs reproduce
-    /// the same id on every retry (RFC 018 idempotency) without a random source or reusing an input report's
-    /// id. Only the payloads that passed CTRF validation are hashed, so a rejected non-CTRF input cannot
-    /// alter the merged report's identity. A non-cryptographic 128-bit FNV-1a fill is sufficient here — the
-    /// id only needs to be deterministic and collision-resistant enough to identify a merged report, not
-    /// secret.
+    /// Derives a stable <c>reportId</c> from the accepted CTRF input reports and the merge mode, so identical
+    /// inputs merged the same way reproduce the same id on every retry (RFC 018 idempotency) without a random
+    /// source or reusing an input report's id, while the same inputs merged a DIFFERENT way — which yields a
+    /// materially different document — get a distinct id, as CTRF 5.3 requires. Only the payloads that passed
+    /// CTRF validation are hashed, so a rejected non-CTRF input cannot alter the merged report's identity. A
+    /// non-cryptographic 128-bit FNV-1a fill is sufficient here — the id only needs to be deterministic and
+    /// collision-resistant enough to identify a merged report, not secret.
     /// </summary>
-    private static string CreateDeterministicReportId(IReadOnlyList<string> acceptedReports)
+    private static string CreateDeterministicReportId(IReadOnlyList<string> acceptedReports, CtrfMergeMode mode)
     {
         const ulong fnvPrime = 1099511628211UL;
         ulong hashLow = 14695981039346656037UL;
         ulong hashHigh = 0x9E3779B97F4A7C15UL;
+
+        // Fold in the merge mode: the same inputs concatenated and collapsed are two materially different
+        // documents, and CTRF 5.3 wants a distinct reportId for each rather than one id naming both.
+        hashLow = (hashLow ^ (ulong)mode) * fnvPrime;
+        hashHigh = (hashHigh ^ ((ulong)mode + 1UL)) * fnvPrime;
 
         foreach (string report in acceptedReports)
         {

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 /// This is a pure, invocation-agnostic JSON-level merge (no I/O, no clock) that mirrors the
 /// TRX and JUnit mergers, demonstrating that the same post-processing shape fits a JSON format:
 /// <list type="bullet">
-///   <item><description><c>results.tests[]</c> arrays are concatenated as-is.</description></item>
+///   <item><description><c>results.tests[]</c> arrays are concatenated as-is, unless <see cref="CtrfMergeMode.CollapseRetryAttempts"/> asks for successive attempts of the same test to be folded into one row.</description></item>
 ///   <item><description><c>results.summary</c> counters are re-derived by counting the merged <c>tests[]</c> (so <c>summary.tests</c> always matches the array length); <c>start</c>/<c>stop</c> use the earliest/latest across inputs, <c>duration</c> is the resulting span.</description></item>
 ///   <item><description><c>reportFormat</c> and <c>specVersion</c> are taken from the first report; <c>reportId</c> is derived deterministically from the inputs, so identical inputs reproduce the same id (RFC 018 idempotency).</description></item>
+///   <item><description><c>runId</c> is carried over when every input agrees on one, because the merged document describes the same logical run as its inputs while remaining a distinct artifact with its own <c>reportId</c> (see ctrf-io/ctrf#58).</description></item>
 ///   <item><description><c>tool</c> keeps a concrete identity only when every input reported the exact same tool object; otherwise (inputs disagree or any input omits it) a neutral merger identity is used, so one framework is not attributed to another's tests.</description></item>
 ///   <item><description><c>environment</c> keeps the first report's shared fields, but module-specific values under <c>extra</c> (<c>testApplication</c>, <c>exitCode</c>) are dropped rather than presented as describing all merged modules.</description></item>
 /// </list>
@@ -32,7 +33,28 @@ internal static class CtrfReportMerger
     // not by any input report.
     private const string GeneratedByName = "Microsoft.Testing.Extensions.CtrfReport";
 
+    // Fields a CTRF retry attempt object (section 11) shares with a test object and that carry over verbatim when
+    // a non-final attempt is folded into 'retryAttempts[]'. 'attempt' and 'status' are handled separately because
+    // they are required, and 'attemptId' is listed here because an input that assigned one keeps it.
+    private static readonly string[] RetryAttemptFields =
+    [
+        "attemptId",
+        "duration",
+        "message",
+        "trace",
+        "line",
+        "snippet",
+        "stdout",
+        "stderr",
+        "start",
+        "stop",
+        "attachments",
+    ];
+
     internal static string Merge(IReadOnlyList<string> inputReports)
+        => Merge(inputReports, CtrfMergeMode.Concatenate);
+
+    internal static string Merge(IReadOnlyList<string> inputReports, CtrfMergeMode mode)
     {
         if (inputReports is null)
         {
@@ -64,6 +86,10 @@ internal static class CtrfReportMerger
         JsonNode? firstTool = null;
         int reportCount = 0;
 
+        // The merged document belongs to the same logical run as its inputs only when they all belong to the
+        // same one, so a run id is carried over only when every input reported the very same value.
+        var distinctRunIds = new HashSet<string>(StringComparer.Ordinal);
+
         // Collect each input's environment so shared fields can be retained and module- or agent-specific
         // ones (values that differ across inputs) dropped, rather than attributing the first report's
         // environment to every merged test.
@@ -93,6 +119,11 @@ internal static class CtrfReportMerger
             first ??= root;
             reportCount++;
             acceptedReports.Add(reportJson);
+
+            distinctRunIds.Add(
+                root["runId"] is JsonValue runIdValue && runIdValue.TryGetValue(out string? runIdText) && !RoslynString.IsNullOrEmpty(runIdText)
+                    ? runIdText
+                    : string.Empty);
 
             if (root["results"]?["environment"] is JsonObject environment)
             {
@@ -157,11 +188,18 @@ internal static class CtrfReportMerger
         long startMs = earliestStart ?? 0;
         long stopMs = latestStop ?? startMs;
 
+        // In retry mode the inputs are successive attempts of the same suite, so the same logical test can
+        // appear in several of them. Collapse those repeats into one row before counting, otherwise the same
+        // test would be reported (and counted) several times.
+        JsonArray tests = mode == CtrfMergeMode.CollapseRetryAttempts
+            ? CollapseRetryAttempts(mergedTests)
+            : mergedTests;
+
         // Counters are derived from the merged tests[] rather than trusting each input's summary, so
         // summary.tests always equals the array length even when an input omitted or under-reported
         // its summary.
         long passed = 0, failed = 0, skipped = 0, pending = 0, other = 0, flaky = 0;
-        foreach (JsonNode? test in mergedTests)
+        foreach (JsonNode? test in tests)
         {
             if (test is null)
             {
@@ -185,7 +223,7 @@ internal static class CtrfReportMerger
 
         var summaryObject = new JsonObject
         {
-            ["tests"] = mergedTests.Count,
+            ["tests"] = tests.Count,
             ["passed"] = passed,
             ["failed"] = failed,
             ["skipped"] = skipped,
@@ -221,20 +259,31 @@ internal static class CtrfReportMerger
             resultsObject["environment"] = commonEnvironment;
         }
 
-        resultsObject["tests"] = mergedTests;
+        resultsObject["tests"] = tests;
 
         var merged = new JsonObject
         {
             ["reportFormat"] = first["reportFormat"]?.DeepClone() ?? "CTRF",
             ["specVersion"] = first["specVersion"]?.DeepClone() ?? "0.0.0",
             ["reportId"] = CreateDeterministicReportId(acceptedReports),
-            ["timestamp"] = DateTimeOffset.FromUnixTimeMilliseconds(stopMs).ToString("O", CultureInfo.InvariantCulture),
-            // The merged document is produced by this merger, not by any input, so stamp its own identity
-            // rather than carrying the first input's 'generatedBy' (which could report a different producer
-            // or version when merging reports from different tool versions).
-            ["generatedBy"] = GeneratedByName,
-            ["results"] = resultsObject,
         };
+
+        // A merged document is a new artifact (hence its own reportId) but it still describes the same logical
+        // run as the documents it was built from, so it carries their runId — provided they all agree on one.
+        // Inputs that disagree, or an input with no runId, contribute the empty sentinel and suppress the field
+        // rather than picking an arbitrary run to represent the whole merge.
+        if (distinctRunIds.Count == 1 && distinctRunIds.First() is { Length: > 0 } sharedRunId)
+        {
+            merged["runId"] = sharedRunId;
+        }
+
+        merged["timestamp"] = DateTimeOffset.FromUnixTimeMilliseconds(stopMs).ToString("O", CultureInfo.InvariantCulture);
+
+        // The merged document is produced by this merger, not by any input, so stamp its own identity
+        // rather than carrying the first input's 'generatedBy' (which could report a different producer
+        // or version when merging reports from different tool versions).
+        merged["generatedBy"] = GeneratedByName;
+        merged["results"] = resultsObject;
 
         return merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
     }
@@ -242,6 +291,13 @@ internal static class CtrfReportMerger
     internal static async Task MergeToFileAsync(
         IReadOnlyList<string> inputPaths,
         string outputPath,
+        CancellationToken cancellationToken)
+        => await MergeToFileAsync(inputPaths, outputPath, CtrfMergeMode.Concatenate, cancellationToken).ConfigureAwait(false);
+
+    internal static async Task MergeToFileAsync(
+        IReadOnlyList<string> inputPaths,
+        string outputPath,
+        CtrfMergeMode mode,
         CancellationToken cancellationToken)
     {
         if (inputPaths is null)
@@ -276,7 +332,7 @@ internal static class CtrfReportMerger
 #endif
         }
 
-        string merged = Merge(reports);
+        string merged = Merge(reports, mode);
 
         string? outputDirectory = Path.GetDirectoryName(outputPath);
         if (!RoslynString.IsNullOrEmpty(outputDirectory))
@@ -295,6 +351,210 @@ internal static class CtrfReportMerger
             await Task.CompletedTask.ConfigureAwait(false);
 #endif
         }).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Folds successive attempts of the same logical test — the tests[] rows contributed, in attempt order, by
+    /// the per-attempt documents of one orchestrated retry run — into a single row per test.
+    /// </summary>
+    /// <remarks>
+    /// The retry model confirmed in ctrf-io/ctrf#58: the last attempt's outcome IS the test object, and
+    /// <c>retryAttempts[]</c> holds attempts <c>1..N-1</c> (the initial execution plus any earlier retries),
+    /// numbered from 1, so <c>retries == retryAttempts.length</c> and the final attempt is <c>retries + 1</c>.
+    /// The test object therefore keeps the FINAL attempt's <c>duration</c> (and <c>start</c>/<c>stop</c>), rather
+    /// than a sum across attempts. Attempts an input already recorded in its own <c>retryAttempts[]</c> (in-process
+    /// retries within a single attempt process) are flattened into the same history so no execution is lost.
+    /// </remarks>
+    private static JsonArray CollapseRetryAttempts(JsonArray tests)
+    {
+        var slots = new List<(JsonNode Final, List<JsonNode> Priors)>();
+        var byIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (JsonNode? test in tests)
+        {
+            if (test is null)
+            {
+                continue;
+            }
+
+            // A row we cannot identify gets its own slot: fusing unrelated rows would lose results, whereas an
+            // uncollapsed duplicate is merely redundant.
+            if (GetTestIdentity(test) is not string identity)
+            {
+                slots.Add((test, []));
+                continue;
+            }
+
+            if (byIdentity.TryGetValue(identity, out int index))
+            {
+                (JsonNode previousFinal, List<JsonNode> priors) = slots[index];
+                priors.Add(previousFinal);
+                slots[index] = (test, priors);
+            }
+            else
+            {
+                byIdentity.Add(identity, slots.Count);
+                slots.Add((test, []));
+            }
+        }
+
+        var collapsed = new JsonArray();
+        foreach ((JsonNode final, List<JsonNode> priors) in slots)
+        {
+            collapsed.Add(BuildCollapsedTest(final, priors));
+        }
+
+        return collapsed;
+    }
+
+    /// <summary>
+    /// Computes the key identifying the logical test a row describes, preferring the CTRF <c>testId</c>, then the
+    /// producer-supplied <c>extra.uid</c>, and finally the suite path plus name. Returns <see langword="null"/>
+    /// when the row carries none of them.
+    /// </summary>
+    private static string? GetTestIdentity(JsonNode test)
+    {
+        if (test["testId"] is JsonValue testIdValue && testIdValue.TryGetValue(out string? testId) && !RoslynString.IsNullOrEmpty(testId))
+        {
+            return $"testId\u001f{testId}";
+        }
+
+        if (test["extra"]?["uid"] is JsonValue uidValue && uidValue.TryGetValue(out string? uid) && !RoslynString.IsNullOrEmpty(uid))
+        {
+            return $"uid\u001f{uid}";
+        }
+
+        if (test["name"] is not JsonValue nameValue || !nameValue.TryGetValue(out string? name) || RoslynString.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        var identity = new StringBuilder("name");
+        if (test["suite"] is JsonArray suite)
+        {
+            foreach (JsonNode? segment in suite)
+            {
+                identity.Append('\u001f').Append((string?)segment);
+            }
+        }
+
+        return identity.Append('\u001f').Append(name).ToString();
+    }
+
+    private static JsonNode BuildCollapsedTest(JsonNode final, List<JsonNode> priors)
+    {
+        var collapsed = (JsonObject)final.DeepClone();
+        if (priors.Count == 0)
+        {
+            return collapsed;
+        }
+
+        var history = new JsonArray();
+        foreach (JsonNode prior in priors)
+        {
+            AppendAttempts(history, prior);
+        }
+
+        // In-process retries observed by the final attempt precede its own outcome in the history.
+        if (collapsed["retryAttempts"] is JsonArray finalAttempts)
+        {
+            AppendNestedAttempts(history, finalAttempts);
+        }
+
+        bool anyFailed = false;
+        for (int i = 0; i < history.Count; i++)
+        {
+            if (history[i] is not JsonObject attempt)
+            {
+                continue;
+            }
+
+            attempt["attempt"] = i + 1;
+            anyFailed |= (string?)attempt["status"] == "failed";
+        }
+
+        collapsed["retryAttempts"] = history;
+        collapsed["retries"] = history.Count;
+
+        // CTRF 9.22: flaky only when the FINAL status is passed after at least one failed attempt. Recomputed
+        // (rather than inherited) because an input's own flag only describes the attempt that produced it.
+        if ((string?)collapsed["status"] == "passed" && anyFailed)
+        {
+            collapsed["flaky"] = true;
+        }
+        else
+        {
+            collapsed.Remove("flaky");
+        }
+
+        return collapsed;
+    }
+
+    /// <summary>
+    /// Appends the executions a non-final attempt row represents — the attempts it already nested, then its own
+    /// outcome — to the retry history being built.
+    /// </summary>
+    private static void AppendAttempts(JsonArray history, JsonNode test)
+    {
+        if (test["retryAttempts"] is JsonArray nested)
+        {
+            AppendNestedAttempts(history, nested);
+        }
+
+        history.Add(ToRetryAttempt(test));
+    }
+
+    /// <summary>
+    /// Copies retry attempt objects an input already recorded into the history being built, skipping entries that
+    /// are not objects: a <see langword="null"/> element could not describe an execution and is not a valid retry
+    /// attempt object.
+    /// </summary>
+    private static void AppendNestedAttempts(JsonArray history, JsonArray nested)
+    {
+        foreach (JsonNode? attempt in nested)
+        {
+            if (attempt is JsonObject attemptObject)
+            {
+                history.Add(attemptObject.DeepClone());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Projects a test row onto the retry attempt object of CTRF section 11, which allows a narrower set of
+    /// fields than a test: everything else (name, suite, tags, labels, ...) either belongs to the collapsed test
+    /// object or, like <c>rawStatus</c>, moves under <c>extra</c>, the only permitted extension point.
+    /// </summary>
+    private static JsonNode ToRetryAttempt(JsonNode test)
+    {
+        // 'attempt' is assigned by the caller, once the position of this execution in the history is known.
+        var attempt = new JsonObject
+        {
+            ["attempt"] = 1,
+            ["status"] = test["status"]?.DeepClone() ?? "other",
+        };
+
+        foreach (string field in RetryAttemptFields)
+        {
+            if (test[field] is JsonNode value)
+            {
+                attempt[field] = value.DeepClone();
+            }
+        }
+
+        JsonObject? extra = test["extra"] is JsonObject testExtra ? (JsonObject)testExtra.DeepClone() : null;
+        if (test["rawStatus"] is JsonNode rawStatus)
+        {
+            extra ??= [];
+            extra["rawStatus"] = rawStatus.DeepClone();
+        }
+
+        if (extra is { Count: > 0 })
+        {
+            attempt["extra"] = extra;
+        }
+
+        return attempt;
     }
 
     private static bool TryReadLong(JsonNode summary, string propertyName, out long value)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 /// This is a pure, invocation-agnostic JSON-level merge (no I/O, no clock) that mirrors the
 /// TRX and JUnit mergers, demonstrating that the same post-processing shape fits a JSON format:
 /// <list type="bullet">
-///   <item><description><c>results.tests[]</c> arrays are concatenated as-is, unless <see cref="CtrfMergeMode.CollapseRetryAttempts"/> asks for successive attempts of the same test to be folded into one row.</description></item>
+///   <item><description><c>results.tests[]</c> arrays are concatenated, except that elements which are not Test objects are dropped so one input's malformed row cannot invalidate the merged document; <see cref="CtrfMergeMode.CollapseRetryAttempts"/> additionally folds successive attempts of the same test into one row.</description></item>
 ///   <item><description><c>results.summary</c> counters are re-derived by counting the merged <c>tests[]</c> (so <c>summary.tests</c> always matches the array length); <c>start</c>/<c>stop</c> use the earliest/latest across inputs, <c>duration</c> is the resulting span.</description></item>
 ///   <item><description><c>reportFormat</c> and <c>specVersion</c> are taken from the first report; <c>reportId</c> is derived deterministically from the inputs AND the merge mode, so identical inputs reproduce the same id (RFC 018 idempotency) while the two modes — which produce materially different documents — get distinct ids.</description></item>
 ///   <item><description><c>runId</c> is carried over when every input agrees on one, because the merged document describes the same logical run as its inputs while remaining a distinct artifact with its own <c>reportId</c> (see ctrf-io/ctrf#58).</description></item>
@@ -417,6 +417,13 @@ internal static class CtrfReportMerger
     /// producer-supplied <c>extra.uid</c>, and finally the suite path plus name. Returns <see langword="null"/>
     /// when the row carries none of them.
     /// </summary>
+    /// <remarks>
+    /// The suite/name fallback length-prefixes every component rather than just separating them. A CTRF
+    /// <c>name</c> or suite segment is an arbitrary non-empty string, so it may itself contain the separator:
+    /// with plain separation, <c>suite: ["A"], name: "B\u001fC"</c> and <c>suite: ["A", "B"], name: "C"</c>
+    /// would produce the same key and collapse two unrelated tests into one, silently dropping a result.
+    /// Length prefixes make the encoding unambiguous whatever the components contain.
+    /// </remarks>
     private static string? GetTestIdentity(JsonObject test)
     {
         if (ReadString(test, "testId") is { Length: > 0 } testId)
@@ -444,15 +451,20 @@ internal static class CtrfReportMerger
                 // A suite segment is normally a string, but the document is untrusted. Fall back to the
                 // segment's JSON text so a non-string segment still contributes a distinct, deterministic part
                 // of the key instead of throwing on the string conversion.
-                identity.Append('\u001f').Append(
+                AppendIdentityComponent(
+                    identity,
                     segment is JsonValue segmentValue && segmentValue.TryGetValue(out string? segmentText)
                         ? segmentText
                         : segment?.ToJsonString());
             }
         }
 
-        return identity.Append('\u001f').Append(name).ToString();
+        AppendIdentityComponent(identity, name);
+        return identity.ToString();
     }
+
+    private static void AppendIdentityComponent(StringBuilder identity, string? component)
+        => identity.Append('\u001f').Append(component?.Length ?? -1).Append(':').Append(component);
 
     private static JsonNode BuildCollapsedTest(JsonObject final, List<JsonObject> priors)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -135,22 +135,29 @@ internal static class CtrfReportMerger
             {
                 foreach (JsonNode? test in testArray)
                 {
-                    mergedTests.Add(test?.DeepClone());
+                    // Only a Test object belongs in tests[]: the CTRF schema types the array's items as objects
+                    // with required members, so carrying a malformed element (a bare string, or a JSON null left
+                    // by a lazy producer) through would turn a defect localized to one input into an invalid
+                    // MERGED document — the artifact consumers actually read. This mirrors the check above, where
+                    // an input that fails the CTRF shape test is rejected outright rather than passed along.
+                    if (test is not JsonObject testObject)
+                    {
+                        continue;
+                    }
+
+                    mergedTests.Add(testObject.DeepClone());
 
                     // Fall back to per-test timing so a summary-less input (which the merger explicitly
                     // supports) still contributes to the merged min/max instead of being dropped or
                     // forcing the merged timestamp back to the Unix epoch.
-                    if (test is not null)
+                    if (TryReadLong(testObject, "start", out long testStart))
                     {
-                        if (TryReadLong(test, "start", out long testStart))
-                        {
-                            earliestStart = Min(earliestStart, testStart);
-                        }
+                        earliestStart = Min(earliestStart, testStart);
+                    }
 
-                        if (TryReadLong(test, "stop", out long testStop))
-                        {
-                            latestStop = Max(latestStop, testStop);
-                        }
+                    if (TryReadLong(testObject, "stop", out long testStop))
+                    {
+                        latestStop = Max(latestStop, testStop);
                     }
                 }
             }
@@ -197,16 +204,16 @@ internal static class CtrfReportMerger
 
         // Counters are derived from the merged tests[] rather than trusting each input's summary, so
         // summary.tests always equals the array length even when an input omitted or under-reported
-        // its summary.
+        // its summary. Every element is a Test object: non-objects were rejected during ingestion.
         long passed = 0, failed = 0, skipped = 0, pending = 0, other = 0, flaky = 0;
         foreach (JsonNode? test in tests)
         {
-            if (test is null)
+            if (test is not JsonObject testObject)
             {
                 continue;
             }
 
-            switch ((string?)test["status"])
+            switch ((string?)testObject["status"])
             {
                 case "passed": passed++; break;
                 case "failed": failed++; break;
@@ -215,7 +222,7 @@ internal static class CtrfReportMerger
                 default: other++; break;
             }
 
-            if (test["flaky"] is JsonValue flakyValue && flakyValue.TryGetValue(out bool isFlaky) && isFlaky)
+            if (testObject["flaky"] is JsonValue flakyValue && flakyValue.TryGetValue(out bool isFlaky) && isFlaky)
             {
                 flaky++;
             }
@@ -367,39 +374,40 @@ internal static class CtrfReportMerger
     /// </remarks>
     private static JsonArray CollapseRetryAttempts(JsonArray tests)
     {
-        var slots = new List<(JsonNode Final, List<JsonNode> Priors)>();
+        var slots = new List<(JsonObject Final, List<JsonObject> Priors)>();
         var byIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
 
         foreach (JsonNode? test in tests)
         {
-            if (test is null)
+            // Non-objects were already rejected during ingestion; this only re-establishes the type.
+            if (test is not JsonObject testObject)
             {
                 continue;
             }
 
             // A row we cannot identify gets its own slot: fusing unrelated rows would lose results, whereas an
             // uncollapsed duplicate is merely redundant.
-            if (GetTestIdentity(test) is not string identity)
+            if (GetTestIdentity(testObject) is not string identity)
             {
-                slots.Add((test, []));
+                slots.Add((testObject, []));
                 continue;
             }
 
             if (byIdentity.TryGetValue(identity, out int index))
             {
-                (JsonNode previousFinal, List<JsonNode> priors) = slots[index];
+                (JsonObject previousFinal, List<JsonObject> priors) = slots[index];
                 priors.Add(previousFinal);
-                slots[index] = (test, priors);
+                slots[index] = (testObject, priors);
             }
             else
             {
                 byIdentity.Add(identity, slots.Count);
-                slots.Add((test, []));
+                slots.Add((testObject, []));
             }
         }
 
         var collapsed = new JsonArray();
-        foreach ((JsonNode final, List<JsonNode> priors) in slots)
+        foreach ((JsonObject final, List<JsonObject> priors) in slots)
         {
             collapsed.Add(BuildCollapsedTest(final, priors));
         }
@@ -412,14 +420,19 @@ internal static class CtrfReportMerger
     /// producer-supplied <c>extra.uid</c>, and finally the suite path plus name. Returns <see langword="null"/>
     /// when the row carries none of them.
     /// </summary>
-    private static string? GetTestIdentity(JsonNode test)
+    private static string? GetTestIdentity(JsonObject test)
     {
         if (test["testId"] is JsonValue testIdValue && testIdValue.TryGetValue(out string? testId) && !RoslynString.IsNullOrEmpty(testId))
         {
             return $"testId\u001f{testId}";
         }
 
-        if (test["extra"]?["uid"] is JsonValue uidValue && uidValue.TryGetValue(out string? uid) && !RoslynString.IsNullOrEmpty(uid))
+        // `extra` is free-form, so a foreign producer may well have written a string or an array there; indexing
+        // anything but an object by property name throws.
+        if (test["extra"] is JsonObject extra
+            && extra["uid"] is JsonValue uidValue
+            && uidValue.TryGetValue(out string? uid)
+            && !RoslynString.IsNullOrEmpty(uid))
         {
             return $"uid\u001f{uid}";
         }
@@ -441,7 +454,7 @@ internal static class CtrfReportMerger
         return identity.Append('\u001f').Append(name).ToString();
     }
 
-    private static JsonNode BuildCollapsedTest(JsonNode final, List<JsonNode> priors)
+    private static JsonNode BuildCollapsedTest(JsonObject final, List<JsonObject> priors)
     {
         var collapsed = (JsonObject)final.DeepClone();
         if (priors.Count == 0)
@@ -450,7 +463,7 @@ internal static class CtrfReportMerger
         }
 
         var history = new JsonArray();
-        foreach (JsonNode prior in priors)
+        foreach (JsonObject prior in priors)
         {
             AppendAttempts(history, prior);
         }
@@ -494,7 +507,7 @@ internal static class CtrfReportMerger
     /// Appends the executions a non-final attempt row represents — the attempts it already nested, then its own
     /// outcome — to the retry history being built.
     /// </summary>
-    private static void AppendAttempts(JsonArray history, JsonNode test)
+    private static void AppendAttempts(JsonArray history, JsonObject test)
     {
         if (test["retryAttempts"] is JsonArray nested)
         {
@@ -525,7 +538,7 @@ internal static class CtrfReportMerger
     /// fields than a test: everything else (name, suite, tags, labels, ...) either belongs to the collapsed test
     /// object or, like <c>rawStatus</c>, moves under <c>extra</c>, the only permitted extension point.
     /// </summary>
-    private static JsonNode ToRetryAttempt(JsonNode test)
+    private static JsonNode ToRetryAttempt(JsonObject test)
     {
         // 'attempt' is assigned by the caller, once the position of this execution in the history is known.
         var attempt = new JsonObject
@@ -557,10 +570,16 @@ internal static class CtrfReportMerger
         return attempt;
     }
 
-    private static bool TryReadLong(JsonNode summary, string propertyName, out long value)
+    /// <summary>
+    /// Reads an integral property from a JSON node, tolerating anything the node may actually be. The node comes
+    /// straight out of an untrusted document — <c>results.summary</c> is not guaranteed to be an object — so a
+    /// non-object must read as "absent" rather than throw: indexing a <see cref="JsonValue"/> by property name is
+    /// an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    private static bool TryReadLong(JsonNode node, string propertyName, out long value)
     {
         value = 0;
-        if (summary[propertyName] is not JsonValue jsonValue)
+        if (node is not JsonObject jsonObject || jsonObject[propertyName] is not JsonValue jsonValue)
         {
             return false;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -552,9 +552,10 @@ internal static class CtrfReportMerger
     }
 
     /// <summary>
-    /// Copies retry attempt objects an input already recorded into the history being built, skipping entries that
-    /// are not objects: a <see langword="null"/> element could not describe an execution and is not a valid retry
-    /// attempt object.
+    /// Copies the retry attempts an input already recorded into the history being built, projecting each through
+    /// the same section 11 shaping as a promoted test row so a foreign producer's nested attempt cannot smuggle a
+    /// wrong-typed status or a disallowed field into the merged history. Entries that are not objects are skipped:
+    /// they could not describe an execution.
     /// </summary>
     private static void AppendNestedAttempts(JsonArray history, JsonArray nested)
     {
@@ -562,7 +563,7 @@ internal static class CtrfReportMerger
         {
             if (attempt is JsonObject attemptObject)
             {
-                history.Add(attemptObject.DeepClone());
+                history.Add(ToRetryAttempt(attemptObject));
             }
         }
     }
@@ -578,7 +579,7 @@ internal static class CtrfReportMerger
         var attempt = new JsonObject
         {
             ["attempt"] = 1,
-            ["status"] = test["status"]?.DeepClone() ?? "other",
+            ["status"] = ReadStatus(test),
         };
 
         foreach (string field in RetryAttemptFields)
@@ -611,6 +612,18 @@ internal static class CtrfReportMerger
     /// </summary>
     private static string? ReadString(JsonObject owner, string propertyName)
         => owner[propertyName] is JsonValue value && value.TryGetValue(out string? text) ? text : null;
+
+    /// <summary>
+    /// Reads a CTRF status, normalizing anything outside the vocabulary section 11.3 allows — a wrong-typed
+    /// value, or a status this producer invented — to <c>other</c>. Copying such a value verbatim into a retry
+    /// attempt would make the merged document schema-invalid, and <c>other</c> is both a legal status and the
+    /// bucket the summary already counts it in.
+    /// </summary>
+    private static string ReadStatus(JsonObject owner)
+    {
+        string? status = ReadString(owner, "status");
+        return status is "passed" or "failed" or "skipped" or "pending" or "other" ? status : "other";
+    }
 
     /// <summary>
     /// Reads an integral property from a JSON node, tolerating anything the node may actually be. The node comes

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -306,11 +306,11 @@ internal static class CtrfReportMerger
         return merged.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
     }
 
-    internal static async Task MergeToFileAsync(
+    internal static Task MergeToFileAsync(
         IReadOnlyList<string> inputPaths,
         string outputPath,
         CancellationToken cancellationToken)
-        => await MergeToFileAsync(inputPaths, outputPath, CtrfMergeMode.Concatenate, cancellationToken).ConfigureAwait(false);
+        => MergeToFileAsync(inputPaths, outputPath, CtrfMergeMode.Concatenate, cancellationToken);
 
     internal static async Task MergeToFileAsync(
         IReadOnlyList<string> inputPaths,

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -110,7 +110,7 @@ internal static class CtrfReportMerger
                 continue;
             }
 
-            string? format = root["reportFormat"] is JsonValue formatValue && formatValue.TryGetValue(out string? formatText) ? formatText : null;
+            string? format = ReadString(root, "reportFormat");
             if (!string.Equals(format, "CTRF", StringComparison.OrdinalIgnoreCase))
             {
                 continue;
@@ -120,10 +120,7 @@ internal static class CtrfReportMerger
             reportCount++;
             acceptedReports.Add(reportJson);
 
-            distinctRunIds.Add(
-                root["runId"] is JsonValue runIdValue && runIdValue.TryGetValue(out string? runIdText) && !RoslynString.IsNullOrEmpty(runIdText)
-                    ? runIdText
-                    : string.Empty);
+            distinctRunIds.Add(ReadString(root, "runId") is { Length: > 0 } runIdText ? runIdText : string.Empty);
 
             if (root["results"]?["environment"] is JsonObject environment)
             {
@@ -213,7 +210,7 @@ internal static class CtrfReportMerger
                 continue;
             }
 
-            switch ((string?)testObject["status"])
+            switch (ReadString(testObject, "status"))
             {
                 case "passed": passed++; break;
                 case "failed": failed++; break;
@@ -422,22 +419,19 @@ internal static class CtrfReportMerger
     /// </summary>
     private static string? GetTestIdentity(JsonObject test)
     {
-        if (test["testId"] is JsonValue testIdValue && testIdValue.TryGetValue(out string? testId) && !RoslynString.IsNullOrEmpty(testId))
+        if (ReadString(test, "testId") is { Length: > 0 } testId)
         {
             return $"testId\u001f{testId}";
         }
 
         // `extra` is free-form, so a foreign producer may well have written a string or an array there; indexing
         // anything but an object by property name throws.
-        if (test["extra"] is JsonObject extra
-            && extra["uid"] is JsonValue uidValue
-            && uidValue.TryGetValue(out string? uid)
-            && !RoslynString.IsNullOrEmpty(uid))
+        if (test["extra"] is JsonObject extra && ReadString(extra, "uid") is { Length: > 0 } uid)
         {
             return $"uid\u001f{uid}";
         }
 
-        if (test["name"] is not JsonValue nameValue || !nameValue.TryGetValue(out string? name) || RoslynString.IsNullOrEmpty(name))
+        if (ReadString(test, "name") is not { Length: > 0 } name)
         {
             return null;
         }
@@ -447,7 +441,13 @@ internal static class CtrfReportMerger
         {
             foreach (JsonNode? segment in suite)
             {
-                identity.Append('\u001f').Append((string?)segment);
+                // A suite segment is normally a string, but the document is untrusted. Fall back to the
+                // segment's JSON text so a non-string segment still contributes a distinct, deterministic part
+                // of the key instead of throwing on the string conversion.
+                identity.Append('\u001f').Append(
+                    segment is JsonValue segmentValue && segmentValue.TryGetValue(out string? segmentText)
+                        ? segmentText
+                        : segment?.ToJsonString());
             }
         }
 
@@ -483,7 +483,7 @@ internal static class CtrfReportMerger
             }
 
             attempt["attempt"] = i + 1;
-            anyFailed |= (string?)attempt["status"] == "failed";
+            anyFailed |= ReadString(attempt, "status") == "failed";
         }
 
         collapsed["retryAttempts"] = history;
@@ -491,7 +491,7 @@ internal static class CtrfReportMerger
 
         // CTRF 9.22: flaky only when the FINAL status is passed after at least one failed attempt. Recomputed
         // (rather than inherited) because an input's own flag only describes the attempt that produced it.
-        if ((string?)collapsed["status"] == "passed" && anyFailed)
+        if (ReadString(collapsed, "status") == "passed" && anyFailed)
         {
             collapsed["flaky"] = true;
         }
@@ -569,6 +569,14 @@ internal static class CtrfReportMerger
 
         return attempt;
     }
+
+    /// <summary>
+    /// Reads a string property, treating a value of any other JSON type as absent. The explicit
+    /// <c>(string?)</c> conversion on a <see cref="JsonNode"/> THROWS for a non-string value rather than
+    /// yielding <see langword="null"/>, and every document reaching the merger is untrusted.
+    /// </summary>
+    private static string? ReadString(JsonObject owner, string propertyName)
+        => owner[propertyName] is JsonValue value && value.TryGetValue(out string? text) ? text : null;
 
     /// <summary>
     /// Reads an integral property from a JSON node, tolerating anything the node may actually be. The node comes

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -22,6 +22,20 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 ///   <item><description><c>tool</c> keeps a concrete identity only when every input reported the exact same tool object; otherwise (inputs disagree or any input omits it) a neutral merger identity is used, so one framework is not attributed to another's tests.</description></item>
 ///   <item><description><c>environment</c> keeps the first report's shared fields, but module-specific values under <c>extra</c> (<c>testApplication</c>, <c>exitCode</c>) are dropped rather than presented as describing all merged modules.</description></item>
 /// </list>
+/// <para>
+/// Validity contract. The merger guarantees the shape of what it SYNTHESIZES — the summary, the identity
+/// fields, and the retry attempt objects it builds and renumbers — and PRESERVES verbatim what it merely
+/// passes through. The only thing it drops is an element that cannot be a Test at all (a non-object), because
+/// that alone would break the array's item type for every consumer of the merged file.
+/// </para>
+/// <para>
+/// It deliberately does NOT validate or repair the Test rows themselves, even though an input may carry a
+/// row with a missing or wrong-typed required field. Dropping such a row would lose a real result and
+/// rewriting it would fabricate an outcome the producer never reported, which are both worse than relaying a
+/// defect that belongs to the input document. A corollary is that merging a single document whose identities
+/// are already unique leaves its <c>tests[]</c> untouched: the merger combines reports, it is not a CTRF
+/// validator or linter.
+/// </para>
 /// </remarks>
 internal static class CtrfReportMerger
 {
@@ -491,6 +505,11 @@ internal static class CtrfReportMerger
     private static JsonNode BuildCollapsedTest(JsonObject final, List<JsonObject> priors)
     {
         var collapsed = (JsonObject)final.DeepClone();
+
+        // Nothing was merged into this row, so it is passed through rather than synthesized: its own
+        // `retryAttempts[]` (from in-process retries the producer already recorded) stays exactly as written.
+        // Below, once there ARE priors, the history becomes the merger's own array — it has to be rebuilt and
+        // renumbered into a contiguous 1..N-1 — which is why those entries are reshaped and these are not.
         if (priors.Count == 0)
         {
             return collapsed;

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -414,21 +414,41 @@ internal static class CtrfReportMerger
 
     /// <summary>
     /// Computes the key identifying the logical test a row describes, preferring the CTRF <c>testId</c>, then the
-    /// producer-supplied <c>extra.uid</c>, and finally the suite path plus name. Returns <see langword="null"/>
-    /// when the row carries none of them.
+    /// legacy <c>id</c>, then the producer-supplied <c>extra.uid</c>, and finally the suite path plus name and the
+    /// other stable discriminators the Test object offers. Returns <see langword="null"/> when the row carries
+    /// none of them.
     /// </summary>
     /// <remarks>
-    /// The suite/name fallback length-prefixes every component rather than just separating them. A CTRF
-    /// <c>name</c> or suite segment is an arbitrary non-empty string, so it may itself contain the separator:
-    /// with plain separation, <c>suite: ["A"], name: "B\u001fC"</c> and <c>suite: ["A", "B"], name: "C"</c>
-    /// would produce the same key and collapse two unrelated tests into one, silently dropping a result.
-    /// Length prefixes make the encoding unambiguous whatever the components contain.
+    /// <para>
+    /// The identifier order follows CTRF 9.1: <c>id</c> is a stable test-case identifier that consumers treat as
+    /// legacy, using <c>testId</c> in preference only when both are present. Ignoring an <c>id</c>-only report
+    /// would drop it to the heuristic fallback and risk fusing distinct same-named tests.
+    /// </para>
+    /// <para>
+    /// The fallback length-prefixes every component rather than just separating them. A CTRF <c>name</c> or suite
+    /// segment is an arbitrary non-empty string, so it may itself contain the separator: with plain separation,
+    /// <c>suite: ["A"], name: "B\u001fC"</c> and <c>suite: ["A", "B"], name: "C"</c> would produce the same key
+    /// and collapse two unrelated tests into one, silently dropping a result. Length prefixes make the encoding
+    /// unambiguous whatever the components contain.
+    /// </para>
+    /// <para>
+    /// The fallback also folds in <c>filePath</c> (9.19) and <c>parameters</c> (9.30), because suite plus name
+    /// alone is not unique: parameterized rows share both while differing only in their parameters, and
+    /// same-named tests in different files differ only by path. If a producer were to serialize <c>parameters</c>
+    /// inconsistently between attempts, the effect is that a retry is not folded — a duplicated row rather than a
+    /// lost result, which is the safe direction to fail in.
+    /// </para>
     /// </remarks>
     private static string? GetTestIdentity(JsonObject test)
     {
         if (ReadString(test, "testId") is { Length: > 0 } testId)
         {
             return $"testId\u001f{testId}";
+        }
+
+        if (ReadString(test, "id") is { Length: > 0 } id)
+        {
+            return $"id\u001f{id}";
         }
 
         // `extra` is free-form, so a foreign producer may well have written a string or an array there; indexing
@@ -460,6 +480,8 @@ internal static class CtrfReportMerger
         }
 
         AppendIdentityComponent(identity, name);
+        AppendIdentityComponent(identity, ReadString(test, "filePath"));
+        AppendIdentityComponent(identity, test["parameters"]?.ToJsonString());
         return identity.ToString();
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,7 +1,12 @@
 #nullable enable
 virtual Microsoft.Testing.Extensions.ReportGeneratorBase<TGenerator, TCapturedTestResult>.ArtifactKind.get -> string?
+Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
+Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.CollapseRetryAttempts = 1 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
+Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.Concatenate = 0 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports) -> string!
+static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports, Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode mode) -> string!
+static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode mode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectoryNotWritableErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -52,6 +52,7 @@ This package extends Microsoft Testing Platform to produce test reports in the C
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\RoslynString.cs" Link="Helpers\RoslynString.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ApplicationStateGuard.cs" Link="Helpers\ApplicationStateGuard.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\EnvironmentVariableConstants.cs" Link="Helpers\EnvironmentVariableConstants.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\ExitCodes.cs" Link="Helpers\ExitCodes.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -2,6 +2,7 @@
 // Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.Policy.Resources;
+using Microsoft.Testing.Platform;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
@@ -83,6 +84,15 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         }
 
         environment.SetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_TRX_TESTRUN_ID, Guid.NewGuid().ToString("N"));
+
+        // Every attempt is a separate process writing its own report, but together they are one logical run.
+        // Formats that can express that (CTRF 'runId') need all attempts to agree on a single id, so seed one
+        // here and let the launched test hosts inherit it. An id set by an outer orchestrator (for example
+        // 'dotnet test' correlating several modules) already covers these attempts, so it is preserved.
+        if (RoslynString.IsNullOrEmpty(environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID)))
+        {
+            environment.SetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID, Guid.NewGuid().ToString("N"));
+        }
 
         ILogger logger = _serviceProvider.GetLoggerFactory().CreateLogger<RetryOrchestrator>();
         IConfiguration configuration = _serviceProvider.GetConfiguration();

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -86,12 +86,18 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
         environment.SetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_TRX_TESTRUN_ID, Guid.NewGuid().ToString("N"));
 
         // Every attempt is a separate process writing its own report, but together they are one logical run.
-        // Formats that can express that (CTRF 'runId') need all attempts to agree on a single id, so seed one
-        // here and let the launched test hosts inherit it. An id set by an outer orchestrator (for example
-        // 'dotnet test' correlating several modules) already covers these attempts, so it is preserved.
+        // Formats that can express that (CTRF 'runId') need all attempts to agree on a single id, so establish
+        // one here and let the launched test hosts inherit it. Preference order:
+        //   - an id already set explicitly (a CI job correlating several modules or machines) is kept;
+        //   - otherwise the dotnet test execution id, which already identifies THIS test application's process
+        //     tree, so the attempts stay part of that run instead of forming a separate one;
+        //   - otherwise a fresh id, because a standalone retried run is its own logical run.
         if (RoslynString.IsNullOrEmpty(environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID)))
         {
-            environment.SetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID, Guid.NewGuid().ToString("N"));
+            string? executionId = environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
+            environment.SetEnvironmentVariable(
+                EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID,
+                RoslynString.IsNullOrEmpty(executionId) ? Guid.NewGuid().ToString("D") : executionId!);
         }
 
         ILogger logger = _serviceProvider.GetLoggerFactory().CreateLogger<RetryOrchestrator>();

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
@@ -58,6 +58,12 @@ internal static class EnvironmentVariableConstants
     // Unhandled Exception
     public const string TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION = nameof(TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION);
 
+    // Correlates every process that takes part in the same logical test run: the successive attempts launched by
+    // the retry orchestrator, or the modules of a single 'dotnet test' invocation. Report formats that model a
+    // logical run spanning several documents (CTRF 'runId') surface this value so a consumer can tie those
+    // documents back together. It may also be set externally to correlate shards running on different machines.
+    public const string TESTINGPLATFORM_LOGICAL_RUN_ID = nameof(TESTINGPLATFORM_LOGICAL_RUN_ID);
+
     // Trx
     public const string TESTINGPLATFORM_TRX_TESTRUN_ID = nameof(TESTINGPLATFORM_TRX_TESTRUN_ID);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/EnvironmentVariableConstants.cs
@@ -58,10 +58,14 @@ internal static class EnvironmentVariableConstants
     // Unhandled Exception
     public const string TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION = nameof(TESTINGPLATFORM_EXIT_PROCESS_ON_UNHANDLED_EXCEPTION);
 
-    // Correlates every process that takes part in the same logical test run: the successive attempts launched by
-    // the retry orchestrator, or the modules of a single 'dotnet test' invocation. Report formats that model a
-    // logical run spanning several documents (CTRF 'runId') surface this value so a consumer can tie those
-    // documents back together. It may also be set externally to correlate shards running on different machines.
+    // Correlates the processes that make up one logical test run, so report formats that can describe a run
+    // spanning several documents (CTRF 'runId') can tie those documents back together. The retry orchestrator
+    // sets it before launching its attempts, and any process tree started from there inherits it.
+    //
+    // NOTE: a multi-project 'dotnet test' does NOT set this. Each module is a separate root test application
+    // with its own execution id (see docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md), so its
+    // modules are distinct execution trees. Correlating them — or correlating shards running on different
+    // machines — requires setting this variable explicitly before launching them.
     public const string TESTINGPLATFORM_LOGICAL_RUN_ID = nameof(TESTINGPLATFORM_LOGICAL_RUN_ID);
 
     // Trx

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
@@ -135,6 +135,10 @@ public class CtrfReportTests : AcceptanceTestBase<CtrfReportTests.TestAssetFixtu
         //  - FlakyTest (retried)     → first attempt failed, retried successfully:
         //                              final status: "passed", retries: 1,
         //                              retryAttempts[].status: "failed", flaky: true
+        //
+        // The retry shape follows the model confirmed in ctrf-io/ctrf#58: `retryAttempts[]`
+        // holds attempts 1..N-1 (the final attempt's outcome IS the test object), so
+        // `retries` equals `retryAttempts.length` and the final attempt is `retries + 1`.
         string actual = File.ReadAllText(filePath);
         string normalized = NormalizeCtrfReport(actual);
 
@@ -143,6 +147,7 @@ public class CtrfReportTests : AcceptanceTestBase<CtrfReportTests.TestAssetFixtu
   "reportFormat": "CTRF",
   "specVersion": "0.0.0",
   "reportId": "<GUID>",
+  "runId": "<RUN_ID>",
   "timestamp": "<TIMESTAMP>",
   "generatedBy": "Microsoft.Testing.Extensions.CtrfReport@<VERSION>",
   "results": {
@@ -228,6 +233,7 @@ public class CtrfReportTests : AcceptanceTestBase<CtrfReportTests.TestAssetFixtu
         // anchored, but runtime-variable values are folded into stable tokens.
         string normalized = actual;
         normalized = Regex.Replace(normalized, @"""reportId"": ""[^""]+""", @"""reportId"": ""<GUID>""");
+        normalized = Regex.Replace(normalized, @"""runId"": ""[^""]+""", @"""runId"": ""<RUN_ID>""");
         normalized = Regex.Replace(normalized, @"""timestamp"": ""[^""]+""", @"""timestamp"": ""<TIMESTAMP>""");
         normalized = Regex.Replace(normalized, @"""generatedBy"": ""Microsoft\.Testing\.Extensions\.CtrfReport@[^""]+""", @"""generatedBy"": ""Microsoft.Testing.Extensions.CtrfReport@<VERSION>""");
         normalized = Regex.Replace(normalized, @"""start"": \d+", @"""start"": <EPOCH_MS>");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -551,9 +551,22 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         testHostResult.AssertOutputDoesNotContain("Minimum expected tests policy violation");
     }
 
+    internal static IEnumerable<(string Tfm, string? SeededVariable)> GetRunIdMatrix()
+    {
+        foreach (string tfm in TargetFrameworks.Net)
+        {
+            // The orchestrator resolves the logical run id as: an explicitly set id wins, else the dotnet test
+            // execution id (which already identifies this test application's process tree), else a fresh one.
+            // Exercise all three branches.
+            yield return (tfm, null);
+            yield return (tfm, EnvironmentVariableConstants.TESTINGPLATFORM_LOGICAL_RUN_ID);
+            yield return (tfm, EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID);
+        }
+    }
+
     [TestMethod]
-    [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
-    public async Task RetryFailedTests_CtrfReports_ShareRunIdButNotReportId(string tfm)
+    [DynamicData(nameof(GetRunIdMatrix))]
+    public async Task RetryFailedTests_CtrfReports_ShareRunIdButNotReportId(string tfm, string? seededVariable)
     {
         // Each attempt is a separate process that writes its own CTRF document, but together they are one
         // logical run. Per ctrf-io/ctrf#58 those documents SHOULD share a `runId` while each stays a distinct
@@ -564,14 +577,25 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
 
         // METHOD1=1 makes TestMethod1 fail on the first attempt and pass on the second, so exactly two
         // attempts run and each writes a CTRF report.
+        Dictionary<string, string?> environmentVariables = new()
+        {
+            { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
+            { "METHOD1", "1" },
+            { "RESULTDIR", resultDirectory },
+        };
+
+        // When a correlation id is supplied from outside, the attempts must adopt THAT id rather than minting
+        // their own — that is what lets a CI job tie several modules or machines into one logical run.
+        string? expectedRunId = null;
+        if (seededVariable is not null)
+        {
+            expectedRunId = $"seeded-{Guid.NewGuid():N}";
+            environmentVariables[seededVariable] = expectedRunId;
+        }
+
         TestHostResult testHostResult = await testHost.ExecuteAsync(
             $"--retry-failed-tests 3 --report-ctrf --results-directory {resultDirectory}",
-            new()
-            {
-                { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
-                { "METHOD1", "1" },
-                { "RESULTDIR", resultDirectory },
-            },
+            environmentVariables,
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
@@ -590,6 +614,15 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         Assert.AreEqual(runIds[0], runIds[1], "Both attempts belong to the same logical run, so they must share a runId.");
         Assert.AreNotEqual(reportIds[0], reportIds[1], "Each attempt is a distinct artifact, so it must have its own reportId.");
         Assert.AreNotEqual(runIds[0], reportIds[0], "runId and reportId identify different things and must not be the same value.");
+
+        if (expectedRunId is not null)
+        {
+            Assert.AreEqual(expectedRunId, runIds[0], $"'{seededVariable}' must be honored instead of minting a new run id.");
+        }
+        else
+        {
+            Assert.IsTrue(Guid.TryParse(runIds[0], out _), $"An uncorrelated run must mint a GUID run id, got '{runIds[0]}'.");
+        }
     }
 
     private static string ReadRequiredStringProperty(string filePath, string propertyName)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -551,6 +551,59 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         testHostResult.AssertOutputDoesNotContain("Minimum expected tests policy violation");
     }
 
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
+    public async Task RetryFailedTests_CtrfReports_ShareRunIdButNotReportId(string tfm)
+    {
+        // Each attempt is a separate process that writes its own CTRF document, but together they are one
+        // logical run. Per ctrf-io/ctrf#58 those documents SHOULD share a `runId` while each stays a distinct
+        // artifact with its own `reportId`. This is the only test that exercises the cross-process contract:
+        // the engine unit tests mock IEnvironment, so they cannot observe the orchestrator's seeding.
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+        string resultDirectory = Path.Combine(testHost.DirectoryName, Guid.NewGuid().ToString("N"));
+
+        // METHOD1=1 makes TestMethod1 fail on the first attempt and pass on the second, so exactly two
+        // attempts run and each writes a CTRF report.
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--retry-failed-tests 3 --report-ctrf --results-directory {resultDirectory}",
+            new()
+            {
+                { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
+                { "METHOD1", "1" },
+                { "RESULTDIR", resultDirectory },
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputContains("Retry summary: Passed! after 2/4 attempts");
+
+        // Attempts 1..N-1 stay under Retries/<n>/; only the final attempt's report is moved to the top level.
+        string[] ctrfFiles =
+        [
+            .. Directory.GetFiles(resultDirectory, "*.ctrf.json", SearchOption.AllDirectories).OrderBy(f => f, StringComparer.Ordinal),
+        ];
+        Assert.HasCount(2, ctrfFiles, $"Expected one CTRF report per attempt.{Environment.NewLine}{string.Join(Environment.NewLine, ctrfFiles)}");
+
+        string[] runIds = [.. ctrfFiles.Select(f => ReadRequiredStringProperty(f, "runId"))];
+        string[] reportIds = [.. ctrfFiles.Select(f => ReadRequiredStringProperty(f, "reportId"))];
+
+        Assert.AreEqual(runIds[0], runIds[1], "Both attempts belong to the same logical run, so they must share a runId.");
+        Assert.AreNotEqual(reportIds[0], reportIds[1], "Each attempt is a distinct artifact, so it must have its own reportId.");
+        Assert.AreNotEqual(runIds[0], reportIds[0], "runId and reportId identify different things and must not be the same value.");
+    }
+
+    private static string ReadRequiredStringProperty(string filePath, string propertyName)
+    {
+        using var document = System.Text.Json.JsonDocument.Parse(File.ReadAllText(filePath));
+        Assert.IsTrue(
+            document.RootElement.TryGetProperty(propertyName, out System.Text.Json.JsonElement value),
+            $"'{propertyName}' is missing from '{filePath}'.");
+
+        string? text = value.GetString();
+        Assert.IsFalse(string.IsNullOrEmpty(text), $"'{propertyName}' must be a non-empty string in '{filePath}'.");
+        return text!;
+    }
+
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {
         public string TargetAssetPath => GetAssetPath(AssetName);
@@ -558,7 +611,8 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
                 TestCode
                 .PatchTargetFrameworks(TargetFrameworks.All)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsCtrfReportVersion$", MicrosoftTestingExtensionsCtrfReportVersion));
 
         private const string TestCode = """
 #file RetryFailedTests.csproj
@@ -574,6 +628,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CtrfReport" Version="$MicrosoftTestingExtensionsCtrfReportVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$MicrosoftTestingPlatformVersion$" />
@@ -611,6 +666,9 @@ public class Program
             (_,__) => new DummyTestFramework());
         builder.AddCrashDumpProvider();
         builder.AddTrxReportProvider();
+#pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates.
+        builder.AddCtrfReportProvider();
+#pragma warning restore TPEXP
         builder.AddRetryProvider();
         builder.AddMSBuild();
         builder.AddTreeNodeFilterService(treeNodeFilterExtension);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -845,6 +845,9 @@ public class CtrfReportEngineTests
 
         using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
         Assert.AreEqual("run-42", document.RootElement.GetProperty("runId").GetString());
+
+        // The run and the document are different things: a correlated run must not leak into the artifact id.
+        Assert.AreNotEqual("run-42", document.RootElement.GetProperty("reportId").GetString());
     }
 
     [TestMethod]
@@ -862,6 +865,7 @@ public class CtrfReportEngineTests
 
         using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
         Assert.AreEqual("execution-7", document.RootElement.GetProperty("runId").GetString());
+        Assert.AreNotEqual("execution-7", document.RootElement.GetProperty("reportId").GetString());
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -833,12 +833,13 @@ public class CtrfReportEngineTests
     [TestMethod]
     public async Task GenerateReportAsync_RunId_UsesTheSharedLogicalRunId()
     {
-        // ctrf-io/ctrf#58: every process of one logical run (the attempts of --retry-failed-tests, the modules
-        // of one dotnet test invocation) must stamp the same runId, so consumers can tie those documents back
-        // together. The orchestrator publishes that id through this environment variable.
+        // ctrf-io/ctrf#58: every process of one logical run — notably the successive attempts of
+        // --retry-failed-tests — must stamp the same runId so consumers can tie those documents back
+        // together. The retry orchestrator publishes that id through this environment variable.
         using var memoryStream = new MemoryFileStream();
         CtrfReportEngine engine = CreateEngine(memoryStream);
         _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_LOGICAL_RUN_ID")).Returns("run-42");
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID")).Returns("execution-7");
 
         await engine.GenerateReportAsync([Captured("p1", "Passing test", "passed")]);
 
@@ -849,6 +850,9 @@ public class CtrfReportEngineTests
     [TestMethod]
     public async Task GenerateReportAsync_RunId_FallsBackToTheDotnetTestExecutionId()
     {
+        // The execution id identifies this test application's own process tree. It is per root test application,
+        // not per 'dotnet test' invocation, so it correlates a module with its child processes — not with the
+        // sibling modules of a multi-project run, which legitimately report different logical runs.
         using var memoryStream = new MemoryFileStream();
         CtrfReportEngine engine = CreateEngine(memoryStream);
         _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_LOGICAL_RUN_ID")).Returns((string?)null);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -830,6 +830,53 @@ public class CtrfReportEngineTests
         Assert.AreEqual("only-line", stdout[0].GetString());
     }
 
+    [TestMethod]
+    public async Task GenerateReportAsync_RunId_UsesTheSharedLogicalRunId()
+    {
+        // ctrf-io/ctrf#58: every process of one logical run (the attempts of --retry-failed-tests, the modules
+        // of one dotnet test invocation) must stamp the same runId, so consumers can tie those documents back
+        // together. The orchestrator publishes that id through this environment variable.
+        using var memoryStream = new MemoryFileStream();
+        CtrfReportEngine engine = CreateEngine(memoryStream);
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_LOGICAL_RUN_ID")).Returns("run-42");
+
+        await engine.GenerateReportAsync([Captured("p1", "Passing test", "passed")]);
+
+        using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
+        Assert.AreEqual("run-42", document.RootElement.GetProperty("runId").GetString());
+    }
+
+    [TestMethod]
+    public async Task GenerateReportAsync_RunId_FallsBackToTheDotnetTestExecutionId()
+    {
+        using var memoryStream = new MemoryFileStream();
+        CtrfReportEngine engine = CreateEngine(memoryStream);
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_LOGICAL_RUN_ID")).Returns((string?)null);
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID")).Returns("execution-7");
+
+        await engine.GenerateReportAsync([Captured("p1", "Passing test", "passed")]);
+
+        using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
+        Assert.AreEqual("execution-7", document.RootElement.GetProperty("runId").GetString());
+    }
+
+    [TestMethod]
+    public async Task GenerateReportAsync_RunId_IsGenerated_WhenNothingCorrelatedTheProcess()
+    {
+        // A standalone run is its own logical run, and CTRF requires runId to be a non-empty string when present.
+        using var memoryStream = new MemoryFileStream();
+        CtrfReportEngine engine = CreateEngine(memoryStream);
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_LOGICAL_RUN_ID")).Returns((string?)null);
+        _ = _environmentMock.Setup(x => x.GetEnvironmentVariable("TESTINGPLATFORM_DOTNETTEST_EXECUTIONID")).Returns((string?)null);
+
+        await engine.GenerateReportAsync([Captured("p1", "Passing test", "passed")]);
+
+        using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
+        string runId = document.RootElement.GetProperty("runId").GetString()!;
+        Assert.IsTrue(Guid.TryParse(runId, out _), $"Expected a generated id, got '{runId}'.");
+        Assert.AreNotEqual(document.RootElement.GetProperty("reportId").GetString(), runId);
+    }
+
     private CtrfReportEngine CreateEngine(MemoryFileStream stream)
     {
         _ = _fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -881,6 +881,35 @@ public sealed class CtrfReportMergerTests
         Assert.IsTrue(Guid.TryParse(collapsed, out _), $"reportId must be a UUID, got '{collapsed}'.");
     }
 
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_DoesNotFuseTestsWhoseNameContainsTheIdentitySeparator()
+    {
+        // A CTRF `name` is an arbitrary non-empty string, so it may contain whatever character the identity key
+        // uses as a separator. With plain separation, suite ["A"] + name "B\u001fC" and suite ["A","B"] + name
+        // "C" flatten to the same key, which would fuse two unrelated tests and silently drop a result.
+        static JsonObject Named(string status, string name, params string[] suite)
+        {
+            JsonObject test = Test(name, status);
+            test["suite"] = new JsonArray([.. suite.Select(s => (JsonNode)JsonValue.Create(s)!)]);
+            return test;
+        }
+
+        string report = BuildReport(testEntries:
+        [
+            Named("failed", "B\u001fC", "A"),
+            Named("passed", "C", "A", "B"),
+        ]);
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([report], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        Assert.HasCount(2, tests, "Two distinct tests must not collapse into one.");
+        Assert.AreEqual("failed", (string?)tests[0]!["status"]);
+        Assert.AreEqual("passed", (string?)tests[1]!["status"]);
+        Assert.IsNull(tests[0]!["retries"], "Neither row is a retry of the other.");
+        Assert.IsNull(tests[1]!["retries"]);
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -575,6 +575,9 @@ public sealed class CtrfReportMergerTests
         JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge([a, b]))!;
 
         Assert.IsNull(merged["runId"]);
+
+        // Suppressing the run correlation must not suppress the merged document's own identity.
+        Assert.IsNotNull((string?)merged["reportId"]);
     }
 
     [TestMethod]
@@ -588,6 +591,7 @@ public sealed class CtrfReportMergerTests
         JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge([a, b]))!;
 
         Assert.IsNull(merged["runId"]);
+        Assert.IsNotNull((string?)merged["reportId"]);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -975,6 +975,47 @@ public sealed class CtrfReportMergerTests
             tests.Select(t => (string?)t!["status"]).ToArray());
     }
 
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_KeepsRetryHistorySchemaValid()
+    {
+        // CTRF section 11 constrains a retry attempt: `status` must be one of five values, and no unknown field
+        // may appear outside `extra`. Both a promoted test row and an attempt an input already nested must be
+        // shaped to that, otherwise one foreign document makes the merged history schema-invalid.
+        JsonObject firstAttempt = Test("t", "failed");
+        firstAttempt["extra"] = new JsonObject { ["uid"] = "u1" };
+        firstAttempt["status"] = 7;
+        firstAttempt["retryAttempts"] = new JsonArray(new JsonObject
+        {
+            ["attempt"] = 1,
+            ["status"] = 3,
+            ["message"] = "nested",
+            ["name"] = "a test-only field section 11 forbids",
+        });
+
+        JsonObject finalAttempt = Test("t", "passed");
+        finalAttempt["extra"] = new JsonObject { ["uid"] = "u1" };
+
+        string report = BuildReport(testEntries: [firstAttempt, finalAttempt]);
+
+        JsonNode test = ((JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([report], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!)[0]!;
+
+        var retryAttempts = (JsonArray)test["retryAttempts"]!;
+        Assert.HasCount(2, retryAttempts);
+
+        // The nested attempt keeps its diagnostics but loses the wrong-typed status and the test-only field.
+        Assert.AreEqual("other", (string?)retryAttempts[0]!["status"], "A non-string status is normalized.");
+        Assert.AreEqual("nested", (string?)retryAttempts[0]!["message"]);
+        Assert.IsNull(retryAttempts[0]!["name"], "Section 11 forbids unknown fields outside 'extra'.");
+
+        // The promoted row is normalized the same way.
+        Assert.AreEqual("other", (string?)retryAttempts[1]!["status"]);
+
+        // Attempt numbers stay a contiguous 1..N-1 sequence after the projection.
+        Assert.AreEqual(1, (long)retryAttempts[0]!["attempt"]!);
+        Assert.AreEqual(2, (long)retryAttempts[1]!["attempt"]!);
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -851,6 +851,32 @@ public sealed class CtrfReportMergerTests
         Assert.IsTrue((bool)tests[0]!["flaky"]!);
     }
 
+    [TestMethod]
+    public void Merge_ReportId_IsDeterministicPerModeAndDiffersBetweenModes()
+    {
+        // The two modes turn the same inputs into materially different documents (three rows vs one collapsed
+        // row here), so CTRF 5.3 requires each to get its own reportId — one id must not name both artifacts.
+        // Determinism per mode (RFC 018 idempotency) must survive that.
+        string attempt1 = BuildReport(testEntries: [Attempt("t", "failed", uid: "u1")]);
+        string attempt2 = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
+        string[] inputs = [attempt1, attempt2];
+
+        string concatenated = (string)JsonNode.Parse(CtrfReportMerger.Merge(inputs, CtrfMergeMode.Concatenate))!["reportId"]!;
+        string collapsed = (string)JsonNode.Parse(CtrfReportMerger.Merge(inputs, CtrfMergeMode.CollapseRetryAttempts))!["reportId"]!;
+
+        Assert.AreNotEqual(concatenated, collapsed, "Two materially different merged documents must not share a reportId.");
+
+        // Re-merging the same inputs the same way reproduces the id.
+        Assert.AreEqual(concatenated, (string)JsonNode.Parse(CtrfReportMerger.Merge(inputs, CtrfMergeMode.Concatenate))!["reportId"]!);
+        Assert.AreEqual(collapsed, (string)JsonNode.Parse(CtrfReportMerger.Merge(inputs, CtrfMergeMode.CollapseRetryAttempts))!["reportId"]!);
+
+        // The default overload keeps concatenating, so it must agree with the explicit Concatenate mode.
+        Assert.AreEqual(concatenated, (string)JsonNode.Parse(CtrfReportMerger.Merge(inputs))!["reportId"]!);
+
+        // CTRF 5.3: reportId MUST be a valid UUID when present.
+        Assert.IsTrue(Guid.TryParse(collapsed, out _), $"reportId must be a UUID, got '{collapsed}'.");
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -490,6 +490,7 @@ public sealed class CtrfReportMergerTests
         string toolName = "MSTest",
         string? toolVersion = null,
         string osPlatform = "test",
+        string? runId = null,
         IEnumerable<JsonObject>? testEntries = null)
     {
         var testArray = new JsonArray();
@@ -542,7 +543,257 @@ public sealed class CtrfReportMergerTests
             },
         };
 
+        if (runId is not null)
+        {
+            report["runId"] = runId;
+        }
+
         return report.ToJsonString();
+    }
+
+    [TestMethod]
+    public void Merge_CarriesRunId_WhenEveryInputReportsTheSameOne()
+    {
+        // Per-attempt (and per-shard) documents of one logical run share a runId; the merged document
+        // describes that same logical run, so it keeps the id while getting its own reportId.
+        string a = BuildReport(runId: "run-42", testEntries: [Test("a", "passed")]);
+        string b = BuildReport(runId: "run-42", testEntries: [Test("b", "passed")]);
+
+        JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge([a, b]))!;
+
+        Assert.AreEqual("run-42", (string?)merged["runId"]);
+        Assert.AreNotEqual("run-42", (string?)merged["reportId"]);
+        Assert.AreNotEqual((string?)JsonNode.Parse(a)!["reportId"], (string?)merged["reportId"]);
+    }
+
+    [TestMethod]
+    public void Merge_OmitsRunId_WhenInputsBelongToDifferentRuns()
+    {
+        string a = BuildReport(runId: "run-1");
+        string b = BuildReport(runId: "run-2");
+
+        JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge([a, b]))!;
+
+        Assert.IsNull(merged["runId"]);
+    }
+
+    [TestMethod]
+    public void Merge_OmitsRunId_WhenAnInputHasNone()
+    {
+        // An input with no runId may or may not belong to the same run, so claiming the known one would
+        // assert a correlation the inputs do not support.
+        string a = BuildReport(runId: "run-1");
+        string b = BuildReport();
+
+        JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge([a, b]))!;
+
+        Assert.IsNull(merged["runId"]);
+    }
+
+    [TestMethod]
+    public void Merge_DefaultMode_DoesNotCollapseRepeatedTests()
+    {
+        // Cross-module merges must keep every row: MTP UIDs are only unique within an assembly, so two
+        // same-named tests can legitimately come from different modules.
+        string attempt1 = BuildReport(testEntries: [Attempt("t", "failed", uid: "u1")]);
+        string attempt2 = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
+
+        JsonNode results = JsonNode.Parse(CtrfReportMerger.Merge([attempt1, attempt2]))!["results"]!;
+
+        Assert.HasCount(2, (JsonArray)results["tests"]!);
+        Assert.AreEqual(2, (long)results["summary"]!["tests"]!);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_FoldsEarlierAttemptsIntoRetryHistory()
+    {
+        // Three per-attempt documents of one orchestrated retry run: attempts 1 and 2 failed, attempt 3 passed.
+        string attempt1 = BuildReport(testEntries: [Attempt("flaky test", "failed", uid: "u1", duration: 120, message: "boom 1")]);
+        string attempt2 = BuildReport(testEntries: [Attempt("flaky test", "failed", uid: "u1", duration: 130, message: "boom 2")]);
+        string attempt3 = BuildReport(testEntries: [Attempt("flaky test", "passed", uid: "u1", duration: 140)]);
+
+        JsonNode results = JsonNode.Parse(CtrfReportMerger.Merge([attempt1, attempt2, attempt3], CtrfMergeMode.CollapseRetryAttempts))!["results"]!;
+
+        var tests = (JsonArray)results["tests"]!;
+        Assert.HasCount(1, tests);
+
+        JsonNode test = tests[0]!;
+        Assert.AreEqual("passed", (string?)test["status"]);
+        Assert.IsTrue((bool)test["flaky"]!);
+
+        // ctrf-io/ctrf#58: retryAttempts holds attempts 1..N-1, so retries == retryAttempts.length and the
+        // final attempt is retries + 1.
+        var retryAttempts = (JsonArray)test["retryAttempts"]!;
+        Assert.HasCount(2, retryAttempts);
+        Assert.AreEqual(2, (long)test["retries"]!);
+        Assert.AreEqual(1, (long)retryAttempts[0]!["attempt"]!);
+        Assert.AreEqual(2, (long)retryAttempts[1]!["attempt"]!);
+        Assert.AreEqual("boom 1", (string?)retryAttempts[0]!["message"]);
+        Assert.AreEqual("boom 2", (string?)retryAttempts[1]!["message"]);
+
+        // The test object carries the FINAL attempt's duration, not the sum across attempts.
+        Assert.AreEqual(140, (long)test["duration"]!);
+        Assert.AreEqual(120, (long)retryAttempts[0]!["duration"]!);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_CountsLogicalTestsOnce()
+    {
+        // The scenario from ctrf-io/ctrf#58: a 4-test suite where each attempt re-runs only what failed.
+        // The merged document describes the logical run, so it reports 4 tests, not the 8 executions.
+        string attempt1 = BuildReport(testEntries:
+        [
+            Attempt("ok1", "passed", uid: "u1"),
+            Attempt("ok2", "passed", uid: "u2"),
+            Attempt("recovers", "failed", uid: "u3"),
+            Attempt("always fails", "failed", uid: "u4"),
+        ]);
+        string attempt2 = BuildReport(testEntries:
+        [
+            Attempt("recovers", "passed", uid: "u3"),
+            Attempt("always fails", "failed", uid: "u4"),
+        ]);
+        string attempt3 = BuildReport(testEntries: [Attempt("always fails", "failed", uid: "u4")]);
+        string attempt4 = BuildReport(testEntries: [Attempt("always fails", "failed", uid: "u4")]);
+
+        JsonNode results = JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2, attempt3, attempt4], CtrfMergeMode.CollapseRetryAttempts))!["results"]!;
+
+        JsonNode summary = results["summary"]!;
+        Assert.AreEqual(4, (long)summary["tests"]!);
+        Assert.AreEqual(3, (long)summary["passed"]!);
+        Assert.AreEqual(1, (long)summary["failed"]!);
+        Assert.AreEqual(1, (long)summary["flaky"]!);
+        Assert.HasCount(4, (JsonArray)results["tests"]!);
+
+        JsonNode alwaysFails = ((JsonArray)results["tests"]!).Single(t => (string?)t!["name"] == "always fails")!;
+        Assert.AreEqual("failed", (string?)alwaysFails["status"]);
+        Assert.AreEqual(3, (long)alwaysFails["retries"]!);
+        Assert.IsNull(alwaysFails["flaky"]);
+
+        JsonNode neverRetried = ((JsonArray)results["tests"]!).Single(t => (string?)t!["name"] == "ok1")!;
+        Assert.IsNull(neverRetried["retries"]);
+        Assert.IsNull(neverRetried["retryAttempts"]);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_FlattensInProcessRetriesOfEachAttempt()
+    {
+        // An attempt process can itself have retried the test in-process; those executions are already in its
+        // retryAttempts[] and must keep their place in the merged history instead of being dropped.
+        JsonObject firstAttempt = Attempt("t", "failed", uid: "u1", message: "second execution");
+        firstAttempt["retryAttempts"] = new JsonArray(new JsonObject
+        {
+            ["attempt"] = 1,
+            ["status"] = "failed",
+            ["message"] = "first execution",
+        });
+
+        string attempt1 = BuildReport(testEntries: [firstAttempt]);
+        string attempt2 = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
+
+        JsonNode test = ((JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!)[0]!;
+
+        var retryAttempts = (JsonArray)test["retryAttempts"]!;
+        Assert.HasCount(2, retryAttempts);
+        Assert.AreEqual(3, (long)test["retries"]! + 1, "The final attempt is retries + 1.");
+        Assert.AreEqual("first execution", (string?)retryAttempts[0]!["message"]);
+        Assert.AreEqual("second execution", (string?)retryAttempts[1]!["message"]);
+        Assert.AreEqual(1, (long)retryAttempts[0]!["attempt"]!);
+        Assert.AreEqual(2, (long)retryAttempts[1]!["attempt"]!);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_ProjectsAttemptsOntoRetryAttemptShape()
+    {
+        // CTRF section 11 forbids unknown fields on a retry attempt, so test-only fields must not leak into it;
+        // rawStatus has no attempt-level slot and moves under 'extra', the only permitted extension point.
+        JsonObject failing = Attempt("t", "failed", uid: "u1", message: "boom");
+        failing["rawStatus"] = "timedOut";
+        failing["suite"] = new JsonArray("NS", "C");
+        failing["tags"] = new JsonArray("slow");
+        failing["trace"] = "at X()";
+
+        string attempt1 = BuildReport(testEntries: [failing]);
+        string attempt2 = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
+
+        JsonNode test = ((JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!)[0]!;
+
+        JsonNode retryAttempt = ((JsonArray)test["retryAttempts"]!)[0]!;
+        Assert.AreEqual("failed", (string?)retryAttempt["status"]);
+        Assert.AreEqual("boom", (string?)retryAttempt["message"]);
+        Assert.AreEqual("at X()", (string?)retryAttempt["trace"]);
+        Assert.AreEqual("timedOut", (string?)retryAttempt["extra"]!["rawStatus"]);
+        Assert.AreEqual("u1", (string?)retryAttempt["extra"]!["uid"]);
+        Assert.IsNull(retryAttempt["name"]);
+        Assert.IsNull(retryAttempt["suite"]);
+        Assert.IsNull(retryAttempt["tags"]);
+        Assert.IsNull(retryAttempt["rawStatus"]);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_DropsStaleFlakyFlag_WhenFinalAttemptFails()
+    {
+        // An input's own flaky flag only describes the attempt that produced it; a later failure means the
+        // logical test is not flaky (CTRF 9.22 requires the FINAL status to be passed).
+        JsonObject recovered = Attempt("t", "passed", uid: "u1");
+        recovered["flaky"] = true;
+
+        string attempt1 = BuildReport(testEntries: [recovered]);
+        string attempt2 = BuildReport(testEntries: [Attempt("t", "failed", uid: "u1")]);
+
+        JsonNode results = JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!;
+
+        JsonNode test = ((JsonArray)results["tests"]!)[0]!;
+        Assert.AreEqual("failed", (string?)test["status"]);
+        Assert.IsNull(test["flaky"]);
+        Assert.AreEqual(0, (long)results["summary"]!["flaky"]!);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_UsesNameAndSuite_WhenNoIdentifierIsAvailable()
+    {
+        // Without testId or extra.uid, the suite path plus name is the only identity available, and two tests
+        // that only share a name must not be fused.
+        static JsonObject Named(string name, string status, string suite)
+        {
+            JsonObject test = Test(name, status);
+            test["suite"] = new JsonArray(suite);
+            return test;
+        }
+
+        string attempt1 = BuildReport(testEntries: [Named("t", "failed", "A"), Named("t", "failed", "B")]);
+        string attempt2 = BuildReport(testEntries: [Named("t", "passed", "A"), Named("t", "failed", "B")]);
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        Assert.HasCount(2, tests);
+        Assert.AreEqual("passed", (string?)tests[0]!["status"]);
+        Assert.AreEqual("failed", (string?)tests[1]!["status"]);
+        Assert.AreEqual(1, (long)tests[0]!["retries"]!);
+        Assert.AreEqual(1, (long)tests[1]!["retries"]!);
+    }
+
+    private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
+    {
+        var test = new JsonObject
+        {
+            ["name"] = name,
+            ["status"] = status,
+            ["duration"] = duration,
+            ["extra"] = new JsonObject { ["uid"] = uid },
+        };
+
+        if (message is not null)
+        {
+            test["message"] = message;
+        }
+
+        return test;
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -1016,6 +1016,37 @@ public sealed class CtrfReportMergerTests
         Assert.AreEqual(2, (long)retryAttempts[1]!["attempt"]!);
     }
 
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_LeavesAnUnmergedRowExactlyAsWritten()
+    {
+        // Validity contract: the merger shapes what it synthesizes and relays what it passes through. A test
+        // that occurs in only one input (for example one that recovered through in-process retries and was
+        // therefore never re-run by the orchestrator) has nothing merged into it, so its row -- including the
+        // retryAttempts[] its producer already recorded -- must come out byte-identical. Repairing it here
+        // would make merging a single document mutate it.
+        JsonObject row = Test("t", "passed");
+        row["extra"] = new JsonObject { ["uid"] = "u1" };
+        row["retryAttempts"] = new JsonArray(new JsonObject
+        {
+            ["attempt"] = 7,
+            ["status"] = "failed",
+            ["message"] = "recorded by the producer",
+        });
+
+        string report = BuildReport(testEntries: [row]);
+        string original = ((JsonArray)JsonNode.Parse(report)!["results"]!["tests"]!)[0]!.ToJsonString();
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([report], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        Assert.HasCount(1, tests);
+        Assert.AreEqual(original, tests[0]!.ToJsonString(), "An unmerged row must be relayed verbatim.");
+
+        // Specifically: the producer's own attempt numbering is not rewritten, and retries/flaky are not invented.
+        Assert.AreEqual(7, (long)((JsonArray)tests[0]!["retryAttempts"]!)[0]!["attempt"]!);
+        Assert.IsNull(tests[0]!["retries"]);
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -790,24 +790,37 @@ public sealed class CtrfReportMergerTests
         // document. Such rows are dropped — the same policy the merger already applies to a whole non-CTRF input
         // — and both modes must agree on that, since the merged tests[] is the same array either way.
         // `summary` is deliberately a string here too: `results.summary` is equally untrusted, and reading a
-        // property off a non-object node throws just as `tests[]` did.
+        // property off a non-object node throws just as `tests[]` did. The well-formed-looking rows carry
+        // wrong-typed VALUES — a numeric `status`, a numeric `suite` segment, a numeric `status` inside a nested
+        // `retryAttempts[]` entry — because the explicit (string?) conversion on a JsonNode throws for a
+        // non-string value instead of yielding null.
         string malformed = """
-            {"reportFormat":"CTRF","specVersion":"0.0.0","results":{"summary":"broken","tests":["oops",null,42]}}
+            {"reportFormat":"CTRF","specVersion":"0.0.0","results":{"summary":"broken","tests":[
+              "oops",
+              null,
+              42,
+              {"name":"numeric status","status":7},
+              {"name":"numeric suite","status":"failed","suite":["A",7,{"x":1}]},
+              {"name":"nested","status":"passed","extra":{"uid":"n1"},"retryAttempts":[{"attempt":1,"status":3}]}
+            ]}}
             """;
         string wellFormed = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
 
         JsonNode results = JsonNode.Parse(CtrfReportMerger.Merge([malformed, wellFormed], mode))!["results"]!;
 
         var tests = (JsonArray)results["tests"]!;
-        Assert.HasCount(1, tests, "Only the real test survives.");
-        Assert.AreEqual("t", (string?)tests[0]!["name"]);
+        Assert.HasCount(4, tests, "The three non-object elements are dropped; wrong-typed values are tolerated.");
+        Assert.AreEqual("numeric status", (string?)tests[0]!["name"]);
+        Assert.AreEqual("t", (string?)tests[3]!["name"]);
 
         // CTRF 8.1: summary.tests equals the tests[] length, and the status buckets must add back up to it —
-        // a dropped row must not leave a phantom entry in either the array or the counters.
+        // a dropped row must not leave a phantom entry in either the array or the counters. An unreadable
+        // status is classified as 'other' rather than crashing the merge.
         JsonNode summary = results["summary"]!;
-        Assert.AreEqual(1, (long)summary["tests"]!);
-        Assert.AreEqual(1, (long)summary["passed"]!);
-        Assert.AreEqual(0, (long)summary["other"]!);
+        Assert.AreEqual(4, (long)summary["tests"]!);
+        Assert.AreEqual(2, (long)summary["passed"]!);
+        Assert.AreEqual(1, (long)summary["failed"]!);
+        Assert.AreEqual(1, (long)summary["other"]!, "A non-string status is unclassifiable.");
         long bucketSum = (long)summary["passed"]! + (long)summary["failed"]! + (long)summary["skipped"]!
             + (long)summary["pending"]! + (long)summary["other"]!;
         Assert.AreEqual((long)summary["tests"]!, bucketSum, "Every counted test must land in exactly one status bucket.");

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -910,6 +910,71 @@ public sealed class CtrfReportMergerTests
         Assert.IsNull(tests[1]!["retries"]);
     }
 
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_UsesLegacyIdWhenTestIdIsAbsent()
+    {
+        // CTRF 9.1: `id` is a stable test-case identifier that consumers treat as legacy, preferring `testId`
+        // only when both are present. An id-only report must therefore collapse on it rather than dropping to
+        // the suite/name heuristic, which would fuse these two distinct same-named tests.
+        static JsonObject WithId(string id, string status)
+        {
+            JsonObject test = Test("same name", status);
+            test["id"] = id;
+            return test;
+        }
+
+        string attempt1 = BuildReport(testEntries: [WithId("id-1", "failed"), WithId("id-2", "failed")]);
+        string attempt2 = BuildReport(testEntries: [WithId("id-1", "passed"), WithId("id-2", "failed")]);
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        Assert.HasCount(2, tests, "Two distinct ids must stay two tests.");
+        Assert.AreEqual("passed", (string?)tests[0]!["status"]);
+        Assert.IsTrue((bool)tests[0]!["flaky"]!);
+        Assert.AreEqual("failed", (string?)tests[1]!["status"]);
+        Assert.AreEqual(1, (long)tests[1]!["retries"]!);
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_DoesNotFuseRowsThatDifferOnlyByParametersOrFilePath()
+    {
+        // Suite plus name is not unique on its own: parameterized rows share both while differing in their
+        // parameters (CTRF 9.30), and same-named tests in different files differ only by path (9.19). Fusing
+        // them would silently drop a result.
+        static JsonObject Row(string status, JsonNode? parameters, string? filePath)
+        {
+            JsonObject test = Test("same name", status);
+            if (parameters is not null)
+            {
+                test["parameters"] = parameters;
+            }
+
+            if (filePath is not null)
+            {
+                test["filePath"] = filePath;
+            }
+
+            return test;
+        }
+
+        string report = BuildReport(testEntries:
+        [
+            Row("failed", new JsonObject { ["value"] = 1 }, null),
+            Row("passed", new JsonObject { ["value"] = 2 }, null),
+            Row("skipped", null, "a.cs"),
+            Row("passed", null, "b.cs"),
+        ]);
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([report], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        Assert.HasCount(4, tests, "Rows differing only by parameters or filePath are distinct tests.");
+        Assert.AreSequenceEqual(
+            (string?[])["failed", "passed", "skipped", "passed"],
+            tests.Select(t => (string?)t!["status"]).ToArray());
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -778,6 +778,66 @@ public sealed class CtrfReportMergerTests
         Assert.AreEqual(1, (long)tests[1]!["retries"]!);
     }
 
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Merge_RejectsMalformedTestRows_SoTheMergedDocumentStaysValid(bool collapseRetryAttempts)
+    {
+        // The mode is passed as a bool because CtrfMergeMode is internal and a test method must be public.
+        CtrfMergeMode mode = collapseRetryAttempts ? CtrfMergeMode.CollapseRetryAttempts : CtrfMergeMode.Concatenate;
+        // tests[] comes from an untrusted file. The CTRF schema types its items as Test objects, so carrying a
+        // bare string or a JSON null through would turn a defect localized to one input into an invalid MERGED
+        // document. Such rows are dropped — the same policy the merger already applies to a whole non-CTRF input
+        // — and both modes must agree on that, since the merged tests[] is the same array either way.
+        // `summary` is deliberately a string here too: `results.summary` is equally untrusted, and reading a
+        // property off a non-object node throws just as `tests[]` did.
+        string malformed = """
+            {"reportFormat":"CTRF","specVersion":"0.0.0","results":{"summary":"broken","tests":["oops",null,42]}}
+            """;
+        string wellFormed = BuildReport(testEntries: [Attempt("t", "passed", uid: "u1")]);
+
+        JsonNode results = JsonNode.Parse(CtrfReportMerger.Merge([malformed, wellFormed], mode))!["results"]!;
+
+        var tests = (JsonArray)results["tests"]!;
+        Assert.HasCount(1, tests, "Only the real test survives.");
+        Assert.AreEqual("t", (string?)tests[0]!["name"]);
+
+        // CTRF 8.1: summary.tests equals the tests[] length, and the status buckets must add back up to it —
+        // a dropped row must not leave a phantom entry in either the array or the counters.
+        JsonNode summary = results["summary"]!;
+        Assert.AreEqual(1, (long)summary["tests"]!);
+        Assert.AreEqual(1, (long)summary["passed"]!);
+        Assert.AreEqual(0, (long)summary["other"]!);
+        long bucketSum = (long)summary["passed"]! + (long)summary["failed"]! + (long)summary["skipped"]!
+            + (long)summary["pending"]! + (long)summary["other"]!;
+        Assert.AreEqual((long)summary["tests"]!, bucketSum, "Every counted test must land in exactly one status bucket.");
+    }
+
+    [TestMethod]
+    public void Merge_CollapseRetryAttempts_ToleratesNonObjectExtra()
+    {
+        // `extra` is free-form, so a foreign producer may put a string or an array there. Identity resolution
+        // must fall back to the suite/name key instead of throwing while indexing it.
+        static JsonObject WithExtra(string status, JsonNode extra)
+        {
+            JsonObject test = Test("t", status);
+            test["extra"] = extra;
+            return test;
+        }
+
+        string attempt1 = BuildReport(testEntries: [WithExtra("failed", "ci-run-14")]);
+        string attempt2 = BuildReport(testEntries: [WithExtra("passed", new JsonArray("a"))]);
+
+        var tests = (JsonArray)JsonNode.Parse(
+            CtrfReportMerger.Merge([attempt1, attempt2], CtrfMergeMode.CollapseRetryAttempts))!["results"]!["tests"]!;
+
+        // Both rows share the name identity, so they collapse even though neither carries a usable extra.uid.
+        Assert.HasCount(1, tests);
+        Assert.AreEqual("passed", (string?)tests[0]!["status"]);
+        Assert.AreEqual(1, (long)tests[0]!["retries"]!);
+        Assert.IsTrue((bool)tests[0]!["flaky"]!);
+    }
+
     private static JsonObject Attempt(string name, string status, string uid, long duration = 1, string? message = null)
     {
         var test = new JsonObject

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/WellKnownEnvironmentVariables.cs
@@ -98,6 +98,11 @@ public static class WellKnownEnvironmentVariables
         "TESTINGPLATFORM_DOTNETTEST_EXECUTIONID",
         "DOTNET_CLI_TEST_COMMAND_WORKING_DIRECTORY",
 
+        // Logical run correlation. A CI job may set this to tie several modules or machines into one
+        // logical run, so it must not bleed into child test hosts and make a test observe an id it did
+        // not choose. Tests that exercise run correlation inject it explicitly.
+        "TESTINGPLATFORM_LOGICAL_RUN_ID",
+
         // Isolate from the skip banner in case of parent, children tests
         "TESTINGPLATFORM_CONSOLEOUTPUTDEVICE_SKIP_BANNER",
 


### PR DESCRIPTION
Follow-up to the answers we got on [ctrf-io/ctrf#58](https://github.com/ctrf-io/ctrf/issues/58), the spec issue I opened from #10293. Closes nothing on its own — #10293 stays open for the parts that are still product decisions (see *Deliberately not in scope*).

## What upstream confirmed, and what it cost us

| Answer from the CTRF maintainer | Our state | Action |
| --- | --- | --- |
| `retryAttempts[]` holds attempts `1..N-1` — the history *preceding* the final attempt, initial execution included. The final attempt is excluded because its outcome and diagnostics are the test object. | Already correct — the "third shape" I described in the issue turned out to be the intended one. | Comment only, no behavior change. |
| `retries == retryAttempts.length`, so the final attempt number is `retries + 1`. | Already correct. | Comment only. |
| Per-process documents of one logical run, and any document merged from them, **should share a `runId`** while each keeps its own `reportId`. | We emitted no `runId` at all. | New. |
| In a merged document, the test object's `duration` is the **final** attempt's. | N/A — no retry-aware merge existed. | Encoded in the new merge mode. |

## Changes

**`runId` (CTRF §5.4).** `CtrfReportEngine` now emits a top-level `runId`, resolved as `TESTINGPLATFORM_LOGICAL_RUN_ID` → `TESTINGPLATFORM_DOTNETTEST_EXECUTIONID` → a fresh GUID. `RetryOrchestrator` establishes that variable once before launching its attempts, so every attempt process stamps the same value.

A caveat worth being explicit about, because my first draft got it wrong: **`TESTINGPLATFORM_DOTNETTEST_EXECUTIONID` is per root test application, not per `dotnet test` invocation** — each module is its own execution tree with its own id ([004-protocol-dotnet-test-pipe.md](https://github.com/microsoft/testfx/blob/main/docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md)). So this correlates the processes of one test application (its retry attempts, its controller), *not* the modules of a multi-project run. Correlating those, or shards across machines, means setting `TESTINGPLATFORM_LOGICAL_RUN_ID` explicitly — which is now possible, and documented on the constant.

**`CtrfReportMerger`.** Carries `runId` over when every accepted input agrees on the same non-empty value (dropped on disagreement, or when any input lacks one, rather than picking an arbitrary run to speak for the whole merge) while still deriving its own deterministic `reportId`.

**New opt-in `CtrfMergeMode.CollapseRetryAttempts`.** Folds rows describing the same logical test into one: last attempt wins; earlier attempts — including in-process retries an input already nested — flatten into `retryAttempts[]` renumbered `1..N-1`; `retries` and `flaky` recomputed per §9.20/§9.22 (recomputed, not inherited: an input's own `flaky` flag only describes the attempt that produced it); the row keeps the **final** attempt's `duration`; summary re-derived so `summary.tests` counts logical tests — the 4-test/8-execution scenario from the issue reports 4. Attempts are projected onto the §11 attempt shape, so test-only fields are dropped and `rawStatus`, which has no attempt-level slot, moves under `extra`.

`Concatenate` remains the default: MTP test UIDs are only unique *within* an assembly, so collapsing by identity across modules would fuse same-named tests from different assemblies.

**Robustness fixes to `CtrfReportMerger`, found while writing the tests.** These are on the pre-existing default path too, not just the new mode. `tests[]` comes from a file we did not write, and a document could clear the merger's `reportFormat`/`results` gate and still crash it:

- a non-object element (`"tests": ["oops", null, 42]`) threw from the summary counter loop, from `TryReadLong` in the ingestion loop, and from the collapse helpers. Such rows are now rejected at ingestion — carrying one through would turn a defect localized to *one input* into a schema-invalid **merged** document, and dropping it matches how a whole non-CTRF input is already rejected. With `tests[]` filtered once at the boundary, the collapse helpers take `JsonObject` and the invariant is enforced by the type system rather than by repeated guards;
- a non-object `extra` (it is free-form, so a foreign producer may well put a string there) threw during identity resolution;
- wrong-*typed* values threw even in well-formed-looking rows, because the explicit `(string?)` conversion on a `JsonNode` throws for a non-string rather than yielding null — a numeric `status`, a `suite` segment that is not a string, a numeric `status` inside a nested `retryAttempts[]`. All string reads now go through one helper that treats another JSON type as absent.

## Testing

- **New acceptance test** `RetryFailedTests_CtrfReports_ShareRunIdButNotReportId` runs `--retry-failed-tests 3 --report-ctrf` and asserts the per-attempt documents share a `runId` and carry distinct `reportId`s. This is the only test that covers the cross-process contract — the engine unit tests mock `IEnvironment` and would pass even if the orchestrator seeding were deleted. Enabling it meant adding the CtrfReport package and provider to the shared `RetryFailedTests` asset; registering a report provider is inert without its `--report-*` option, and the other 13 tests in that class assert on extension-scoped globs, so none are perturbed (all 44 pass).
- **Unit tests** for `runId` resolution and its fallbacks, merger `runId` propagation, the collapse mode, and the malformed/wrong-typed input cases.
- **Every new test was mutation-verified**: reverting the production logic it pins makes it fail. That is how the last two robustness bugs were found rather than assumed.
- 845 unit tests and 59 CTRF + retry acceptance tests pass; `build.cmd -pack -c Debug` is clean.

## Deliberately not in scope

`CollapseRetryAttempts` has no production caller yet, by design. Wiring it needs a `CtrfArtifactPostProcessor` (mechanical — `TrxArtifactPostProcessor` is the template) plus a **retry-triggered** post-processing entry point, and #10293 still lists the policy questions that entry point encodes as undecided: collapse vs. concatenate per format, what formats without a retry concept should do, and whether the per-attempt files are kept. Those are maintainer calls, not conformance fixes, so this PR ships the mechanism they will consume — opt-in and unit-tested — and leaves the wiring to the follow-up. Note `CtrfReportMerger` has had no production caller since it was introduced in #9805; this PR does not change that.

The JUnit question raised in #10293 is likewise untouched — there is no upstream spec to conform to there, so it is purely a product decision.

## Review notes

Three review rounds were run over this. The findings worth knowing about, because they changed the shape of the code: the original `runId` comments claimed the execution id correlates the modules of one `dotnet test` invocation, which the repo's own protocol spec contradicts; and the malformed-input handling went from "carry through" to "reject at ingestion" once it was clear the former produces a schema-invalid merged document.