### PR TITLE
Cache the parsed managed name per TestMethod to avoid redundant parsing

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -33,14 +33,20 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 internal static class MSTestTestNodeConverter
 {
     /// <summary>
-    /// Caches the <see cref="TestMethodIdentifierProperty"/> built for a given <see cref="TestMethod"/>.
+    /// Caches the parsed pieces of a <see cref="TestMethod"/>'s managed name.
     /// </summary>
     /// <remarks>
-    /// The property is a pure function of <see cref="TestMethod.ManagedTypeName"/> and
-    /// <see cref="TestMethod.ManagedMethodName"/>, both immutable for the lifetime of the instance, and building it
-    /// parses the managed method signature and allocates the namespace/type substrings. The same
-    /// <see cref="TestMethod"/> is converted several times per executed test (the in-progress node, then one result
-    /// node per data row), so the parse and its allocations are paid once per test method rather than once per node.
+    /// The parse is a pure function of <see cref="TestMethod.ManagedTypeName"/> and
+    /// <see cref="TestMethod.ManagedMethodName"/>, both immutable for the lifetime of the instance, and it scans the
+    /// managed method signature and allocates the namespace/type substrings. The same <see cref="TestMethod"/> is
+    /// converted several times per executed test (the in-progress node, then one result node per data row), so the
+    /// parse is paid once per test method rather than once per node.
+    /// <para>
+    /// Only the parse is cached, not the resulting <see cref="TestMethodIdentifierProperty"/>: that type publicly
+    /// exposes its <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> array, so handing one instance
+    /// to several nodes would let any consumer that writes to the array corrupt every other node built from the
+    /// same test method. Each node therefore still gets its own property (see <see cref="ParsedManagedName.ToProperty"/>).
+    /// </para>
     /// <para>
     /// The cache lives here rather than as a lazy property on <see cref="TestMethod"/> (the way
     /// <see cref="TestMethod.ManagedTypeName"/> caches itself) because <see cref="TestMethodIdentifierProperty"/>
@@ -49,19 +55,13 @@ internal static class MSTestTestNodeConverter
     /// from this folder, through the file-level RS0030 suppression above (see this project's BannedSymbols.txt).
     /// </para>
     /// <para>
-    /// Every consumer only ever reads the property, so handing the same instance to several nodes is safe. Note
-    /// that the type is not deeply immutable: <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> is
-    /// an array that used to be freshly allocated per node and is now shared, so consumers must keep treating it
-    /// as read-only.
-    /// </para>
-    /// <para>
     /// The table holds only weak references to its keys, so entries disappear as soon as the
     /// <see cref="TestMethod"/> becomes unreachable. <c>GetValue</c> is thread-safe: concurrent misses may each run
     /// the factory, but a single value is published to every caller.
     /// </para>
     /// </remarks>
 #pragma warning disable IDE0028 // ConditionalWeakTable is not collection-expression-constructible on .NET Framework (CS9174).
-    private static readonly ConditionalWeakTable<TestMethod, TestMethodIdentifierProperty> TestMethodIdentifierCache = new();
+    private static readonly ConditionalWeakTable<TestMethod, ParsedManagedName> ParsedManagedNameCache = new();
 #pragma warning restore IDE0028
 
     /// <summary>
@@ -193,27 +193,59 @@ internal static class MSTestTestNodeConverter
         }
 
         // The method group conversion is cached by the compiler, so the lookup does not allocate a delegate.
-        TestMethodIdentifierProperty testMethodIdentifier = TestMethodIdentifierCache.GetValue(testMethod, BuildTestMethodIdentifier);
+        TestMethodIdentifierProperty testMethodIdentifier = ParsedManagedNameCache.GetValue(testMethod, ParsedManagedName.Parse).ToProperty();
         testNode.Properties.Add(testMethodIdentifier);
         return testMethodIdentifier;
     }
 
