### PR TITLE
Report MSTest assertion expected/actual through a platform property

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -78,6 +78,15 @@ internal static class MSTestTestNodeConverter
 
         AddOutcome(testNode, outcome, errorMessage, errorStackTrace);
 
+        // Surface the structured assertion values so consumers can render an expected-vs-actual diff. They
+        // cannot be read back from the reported exception: AddOutcome reports a synthetic
+        // MSTestTestNodeException built from the message and stack trace strings, not the original
+        // AssertFailedException.
+        if (result.ExceptionExpectedText is not null || result.ExceptionActualText is not null)
+        {
+            testNode.Properties.Add(new AssertionFailureProperty(result.ExceptionExpectedText, result.ExceptionActualText));
+        }
+
         if (isTrxEnabled)
         {
             AddTrxResultProperties(testNode, element, errorMessage, errorStackTrace, testMethodIdentifier);

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
@@ -87,6 +87,7 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
         TestNodeStateProperty? stateProperty = null;
         TimingProperty? timingProperty = null;
         TestFileLocationProperty? testFileLocationProperty = null;
+        AssertionFailureProperty? assertionFailureProperty = null;
 
         PropertyBag.PropertyBagEnumerator enumerator = testNodeStateChanged.TestNode.Properties.GetStructEnumerator();
         while (enumerator.MoveNext())
@@ -111,6 +112,14 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
                     }
 
                     testFileLocationProperty = f;
+                    break;
+                case AssertionFailureProperty a:
+                    if (assertionFailureProperty is not null)
+                    {
+                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(AssertionFailureProperty)}'.");
+                    }
+
+                    assertionFailureProperty = a;
                     break;
             }
         }
@@ -138,8 +147,8 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
                     duration: timingProperty is null ? null : ToHumanReadableDuration(timingProperty.GlobalTiming.Duration.TotalMilliseconds),
                     errorMessage: failedState.Exception?.Message ?? failedState.Explanation,
                     errorStackTrace: failedState.Exception?.StackTrace,
-                    expected: failedState.Exception?.Data["assert.expected"] as string,
-                    actual: failedState.Exception?.Data["assert.actual"] as string,
+                    expected: assertionFailureProperty is not null ? assertionFailureProperty.Expected : failedState.Exception?.Data["assert.expected"] as string,
+                    actual: assertionFailureProperty is not null ? assertionFailureProperty.Actual : failedState.Exception?.Data["assert.actual"] as string,
                     testFileLocationProperty?.FilePath,
                     testFileLocationProperty?.LineSpan.Start.Line ?? 0,
                     cancellationToken).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/Messages/AssertionFailureProperty.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/AssertionFailureProperty.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Extensions.Messages;
+
+/// <summary>
+/// Property that carries the structured <c>expected</c> and <c>actual</c> values of a failed assertion,
+/// so consumers can render an expected-vs-actual diff instead of only a flat failure message.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Historically this information could only travel on <see cref="Exception.Data"/> under the
+/// <c>assert.expected</c> / <c>assert.actual</c> keys. That channel requires the test framework to hand the
+/// platform the very exception instance the assertion library threw, which is not always possible: a framework
+/// may report a failure without any exception at all (see the
+/// <see cref="FailedTestNodeStateProperty(string)"/> overload), or it may only have the message and stack trace
+/// as strings once the failure has crossed a process or AppDomain boundary.
+/// </para>
+/// <para>
+/// Consumers should prefer this property and fall back to the <see cref="Exception.Data"/> keys for producers
+/// that have not been updated yet.
+/// </para>
+/// </remarks>
+public sealed class AssertionFailureProperty : IProperty, IEquatable<AssertionFailureProperty>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AssertionFailureProperty"/> class.
+    /// </summary>
+    /// <param name="expected">
+    /// The pre-formatted text representation of the expected value, or <see langword="null"/> when the
+    /// assertion has no natural expected value.
+    /// </param>
+    /// <param name="actual">
+    /// The pre-formatted text representation of the actual value, or <see langword="null"/> when the
+    /// assertion has no natural actual value.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Both <paramref name="expected"/> and <paramref name="actual"/> are <see langword="null"/>, which would
+    /// make the property carry no information. Rejecting that state is what lets consumers treat the mere
+    /// presence of this property as authoritative and stop consulting the legacy
+    /// <see cref="Exception.Data"/> keys.
+    /// </exception>
+    public AssertionFailureProperty(string? expected, string? actual)
+    {
+        if (expected is null && actual is null)
+        {
+            throw new ArgumentException($"At least one of '{nameof(expected)}' or '{nameof(actual)}' must be non-null.", nameof(expected));
+        }
+
+        Expected = expected;
+        Actual = actual;
+    }
+
+    /// <summary>
+    /// Gets the pre-formatted text representation of the expected value, or <see langword="null"/> when the
+    /// assertion has no natural expected value.
+    /// </summary>
+    public string? Expected { get; }
+
+    /// <summary>
+    /// Gets the pre-formatted text representation of the actual value, or <see langword="null"/> when the
+    /// assertion has no natural actual value.
+    /// </summary>
+    public string? Actual { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(AssertionFailureProperty));
+        builder.Append(" { ");
+        builder.Append($"{nameof(Expected)} = ");
+        builder.Append(Expected);
+        builder.Append($", {nameof(Actual)} = ");
+        builder.Append(Actual);
+        builder.Append(" }");
+        return builder.ToString();
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+        => Equals(obj as AssertionFailureProperty);
+
+    /// <inheritdoc />
+    public bool Equals(AssertionFailureProperty? other)
+        => other is not null && Expected == other.Expected && Actual == other.Actual;
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => RoslynHashCode.Combine(Expected, Actual);
+}

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
@@ -172,6 +172,7 @@ internal sealed partial class TerminalOutputDevice
                 StandardErrorProperty? stderrProp = null;
                 TestNodeStateProperty? nodeState = null;
                 AssertionFailureProperty? assertionFailure = null;
+                bool hasAssertionFailure = false;
                 bool executionCompleted = false;
                 PropertyBag.PropertyBagEnumerator enumerator = testNodeStateChanged.TestNode.Properties.GetStructEnumerator();
                 while (enumerator.MoveNext())
@@ -182,7 +183,14 @@ internal sealed partial class TerminalOutputDevice
                         case StandardOutputProperty so: stdoutProp = so; break;
                         case StandardErrorProperty se: stderrProp = se; break;
                         case TestNodeStateProperty s: nodeState = s; break;
