### PR TITLE
Simplify null-filtering and null-conditional patterns in recent WinUI additions

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs
@@ -238,8 +238,7 @@ internal sealed class AppxManifestInfo
                     ? null
                     : new AppxApplicationInfo(applicationId, executable, $"{packageFamilyName}!{applicationId}");
             })
-            .Where(static application => application is not null)
-            .Select(static application => application!)
+            .OfType<AppxApplicationInfo>()
             .ToList()
             ?? [];
 

--- a/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
+++ b/src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs
@@ -106,10 +106,7 @@ public class UITestMethodAttribute : TestMethodAttribute
     }
 
     private static Type? GetApplicationType(Assembly assembly)
-    {
-        WinUITestTargetAttribute? attribute = assembly.GetCustomAttribute<WinUITestTargetAttribute>();
-        return attribute == null || attribute.ApplicationType == null ? null : attribute.ApplicationType;
-    }
+        => assembly.GetCustomAttribute<WinUITestTargetAttribute>()?.ApplicationType;
 
     private static DispatcherQueue? GetApplicationDispatcherQueue(Assembly assembly)
     {


### PR DESCRIPTION
Fixes #10344.

The [code-simplifier] agentic workflow could not open its own PR (GitHub Actions is not permitted to create pull requests in this repo), so this PR carries the same change.

Simplifies two spots added by #10330 (Support testing unpackaged WinUI apps under Microsoft.Testing.Platform). No behavioral change.

### Changes

- `src/Platform/Microsoft.Testing.Extensions.PackagedApp/AppxManifestInfo.cs` — replaced the `.Where(x => x is not null).Select(x => x!)` null-filtering pair with the idiomatic `.OfType<AppxApplicationInfo>()`, which filters and narrows the type in one step and drops the null-forgiving operator.
- `src/TestFramework/TestFramework.Extensions/Attributes/WinUI_UITestMethodAttribute.cs` — replaced the local-variable + ternary body of `GetApplicationType` with `assembly.GetCustomAttribute<WinUITestTargetAttribute>()?.ApplicationType`, matching the repo's preferred `?.` style.

### Verification

Built both affected projects (`.\build.cmd -projects ...`) — succeeded with 0 warnings / 0 errors across all target frameworks, including the WinUI TFM `net8.0-windows10.0.18362.0` that actually compiles `WinUI_UITestMethodAttribute.cs`.