-    private static TestMethodIdentifierProperty BuildTestMethodIdentifier(TestMethod testMethod)
+    /// <summary>
+    /// The parsed pieces of a <see cref="TestMethod"/>'s managed type and method names, cached by
+    /// <see cref="ParsedManagedNameCache"/>.
+    /// </summary>
+    private sealed class ParsedManagedName
     {
-        // AddTestMethodIdentifier is the only caller and has already validated both managed names.
-        string managedType = testMethod.ManagedTypeName!;
-        string managedMethod = testMethod.ManagedMethodName!;
+        private readonly string _namespace;
+        private readonly string _typeName;
+        private readonly string _methodName;
+        private readonly int _arity;
+        private readonly string[] _parameterTypeFullNames;
 
-        ManagedNameParser.ParseManagedMethodName(managedMethod, out string methodName, out int arity, out string[]? parameterTypes);
-        parameterTypes ??= [];
+        private ParsedManagedName(string @namespace, string typeName, string methodName, int arity, string[] parameterTypeFullNames)
+        {
+            _namespace = @namespace;
+            _typeName = typeName;
+            _methodName = methodName;
+            _arity = arity;
+            _parameterTypeFullNames = parameterTypeFullNames;
+        }
 
-        int lastIndexOfDot = managedType.LastIndexOf('.');
-        string @namespace = lastIndexOfDot == -1 ? string.Empty : managedType[..lastIndexOfDot];
-        string typeName = lastIndexOfDot == -1 ? managedType : managedType[(lastIndexOfDot + 1)..];
+        public static ParsedManagedName Parse(TestMethod testMethod)
+        {
+            // AddTestMethodIdentifier is the only caller and has already validated both managed names.
+            string managedType = testMethod.ManagedTypeName!;
+            string managedMethod = testMethod.ManagedMethodName!;
 
-        // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to match
-        // the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
-        return new TestMethodIdentifierProperty(assemblyFullName: string.Empty, @namespace, typeName, methodName, arity, parameterTypes, returnTypeFullName: string.Empty);
+            ManagedNameParser.ParseManagedMethodName(managedMethod, out string methodName, out int arity, out string[]? parameterTypes);
+
+            int lastIndexOfDot = managedType.LastIndexOf('.');
+            string @namespace = lastIndexOfDot == -1 ? string.Empty : managedType[..lastIndexOfDot];
+            string typeName = lastIndexOfDot == -1 ? managedType : managedType[(lastIndexOfDot + 1)..];
+
+            return new ParsedManagedName(@namespace, typeName, methodName, arity, parameterTypes ?? []);
+        }
+
+        public TestMethodIdentifierProperty ToProperty()
+        {
+            // Every node gets its own parameter array. TestMethodIdentifierProperty exposes it publicly, so
+            // aliasing one array across nodes would let a consumer that writes to it corrupt every other node
+            // built from the same test method. An empty array cannot be mutated, so the common parameterless
+            // case still allocates nothing here.
+            string[] parameterTypeFullNames = _parameterTypeFullNames.Length == 0 ? _parameterTypeFullNames : [.. _parameterTypeFullNames];
+
+            // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to
+            // match the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
+            return new TestMethodIdentifierProperty(assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, parameterTypeFullNames, returnTypeFullName: string.Empty);
+        }
     }
 
     private static void AddOutcome(TestNode testNode, TestOutcome outcome, string? errorMessage, string? errorStackTrace)

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -33,6 +33,38 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 internal static class MSTestTestNodeConverter
 {
     /// <summary>
+    /// Caches the <see cref="TestMethodIdentifierProperty"/> built for a given <see cref="TestMethod"/>.
+    /// </summary>
+    /// <remarks>
+    /// The property is a pure function of <see cref="TestMethod.ManagedTypeName"/> and
+    /// <see cref="TestMethod.ManagedMethodName"/>, both immutable for the lifetime of the instance, and building it
+    /// parses the managed method signature and allocates the namespace/type substrings. The same
+    /// <see cref="TestMethod"/> is converted several times per executed test (the in-progress node, then one result
+    /// node per data row), so the parse and its allocations are paid once per test method rather than once per node.
+    /// <para>
+    /// The cache lives here rather than as a lazy property on <see cref="TestMethod"/> (the way
+    /// <see cref="TestMethod.ManagedTypeName"/> caches itself) because <see cref="TestMethodIdentifierProperty"/>
+    /// is a Microsoft.Testing.Platform type, and MSTestAdapter.PlatformServices - where <see cref="TestMethod"/>
+    /// lives - does not reference the platform at all. Even within this assembly the platform is only reachable
+    /// from this folder, through the file-level RS0030 suppression above (see this project's BannedSymbols.txt).
+    /// </para>
+    /// <para>
+    /// Every consumer only ever reads the property, so handing the same instance to several nodes is safe. Note
+    /// that the type is not deeply immutable: <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> is
+    /// an array that used to be freshly allocated per node and is now shared, so consumers must keep treating it
+    /// as read-only.
+    /// </para>
+    /// <para>
+    /// The table holds only weak references to its keys, so entries disappear as soon as the
+    /// <see cref="TestMethod"/> becomes unreachable. <c>GetValue</c> is thread-safe: concurrent misses may each run
+    /// the factory, but a single value is published to every caller.
+    /// </para>
+    /// </remarks>
+#pragma warning disable IDE0028 // ConditionalWeakTable is not collection-expression-constructible on .NET Framework (CS9174).
+    private static readonly ConditionalWeakTable<TestMethod, TestMethodIdentifierProperty> TestMethodIdentifierCache = new();
+#pragma warning restore IDE0028
+
+    /// <summary>
     /// Builds a discovered-state <see cref="TestNode"/> for a discovered test.
     /// </summary>
     public static TestNode ToDiscoveredTestNode(UnitTestElement element, bool isTrxEnabled)
@@ -155,17 +187,22 @@ internal static class MSTestTestNodeConverter
     {
         // NOTE: ManagedMethodName, in case of MSTest, carries the parameter types, so we prefer it to display the
         // parameter types in Test Explorer. This mirrors what the VSTest bridge did in AddAdditionalProperties.
-        if (!testMethod.HasManagedMethodAndTypeProperties)
+        if (!testMethod.HasManagedMethodAndTypeProperties || StringEx.IsNullOrEmpty(testMethod.ManagedTypeName))
         {
             return null;
         }
 
-        string? managedType = testMethod.ManagedTypeName;
-        string? managedMethod = testMethod.ManagedMethodName;
-        if (StringEx.IsNullOrEmpty(managedType) || StringEx.IsNullOrEmpty(managedMethod))
-        {
-            return null;
-        }
+        // The method group conversion is cached by the compiler, so the lookup does not allocate a delegate.
+        TestMethodIdentifierProperty testMethodIdentifier = TestMethodIdentifierCache.GetValue(testMethod, BuildTestMethodIdentifier);
+        testNode.Properties.Add(testMethodIdentifier);
+        return testMethodIdentifier;
+    }
+
+    private static TestMethodIdentifierProperty BuildTestMethodIdentifier(TestMethod testMethod)
+    {
+        // AddTestMethodIdentifier is the only caller and has already validated both managed names.
+        string managedType = testMethod.ManagedTypeName!;
+        string managedMethod = testMethod.ManagedMethodName!;
 
         ManagedNameParser.ParseManagedMethodName(managedMethod, out string methodName, out int arity, out string[]? parameterTypes);
         parameterTypes ??= [];
@@ -176,9 +213,7 @@ internal static class MSTestTestNodeConverter
 
         // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to match
         // the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
-        var testMethodIdentifier = new TestMethodIdentifierProperty(assemblyFullName: string.Empty, @namespace, typeName, methodName, arity, parameterTypes, returnTypeFullName: string.Empty);
-        testNode.Properties.Add(testMethodIdentifier);
-        return testMethodIdentifier;
+        return new TestMethodIdentifierProperty(assemblyFullName: string.Empty, @namespace, typeName, methodName, arity, parameterTypes, returnTypeFullName: string.Empty);
     }
 
     private static void AddOutcome(TestNode testNode, TestOutcome outcome, string? errorMessage, string? errorStackTrace)

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -331,10 +331,10 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     }
 
     // --- TestMethodIdentifier caching -------------------------------------------------------------------------
