### PR TITLE
Use `is not null` instead of `!= null` in new files from PR #10353

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs
@@ -200,8 +200,8 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
     {
         _totalTests++;
         _totalFailedTests++;
-        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks != null);
-        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks.PipeClient != null);
+        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks is not null);
+        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks.PipeClient is not null);
         var failedTestInfoRequest = new FailedTestInfoRequest(testDisplayName, isCanceled, duration, errorMessage, errorStackTrace, expected, actual, codeFilePath, lineNumber);
         await _msBuildTestApplicationLifecycleCallbacks.PipeClient.RequestReplyAsync<FailedTestInfoRequest, VoidResponse>(failedTestInfoRequest, cancellationToken).ConfigureAwait(false);
     }
@@ -210,8 +210,8 @@ internal sealed class MSBuildConsumer : IDataConsumer, ITestSessionLifetimeHandl
     {
         string? duration = ToHumanReadableDuration(elapsed.TotalMilliseconds);
 
-        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks != null);
-        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks.PipeClient != null);
+        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks is not null);
+        ApplicationStateGuard.Ensure(_msBuildTestApplicationLifecycleCallbacks.PipeClient is not null);
         bool allowSkipped = PlatformCommandLineProvider.GetZeroTestsPolicy(_commandLineOptions) == ZeroTestsPolicy.AllowSkipped;
         var runSummaryInfoRequest = new RunSummaryInfoRequest(_totalTests, _totalFailedTests, _totalPassedTests, _totalSkippedTests, duration, allowSkipped);
         await _msBuildTestApplicationLifecycleCallbacks.PipeClient.RequestReplyAsync<RunSummaryInfoRequest, VoidResponse>(runSummaryInfoRequest, cancellationToken).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
@@ -175,7 +175,7 @@ internal static partial class SerializerUtilities
                                     properties["execution-state"] = "failed";
                                     properties["error.message"] = failedTestNodeStateProperty.Explanation ?? failedTestNodeStateProperty.Exception?.Message;
                                     Exception? exception = failedTestNodeStateProperty.Exception;
-                                    if (exception != null)
+                                    if (exception is not null)
                                     {
                                         properties["error.stacktrace"] = exception.StackTrace ?? string.Empty;
                                     }
@@ -188,7 +188,7 @@ internal static partial class SerializerUtilities
                                         properties["assert.actual"] = assertionFailure.Actual ?? string.Empty;
                                         properties["assert.expected"] = assertionFailure.Expected ?? string.Empty;
                                     }
-                                    else if (exception != null)
+                                    else if (exception is not null)
                                     {
                                         properties["assert.actual"] = exception.Data["assert.actual"] ?? string.Empty;
                                         properties["assert.expected"] = exception.Data["assert.expected"] ?? string.Empty;
@@ -201,7 +201,7 @@ internal static partial class SerializerUtilities
                                 {
                                     properties["execution-state"] = "timed-out";
                                     properties["error.message"] = timeoutTestNodeStateProperty.Explanation ?? timeoutTestNodeStateProperty.Exception?.Message;
-                                    if (timeoutTestNodeStateProperty.Exception != null)
+                                    if (timeoutTestNodeStateProperty.Exception is not null)
                                     {
                                         properties["error.stacktrace"] = timeoutTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
                                     }
@@ -213,7 +213,7 @@ internal static partial class SerializerUtilities
                                 {
                                     properties["execution-state"] = "error";
                                     properties["error.message"] = errorTestNodeStateProperty.Explanation ?? errorTestNodeStateProperty.Exception?.Message;
-                                    if (errorTestNodeStateProperty.Exception != null)
+                                    if (errorTestNodeStateProperty.Exception is not null)
                                     {
                                         properties["error.stacktrace"] = errorTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
                                     }
@@ -227,7 +227,7 @@ internal static partial class SerializerUtilities
                                 {
                                     properties["execution-state"] = "canceled";
                                     properties["error.message"] = canceledTestNodeStateProperty.Explanation ?? canceledTestNodeStateProperty.Exception?.Message;
-                                    if (canceledTestNodeStateProperty.Exception != null)
+                                    if (canceledTestNodeStateProperty.Exception is not null)
                                     {
                                         properties["error.stacktrace"] = canceledTestNodeStateProperty.Exception.StackTrace ?? string.Empty;
                                     }


### PR DESCRIPTION
Fixes #10361

Replaces `!= null` with `is not null` in the two files introduced by #10353, aligning them with the repo convention used everywhere else in the Platform codebase.

- `src/Platform/Microsoft.Testing.Extensions.MSBuild/MSBuildConsumer.cs` — 4 occurrences (`ApplicationStateGuard.Ensure(...)`)
- `src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs` — 5 occurrences

Style-only change; no behavior difference. Verified both projects build with 0 warnings / 0 errors.