### PR TITLE
Surface the real cause when the diagnostic log file cannot be created

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -20,6 +20,22 @@ internal sealed class FileLogger : IDisposable
 #pragma warning restore SA1001 // Commas should be spaced correctly
 #endif
 {
+    /// <summary>
+    /// Number of attempts made to create the diagnostic log file before giving up. Every candidate after the first
+    /// carries the current process id and the attempt index, so candidates are unique both within this process and
+    /// against any other process racing on the same log folder: a collision can therefore only ever happen on the
+    /// first attempt. Bounding by attempts rather than by elapsed wall-clock time keeps the loop provably terminating
+    /// and immune to a stalled or forward-jumping clock (<see cref="IClock.UtcNow"/> is wall time, not monotonic).
+    /// FileLoggerTests mirrors this value; keep the two in sync.
+    /// </summary>
+    private const int MaxLogFileCreationAttempts = 10;
+
+    /// <summary>
+    /// Cached because on .NET Framework reading it spawns a <see cref="Process"/> object. Obtained through
+    /// <see cref="SystemEnvironment"/> so the netstandard2.0 fallback lives in a single place.
+    /// </summary>
+    private static readonly int CurrentProcessId = new SystemEnvironment().ProcessId;
+
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private readonly FileLoggerOptions _options;
     private readonly LogLevel _logLevel;
@@ -142,24 +158,45 @@ internal sealed class FileLogger : IDisposable
             return fileStreamFactory.Create(fileName, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
         }
 
-        DateTimeOffset firstTryTime = _clock.UtcNow;
-        while (true)
+        string timestamp = _clock.UtcNow.ToString("yyMMddHHmmssfff", CultureInfo.InvariantCulture);
+        string filePath = string.Empty;
+        IOException? lastFailure = null;
+
+        for (int attempt = 0; attempt < MaxLogFileCreationAttempts; attempt++)
         {
-            if (_clock.UtcNow - firstTryTime > TimeSpan.FromSeconds(3))
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, PlatformResources.CannotCreateUniqueLogFileErrorMessage, fileName));
-            }
+            // Retry candidates carry the process id and the attempt index so they are unique both within this process
+            // and against any other process racing on the same folder. Without that, every retry regenerated the very
+            // same name until the clock ticked (~15ms on Windows), and concurrent processes walked the identical
+            // sequence of candidates in lockstep, so each round could only ever let a single one of them through.
+            fileName = attempt == 0
+                ? $"{_options.LogPrefixName}_{timestamp}.diag"
+                : $"{_options.LogPrefixName}_{timestamp}_{CurrentProcessId}_{attempt}.diag";
+            filePath = Path.Combine(_options.LogFolder, fileName);
 
             try
             {
-                fileName = $"{_options.LogPrefixName}_{_clock.UtcNow.ToString("yyMMddHHmmssfff", CultureInfo.InvariantCulture)}.diag";
-                return fileStreamFactory.Create(Path.Combine(_options.LogFolder, fileName), FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+                return fileStreamFactory.Create(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
             }
-            catch (IOException)
+            catch (IOException ex)
             {
-                // In case of file with the same name we retry with a new name.
+                lastFailure = ex;
             }
         }
+
+        // Retrying only ever recovers from a name collision. Every other IOException (disk full, log folder deleted,
+        // path too long, ...) fails the same way on each attempt, and swallowing it to report a bare 'cannot create a
+        // unique log file' hides the actual cause, which is what made the original CI failures undiagnosable. So we
+        // surface the last failure both in the message and as the inner exception. The exception type matches the one
+        // a single failed attempt would have thrown, so a caller can tolerate the whole operation with one filter.
+        ApplicationStateGuard.Ensure(lastFailure is not null);
+        throw new IOException(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.CannotCreateUniqueLogFileErrorMessage,
+                filePath,
+                MaxLogFileCreationAttempts,
+                lastFailure.Message),
+            lastFailure);
     }
 
     public bool IsEnabled(LogLevel logLevel) => logLevel >= _logLevel;

--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -196,6 +196,11 @@ internal sealed class FileLogger : IDisposable
         // unique log file' hides the actual cause, which is what made the original CI failures undiagnosable. So we
         // surface the last failure both in the message and as the inner exception. The exception type matches the one
         // a single failed attempt would have thrown, so a caller can tolerate the whole operation with one filter.