-    public void ToResultTestNode_ReusesTestMethodIdentifier_FromInProgressNode()
+    public void ToResultTestNode_ProducesEquivalentTestMethodIdentifier_AsInProgressNode()
     {
-        // The property is a pure function of the immutable managed names, so it is parsed and allocated once per
-        // TestMethod: the in-progress node and every result node are handed the very same cached instance.
+        // The managed-name parse is cached per TestMethod, so the in-progress node and every result node must
+        // still agree on every field of the identifier.
         UnitTestElement element = CreateElement();
 
         TestMethodIdentifierProperty? inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
@@ -343,7 +343,23 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
             .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
 
         inProgress.Should().NotBeNull();
-        result.Should().BeSameAs(inProgress);
+        result.Should().Be(inProgress);
+    }
+
+    public void ToResultTestNode_DoesNotShareParameterTypeArray_WithInProgressNode()
+    {
+        // TestMethodIdentifierProperty exposes ParameterTypeFullNames publicly, so nodes must never alias one
+        // array: a consumer that writes to it would otherwise corrupt every other node of the same test method.
+        UnitTestElement element = CreateElement(managedMethodName: "MyMethod(System.String)");
+
+        TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
+            .Properties.Single<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
+            .Properties.Single<TestMethodIdentifierProperty>();
+
+        inProgress.ParameterTypeFullNames.Should().Equal("System.String");
+        result.ParameterTypeFullNames.Should().Equal("System.String");
+        result.ParameterTypeFullNames.Should().NotBeSameAs(inProgress.ParameterTypeFullNames);
     }
 
     public void ToDiscoveredTestNode_DoesNotShareTestMethodIdentifier_AcrossDistinctTestMethods()

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -331,19 +331,25 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     }
 
     // --- TestMethodIdentifier caching -------------------------------------------------------------------------