-                        case AssertionFailureProperty af: assertionFailure = af; break;
+
+                        // Two competing pairs cannot both be rendered and neither carries a label, so a
+                        // duplicate suppresses the diff instead of picking an arbitrary one. This walk is
+                        // deliberately non-throwing (see above), so it drops the value rather than failing.
+                        case AssertionFailureProperty af:
+                            assertionFailure = hasAssertionFailure ? null : af;
+                            hasAssertionFailure = true;
+                            break;
                         case TestNodeExecutionCompletedProperty: executionCompleted = true; break;
                         case FileArtifactProperty fa:
                             terminalTestReporter.ArtifactAdded(

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
@@ -256,8 +256,11 @@ internal sealed partial class TerminalOutputDevice
                             // AssertionFailureProperty is the supported channel; Exception.Data is the legacy
                             // fallback for producers that have not been updated yet. The choice is
                             // all-or-nothing so the two halves of a diff always come from the same producer.
-                            expected: assertionFailure is not null ? assertionFailure.Expected : failedState.Exception?.Data["assert.expected"] as string,
-                            actual: assertionFailure is not null ? assertionFailure.Actual : failedState.Exception?.Data["assert.actual"] as string,
+                            // Gated on whether a property was seen at all, not on the resolved value: a
+                            // duplicate resolves to null to suppress the diff, and that suppression must not
+                            // fall through to the legacy values.
+                            expected: hasAssertionFailure ? assertionFailure?.Expected : failedState.Exception?.Data["assert.expected"] as string,
+                            actual: hasAssertionFailure ? assertionFailure?.Actual : failedState.Exception?.Data["assert.actual"] as string,
                             standardOutput,
                             standardError);
                         break;

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.DataConsumption.cs
@@ -171,6 +171,7 @@ internal sealed partial class TerminalOutputDevice
                 StandardOutputProperty? stdoutProp = null;
                 StandardErrorProperty? stderrProp = null;
                 TestNodeStateProperty? nodeState = null;
+                AssertionFailureProperty? assertionFailure = null;
                 bool executionCompleted = false;
                 PropertyBag.PropertyBagEnumerator enumerator = testNodeStateChanged.TestNode.Properties.GetStructEnumerator();
                 while (enumerator.MoveNext())
@@ -181,6 +182,7 @@ internal sealed partial class TerminalOutputDevice
                         case StandardOutputProperty so: stdoutProp = so; break;
                         case StandardErrorProperty se: stderrProp = se; break;
                         case TestNodeStateProperty s: nodeState = s; break;
+                        case AssertionFailureProperty af: assertionFailure = af; break;
                         case TestNodeExecutionCompletedProperty: executionCompleted = true; break;
                         case FileArtifactProperty fa:
                             terminalTestReporter.ArtifactAdded(
@@ -242,8 +244,12 @@ internal sealed partial class TerminalOutputDevice
                             null,
                             failedState.Explanation,
                             failedState.Exception,
-                            expected: failedState.Exception?.Data["assert.expected"] as string,
-                            actual: failedState.Exception?.Data["assert.actual"] as string,
+
+                            // AssertionFailureProperty is the supported channel; Exception.Data is the legacy
+                            // fallback for producers that have not been updated yet. The choice is
+                            // all-or-nothing so the two halves of a diff always come from the same producer.
+                            expected: assertionFailure is not null ? assertionFailure.Expected : failedState.Exception?.Data["assert.expected"] as string,
+                            actual: assertionFailure is not null ? assertionFailure.Actual : failedState.Exception?.Data["assert.actual"] as string,
                             standardOutput,
                             standardError);
                         break;

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -188,3 +188,11 @@ Microsoft.Testing.Platform.OutputDevice.SessionMessageOutputDeviceData.Message.g
 [TPEXP]Microsoft.Testing.Platform.Tools.IToolCommandLineOptionsProvider.ToolName.get -> string!
 [TPEXP]Microsoft.Testing.Platform.Tools.IToolsManager
 [TPEXP]Microsoft.Testing.Platform.Tools.IToolsManager.AddTool(System.Func<System.IServiceProvider!, Microsoft.Testing.Platform.Tools.ITool!>! toolFactory) -> void
+Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty
+Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.Actual.get -> string?
+Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.AssertionFailureProperty(string? expected, string? actual) -> void
+Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.Equals(Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty? other) -> bool
+Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.Expected.get -> string?
+override Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.Equals(object? obj) -> bool
+override Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.GetHashCode() -> int
+override Microsoft.Testing.Platform.Extensions.Messages.AssertionFailureProperty.ToString() -> string!

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/DotnetTestDataConsumer.cs
@@ -243,6 +243,7 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
         TimingProperty? timingProperty = null;
         StandardOutputProperty? standardOutputProperty = null;
         StandardErrorProperty? standardErrorProperty = null;
+        AssertionFailureProperty? assertionFailureProperty = null;
 
         // Mirror PropertyBag.OfType<T>()'s "first + overflow list" pattern so the common case of
         // zero or one match doesn't allocate a List<T>.
@@ -263,6 +264,9 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                     break;
                 case StandardErrorProperty errorProperty:
                     standardErrorProperty = GetSingleOrDefaultValue(standardErrorProperty, errorProperty);
+                    break;
+                case AssertionFailureProperty assertionFailure:
+                    assertionFailureProperty = GetSingleOrDefaultValue(assertionFailureProperty, assertionFailure);
                     break;
                 case FileArtifactProperty artifact:
                     if (firstArtifact is null)
@@ -330,11 +334,13 @@ internal sealed class DotnetTestDataConsumer : IPushOnlyProtocolConsumer
                     reason = nodeState.Explanation;
                     exceptions = FlattenToExceptionMessages(reason, failedTestNodeStateProperty.Exception);
 
-                    // Mirror TerminalOutputDevice's single-assembly rendering: assertion libraries store the
-                    // structured expected/actual values on Exception.Data so the reporter can show a diff.
+                    // Mirror TerminalOutputDevice's single-assembly rendering so the SDK can show an
+                    // expected-vs-actual diff. AssertionFailureProperty is the supported channel;
+                    // Exception.Data is the legacy fallback for producers that have not been updated yet. The
+                    // choice is all-or-nothing so the two halves of a diff always come from the same producer.
                     // Only failed tests carry these (error/timeout/cancelled pass null, as in single-assembly).