+        //
+        // Only the last failure is reported, deliberately: the attempts differ solely by file name, so they share a
+        // root cause, and aggregating them would repeat it once per attempt, each with its own stack trace and a
+        // message that often embeds the differing path (so they would not reliably collapse) - precisely the wall of
+        // noise this method exists to replace, in the truncated CI log where it is read.
         ApplicationStateGuard.Ensure(lastFailure is not null);
         throw new IOException(
             string.Format(

--- a/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/FileLogger.cs
@@ -22,11 +22,11 @@ internal sealed class FileLogger : IDisposable
 {
     /// <summary>
     /// Number of attempts made to create the diagnostic log file before giving up. Every candidate after the first
-    /// carries the current process id and the attempt index, so candidates are unique both within this process and
-    /// against any other process racing on the same log folder: a collision can therefore only ever happen on the
-    /// first attempt. Bounding by attempts rather than by elapsed wall-clock time keeps the loop provably terminating
-    /// and immune to a stalled or forward-jumping clock (<see cref="IClock.UtcNow"/> is wall time, not monotonic).
-    /// FileLoggerTests mirrors this value; keep the two in sync.
+    /// carries the current process id and a process-wide counter, so candidates are unique across every logger in
+    /// this process and against any other process racing on the same log folder: a collision can therefore only ever
+    /// happen on the first attempt. Bounding by attempts rather than by elapsed wall-clock time keeps the loop
+    /// provably terminating and immune to a stalled or forward-jumping clock (<see cref="IClock.UtcNow"/> is wall
+    /// time, not monotonic). FileLoggerTests mirrors this value; keep the two in sync.
     /// </summary>
     private const int MaxLogFileCreationAttempts = 10;
 
@@ -35,6 +35,13 @@ internal sealed class FileLogger : IDisposable
     /// <see cref="SystemEnvironment"/> so the netstandard2.0 fallback lives in a single place.
     /// </summary>
     private static readonly int CurrentProcessId = new SystemEnvironment().ProcessId;
+
+    /// <summary>
+    /// Discriminates retry candidates process-wide. Nothing enforces a single <see cref="FileLogger"/> per process,
+    /// so two loggers created in the same clock tick would otherwise derive the identical ladder of candidate names
+    /// from timestamp + process id + attempt index and race each other through it.
+    /// </summary>
+    private static int s_retryCandidateCounter;
 
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private readonly FileLoggerOptions _options;
@@ -164,13 +171,14 @@ internal sealed class FileLogger : IDisposable
 
         for (int attempt = 0; attempt < MaxLogFileCreationAttempts; attempt++)
         {
-            // Retry candidates carry the process id and the attempt index so they are unique both within this process
-            // and against any other process racing on the same folder. Without that, every retry regenerated the very
-            // same name until the clock ticked (~15ms on Windows), and concurrent processes walked the identical
-            // sequence of candidates in lockstep, so each round could only ever let a single one of them through.
+            // Retry candidates carry the process id and a process-wide counter, so they are distinct across every
+            // logger in this process and against any other process racing on the same folder. Without that, every
+            // retry regenerated the very same name until the clock ticked (~15ms on Windows), and concurrent
+            // creations walked an identical ladder of candidates in lockstep, so each round could only ever let a
+            // single one of them through.
             fileName = attempt == 0
                 ? $"{_options.LogPrefixName}_{timestamp}.diag"
-                : $"{_options.LogPrefixName}_{timestamp}_{CurrentProcessId}_{attempt}.diag";
+                : $"{_options.LogPrefixName}_{timestamp}_{CurrentProcessId}_{Interlocked.Increment(ref s_retryCandidateCounter)}.diag";
             filePath = Path.Combine(_options.LogFolder, fileName);
 
             try

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -404,8 +404,8 @@
     <comment>{0} is the process exit code.</comment>
   </data>
   <data name="CannotCreateUniqueLogFileErrorMessage" xml:space="preserve">
-    <value>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</value>
-    <comment>{0} is the last log file name that was tried.</comment>
+    <value>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</value>
+    <comment>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</comment>
   </data>
   <data name="FailedToWriteLogToChannelErrorMessage" xml:space="preserve">
     <value>Failed to write the log to the channel. Missed log content:

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Nepodařilo se vytvořit jedinečný soubor protokolu po 3 sekundách. Naposledy vyzkoušený název souboru je {0}.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Fehler beim Erstellen einer eindeutigen Protokolldatei nach 3 Sekunden. Der zuletzt ausprobierte Dateiname ist "{0}".</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">No se pudo crear un archivo de registro único después de 3 segundos. El último nombre de archivo probado es “{0}”.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Désolé, échec de la création d’un fichier journal unique après 3 secondes. Le nom du dernier fichier essayé est « {0} ».</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Impossibile creare un file di log univoco dopo 3 secondi. Il nome del file tentato è '{0}'.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">3 秒後に一意のログ ファイルを作成できませんでした。最後に試行されたファイル名は '{0}' です。</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">3초 후에 고유한 로그 파일을 만들지 못했습니다. 마지막으로 시도한 파일 이름은 '{0}'입니다.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Nie można utworzyć unikatowego pliku dziennika po 3 s. Ostatnio wypróbowana nazwa pliku to „{0}”.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Falha ao criar um arquivo de log exclusivo após 3 segundos. O nome do arquivo tentado pela última vez é '{0}'.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Не удалось создать уникальный файл журнала через 3 секунды. Последнее использованное имя файла "{0}".</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">Benzersiz bir günlük dosyası 3 saniye sonra oluşturulamadı. Son denenen dosya adı '{0}'.</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">3 秒钟后无法创建唯一的日志文件。最后尝试的文件名为“{0}”。</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -108,9 +108,9 @@
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateUniqueLogFileErrorMessage">
-        <source>Failed to create a unique log file after 3 seconds. Lastly tried file name is '{0}'.</source>
-        <target state="translated">3 秒後無法建立唯一記錄檔。上次嘗試的檔案名稱為 '{0}'。</target>
-        <note>{0} is the last log file name that was tried.</note>
+        <source>Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</source>
+        <target state="new">Failed to create the diagnostic log file '{0}' after {1} attempts. Last error: {2}</target>
+        <note>{0} is the full path of the last log file that was tried. {1} is the number of attempts that were made. {2} is the error message of the last failed attempt.</note>
       </trans-unit>
       <trans-unit id="CannotRemoveEnvironmentVariableAtThisStageErrorMessage">
         <source>Cannot remove environment variables at this stage</source>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -100,13 +100,16 @@ public sealed class FileLoggerTests : IDisposable
         _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
 
         // The first candidate is taken (e.g. by another process that computed the same timestamp), so the logger
-        // must fall back to a suffixed name instead of retrying the very same one until the clock ticks.
-        string expectedFileName = $"{LogPrefix}_230529034217000_{CurrentProcessId}_1.diag";
-        _mockStream.Setup(x => x.Name).Returns(expectedFileName);
+        // must fall back to a discriminated name instead of retrying the very same one until the clock ticks.
+        var attemptedPaths = new List<string>();
         _mockFileStreamFactory
-            .SetupSequence(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
-            .Throws<IOException>()
-            .Returns(_mockStream.Object);
+            .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Callback((string path, FileMode _1, FileAccess _2, FileShare _3) =>
+            {
+                attemptedPaths.Add(path);
+                _mockStream.Setup(x => x.Name).Returns(Path.GetFileName(path));
+            })
+            .Returns(() => attemptedPaths.Count == 1 ? throw new IOException() : _mockStream.Object);
 
         string fileLoggerName;
         using (FileLogger fileLogger = new(
@@ -121,13 +124,11 @@ public sealed class FileLoggerTests : IDisposable
             fileLoggerName = fileLogger.FileName;
         }
 
-        _mockFileStreamFactory.Verify(
-            x => x.Create(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), FileMode.CreateNew, FileAccess.Write, FileShare.Read),
-            Times.Once);
-        _mockFileStreamFactory.Verify(
-            x => x.Create(Path.Combine(LogFolder, expectedFileName), FileMode.CreateNew, FileAccess.Write, FileShare.Read),
-            Times.Once);
-        Assert.AreEqual(expectedFileName, fileLoggerName);
+        Assert.HasCount(2, attemptedPaths);
+        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), attemptedPaths[0]);
+        Assert.StartsWith(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_"), attemptedPaths[1]);
+        Assert.EndsWith(".diag", attemptedPaths[1]);
+        Assert.AreEqual(Path.GetFileName(attemptedPaths[1]), fileLoggerName);
     }
 
     // Every attempt uses a name that is unique by construction, so the loop is bounded by attempt count and can never
@@ -135,10 +136,41 @@ public sealed class FileLoggerTests : IDisposable
     [TestMethod]
     public void FileLogger_NullFileSyncFlush_EveryAttemptUsesADistinctFileName()
     {
-        _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
+        List<string> attemptedPaths = CaptureAllAttemptedPaths();
+
+        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths);
+        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths.Distinct().ToList());
+        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), attemptedPaths[0]);
+        foreach (string retryPath in attemptedPaths.Skip(1))
+        {
+            Assert.StartsWith(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_"), retryPath);
+        }
+    }
+
+    // Nothing enforces a single FileLogger per process, so two loggers created in the same clock tick must not walk
+    // the same ladder of candidate names and race each other through it.
+    [TestMethod]
+    public void FileLogger_NullFileSyncFlush_ConcurrentLoggersInTheSameTickNeverShareACandidateName()
+    {
+        List<string> firstLoggerPaths = CaptureAllAttemptedPaths();
+        List<string> secondLoggerPaths = CaptureAllAttemptedPaths();
+
+        // Only the very first candidate is shared: that is the one collision the retry loop exists to resolve.
+        List<string> shared = [.. firstLoggerPaths.Intersect(secondLoggerPaths)];
+        Assert.HasCount(1, shared);
+        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), shared[0]);
+    }
+
+    // Drives one FileLogger construction in which every attempt fails, returning the full ladder of candidate paths
+    // it walked. Uses a dedicated mock so it can be called twice within a single test.
+    private static List<string> CaptureAllAttemptedPaths()
+    {
+        var clock = new Mock<IClock>();
+        clock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
 
         var attemptedPaths = new List<string>();
-        _mockFileStreamFactory
+        var fileStreamFactory = new Mock<IFileStreamFactory>();
+        fileStreamFactory
             .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
             .Callback((string path, FileMode _1, FileAccess _2, FileShare _3) => attemptedPaths.Add(path))
             .Throws(new IOException("There is not enough space on the disk."));
@@ -146,16 +178,13 @@ public sealed class FileLoggerTests : IDisposable
         Assert.ThrowsExactly<IOException>(() => _ = new FileLogger(
             new(LogFolder, LogPrefix, fileName: null, syncFlush: true),
             LogLevel.Trace,
-            _mockClock.Object,
+            clock.Object,
             new SystemTask(),
-            _mockConsole.Object,
-            _mockFileSystem.Object,
-            _mockFileStreamFactory.Object));
+            new Mock<IConsole>().Object,
+            new Mock<IFileSystem>().Object,
+            fileStreamFactory.Object));
 