-    public void ToResultTestNode_ProducesEquivalentTestMethodIdentifier_AsInProgressNode()
+    public void ToResultTestNode_ReusesCachedManagedNameParse_FromInProgressNode()
     {
         // The managed-name parse is cached per TestMethod, so the in-progress node and every result node must
         // still agree on every field of the identifier.
         UnitTestElement element = CreateElement();
 
-        TestMethodIdentifierProperty? inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
-            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
-        TestMethodIdentifierProperty? result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
-            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
+            .Properties.Single<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
+            .Properties.Single<TestMethodIdentifierProperty>();
 
-        inProgress.Should().NotBeNull();
         result.Should().Be(inProgress);
+
+        // Namespace and TypeName are partial Substring results of ManagedTypeName, so re-running the parse would
+        // hand back fresh string instances. Reference equality is therefore what proves the cached parse was
+        // reused rather than redone - without the cache these assertions fail while the value equality above
+        // still passes.
+        result.Namespace.Should().BeSameAs(inProgress.Namespace);
+        result.TypeName.Should().BeSameAs(inProgress.TypeName);
     }
 
     public void ToResultTestNode_DoesNotShareParameterTypeArray_WithInProgressNode()

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -91,6 +91,16 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         node.Properties.Any<TestMethodIdentifierProperty>().Should().BeFalse();
     }
 
+    public void ToDiscoveredTestNode_DoesNotAddTestMethodIdentifier_WhenManagedTypeNameIsEmpty()
+    {
+        // ManagedTypeName is derived from FullClassName, so an empty class name leaves no usable type identity.
+        UnitTestElement element = CreateElement(fullClassName: string.Empty);
+
+        TestNode node = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        node.Properties.Any<TestMethodIdentifierProperty>().Should().BeFalse();
+    }
+
     public void ToDiscoveredTestNode_AddsFileLocation_WhenDeclaringFileKnown()
     {
         UnitTestElement element = CreateElement();
@@ -318,6 +328,37 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
 
         node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxExceptionProperty>().Should().BeFalse();
         node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxMessagesProperty>().Should().BeFalse();
+    }
+
+    // --- TestMethodIdentifier caching -------------------------------------------------------------------------
+    public void ToResultTestNode_ReusesTestMethodIdentifier_FromInProgressNode()
+    {
+        // The property is a pure function of the immutable managed names, so it is parsed and allocated once per
+        // TestMethod: the in-progress node and every result node are handed the very same cached instance.
+        UnitTestElement element = CreateElement();
+
+        TestMethodIdentifierProperty? inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
+            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty? result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
+            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+
+        inProgress.Should().NotBeNull();
+        result.Should().BeSameAs(inProgress);
+    }
+
+    public void ToDiscoveredTestNode_DoesNotShareTestMethodIdentifier_AcrossDistinctTestMethods()
+    {
+        // The cache is keyed on the TestMethod instance, so two different test methods must never be conflated.
+        TestMethodIdentifierProperty? first = MSTestTestNodeConverter.ToDiscoveredTestNode(CreateElement(managedMethodName: "MethodA", name: "MethodA"), isTrxEnabled: false)
+            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty? second = MSTestTestNodeConverter.ToDiscoveredTestNode(CreateElement(managedMethodName: "MethodB", name: "MethodB"), isTrxEnabled: false)
+            .Properties.SingleOrDefault<TestMethodIdentifierProperty>();
+
+        first.Should().NotBeNull();
+        second.Should().NotBeNull();
+        second.Should().NotBeSameAs(first);
+        first!.MethodName.Should().Be("MethodA");
+        second!.MethodName.Should().Be("MethodB");
     }
 
     // --- GetTestId caching ------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #10363

