### PR TITLE
Cover the fixture-scope branches of MSTEST0075

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CurrentDirectoryMutationUnderParallelizationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CurrentDirectoryMutationUnderParallelizationAnalyzerTests.cs
@@ -298,6 +298,139 @@ public sealed class CurrentDirectoryMutationUnderParallelizationAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestInitializeSetsCurrentDirectoryViaDirectory_Diagnostic()
+    {
+        // [TestInitialize] is a class-scoped fixture included in GetFixtureAttributeSymbols, so a mutation inside it
+        // must be reported just like one inside a test method.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                public void Setup()
+                {
+                    {|#0:Directory.SetCurrentDirectory("/tmp")|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        // Discovery reads resource locks only from the test class and the test method, so a lock on the fixture method
+        // itself would be ignored. The fixer therefore annotates the enclosing test class, where the lock takes effect.
+        string fixedCode = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            [ResourceLock(WellKnownResources.CurrentDirectory)]
+            public class MyTestClass
+            {
+                [TestInitialize]
+                public void Setup()
+                {
+                    Directory.SetCurrentDirectory("/tmp");
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(CurrentDirectoryMutationUnderParallelizationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("Directory.SetCurrentDirectory"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenAssemblyInitializeSetsCurrentDirectoryViaDirectory_NoDiagnostic()
+    {
+        // [AssemblyInitialize] is deliberately excluded from GetFixtureAttributeSymbols: it is serialized and every
+        // worker awaits it before running any test, so a process-global mutation there cannot race a concurrent test.
+        // Flagging it would be a false positive.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblyInit(TestContext context)
+                {
+                    Directory.SetCurrentDirectory("/tmp");
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenGlobalTestInitializeSetsCurrentDirectoryViaDirectory_DiagnosticWithoutFix()
+    {
+        // [GlobalTestInitialize] runs around every test in the assembly, so the mutation genuinely races and is
+        // reported. But it is a global fixture, not a class-scoped one: it is in GetFixtureAttributeSymbols yet
+        // absent from GetClassScopedFixtureAttributeSymbols, so GetResourceLockFixScope returns null and the
+        // analyzer omits the fixer properties. This pins the third branch - report, but offer no fix - because a
+        // global fixture has no effective lock target: the enclosing class is not one, since locking it would
+        // serialize only that class's tests while the fixture kept racing the tests of every other class. (That
+        // is a different mechanism from the class-scoped case above, where the class lock *is* the effective
+        // target and it is a lock on the fixture method that discovery would ignore.) Asserting the code is
+        // unchanged is what catches a regression that started offering that do-nothing fix.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [GlobalTestInitialize]
+                public static void GlobalSetup(TestContext context)
+                {
+                    {|#0:Directory.SetCurrentDirectory("/tmp")|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(CurrentDirectoryMutationUnderParallelizationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("Directory.SetCurrentDirectory"),
+            code);
+    }
+
+    [TestMethod]
     public async Task WhenTestMethodSetsCurrentDirectory_VisualBasic_Diagnostic()
     {
         string code = """


### PR DESCRIPTION
Closes #10349
Closes #10369

(#10349 and #10369 are duplicates of each other — the test-improver workflow filed the same gap twice.)

## What this covers

`CurrentDirectoryMutationUnderParallelizationAnalyzer` decides, per enclosing method, whether to report a current-directory mutation and — if so — where `AddResourceLockFixer` may place `[ResourceLock]`. That yields **three** distinct outcomes, and this file covered none of them: every pre-existing test here pins the plain test-method case.

| New test | Enclosing method | Outcome |
|---|---|---|
| `WhenTestInitializeSetsCurrentDirectoryViaDirectory_Diagnostic` | `[TestInitialize]` | Reported; fix placed on the **class** |
| `WhenAssemblyInitializeSetsCurrentDirectoryViaDirectory_NoDiagnostic` | `[AssemblyInitialize]` | Silent |
| `WhenGlobalTestInitializeSetsCurrentDirectoryViaDirectory_DiagnosticWithoutFix` | `[GlobalTestInitialize]` | Reported; **no fix offered** |

Notes on each:

- **`[TestInitialize]`** is a class-scoped fixture, so a `[ResourceLock]` on the fixture method itself would be ignored — discovery reads locks only from the test class and the test method. The test asserts the fixer's class-scope placement, which is the first class-scope fix assertion in this file. (The sibling `CultureMutationUnderParallelizationAnalyzerTests` only calls `VerifyAnalyzerAsync`, so it cannot pin this at all.)
- **`[AssemblyInitialize]`** is serialized ahead of every worker, so it cannot race a concurrent test — flagging it would be a false positive.
- **`[GlobalTestInitialize]`** genuinely races, but a global fixture has no *effective* lock target: the enclosing class is not one, because locking it would serialize only that class's tests while the fixture kept racing the tests of every other class. So the analyzer reports without offering a fix. This third branch had no coverage in **any** of the three parallel-safety analyzer test files.

## Mutation-verified

These are not decorative — each was checked by breaking the analyzer and confirming exactly one test caught it, with **no pre-existing test in the repo noticing**:

| Injected regression | Result |
|---|---|
| Add `AssemblyInitializeAttribute` to `GetFixtureAttributeSymbols` | only the `[AssemblyInitialize]` test fails |
| Add `GlobalTestInitializeAttribute` to `GetClassScopedFixtureAttributeSymbols` | only the `[GlobalTestInitialize]` test fails |

The second is the interesting one: that regression would make the fixer emit a class-level `[ResourceLock]` that does nothing at run time, and before this PR nothing would have caught it.

## Validation

Full `MSTest.Analyzers.UnitTests` suite: **net8.0 1688/1688**, **net472 1632/1632**. Build clean, 0 warnings. No production code changed.

---

The MSTEST0081 half of this backlog is split out into #10386, since it covers a different analyzer and issue.