-                    expected = failedTestNodeStateProperty.Exception?.Data["assert.expected"] as string;
-                    actual = failedTestNodeStateProperty.Exception?.Data["assert.actual"] as string;
+                    expected = assertionFailureProperty is not null ? assertionFailureProperty.Expected : failedTestNodeStateProperty.Exception?.Data["assert.expected"] as string;
+                    actual = assertionFailureProperty is not null ? assertionFailureProperty.Actual : failedTestNodeStateProperty.Exception?.Data["assert.actual"] as string;
                     break;
 
                 case ErrorTestNodeStateProperty errorTestNodeStateProperty:

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.TestNodeSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.TestNodeSerializer.cs
@@ -19,6 +19,14 @@ internal sealed partial class Json
         List<KeyValuePair<string, string>>? traits = null;
         bool hasActionNodeType = false;
 
+        // Collected up-front because the assertion values are rendered inside the failed-state branch below,
+        // and property order inside the bag is not guaranteed. The state lookup is O(1) (it is a dedicated
+        // PropertyBag field), so non-failed nodes — discovery, in-progress, passed, which are the vast
+        // majority — never pay for the linked-list walk.
+        AssertionFailureProperty? assertionFailure = message.Properties.SingleOrDefault<TestNodeStateProperty>() is FailedTestNodeStateProperty
+            ? message.Properties.SingleOrDefault<AssertionFailureProperty>()
+            : null;
+
         int attachmentIndex = 0;
         foreach (IProperty property in message.Properties)
         {
@@ -120,6 +128,18 @@ internal sealed partial class Json
                             if (exception is not null)
                             {
                                 properties.Add(("error.stacktrace", exception.StackTrace ?? string.Empty));
+                            }
+
+                            // AssertionFailureProperty is the supported channel; Exception.Data is the legacy
+                            // fallback for producers that have not been updated yet. The choice is
+                            // all-or-nothing so the two halves of a diff always come from the same producer.
+                            if (assertionFailure is not null)
+                            {
+                                properties.Add(("assert.actual", assertionFailure.Actual ?? string.Empty));
+                                properties.Add(("assert.expected", assertionFailure.Expected ?? string.Empty));
+                            }
+                            else if (exception is not null)
+                            {
                                 properties.Add(("assert.actual", exception.Data["assert.actual"] ?? string.Empty));
                                 properties.Add(("assert.expected", exception.Data["assert.expected"] ?? string.Empty));
                             }

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Note: System.Text.Json is only available in .NET 6.0 and above.
@@ -65,6 +65,14 @@ internal static partial class SerializerUtilities
 #else
                 JsonArray? traits = null;
 #endif
+
+                // Collected up-front because the assertion values are rendered inside the failed-state branch
+                // below, and property order inside the bag is not guaranteed. The state lookup is O(1) (it is a
+                // dedicated PropertyBag field), so non-failed nodes — discovery, in-progress, passed, which are
+                // the vast majority — never pay for the linked-list walk.
+                AssertionFailureProperty? assertionFailure = n.Properties.SingleOrDefault<TestNodeStateProperty>() is FailedTestNodeStateProperty
+                    ? n.Properties.SingleOrDefault<AssertionFailureProperty>()
+                    : null;
 
                 foreach (IProperty property in n.Properties)
                 {
@@ -166,10 +174,22 @@ internal static partial class SerializerUtilities
                                 {
                                     properties["execution-state"] = "failed";
                                     properties["error.message"] = failedTestNodeStateProperty.Explanation ?? failedTestNodeStateProperty.Exception?.Message;
-                                    if (failedTestNodeStateProperty.Exception != null)
+                                    Exception? exception = failedTestNodeStateProperty.Exception;
+                                    if (exception != null)
                                     {
-                                        Exception exception = failedTestNodeStateProperty.Exception;
                                         properties["error.stacktrace"] = exception.StackTrace ?? string.Empty;
+                                    }
+
+                                    // AssertionFailureProperty is the supported channel; Exception.Data is the
+                                    // legacy fallback for producers that have not been updated yet. The choice is
+                                    // all-or-nothing so the two halves of a diff always come from the same producer.
+                                    if (assertionFailure is not null)
+                                    {
+                                        properties["assert.actual"] = assertionFailure.Actual ?? string.Empty;
+                                        properties["assert.expected"] = assertionFailure.Expected ?? string.Empty;
+                                    }
+                                    else if (exception != null)
+                                    {
                                         properties["assert.actual"] = exception.Data["assert.actual"] ?? string.Empty;
                                         properties["assert.expected"] = exception.Data["assert.expected"] ?? string.Empty;
                                     }

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+#if NETFRAMEWORK
+using System.Runtime.Serialization;
+#endif
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -25,9 +28,14 @@ public class TestResult
     /// <para>
     /// Deliberately serialized on .NET Framework, unlike <see cref="TestFailureException"/>: the values this
     /// guards (<see cref="ExceptionExpectedText"/> / <see cref="ExceptionActualText"/>) do cross an AppDomain
-    /// boundary, so the count that governs them must cross too or the invariant is lost on the far side.
+    /// boundary, so the count that governs them must cross too or the invariant is lost on the far side. It is
+    /// optional so a payload written by a TestFramework build that predates this field still deserializes,
+    /// defaulting to zero.
     /// </para>
     /// </remarks>
+#if NETFRAMEWORK
+    [OptionalField]
+#endif
     private int _assertionComparisonCount;
 
     /// <summary>
@@ -119,12 +127,26 @@ public class TestResult
     /// Gets or sets the pre-formatted <c>expected</c> text of the assertion that failed the test, when the
     /// failure came from an assertion that has a natural expected value.
     /// </summary>
+    /// <remarks>
+    /// Optional on .NET Framework so a payload written by a TestFramework build that predates this member still
+    /// deserializes, defaulting to <see langword="null"/>.
+    /// </remarks>
+#if NETFRAMEWORK
+    [field: OptionalField]
+#endif
     internal string? ExceptionExpectedText { get; set; }
 
     /// <summary>
     /// Gets or sets the pre-formatted <c>actual</c> text of the assertion that failed the test, when the
     /// failure came from an assertion that has a natural actual value.
     /// </summary>
+    /// <remarks>
+    /// Optional on .NET Framework so a payload written by a TestFramework build that predates this member still
+    /// deserializes, defaulting to <see langword="null"/>.
+    /// </remarks>
+#if NETFRAMEWORK
+    [field: OptionalField]
+#endif
     internal string? ExceptionActualText { get; set; }
 
     /// <summary>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
@@ -14,6 +14,23 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 public class TestResult
 {
     /// <summary>
+    /// Number of assertion failures carrying comparison values (an expected and/or actual text) observed across
+    /// all <see cref="TestFailureException"/> assignments, capped at 2. A single comparison can always be
+    /// attributed to the result; two or more compete, so none is reported.
+    /// </summary>
+    /// <remarks>
+    /// Failures that carry no comparison — <c>Assert.Fail</c>, or any non-assertion exception — deliberately do
+    /// not count. They add nothing that could be confused with the surviving pair, and counting them would make
+    /// a cleanup <c>Assert.Fail</c> suppress the body's diff while a cleanup <c>throw</c> would not.
+    /// <para>
+    /// Deliberately serialized on .NET Framework, unlike <see cref="TestFailureException"/>: the values this
+    /// guards (<see cref="ExceptionExpectedText"/> / <see cref="ExceptionActualText"/>) do cross an AppDomain
+    /// boundary, so the count that governs them must cross too or the invariant is lost on the far side.
+    /// </para>
+    /// </remarks>
+    private int _assertionComparisonCount;
+
+    /// <summary>
     /// Gets or sets the display name of the result. Useful when returning multiple results.
     /// If null then Method name is used as DisplayName.
     /// </summary>
@@ -72,12 +89,43 @@ public class TestResult
 
             ExceptionMessage = field.Message;
             ExceptionStackTrace = field.StackTrace;
+
+            // Capture the structured assertion values as strings, for the same reason ExceptionMessage and
+            // ExceptionStackTrace are captured: the exception instance itself does not survive an AppDomain
+            // boundary, and the adapter reports results from these strings rather than from the exception.
+            //
+            // Only an unambiguous single comparison is surfaced. This setter can be called more than once
+            // (e.g. a TestInitialize failure followed by a TestCleanup failure) and a single exception can
+            // itself report several failures, so the count is accumulated across both.
+            if (_assertionComparisonCount < 2)
+            {
+                int newComparisons = FindAssertionTexts(value, out string? expectedText, out string? actualText);
+                if (newComparisons > 0)
+                {
+                    bool isOnlyComparison = _assertionComparisonCount == 0 && newComparisons == 1;
+                    ExceptionExpectedText = isOnlyComparison ? expectedText : null;
+                    ExceptionActualText = isOnlyComparison ? actualText : null;
+                    _assertionComparisonCount += newComparisons;
+                }
+            }
         }
     }
 
     internal string? ExceptionMessage { get; set; }
 
     internal string? ExceptionStackTrace { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pre-formatted <c>expected</c> text of the assertion that failed the test, when the
+    /// failure came from an assertion that has a natural expected value.
+    /// </summary>
+    internal string? ExceptionExpectedText { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pre-formatted <c>actual</c> text of the assertion that failed the test, when the
+    /// failure came from an assertion that has a natural actual value.
+    /// </summary>
+    internal string? ExceptionActualText { get; set; }
 
     /// <summary>
     /// Gets or sets the output of the message logged by test code.
@@ -151,4 +199,71 @@ public class TestResult
             Outcome = UnitTestOutcome.Ignored,
             IgnoreReason = ignoreReason,
         };
+
+    /// <summary>
+    /// Counts the assertion failures that carry comparison values (capped at 2) and reports the values of the
+    /// first one.
+    /// </summary>
+    /// <remarks>
+    /// The adapter wraps the original assertion exception in its own exception type, so the assertion the user
+    /// cares about is usually not the outermost one. The count matters because <c>assert.expected</c> /
+    /// <c>assert.actual</c> carry no label: two competing comparisons cannot both be reported and the surviving
+    /// one would look authoritative. Soft assertions (<c>Assert.Scope</c>) reach this shape by throwing a single
+    /// <see cref="AssertFailedException"/> wrapping an <see cref="AggregateException"/> of every collected
+    /// failure. The per-assertion values remain visible in the failure message itself.
+    /// </remarks>
+    /// <returns>The number of comparisons found, saturating at 2.</returns>
+    private static int FindAssertionTexts(Exception? exception, out string? expectedText, out string? actualText)
+    {
+        expectedText = null;
+        actualText = null;
+        int comparisonCount = 0;
+        Visit(exception, 0, ref comparisonCount, ref expectedText, ref actualText);
+
+        if (comparisonCount != 1)
+        {
+            expectedText = null;
+            actualText = null;
+        }
+
+        return comparisonCount;
+
+        static void Visit(Exception? exception, int depth, ref int comparisonCount, ref string? expectedText, ref string? actualText)
+        {
+            // Bound the walk so a pathologically deep exception chain cannot stall the test host. The depth is
+            // carried into the recursion so nesting cannot escape the bound.
+            const int MaxDepth = 10;
+
+            while (exception is not null && depth < MaxDepth && comparisonCount < 2)
+            {
+                if (exception is AssertFailedException assertFailedException
+                    && (assertFailedException.ExpectedText is not null || assertFailedException.ActualText is not null))
+                {
+                    comparisonCount++;
+                    if (expectedText is null && actualText is null)
+                    {
+                        expectedText = assertFailedException.ExpectedText;
+                        actualText = assertFailedException.ActualText;
+                    }
+                }
+
+                if (exception is AggregateException aggregateException)
+                {
+                    foreach (Exception innerException in aggregateException.InnerExceptions)
+                    {
+                        Visit(innerException, depth + 1, ref comparisonCount, ref expectedText, ref actualText);
+                        if (comparisonCount > 1)
+                        {
+                            return;
+                        }
+                    }
+
+                    return;
+                }
+
+                exception = exception.InnerException;
+                depth++;
+            }
+        }
+    }
 }

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/TestResult.cs
@@ -105,7 +105,7 @@ public class TestResult
                     bool isOnlyComparison = _assertionComparisonCount == 0 && newComparisons == 1;
                     ExceptionExpectedText = isOnlyComparison ? expectedText : null;
                     ExceptionActualText = isOnlyComparison ? actualText : null;
-                    _assertionComparisonCount += newComparisons;
+                    _assertionComparisonCount = Math.Min(2, _assertionComparisonCount + newComparisons);
                 }
             }
         }