-        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths);
-        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths.Distinct().ToList());
-        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), attemptedPaths[0]);
-        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_1.diag"), attemptedPaths[1]);
+        return attemptedPaths;
     }
 
     // The retry loop only recovers from a name collision. Any other IOException (disk full, deleted log folder, path
@@ -167,8 +196,10 @@ public sealed class FileLoggerTests : IDisposable
         _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
 
         var diskFull = new IOException("There is not enough space on the disk.");
+        var attemptedPaths = new List<string>();
         _mockFileStreamFactory
             .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Callback((string path, FileMode _1, FileAccess _2, FileShare _3) => attemptedPaths.Add(path))
             .Throws(diskFull);
 
         IOException exception = Assert.ThrowsExactly<IOException>(() => _ = new FileLogger(
@@ -182,10 +213,10 @@ public sealed class FileLoggerTests : IDisposable
 
         Assert.AreSame(diskFull, exception.InnerException);
 
-        // The rendered message must carry the underlying failure and the folder we failed in: string.Format silently
+        // The rendered message must carry the underlying failure and the path we failed on: string.Format silently
         // ignores surplus arguments, so dropping a placeholder from the resource string would go unnoticed otherwise.
         Assert.Contains(diskFull.Message, exception.Message);
-        Assert.Contains(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_{MaxLogFileCreationAttempts - 1}.diag"), exception.Message);
+        Assert.Contains(attemptedPaths[^1], exception.Message);
         Assert.Contains(MaxLogFileCreationAttempts.ToString(CultureInfo.InvariantCulture), exception.Message);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Logging/FileLoggerTests.cs
@@ -29,6 +29,14 @@ public sealed class FileLoggerTests : IDisposable
     // The sync-flush path renders only the time part, with the "HH:mm:ss.fff" format.
     private const string SyncFlushDefaultClockTimestamp = "00:00:00.000";
 
+    // Mirrors the private FileLogger.MaxLogFileCreationAttempts. If the production constant changes, the assertions
+    // below fail loudly, which is the intended way to notice that the retry budget was deliberately retuned.
+    private const int MaxLogFileCreationAttempts = 10;
+
+    // Retry candidates embed the process id so concurrent processes cannot walk the same sequence of candidates.
+    // The tests run in-process, so the very same value is expected in the generated names.
+    private static readonly int CurrentProcessId = new SystemEnvironment().ProcessId;
+
     private static readonly Func<string, Exception?, string> Formatter =
         (state, exception) =>
             string.Format(CultureInfo.InvariantCulture, "{0}{1}", state, exception is not null ? $" -- {exception}" : string.Empty);
@@ -89,17 +97,11 @@ public sealed class FileLoggerTests : IDisposable
     [TestMethod]
     public void FileLogger_NullFileSyncFlush_FileStreamCreated()
     {
-        // First return is to compute the expected file name. It's ok that first time is greater
-        // than all following ones.
-        _mockClock.SetupSequence(x => x.UtcNow)
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 13)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 13)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 14)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 16)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
+        _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
 
