### PR TITLE
Harden the server-mode transport read path

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/FormatterUtilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/FormatterUtilities.cs
@@ -14,7 +14,7 @@ internal sealed class FormatterUtilities
     // The formatter selection mirrors the IMessageFormatter guard (#if NETCOREAPP): System.Text.Json on
     // .NET, Jsonite everywhere else. Using !NETCOREAPP (rather than NETSTANDARD2_0) keeps this correct when
     // the file is shipped as source and compiled on .NET Framework (net462), where NETSTANDARD2_0 is not
-    // defined — there the STJ branch (ReadOnlyMemory<char>, Json.Json) does not exist. Behavior is identical
+    // defined — there the STJ branch (ReadOnlyMemory<byte>, Json.Json) does not exist. Behavior is identical
     // for the platform build, which only ever compiles this file as netstandard2.0 or .NET.
 #if !NETCOREAPP
     internal static IMessageFormatter CreateFormatter()
@@ -60,7 +60,7 @@ internal sealed class FormatterUtilities
 
         public string Id => "System.Text.Json";
 
-        public T Deserialize<T>(ReadOnlyMemory<char> serializedUtf8Content) => _json.Deserialize<T>(serializedUtf8Content);
+        public T Deserialize<T>(ReadOnlyMemory<byte> serializedUtf8Content) => _json.Deserialize<T>(serializedUtf8Content);
 
         public Task<string> SerializeAsync(object obj) => _json.SerializeAsync(obj);
     }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/IMessageFormatter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/IMessageFormatter.cs
@@ -20,15 +20,16 @@ internal interface IMessageFormatter
     /// <typeparam name="T">The type of the object to deserialize.</typeparam>
     /// <param name="serializedUtf8Content">The serialized utf-8 content.</param>
     /// <returns>The deserialized object.</returns>
-    // Note: The current design might impose performance overhead, since the data
-    //       is not directly deserialized from a stream, but rather first a string is extracted
-    //       and allocated and then a string is deserialized.
-    //       We could create a version that uses System.Buffers APIs that would only be supported for
-    //       .NET 6 and above.
 #if NETCOREAPP
-    T Deserialize<T>(ReadOnlyMemory<char> serializedUtf8Content);
+    // The content is passed as UTF-8 bytes because that is what the wire carries (Content-Length counts
+    // bytes) and what System.Text.Json parses, so no transcoding is needed on the read path.
+    //
+    // Implementations must fully materialize the result before returning: JsonDocument.Parse does not copy
+    // the buffer it is given, and the caller is free to reuse or pool it once this returns.
+    T Deserialize<T>(ReadOnlyMemory<byte> serializedUtf8Content);
 
 #else
+    // Jsonite only accepts a string, so the net462/netstandard2.0 path still decodes before parsing.
     T Deserialize<T>(string serializedUtf8Content);
 
 #endif

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.cs
@@ -69,7 +69,19 @@ internal sealed partial class Json
         }
     }
 