--- a/src/TestFramework/TestFramework/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/TestFramework/TestFramework/InternalAPI/InternalAPI.Unshipped.txt
@@ -6,3 +6,7 @@ static Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceResolver.Tr
 static Microsoft.VisualStudio.TestTools.UnitTesting.DynamicDataSourceResolver.TryGetDisplayName(System.Type! declaringType, string! methodName, System.Reflection.MethodInfo! testMethodInfo, object?[]? data, out string? displayName) -> bool
 Microsoft.VisualStudio.TestTools.UnitTesting.ITestFilterProviderAttribute
 Microsoft.VisualStudio.TestTools.UnitTesting.ITestFilterProviderAttribute.FilterType.get -> System.Type!
+Microsoft.VisualStudio.TestTools.UnitTesting.TestResult.ExceptionActualText.get -> string?
+Microsoft.VisualStudio.TestTools.UnitTesting.TestResult.ExceptionActualText.set -> void
+Microsoft.VisualStudio.TestTools.UnitTesting.TestResult.ExceptionExpectedText.get -> string?
+Microsoft.VisualStudio.TestTools.UnitTesting.TestResult.ExceptionExpectedText.set -> void

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/OutputTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/OutputTests.cs
@@ -19,6 +19,12 @@ public sealed class OutputTests : AcceptanceTestBase<OutputTests.TestAssetFixtur
         // Assert
         testHostResult.AssertOutputContains("Assertion failed. Expected values to be equal.");
         testHostResult.AssertOutputContains("Assert.AreEqual(1, 2)");