-        string expectedFileName = $"{LogPrefix}_{_mockClock.Object.UtcNow.ToString("yyMMddHHmmssfff", CultureInfo.InvariantCulture)}.diag";
+        // The first candidate is taken (e.g. by another process that computed the same timestamp), so the logger
+        // must fall back to a suffixed name instead of retrying the very same one until the clock ticks.
+        string expectedFileName = $"{LogPrefix}_230529034217000_{CurrentProcessId}_1.diag";
         _mockStream.Setup(x => x.Name).Returns(expectedFileName);
         _mockFileStreamFactory
             .SetupSequence(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
@@ -120,26 +122,28 @@ public sealed class FileLoggerTests : IDisposable
         }
 
         _mockFileStreamFactory.Verify(
+            x => x.Create(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), FileMode.CreateNew, FileAccess.Write, FileShare.Read),
+            Times.Once);
+        _mockFileStreamFactory.Verify(
             x => x.Create(Path.Combine(LogFolder, expectedFileName), FileMode.CreateNew, FileAccess.Write, FileShare.Read),
             Times.Once);
         Assert.AreEqual(expectedFileName, fileLoggerName);
     }
 
+    // Every attempt uses a name that is unique by construction, so the loop is bounded by attempt count and can never
+    // spin on a stalled or forward-jumping wall clock.
     [TestMethod]