-    public T Deserialize<T>(ReadOnlyMemory<char> utf8Json)
+    /// <summary>
+    /// Deserializes a UTF-8 encoded JSON payload.
+    /// </summary>
+    /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+    /// <param name="utf8Json">The UTF-8 encoded JSON payload.</param>
+    /// <returns>The deserialized object.</returns>
+    /// <remarks>
+    /// <see cref="JsonDocument.Parse(ReadOnlyMemory{byte}, JsonDocumentOptions)"/> reads directly out of
+    /// <paramref name="utf8Json"/> rather than copying it, so the payload must stay valid until the document
+    /// is disposed. <see cref="Bind{T}"/> materializes the whole object graph before that happens, which is
+    /// what lets callers hand in a pooled buffer and reuse it as soon as this returns.
+    /// </remarks>
+    public T Deserialize<T>(ReadOnlyMemory<byte> utf8Json)
     {
         using var document = JsonDocument.Parse(utf8Json);
         return Bind<T>(document.RootElement, null);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TcpMessageHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TcpMessageHandler.cs
@@ -48,8 +48,12 @@ internal sealed class TcpMessageHandler(
     // Reused across header lines so the hot read path (server mode emits a notification per test) does not
     // allocate a fresh buffer per line. Safe to keep as state for the same reason _readBufferOffset/
     // _readBufferCount are: reads are single-threaded by construction, driven by exactly one read loop.
-    // It grows to the longest header line seen on the connection and stays there, which is bounded by the
-    // same trust boundary as Content-Length below (a loopback channel to a test host this process launched).
+    //
+    // It grows to the longest header line seen on the connection and stays there. Unlike a message body,
+    // a header line has no legitimate large case, so this is a weaker guarantee than the one that justifies
+    // leaving Content-Length uncapped: a peer that never sends a line terminator would grow it without
+    // bound. It is left uncapped because server mode is a loopback channel to a test host this process
+    // launched, but if a cap is ever wanted, headers are the cheaper and more defensible place to put one.
     private byte[] _headerLineBuffer = new byte[HeaderLineInitialCapacity];
 
     private int _readBufferOffset;
@@ -91,15 +95,14 @@ internal sealed class TcpMessageHandler(
                     return null;
                 }
 
-                // Content-Length counts UTF-8 bytes, so consume exactly that many bytes and decode
-                // afterwards. Reading characters here would under-read every multi-byte frame.
+                // Content-Length counts UTF-8 bytes, so consume exactly that many bytes and hand them to the
+                // formatter as bytes. Reading characters here would under-read every multi-byte frame.
                 //
-                // commandSize is taken from the wire without an upper bound. That is deliberate and
-                // pre-existing: server mode is a loopback channel to a test host this process launched, and
-                // legitimate bodies are unbounded in principle (a test node update can carry an arbitrarily
-                // large stack trace or captured stdout), so any cap would be a guess that risks rejecting
-                // valid traffic. Note the byte-based read below more than halves the previous worst-case
-                // allocation, which rented commandSize *chars*.
+                // commandSize is known non-negative (ReadHeadersAsync rejects anything else) but is otherwise
+                // taken from the wire without an upper bound. That is deliberate and pre-existing: server mode
+                // is a loopback channel to a test host this process launched, and legitimate bodies are
+                // unbounded in principle (a test node update can carry an arbitrarily large stack trace or
+                // captured stdout), so any cap would be a guess that risks rejecting valid traffic.
 #if NETCOREAPP
                 byte[] bodyBuffer = ArrayPool<byte>.Shared.Rent(commandSize);
                 try
@@ -110,17 +113,14 @@ internal sealed class TcpMessageHandler(
                         return null;
                     }
 
-                    int charCount = Encoding.UTF8.GetCharCount(bodyBuffer, 0, commandSize);
-                    char[] charsBuffer = ArrayPool<char>.Shared.Rent(charCount);
-                    try
-                    {
-                        Encoding.UTF8.GetChars(bodyBuffer, 0, commandSize, charsBuffer, 0);
-                        return _formatter.Deserialize<RpcMessage>(new ReadOnlyMemory<char>(charsBuffer, 0, charCount));
-                    }
-                    finally
-                    {
-                        ArrayPool<char>.Shared.Return(charsBuffer);
-                    }
+                    // The body is already UTF-8, which is what the formatter parses, so it is passed straight
+                    // through without transcoding. Note JsonDocument.Parse(ReadOnlyMemory<byte>) does NOT copy
+                    // its input: it reads out of this rented buffer until the document is disposed. That is
+                    // safe because Deserialize fully materializes the message before disposing the document,
+                    // which is the same requirement the previous char-based call already had (the char overload
+                    // rents its own byte array internally and returns it on dispose). Keep it that way: no
+                    // deserializer may retain a JsonElement past this call.
+                    return _formatter.Deserialize<RpcMessage>(new ReadOnlyMemory<byte>(bodyBuffer, 0, commandSize));
                 }
                 finally
                 {
@@ -191,14 +191,28 @@ internal sealed class TcpMessageHandler(
             if (line.StartsWith(ContentLengthHeaderName, StringComparison.OrdinalIgnoreCase))
             {
 #if NETCOREAPP
-                _ = int.TryParse(line.AsSpan()[ContentLengthHeaderName.Length..].Trim(), out contentSize);
+                bool parsed = int.TryParse(line.AsSpan()[ContentLengthHeaderName.Length..].Trim(), out contentSize);
 #else
                 // Substring rather than the range operator: string range indexing lowers to
                 // System.Range.GetOffsetAndLength, which pulls in System.Range/System.ValueTuple —
                 // neither is in-framework on net462, where this file is also compiled as source into
                 // the dependency-free MTP client package. Substring is behavior-identical.
-                _ = int.TryParse(line.Substring(ContentLengthHeaderName.Length).Trim(), out contentSize);
+                bool parsed = int.TryParse(line.Substring(ContentLengthHeaderName.Length).Trim(), out contentSize);
 #endif
+
+                // A Content-Length that does not parse (empty, non-numeric, or larger than Int32) or that is
+                // negative cannot frame a message, so report it as a lost connection and let ReadAsync return
+                // null. Both cases must be rejected here rather than passed on:
+                //
+                //  * int.TryParse leaves contentSize at 0 when it fails, which would silently be read as a
+                //    valid empty body instead of the malformed header it is;
+                //  * a negative length would reach ArrayPool.Rent (or new byte[]) below and surface as an
+                //    ArgumentOutOfRangeException (OverflowException on net462) that escapes the
+                //    SocketException/IOException filter in ReadAsync and tears down the read loop.
+                if (!parsed || contentSize < 0)
+                {
+                    return -1;
+                }
             }
         }
 
@@ -210,6 +224,11 @@ internal sealed class TcpMessageHandler(
     /// but they are decoded as UTF-8 (a superset) so a non-conformant peer cannot corrupt the framing.
     /// Returns <see langword="null"/> at end of stream.
     /// </summary>
+    /// <remarks>
+    /// Only LF terminates a line here. The <see cref="StreamReader"/> this replaced also treated a lone CR as
+    /// a terminator; the protocol always sends CRLF, so dropping that is deliberate and keeps a CR inside a
+    /// header value from splitting the line.
+    /// </remarks>
     private async Task<string?> ReadHeaderLineAsync(CancellationToken cancellationToken)
     {
         int lineLength = 0;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -17,6 +17,18 @@ public sealed class FormatterUtilitiesTests
     public static IEnumerable<object[]> SerializerTypesForDynamicData
         => SerializerUtilities.SerializerTypes.Select(x => new object[] { x });
 
+    /// <summary>
+    /// Feeds a JSON string to the formatter the way the transport does. On .NET the formatter consumes UTF-8
+    /// bytes (Content-Length counts bytes, and that is what System.Text.Json parses); the Jsonite formatter
+    /// used elsewhere only accepts a string. Wrapping it here keeps that split out of every call site.
+    /// </summary>
+    private T Deserialize<T>(string json)
+#if NETCOREAPP
+        => _formatter.Deserialize<T>(Encoding.UTF8.GetBytes(json).AsMemory());
+#else
+        => _formatter.Deserialize<T>(json);
+#endif
+
     public FormatterUtilitiesTests()
         =>
 #if NETCOREAPP
@@ -28,21 +40,13 @@ public sealed class FormatterUtilitiesTests
     [TestMethod]
     public void CanDeserializeTaskResponse()
     {
-#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
-#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
-        RpcMessage msg = _formatter.Deserialize<RpcMessage>("""
+        RpcMessage msg = Deserialize<RpcMessage>("""
             {
                 "jsonrpc": "2.0",
                 "id": 1,
                 "result": null
             }
-            """
-#if NETCOREAPP
-            .AsMemory()
-#endif
-            );
-#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
-#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+            """);
 
         var response = (ResponseMessage)msg;
         Assert.AreEqual(1, response.Id);
@@ -133,15 +137,7 @@ public sealed class FormatterUtilitiesTests
             }
             """;
 
-#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
-#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
-        RpcMessage msg = _formatter.Deserialize<RpcMessage>(json
-#if NETCOREAPP
-            .AsMemory()
-#endif
-            );
-#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
-#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+        RpcMessage msg = Deserialize<RpcMessage>(json);
 
         var request = (RequestMessage)msg;
         Assert.AreEqual(42, request.Id);
@@ -166,15 +162,7 @@ public sealed class FormatterUtilitiesTests
             }
             """;
 
-#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
-#pragma warning disable SA1111 // Closing parenthesis should be on line of last parameter
-        RpcMessage msg = _formatter.Deserialize<RpcMessage>(json
-#if NETCOREAPP
-            .AsMemory()
-#endif
-            );
-#pragma warning restore SA1111 // Closing parenthesis should be on line of last parameter
-#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
+        RpcMessage msg = Deserialize<RpcMessage>(json);
 
         var request = (RequestMessage)msg;
         Assert.AreEqual(42, request.Id);
@@ -552,79 +540,16 @@ public sealed class FormatterUtilitiesTests
     }
 
     private object Deserialize(Type type, string instanceSerialized)
-    {
-        if (type == typeof(ErrorMessage))
+        => true switch
         {
-#if NETCOREAPP
-            return _formatter.Deserialize<ErrorMessage>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<ErrorMessage>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(InitializeResponseArgs))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<InitializeResponseArgs>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<InitializeResponseArgs>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(ServerInfo))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<ServerInfo>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<ServerInfo>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(CancelRequestArgs))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<CancelRequestArgs>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<CancelRequestArgs>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(TestNode))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<TestNode>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<TestNode>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(DiscoverRequestArgs))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<DiscoverRequestArgs>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<DiscoverRequestArgs>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(RunRequestArgs))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<RunRequestArgs>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<RunRequestArgs>(instanceSerialized);
-#endif
-        }
-
-        if (type == typeof(ServerCapabilities))
-        {
-#if NETCOREAPP
-            return _formatter.Deserialize<ServerCapabilities>(instanceSerialized.AsMemory());
-#else
-            return _formatter.Deserialize<ServerCapabilities>(instanceSerialized);
-#endif
-        }
-
-        throw new NotImplementedException($"Deserializer for type not implemented '{type}'");
-    }
+            _ when type == typeof(ErrorMessage) => Deserialize<ErrorMessage>(instanceSerialized)!,
+            _ when type == typeof(InitializeResponseArgs) => Deserialize<InitializeResponseArgs>(instanceSerialized)!,
+            _ when type == typeof(ServerInfo) => Deserialize<ServerInfo>(instanceSerialized)!,
+            _ when type == typeof(CancelRequestArgs) => Deserialize<CancelRequestArgs>(instanceSerialized)!,
+            _ when type == typeof(TestNode) => Deserialize<TestNode>(instanceSerialized)!,
+            _ when type == typeof(DiscoverRequestArgs) => Deserialize<DiscoverRequestArgs>(instanceSerialized)!,
+            _ when type == typeof(RunRequestArgs) => Deserialize<RunRequestArgs>(instanceSerialized)!,
+            _ when type == typeof(ServerCapabilities) => Deserialize<ServerCapabilities>(instanceSerialized)!,
+            _ => throw new NotImplementedException($"Deserializer for type not implemented '{type}'"),
+        };
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
@@ -161,7 +161,7 @@ public sealed class JsonTests
 
         // Act
         string serialized = await _json.SerializeAsync(original);