+
+        // The structured expected/actual block. MSTest reports results through a synthetic exception that
+        // carries no Exception.Data, so this block only renders because the adapter publishes an
+        // AssertionFailureProperty. Matched with a whitespace-tolerant regex to stay independent of the
+        // renderer's indentation.
+        testHostResult.AssertOutputMatchesRegex(@"Expected\s+1\s+Actual\s+2");
         testHostResult.AssertOutputContains("""
               Standard output
                 Console message

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SoftAssertionTests.cs
@@ -29,6 +29,10 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
         testHostResult.AssertOutputMatchesRegex(
             $"""failed ScopeWithSingleFailure {AcceptanceAssert.DurationPattern}[\s\S]+Assertion failed\. Expected values to be equal\.[\s\S]+expected: 1[\s\S]+actual:\s+2[\s\S]+Assert\.AreEqual\(1, 2\)[\s\S]+at UnitTest1\.ScopeWithSingleFailure\(\)""");
+
+        // A scope that collected exactly one failure rethrows the original assertion exception, so the
+        // structured expected/actual block is unambiguous and is reported.
+        testHostResult.AssertOutputMatchesRegex(@"Expected\s+1\s+Actual\s+2");
     }
 
     [TestMethod]
@@ -42,6 +46,10 @@ public sealed class SoftAssertionTests : AcceptanceTestBase<SoftAssertionTests.T
         // point to the test method (assertion call site).
         testHostResult.AssertOutputMatchesRegex(
             $"""failed ScopeWithMultipleFailures {AcceptanceAssert.DurationPattern}[\s\S]+2 assertion\(s\) failed within the assert scope\.[\s\S]+at UnitTest1\.ScopeWithMultipleFailures\(\)""");
+
+        // With more than one assertion failure, no single expected/actual pair can be attributed to the
+        // result, so the structured block must not be rendered. The per-assertion values stay in the message.
+        testHostResult.AssertOutputDoesNotMatchRegex(@"Expected\s+1\s+Actual\s+2");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -158,6 +158,51 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         failed.Exception.StackTrace.Should().Be("at Some.Method()");
     }
 
+    public void ToResultTestNode_AddsAssertionFailureProperty_WhenResultCarriesAssertionTexts()
+    {
+        var result = new FrameworkTestResult
+        {
+            Outcome = UnitTestOutcome.Failed,
+            ExceptionMessage = "Assert.AreEqual failed.",
+            ExceptionExpectedText = "5",
+            ExceptionActualText = "2",
+        };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        AssertionFailureProperty? assertionFailure = node.Properties.SingleOrDefault<AssertionFailureProperty>();
+        assertionFailure.Should().NotBeNull();
+        assertionFailure!.Expected.Should().Be("5");
+        assertionFailure.Actual.Should().Be("2");
+    }
+
+    public void ToResultTestNode_AddsAssertionFailureProperty_WhenOnlyExpectedTextIsKnown()
+    {
+        // Some assertions (e.g. CollectionAssert.Contains) only have a natural expected value.
+        var result = new FrameworkTestResult
+        {
+            Outcome = UnitTestOutcome.Failed,
+            ExceptionMessage = "CollectionAssert.Contains failed.",
+            ExceptionExpectedText = "\"c\"",
+        };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        AssertionFailureProperty? assertionFailure = node.Properties.SingleOrDefault<AssertionFailureProperty>();
+        assertionFailure.Should().NotBeNull();
+        assertionFailure!.Expected.Should().Be("\"c\"");
+        assertionFailure.Actual.Should().BeNull();
+    }
+
+    public void ToResultTestNode_DoesNotAddAssertionFailureProperty_WhenFailureIsNotAnAssertion()
+    {
+        var result = new FrameworkTestResult { Outcome = UnitTestOutcome.Failed, ExceptionMessage = "boom" };
+
+        TestNode node = MSTestTestNodeConverter.ToResultTestNode(CreateElement(), result, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings());
+
+        node.Properties.Any<AssertionFailureProperty>().Should().BeFalse();
+    }
+
     public void ToResultTestNode_MapsIgnoredOutcomeToSkipped()
     {
         TestNode node = ResultNode(UnitTestOutcome.Ignored);

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AssertionFailurePropertyTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AssertionFailurePropertyTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Extensions.Messages.UnitTests;
+
+[TestClass]
+public sealed class AssertionFailurePropertyTests
+{
+    [TestMethod]
+    public void ToStringIsCorrect()
+        => Assert.AreEqual(
+            "AssertionFailureProperty { Expected = 5, Actual = 2 }",
+            new AssertionFailureProperty("5", "2").ToString());
+
+    [TestMethod]
+    public void Constructor_WhenOnlyExpectedIsProvided_KeepsActualNull()
+    {
+        var property = new AssertionFailureProperty("5", null);
+
+        Assert.AreEqual("5", property.Expected);
+        Assert.IsNull(property.Actual);
+    }
+
+    [TestMethod]
+    public void Constructor_WhenOnlyActualIsProvided_KeepsExpectedNull()
+    {
+        var property = new AssertionFailureProperty(null, "2");
+
+        Assert.IsNull(property.Expected);
+        Assert.AreEqual("2", property.Actual);
+    }
+
+    [TestMethod]
+    public void Constructor_WhenBothValuesAreNull_Throws()
+        => Assert.ThrowsExactly<ArgumentException>(() => new AssertionFailureProperty(null, null));
+
+    [TestMethod]
+    public void Constructor_AllowsEmptyStrings()
+    {
+        // An empty string is a meaningful rendering (e.g. an empty expected string), unlike null.
+        var property = new AssertionFailureProperty(string.Empty, string.Empty);
+
+        Assert.IsEmpty(property.Expected!);
+        Assert.IsEmpty(property.Actual!);
+    }
+
+    [TestMethod]
+    public void Equals_WhenSameValues_ReturnsTrue()
+    {
+        var property = new AssertionFailureProperty("5", "2");
+        var other = new AssertionFailureProperty("5", "2");
+
+        Assert.AreEqual(property, other);
+        Assert.AreEqual(property.GetHashCode(), other.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Equals_WhenDifferentValues_ReturnsFalse()
+    {
+        var property = new AssertionFailureProperty("5", "2");
+
+        Assert.AreNotEqual(property, new AssertionFailureProperty("5", "3"));
+        Assert.AreNotEqual(property, new AssertionFailureProperty("4", "2"));
+    }
+
+    [TestMethod]
+    public void Equals_WhenOtherIsNullOrDifferentType_ReturnsFalse()
+    {
+        var property = new AssertionFailureProperty("5", "2");
+
+        Assert.IsFalse(property.Equals(null));
+        Assert.IsFalse(property.Equals((object?)"5"));
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/DotnetTestDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/DotnetTestDataConsumerTests.cs
@@ -37,6 +37,49 @@ public sealed class DotnetTestDataConsumerTests
         yield return [typeof(TimingProperty), CreateTimingProperty(), CreateTimingProperty()];
         yield return [typeof(StandardOutputProperty), new StandardOutputProperty("first"), new StandardOutputProperty("second")];
         yield return [typeof(StandardErrorProperty), new StandardErrorProperty("first"), new StandardErrorProperty("second")];
+        yield return [typeof(AssertionFailureProperty), new AssertionFailureProperty("first", null), new AssertionFailureProperty("second", null)];
+    }
+
+    [TestMethod]
+    public void GetTestNodeDetails_WhenFailedWithAssertionFailureProperty_PopulatesExpectedAndActual()
+    {
+        // The supported channel: no exception is required for the diff to reach the SDK.
+        DotnetTestDataConsumer.TestNodeDetails details = InvokeGetTestNodeDetails(
+            [new FailedTestNodeStateProperty("Assert.AreEqual failed."), new AssertionFailureProperty("5", "2")]);
+
+        Assert.AreEqual(TestStates.Failed, details.State);
+        Assert.AreEqual("5", details.Expected);
+        Assert.AreEqual("2", details.Actual);
+    }
+
+    [TestMethod]
+    public void GetTestNodeDetails_WhenFailedWithAssertionFailureProperty_PrefersPropertyOverExceptionData()
+    {
+        var exception = new InvalidOperationException("boom");
+        exception.Data["assert.expected"] = "legacy expected";
+        exception.Data["assert.actual"] = "legacy actual";
+
+        DotnetTestDataConsumer.TestNodeDetails details = InvokeGetTestNodeDetails(
+            [new FailedTestNodeStateProperty(exception), new AssertionFailureProperty("5", "2")]);
+
+        Assert.AreEqual("5", details.Expected);
+        Assert.AreEqual("2", details.Actual);
+    }
+
+    [TestMethod]
+    public void GetTestNodeDetails_WhenAssertionFailurePropertyIsOneSided_DoesNotSpliceInExceptionData()
+    {
+        // The property is authoritative as a whole: a half taken from the property and the other half from a
+        // stale Exception.Data entry would render a diff that never existed.
+        var exception = new InvalidOperationException("boom");
+        exception.Data["assert.expected"] = "legacy expected";
+        exception.Data["assert.actual"] = "legacy actual";
+
+        DotnetTestDataConsumer.TestNodeDetails details = InvokeGetTestNodeDetails(
+            [new FailedTestNodeStateProperty(exception), new AssertionFailureProperty("5", null)]);
+
+        Assert.AreEqual("5", details.Expected);
+        Assert.IsNull(details.Actual);
     }
 
     [TestMethod]
@@ -142,12 +185,15 @@ public sealed class DotnetTestDataConsumerTests
     }
 
     private static DotnetTestDataConsumer.TestNodeDetails InvokeGetTestNodeDetails(IProperty stateProperty)
+        => InvokeGetTestNodeDetails([stateProperty]);
+
+    private static DotnetTestDataConsumer.TestNodeDetails InvokeGetTestNodeDetails(IProperty[] properties)
     {
         TestNodeUpdateMessage testNodeUpdateMessage = new(new SessionUid("session"), new TestNode
         {
             Uid = new TestNodeUid("uid"),
             DisplayName = "DisplayName",
-            Properties = new PropertyBag(stateProperty),
+            Properties = new PropertyBag(properties),
         });
 
         MethodInfo getTestNodeDetails = typeof(DotnetTestDataConsumer).GetMethod("GetTestNodeDetails", BindingFlags.Static | BindingFlags.NonPublic)!;

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -90,6 +90,74 @@ public sealed class FormatterUtilitiesTests
             serialized);
     }
 
+    [TestMethod]
+    public async Task Serialize_FailedTestNodeWithAssertionFailureProperty_EmitsAssertValues()
+    {
+        // No exception at all: the assertion diff must still reach the client. This is the case the
+        // Exception.Data channel structurally cannot express.
+        var testNode = new TestNode
+        {
+            Uid = "failing-test",
+            DisplayName = "FailingTest",
+            Properties = new PropertyBag(
+                new FailedTestNodeStateProperty("Assert.AreEqual failed."),
+                new AssertionFailureProperty("5", "2")),
+        };
+
+        string serialized = (await _formatter.SerializeAsync(testNode)).Replace(" ", string.Empty);
+
+        Assert.AreEqual(
+            """{"uid":"failing-test","display-name":"FailingTest","node-type":"action","execution-state":"failed","error.message":"Assert.AreEqualfailed.","assert.actual":"2","assert.expected":"5"}""",
+            serialized);
+    }
+
+    [TestMethod]
+    public async Task Serialize_FailedTestNodeWithAssertionFailureProperty_PrefersPropertyOverExceptionData()
+    {
+        var exception = new InvalidOperationException("boom");
+        exception.Data["assert.expected"] = "legacy expected";
+        exception.Data["assert.actual"] = "legacy actual";
+
+        var testNode = new TestNode
+        {
+            Uid = "failing-test",
+            DisplayName = "FailingTest",
+            Properties = new PropertyBag(
+                new FailedTestNodeStateProperty(exception),
+                new AssertionFailureProperty("5", "2")),
+        };
+
+        string serialized = (await _formatter.SerializeAsync(testNode)).Replace(" ", string.Empty);
+
+        Assert.Contains("\"assert.actual\":\"2\"", serialized);
+        Assert.Contains("\"assert.expected\":\"5\"", serialized);
+    }
+
+    [TestMethod]
+    public async Task Serialize_OneSidedAssertionFailureProperty_DoesNotSpliceInExceptionData()
+    {
+        // The property is authoritative as a whole; the missing half must serialize as empty rather than
+        // falling back to an unrelated Exception.Data entry.
+        var exception = new InvalidOperationException("boom");
+        exception.Data["assert.expected"] = "legacy expected";
+        exception.Data["assert.actual"] = "legacy actual";
+
+        var testNode = new TestNode
+        {
+            Uid = "failing-test",
+            DisplayName = "FailingTest",
+            Properties = new PropertyBag(
+                new FailedTestNodeStateProperty(exception),
+                new AssertionFailureProperty("5", null)),
+        };
+
+        string serialized = (await _formatter.SerializeAsync(testNode)).Replace(" ", string.Empty);
+
+        Assert.Contains("\"assert.expected\":\"5\"", serialized);
+        Assert.Contains("\"assert.actual\":\"\"", serialized);
+        Assert.DoesNotContain("legacy", serialized);
+    }
+
     [DataRow(typeof(DiscoverRequestArgs))]
     [DataRow(typeof(RunRequestArgs))]
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -131,6 +131,10 @@ public sealed class FormatterUtilitiesTests
 
         Assert.Contains("\"assert.actual\":\"2\"", serialized);
         Assert.Contains("\"assert.expected\":\"5\"", serialized);
+
+        // Proves the property won rather than merely being present: an implementation that emitted both
+        // channels would satisfy the two assertions above.
+        Assert.DoesNotContain("legacy", serialized);
     }
 
     [TestMethod]

--- a/test/UnitTests/TestFramework.UnitTests/TestResultTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/TestResultTests.cs
@@ -36,4 +36,157 @@ public sealed class TestResultTests : TestContainer
         aggregateException.InnerExceptions[1].Message.Should().Be("Failure2");
         aggregateException.InnerExceptions[2].Message.Should().Be("Failure3");
     }
+
+    public void SettingTestFailureExceptionShouldCaptureAssertionTextsFromDirectAssertFailedException()
+    {
+        AssertFailedException exception = CreateAssertFailedException("5", "2");
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionShouldCaptureAssertionTextsFromWrappedAssertFailedException()
+    {
+        // The adapter always wraps the original assertion exception (in TestFailedException), so the
+        // assertion values must be found by walking the InnerException chain rather than only looking at
+        // the outermost exception.
+        var exception = new InvalidOperationException("outer", new InvalidOperationException("middle", CreateAssertFailedException("5", "2")));
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionShouldCaptureAssertionTextsFromAggregateException()
+    {
+        var exception = new AggregateException(new InvalidOperationException("unrelated"), CreateAssertFailedException("5", "2"));
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionShouldNotCaptureAssertionTextsWhenScopeReportsMultipleFailures()
+    {
+        // This is the exact shape Assert.Scope throws for two or more collected failures: an outer
+        // AssertFailedException (carrying no values of its own) wrapping an AggregateException of the
+        // individual assertion failures. Reporting only the first pair next to a message describing N
+        // failures would misrepresent the result.
+        var exception = new AssertFailedException(
+            "2 assertions failed.",
+            new AggregateException(CreateAssertFailedException("5", "2"), CreateAssertFailedException("7", "3")));
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().BeNull();
+        testResult.ExceptionActualText.Should().BeNull();
+    }
+
+    public void SettingTestFailureExceptionShouldCaptureAssertionTextsWhenASecondAssertionCarriesNoValues()
+    {
+        // Only one comparison exists, so it is unambiguous and is reported. A failure that carries no
+        // comparison (Assert.Fail here) adds nothing that could be confused with it.
+        var exception = new AssertFailedException(
+            "2 assertions failed.",
+            new AggregateException(CreateAssertFailedException("5", "2"), CreateAssertFailedException(null, null)));
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionShouldCaptureAssertionTextsWhenScopeReportsASingleFailure()
+    {
+        // Assert.Scope re-throws the original exception as-is when it collected exactly one failure.
+        var testResult = new TestResult { TestFailureException = CreateAssertFailedException("5", "2") };
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionTwiceWithTwoAssertionsShouldDropAmbiguousAssertionTexts()
+    {
+        var testResult = new TestResult { TestFailureException = CreateAssertFailedException("first-expected", "first-actual") };
+
+        // A second assertion failure (e.g. from TestCleanup) makes any single pair ambiguous.
+        testResult.TestFailureException = CreateAssertFailedException("second-expected", "second-actual");
+
+        testResult.ExceptionExpectedText.Should().BeNull();
+        testResult.ExceptionActualText.Should().BeNull();
+    }
+
+    public void SettingTestFailureExceptionAfterAMultiFailureScopeShouldNotCaptureAssertionTexts()
+    {
+        // The scope already contributed two assertion failures, so the later single assertion from cleanup
+        // must not get to claim the diff for the whole result.
+        var testResult = new TestResult
+        {
+            TestFailureException = new AssertFailedException(
+                "2 assertions failed.",
+                new AggregateException(CreateAssertFailedException("1", "2"), CreateAssertFailedException("3", "4"))),
+        };
+
+        testResult.TestFailureException = CreateAssertFailedException("5", "6");
+
+        testResult.ExceptionExpectedText.Should().BeNull();
+        testResult.ExceptionActualText.Should().BeNull();
+    }
+
+    public void SettingTestFailureExceptionAfterAValueLessAssertionShouldCaptureAssertionTexts()
+    {
+        // Assert.Fail produces an assertion failure with no comparison to report. It must not suppress a later
+        // one, otherwise a cleanup Assert.Fail would hide the body's diff while a cleanup throw would not.
+        var testResult = new TestResult { TestFailureException = CreateAssertFailedException(null, null) };
+
+        testResult.TestFailureException = CreateAssertFailedException("5", "6");
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("6");
+    }
+
+    public void SettingTestFailureExceptionTwiceShouldKeepAssertionTextsWhenSecondFailureIsNotAnAssertion()
+    {
+        var testResult = new TestResult { TestFailureException = CreateAssertFailedException("5", "2") };
+
+        testResult.TestFailureException = new InvalidOperationException("cleanup blew up");
+
+        testResult.ExceptionExpectedText.Should().Be("5");
+        testResult.ExceptionActualText.Should().Be("2");
+    }
+
+    public void SettingTestFailureExceptionShouldNotCaptureAssertionTextsForNonAssertionFailure()
+    {
+        var testResult = new TestResult { TestFailureException = new InvalidOperationException("boom") };
+
+        testResult.ExceptionExpectedText.Should().BeNull();
+        testResult.ExceptionActualText.Should().BeNull();
+    }
+
+    public void SettingTestFailureExceptionShouldStopWalkingBeyondBoundedChainDepth()
+    {
+        // The walk is bounded so a pathological exception chain cannot stall the test host. An assertion
+        // buried deeper than the bound is intentionally not reported.
+        Exception exception = CreateAssertFailedException("5", "2");
+        for (int i = 0; i < 15; i++)
+        {
+            exception = new InvalidOperationException("wrapper", exception);
+        }
+
+        var testResult = new TestResult { TestFailureException = exception };
+
+        testResult.ExceptionExpectedText.Should().BeNull();
+        testResult.ExceptionActualText.Should().BeNull();
+    }
+
+    private static AssertFailedException CreateAssertFailedException(string? expectedText, string? actualText)
+        => new("Assert.AreEqual failed.")
+        {
+            ExpectedText = expectedText,
+            ActualText = actualText,
+        };
 }


### PR DESCRIPTION
## Summary

The terminal's `Expected:` / `Actual:` block and the `assert.expected` / `assert.actual` protocol fields have been dead code for MSTest. Both paths that build a failed `TestNode` replace the original assertion exception with a synthetic one carrying only a message and stack trace string (`MSTestTestNodeException`, `VSTestException`), and the only channel for the structured values was `Exception.Data`, which those synthetic exceptions do not have. So all five consumers read `null` and MSTest users never saw the diff block, even though the renderer was fully implemented.

Verified with an A/B run of `samples/Playground` on `Assert.AreEqual(5, 2)`:

```
  Assert.AreEqual(5, 2)            <- before: block absent
  Expected                          <- after
    5
  Actual
    2
```

## Approach

Add an `AssertionFailureProperty` to Microsoft.Testing.Platform so the values are a first-class property instead of riding on `Exception.Data`:

- **Capture** - MSTest's `TestResult` records the values as strings when `TestFailureException` is assigned, for the same reason `ExceptionMessage` / `ExceptionStackTrace` are recorded: the exception instance does not survive an AppDomain boundary and the adapter reports from these strings. The chain is walked because the adapter always wraps the assertion in `TestFailedException`, so the outermost exception is never the one holding the values.
- **Produce** - `MSTestTestNodeConverter` publishes the property alongside the failed state.
- **Consume** - the terminal, the MSBuild extension, the `dotnet test` pipe and both server-mode serializers prefer the property and fall back to `Exception.Data` for producers that have not been updated. The choice is all-or-nothing per node so the two halves of a diff always come from the same producer.

The wire format is deliberately unchanged: same protocol keys, same key ordering, same pipe field ids, so no protocol doc or golden-string churn. What the property adds is the ability to emit those keys when there is no exception at all, which `Exception.Data` structurally cannot express (relevant for `FailedTestNodeStateProperty(string explanation)`, added in #2536 precisely so frameworks can fail without an exception).

## Reporting policy worth a careful look

Values are reported only when the result contains **exactly one** assertion failure carrying a comparison:

| Assertion failures carrying expected/actual | Behaviour |
| --- | --- |
| 0 | no property |
| 1 | reported, regardless of how many other failures occurred |
| 2+ | suppressed; per-assertion values remain in the failure message |

`Assert.Scope()` throws a single `AssertFailedException` wrapping an `AggregateException` of every collected failure. Since `assert.expected` / `assert.actual` carry no label, two competing comparisons cannot both be reported and whichever survived would look authoritative next to a message saying "N assertion(s) failed". The count is accumulated across the whole result because `TestFailureException` can be assigned more than once (TestInitialize plus TestCleanup).

Failures that carry no comparison (`Assert.Fail`, or any non-assertion exception) deliberately do not count, so a cleanup `Assert.Fail` does not hide the body's diff while a cleanup `throw` would not. Note `Assert.IsTrue` / `IsFalse` do carry a comparison (`true` / `false`), so a scope mixing `AreEqual` and `IsTrue` is suppressed.

A list-shaped property that could carry N diffs properly is the better long-term answer, but it is a much larger public API surface and is out of scope here.

## Notes for reviewers

- The VSTest bridge path still loses the values; it would need a VSTest-side carrier to benefit.
- Both serializers gained a property lookup, gated behind the `O(1)` `SingleOrDefault<TestNodeStateProperty>()` state check so discovery, in-progress and passed nodes never pay for a linked-list walk.
- `SerializerUtilities.TestNodeSerializers.cs` picked up a UTF-8 BOM on line 1 (the file had none). That matches the repo's stated encoding policy for rewritten `.cs` files, but happy to drop it if the unrelated diff line is unwanted.

## Validation

Full build clean. Unit tests: `Microsoft.Testing.Platform.UnitTests` 1940 on net9.0 and 1899 on net462 (covering both the System.Text.Json and Jsonite serializers), `TestFramework.UnitTests` 1502, `MSTestAdapter.PlatformServices.UnitTests` 1062, `Microsoft.Testing.Extensions.UnitTests` 848, `MSTestAdapter.UnitTests` 64, `Microsoft.Testing.Platform.MSBuild.UnitTests` 20.

Acceptance tests after `-pack`: `OutputTests` and `SoftAssertionTests` 13/13 across net462, net8.0 and net10.0, including new guards that the block is rendered for a single-failure scope and is not rendered for a multi-failure one.