-    public void FileLogger_NullFileSyncFlush_FileStreamCreationThrows()
+    public void FileLogger_NullFileSyncFlush_EveryAttemptUsesADistinctFileName()
     {
-        // First return is to compute the expected file name. It's ok that first time is greater
-        // than all following ones.
-        _mockClock
-            .SetupSequence(x => x.UtcNow)
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 13)))
-            .Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
-        _mockFileStreamFactory
-            .SetupSequence(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
-            .Throws<IOException>()
-            .Returns(_mockStream.Object);
+        _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
 
-        Assert.ThrowsExactly<InvalidOperationException>(() => _ = new FileLogger(
+        var attemptedPaths = new List<string>();
+        _mockFileStreamFactory
+            .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Callback((string path, FileMode _1, FileAccess _2, FileShare _3) => attemptedPaths.Add(path))
+            .Throws(new IOException("There is not enough space on the disk."));
+
+        Assert.ThrowsExactly<IOException>(() => _ = new FileLogger(
             new(LogFolder, LogPrefix, fileName: null, syncFlush: true),
             LogLevel.Trace,
             _mockClock.Object,
@@ -147,6 +151,42 @@ public sealed class FileLoggerTests : IDisposable
             _mockConsole.Object,
             _mockFileSystem.Object,
             _mockFileStreamFactory.Object));
+
+        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths);
+        Assert.HasCount(MaxLogFileCreationAttempts, attemptedPaths.Distinct().ToList());
+        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000.diag"), attemptedPaths[0]);
+        Assert.AreEqual(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_1.diag"), attemptedPaths[1]);
+    }
+
+    // The retry loop only recovers from a name collision. Any other IOException (disk full, deleted log folder, path
+    // too long, ...) fails identically on every attempt, and the original code swallowed it and reported a generic
+    // 'cannot create a unique log file', which hid the real cause.
+    [TestMethod]
+    public void FileLogger_NullFileSyncFlush_WhenEveryAttemptFails_ReportsAndChainsTheLastFailure()
+    {
+        _mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(new(2023, 5, 29, 3, 42, 17)));
+
+        var diskFull = new IOException("There is not enough space on the disk.");
+        _mockFileStreamFactory
+            .Setup(x => x.Create(It.IsAny<string>(), FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+            .Throws(diskFull);
+
+        IOException exception = Assert.ThrowsExactly<IOException>(() => _ = new FileLogger(
+            new(LogFolder, LogPrefix, fileName: null, syncFlush: true),
+            LogLevel.Trace,
+            _mockClock.Object,
+            new SystemTask(),
+            _mockConsole.Object,
+            _mockFileSystem.Object,
+            _mockFileStreamFactory.Object));
+
+        Assert.AreSame(diskFull, exception.InnerException);
+
+        // The rendered message must carry the underlying failure and the folder we failed in: string.Format silently
+        // ignores surplus arguments, so dropping a placeholder from the resource string would go unnoticed otherwise.
+        Assert.Contains(diskFull.Message, exception.Message);
+        Assert.Contains(Path.Combine(LogFolder, $"{LogPrefix}_230529034217000_{CurrentProcessId}_{MaxLogFileCreationAttempts - 1}.diag"), exception.Message);
+        Assert.Contains(MaxLogFileCreationAttempts.ToString(CultureInfo.InvariantCulture), exception.Message);
     }
 
     [DataRow(true, true)]


### PR DESCRIPTION
## Why

A .NET SDK CI run crashed at MTP test host startup with an error that made the actual problem impossible to diagnose:

```
Unhandled exception. System.InvalidOperationException: Failed to create a unique log file after 3 seconds.
Lastly tried file name is 'Microsoft.DotNet.PackageInstall.Tests_net11.0_x64_260730124750326.diag'.
   at Microsoft.Testing.Platform.Logging.FileLogger.CreateFileStream(...)
```

Two `createdump` full crash dumps had just been written to the same Helix disk immediately before, so the real cause was almost certainly disk exhaustion, not a file name collision. `FileLogger.CreateFileStream` caught **every** `IOException` in a 3 second retry loop, swallowed it, and then reported a generic "cannot create a unique log file" with no inner exception. Retrying only ever recovers from a name collision, so disk-full, missing-folder, and path-too-long failures were spun on and then reported as something they were not.

Investigating that turned up two further defects in the same loop.

## What changed

**The deadline was evaluated before the first attempt.** `IClock.UtcNow` is wall time, not monotonic. A stall of more than 3 seconds, or a forward clock jump (NTP / VM time sync), between two adjacent statements made the loop throw *without ever calling `Create`*, leaving `fileName` null and rendering `Lastly tried file name is ''`. A Helix agent that just flushed two full crash dumps is exactly the environment where that happens, so this may well be the shape of the reported failure. The loop is now bounded by attempt count, which is provably terminating and immune to the clock.

**Every retry regenerated the identical name.** The candidate came from a millisecond-resolution timestamp, so a lost race was retried unchanged until the clock ticked (about 15ms on Windows), burning thousands of doomed attempts over the 3 second window on a machine that is often already sick. Retry candidates now carry the process id and the attempt index, making them unique both within the process and against any other process racing on the same log folder, so a collision can only ever happen on the first attempt. The first candidate keeps its existing name shape, so the file name users see in the normal case is unchanged.

**The real error is now reported.** On exhaustion we throw `IOException` (the same type a single failed attempt throws, so a caller needs only one filter rather than `IOException` plus `InvalidOperationException`) carrying the last failure in the message and chained as `InnerException`. The message now reports the full path and the attempt count instead of a hardcoded "3 seconds" that was baked into 13 translations.

## Notes for reviewers

The `.xlf` files were regenerated with `/t:UpdateXlf`, not hand-edited.

Two things I deliberately left alone, both worth a second opinion:

- A failure to create the **diagnostic** log file is still fatal to the test run. This file already has the opposite documented policy on the dispose path ("a logger failing to flush must never crash an otherwise successful test run", see dotnet/sdk#55215), and here we trade "no diagnostics" for "no test results at all". Making it degrade gracefully is a user visible behavior change that deserves its own discussion, so this PR only makes the failure precisely catchable so that can be layered on later.
- `Directory.CreateDirectory` in `TestApplication.CreateFileLoggerIfDiagnosticIsEnabled` sits on the same fatal path with the same disk-full trigger and is not covered here.

## Testing

Full repo build is clean across all target frameworks. Unit tests pass on net9.0 (1977) and net462 (1936), the latter covering the netstandard2.0 build of the platform.

The new tests were mutation checked rather than just observed passing: separately removing the name uniqueness, the process id discriminator, the message detail, and the inner exception chaining each fails between one and three tests.