## Problem

`MSTestTestNodeConverter.AddTestMethodIdentifier` called `ManagedNameParser.ParseManagedMethodName` and re-derived the namespace/type substrings on **every** node conversion — even though the parse is a pure function of `TestMethod.ManagedTypeName` and `TestMethod.ManagedMethodName`, both of which are immutable for the lifetime of the instance.

The same `TestMethod` instance is converted several times per executed test: `TestExecutionManager.ExecuteTestsWithTestRunnerAsync` reports the *original* `currentTest` element to `RecordStartAsync` (in-progress node) and then to `SendTestResultsAsync`, which loops over the results and calls `RecordResultAsync` once per row. So a plain test parses twice, and a data-driven test parses once per data row plus one.

## Change

Cache the parsed pieces — namespace, type name, method name, arity and parameter types — in a static `ConditionalWeakTable<TestMethod, ParsedManagedName>` keyed on the `TestMethod` instance. Per repeated conversion this removes:

- 1× `ParseManagedMethodName` call (scans the managed signature, allocates the parameter-type list/array)
- 2× `string` allocations (the `namespace` and `typeName` substrings)

Each node still builds its **own** `TestMethodIdentifierProperty`, with its own parameter array. That type publicly exposes `ParameterTypeFullNames`, and `TestNode.Properties` is handed to arbitrary platform extensions, so caching and sharing the property instance itself would let any consumer that writes to the array corrupt every other node built from the same test method. An empty array cannot be mutated, so the (overwhelmingly common) parameterless case still allocates no array.

The cache lives in the converter rather than as a lazy property on `TestMethod` (the way `TestMethod.ManagedTypeName` caches itself) because `TestMethodIdentifierProperty` is a Microsoft.Testing.Platform type and `MSTestAdapter.PlatformServices` does not reference the platform; within `MSTest.TestAdapter` the platform is only reachable from the `TestingPlatformAdapter` folder via the file-level `RS0030` suppression.

Behavior is unchanged: the null/empty guards are equivalent (`HasManagedMethodAndTypeProperties` already subsumes the removed `IsNullOrEmpty(ManagedMethodName)` check), and `InvalidManagedNameException` still propagates out of the factory with nothing cached, so it is re-thrown identically on the next call.

## Safety notes

- **Key stability** — `ManagedMethodName` and `FullClassName` are assigned only in the `TestMethod` constructor; `Clone()`, `CloneWithSource()`, `CloneWithUpdatedSource()` and the `[Serializable]` app-domain path all produce *new* key objects with identical values, so the cache can only miss, never go stale.
- **No aliasing** — the cached object is private to the converter and never escapes; every `TestNode` gets a freshly built property and a non-aliased parameter array.
- **Lifetime** — weak keys mean entries disappear as soon as the `TestMethod` becomes unreachable, so there is no unbounded growth.
- **Thread safety** — `ConditionalWeakTable.GetValue` is thread-safe; concurrent misses may each run the factory, but a single value is published.
- The `#pragma warning disable IDE0028` is required: a collection expression on `ConditionalWeakTable` is `CS9174` on `net462`, which lacks `IEnumerable<KeyValuePair<,>>` on that type.

## Tests

Four tests added to `MSTestTestNodeConverterTests`:

- `ToResultTestNode_ProducesEquivalentTestMethodIdentifier_AsInProgressNode` — the cached parse must yield an identifier equal on every field across nodes.
- `ToResultTestNode_DoesNotShareParameterTypeArray_WithInProgressNode` — pins the non-aliasing guarantee using a parameterized managed name.
- `ToDiscoveredTestNode_DoesNotShareTestMethodIdentifier_AcrossDistinctTestMethods` — the cache must not conflate two test methods that share a class name.
- `ToDiscoveredTestNode_DoesNotAddTestMethodIdentifier_WhenManagedTypeNameIsEmpty` — pins the pre-existing empty-`ManagedTypeName` guard that moved into the fast path.

Full repo `build.cmd` is clean (0 warnings, 0 errors); `MSTestAdapter.UnitTests` is 68/68 green on both `net9.0` and `net462`.

> Note: the perf claim is based on code inspection (call-path analysis + removed allocations), not a benchmark.