-        ErrorMessage roundTripped = _json.Deserialize<ErrorMessage>(serialized.AsMemory());
+        ErrorMessage roundTripped = _json.Deserialize<ErrorMessage>(Encoding.UTF8.GetBytes(serialized).AsMemory());
 
         // Assert
         Assert.AreEqual(original.Id, roundTripped.Id);
@@ -182,7 +182,7 @@ public sealed class JsonTests
         });
 
         // Act
-        Person actual = json.Deserialize<Person>(new("""{"name":"Thomas"}""".ToCharArray()));
+        Person actual = json.Deserialize<Person>(Encoding.UTF8.GetBytes("""{"name":"Thomas"}""").AsMemory());
 
         // Assert
         Assert.AreEqual("Thomas", actual.Name);
@@ -216,7 +216,7 @@ public sealed class JsonTests
             """;
 
         // Act
-        InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(initializeParams.AsMemory());
+        InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory());
 
         // Assert
         Assert.IsTrue(args.Capabilities.IsStateful);
@@ -236,7 +236,7 @@ public sealed class JsonTests
             """;
 
         // Act
-        InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(initializeParams.AsMemory());
+        InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory());
 
         // Assert
         Assert.IsFalse(args.Capabilities.IsStateful);
@@ -301,7 +301,7 @@ public sealed class JsonTests
             """;
 
         // Act
-        IDictionary<string, object?> actual = json.Deserialize<IDictionary<string, object?>>(payload.AsMemory());
+        IDictionary<string, object?> actual = json.Deserialize<IDictionary<string, object?>>(Encoding.UTF8.GetBytes(payload).AsMemory());
 
         // Assert
         // Mirror the Jsonite reader exactly: a value that fits Int32 stays int, a larger integer widens to
@@ -324,7 +324,7 @@ public sealed class JsonTests
         const string payload = "[ 42, 9999999999, 40.5 ]";
 
         // Act
-        object[] actual = json.Deserialize<object[]>(payload.AsMemory());
+        object[] actual = json.Deserialize<object[]>(Encoding.UTF8.GetBytes(payload).AsMemory());
 
         // Assert
         Assert.HasCount(3, actual);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TcpMessageHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TcpMessageHandlerTests.cs
@@ -150,6 +150,10 @@ public sealed class TcpMessageHandlerTests
     /// A peer that writes its headers through a preamble-emitting encoder (for example
     /// <c>new StreamWriter(stream, Encoding.UTF8)</c>) prefixes the very first header line with a UTF-8
     /// byte-order mark. The reader must skip it, as the previous StreamReader-based implementation did.
+    /// <para>
+    /// Deliberately ASCII-only: the byte/char defect is covered elsewhere, and keeping non-ASCII out of this
+    /// frame means a failure here can only mean the preamble handling itself broke.
+    /// </para>
     /// </summary>
     [TestMethod]
     public async Task ReadAsync_LeadingByteOrderMark_IsSkipped()
@@ -158,13 +162,13 @@ public sealed class TcpMessageHandlerTests
 
         byte[] preamble = Encoding.UTF8.GetPreamble();
         await handlers.WriterStream.WriteAsync(preamble, 0, preamble.Length, TestContext.CancellationToken).ConfigureAwait(false);
-        WriteRawFrame(handlers.WriterStream, BuildNotificationJson(NonAsciiMethod));
+        WriteRawFrame(handlers.WriterStream, BuildNotificationJson("testing/first"));
         WriteRawFrame(handlers.WriterStream, BuildNotificationJson("testing/second"));
 
         var first = (NotificationMessage)(await ReadWithTimeoutAsync(handlers).ConfigureAwait(false))!;
         var second = (NotificationMessage)(await ReadWithTimeoutAsync(handlers).ConfigureAwait(false))!;
 
-        Assert.AreEqual(NonAsciiMethod, first.Method);
+        Assert.AreEqual("testing/first", first.Method);
         Assert.AreEqual("testing/second", second.Method);
     }
 
@@ -251,6 +255,40 @@ public sealed class TcpMessageHandlerTests
     }
 
     /// <summary>
+    /// A Content-Length that cannot frame a message must be reported as a graceful disconnect rather than
+    /// escaping as an exception the read loop does not expect.
+    /// <para>
+    /// A negative length is the sharp case: it reaches <c>ArrayPool.Rent</c> (or <c>new byte[]</c> on net462)
+    /// and surfaces as an <see cref="ArgumentOutOfRangeException"/>/<see cref="OverflowException"/>, neither
+    /// of which the <c>SocketException</c>/<c>IOException</c> filter in <c>ReadAsync</c> catches.
+    /// </para>
+    /// <para>
+    /// The unparseable cases are the quiet ones: <c>int.TryParse</c> leaves the length at 0 when it fails, so
+    /// a malformed header used to be read as a valid empty body and then fail later as a JSON parse error,
+    /// pointing at the payload instead of at the header that was actually wrong.
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    [DataRow("-5", DisplayName = "negative")]
+    [DataRow("-2147483648", DisplayName = "int.MinValue")]
+    [DataRow("99999999999999", DisplayName = "larger than Int32")]
+    [DataRow("abc", DisplayName = "non-numeric")]
+    [DataRow("", DisplayName = "empty")]
+    public async Task ReadAsync_MalformedContentLength_ReturnsNull(string contentLength)
+    {
+        using ConnectedHandlers handlers = await ConnectedHandlers.CreateAsync().ConfigureAwait(false);
+
+        byte[] header = Encoding.ASCII.GetBytes(
+            $"Content-Length: {contentLength}\r\nContent-Type: application/testingplatform\r\n\r\n");
+        await handlers.WriterStream.WriteAsync(header, 0, header.Length, TestContext.CancellationToken).ConfigureAwait(false);
+        await handlers.WriterStream.FlushAsync(TestContext.CancellationToken).ConfigureAwait(false);
+
+        RpcMessage? message = await ReadWithTimeoutAsync(handlers).ConfigureAwait(false);
+
+        Assert.IsNull(message);
+    }
+
+    /// <summary>
     /// Builds a JSON-RPC notification body by hand, so the test controls the exact bytes that hit the wire
     /// rather than going through a formatter that may escape non-ASCII characters.
     /// </summary>
@@ -326,16 +364,31 @@ public sealed class TcpMessageHandlerTests
         {
             TcpListener listener = new(IPAddress.Loopback, 0);
             listener.Start();
-            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
-            TcpClient clientSocket = new();
-            await clientSocket.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
-            clientSocket.NoDelay = true;
+            TcpClient? clientSocket = null;
+            TcpClient? serverSocket = null;
+            try
+            {
+                int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
-            TcpClient serverSocket = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
-            serverSocket.NoDelay = true;
+                clientSocket = new TcpClient();
+                await clientSocket.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
+                clientSocket.NoDelay = true;
 
-            return new ConnectedHandlers(listener, clientSocket, serverSocket);
+                serverSocket = await listener.AcceptTcpClientAsync().ConfigureAwait(false);
+                serverSocket.NoDelay = true;
+
+                return new ConnectedHandlers(listener, clientSocket, serverSocket);
+            }
+            catch
+            {
+                // Without this the listener and any half-established socket leak for the rest of the run,
+                // which on a loopback-heavy suite shows up as port exhaustion rather than as this failure.
+                serverSocket?.Dispose();
+                clientSocket?.Dispose();
+                listener.Stop();
+                throw;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Follow-up to #10297, from findings raised reviewing it. Based on `nohwnd-mtp-client-source-package` (where #10297 landed), not `main`.

Three of these are behavioral; the rest are comments and test hygiene.

## 1. A malformed `Content-Length` tore down the read loop

The comment #10297 added says `commandSize` is trusted unbounded, and that reasoning is right for *large* values. But negative and unparseable values aren't just unbounded — they escape.

Probed against the merged code:

```
Content-Length: -5              -> System.ArgumentOutOfRangeException:
                                   minimumLength ('-5') must be a non-negative value.
Content-Length: 99999999999999  -> System.Text.Json.JsonReaderException:
                                   The input does not contain any JSON tokens.
Content-Length: abc             -> (same JsonReaderException)
Content-Length:                 -> (same JsonReaderException)
```

Two distinct defects:

**Negative** — `int.TryParse` happily yields `-5`, the `is -1` guard doesn't catch it, and `ArrayPool.Rent(-5)` (`new byte[-5]` → `OverflowException` on net462) throws straight past the `SocketException`/`IOException` filter. A malformed header kills the connection with an argument-validation exception rather than the graceful `null` every other malformed-frame path produces.

**Unparseable** — quieter and arguably worse. `_ = int.TryParse(...)` discards the result, and `out contentSize` is set to `0` on failure. So a header that failed to parse was read as *a valid frame with an empty body*, and only failed later as a JSON error pointing at the payload instead of at the header that was actually wrong.

Both now return `-1`, so `ReadAsync` returns `null` like every other unusable frame. `Content-Length: 0` is untouched — it's well-formed framing and still reaches the formatter.

## 2. The read path transcoded bytes → chars → bytes

`JsonDocument.Parse(ReadOnlyMemory<char>)` immediately transcodes back to UTF-8 into its own pooled array:

```csharp
public static JsonDocument Parse(ReadOnlyMemory<char> json, JsonDocumentOptions options = default)
{
    ReadOnlySpan<char> jsonChars = json.Span;
    int expectedByteCount = JsonReaderHelper.GetUtf8ByteCount(jsonChars);
    byte[] utf8Bytes = ArrayPool<byte>.Shared.Rent(expectedByteCount);
    ...
```

So every frame did `GetCharCount` + `Rent<char>` + `GetChars`, and STJ undid all three — while the raw UTF-8 bytes were already sitting in `bodyBuffer`. The formatter now takes `ReadOnlyMemory<byte>` on .NET and the body goes straight through. net462/Jsonite is unchanged (it only accepts a string).

This also retires the note that was sitting on `IMessageFormatter` asking for exactly this:

```csharp
// Note: The current design might impose performance overhead, since the data
//       is not directly deserialized from a stream, but rather first a string is extracted
//       and allocated and then a string is deserialized.
//       We could create a version that uses System.Buffers APIs ...
```

and removes `Deserialize<T>(ReadOnlyMemory<char> utf8Json)` — a `char` buffer with a `utf8` name, which is the byte/char ambiguity #10297 exists to fix, one layer down.

**Lifetime note, since this is the subtle part.** `JsonDocument.Parse(ReadOnlyMemory<byte>)` does *not* copy; it reads out of the buffer until the document is disposed. The pooled buffer therefore has to outlive the document, and it does — `Deserialize` disposes the document after `Bind` has fully materialized the graph, and only then does the `finally` return the buffer.

This requirement is **not new**: the char overload rents its own byte array and returns it on `Dispose`, so anything retaining a `JsonElement` past `Deserialize` would already have been broken. I checked all the deserializers — including the recursive `IDictionary<string, object?>` and `object[]` ones, which are the only plausible offenders — and every one materializes into owned objects (`string`, `Dictionary`, `object[]`, primitives). Nothing boxes a `JsonElement`. Documented on both sides so it stays that way.

## 3. Comments that overstated their guarantee

The header-buffer comment justified unbounded growth by pointing at `Content-Length`'s trust boundary. The two aren't equivalent: a body is legitimately unbounded (stack traces, captured stdout), which is what makes refusing to cap it correct; a header line has no legitimate large case, and a peer that never sends `\n` doubles the buffer forever. Still uncapped, but the comment now says which argument actually applies and that headers are the cheaper place for a cap if one is ever wanted.

Also documented that `ReadHeaderLineAsync` breaks only on LF, whereas the `StreamReader` it replaced also treated a lone CR as a terminator. Protocol-irrelevant and arguably stricter-is-better, but the comment read as if it enumerated the cases.

## Tests

- `ReadAsync_MalformedContentLength_ReturnsNull` — negative, `int.MinValue`, larger-than-`Int32`, non-numeric, empty.
- `ConnectedHandlers.CreateAsync` no longer leaks the listener and a half-open socket if connect/accept throws. On a loopback-heavy suite that surfaces as port exhaustion in an unrelated test rather than as the failure that caused it.
- `ReadAsync_LeadingByteOrderMark_IsSkipped` is now ASCII-only. It carried `NonAsciiMethod`, so pre-#10297 it failed for the byte/char reason rather than isolating BOM handling; it can now only fail if preamble handling itself breaks.
- `FormatterUtilitiesTests` gets a `Deserialize<T>(string)` helper hiding the per-TFM split, which removes eight `#if NETCOREAPP` blocks and four `SA1009`/`SA1111` pragma pairs that only existed to work around a `#if` in the middle of a call expression.

### Verification

Guard confirmed load-bearing by neutralizing just the `if (!parsed || contentSize < 0)` condition and re-running — all five rows fail, two with `ArgumentOutOfRangeException` and three with `JsonReaderException`, matching the probe above. Restoring it returns them to green.

| Suite | Result |
| --- | --- |
| `Microsoft.Testing.Platform.UnitTests` (net8.0) | 1452/1452 |
| `Microsoft.Testing.Platform.UnitTests` (net9.0) | 1452/1452 |
| `Microsoft.Testing.Platform.UnitTests` (net462) | 1428/1428 |
| `Microsoft.Testing.Platform.ServerClient.UnitTests` (net8.0) | 24/24 |
| `Microsoft.Testing.Platform.ServerClient.UnitTests` (net462) | 24/24 |
| Full repo build (Debug) | 0 warnings, 0 errors |

Platform suites are up 5 from the 1447/1423 baseline #10297 established — the five new data rows. `ServerClient.UnitTests` is unchanged at 24, which matters because that project compiles `TcpMessageHandler.cs`, `IMessageFormatter.cs` and `FormatterUtilities.cs` as source and exercises the net462/Jsonite side of every `#if` touched here.
