### PR TITLE
Clear the perf-improver backlog: reporting and terminal allocations

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -42,10 +42,13 @@ internal static class MSTestTestNodeConverter
     /// converted several times per executed test (the in-progress node, then one result node per data row), so the
     /// parse is paid once per test method rather than once per node.
     /// <para>
-    /// Only the parse is cached, not the resulting <see cref="TestMethodIdentifierProperty"/>: that type publicly
-    /// exposes its <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> array, so handing one instance
-    /// to several nodes would let any consumer that writes to the array corrupt every other node built from the
-    /// same test method. Each node therefore still gets its own property (see <see cref="ParsedManagedName.ToProperty"/>).
+    /// The resulting <see cref="TestMethodIdentifierProperty"/> is cached alongside the parse only for
+    /// parameterless test methods. That type publicly exposes its
+    /// <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> array, so sharing one instance is safe
+    /// exactly when that array is empty and therefore cannot be mutated; every other field is an immutable string
+    /// or int. A parameterized method must keep getting a fresh property carrying a fresh array copy, otherwise a
+    /// consumer that writes to the array would corrupt every other node built from the same test method (see
+    /// <see cref="ParsedManagedName.ToProperty"/>).
     /// </para>
     /// <para>
     /// The cache lives here rather than as a lazy property on <see cref="TestMethod"/> (the way
@@ -218,8 +221,11 @@ internal static class MSTestTestNodeConverter
         private readonly int _arity;
         private readonly string[] _parameterTypeFullNames;
 
-        // Only set for the parameterless case, where the produced property is fully immutable. See ToProperty().
-        private TestMethodIdentifierProperty? _cachedParameterlessProperty;
+        // Non-null exactly for parameterless methods, where the property is fully immutable and can therefore be
+        // handed to every node. Built eagerly so the field can stay readonly: ToProperty() is called immediately
+        // after every parse, so nothing is built that would not have been built anyway, and a lazy `??=` would
+        // make the shared instance depend on call ordering. See ToProperty().
+        private readonly TestMethodIdentifierProperty? _parameterlessProperty;
 
         private ParsedManagedName(string @namespace, string typeName, string methodName, int arity, string[] parameterTypeFullNames)
         {
@@ -228,6 +234,14 @@ internal static class MSTestTestNodeConverter
             _methodName = methodName;
             _arity = arity;
             _parameterTypeFullNames = parameterTypeFullNames;
+
+            // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to
+            // match the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
+            if (parameterTypeFullNames.Length == 0)
+            {
+                _parameterlessProperty = new TestMethodIdentifierProperty(
+                    assemblyFullName: string.Empty, @namespace, typeName, methodName, arity, parameterTypeFullNames, returnTypeFullName: string.Empty);
+            }
         }
 
         public static ParsedManagedName Parse(TestMethod testMethod)
@@ -247,21 +261,18 @@ internal static class MSTestTestNodeConverter
 
         public TestMethodIdentifierProperty ToProperty()
         {
-            // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to
-            // match the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
-            if (_parameterTypeFullNames.Length == 0)
+            // A parameterless property is fully immutable - every field is a string or int, and the empty array
+            // cannot be mutated - so the same instance is handed to every node. This is the common case, and the
+            // ParsedManagedName is cached per TestMethod, so the several nodes one executed test produces (the
+            // in-progress node, then one result node per data row and per in-process retry attempt) share it.
+            if (_parameterlessProperty is not null)
             {
-                // Every other piece of state on the property is an immutable string or int, and an empty array
-                // cannot be mutated, so the whole property is safe to share across nodes. This is the common
-                // case (most test methods take no parameters), and the ParsedManagedName itself is cached per
-                // TestMethod, so a test that reports more than once (retries, re-runs) allocates nothing here.
-                return _cachedParameterlessProperty ??= new TestMethodIdentifierProperty(
-                    assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, _parameterTypeFullNames, returnTypeFullName: string.Empty);
+                return _parameterlessProperty;
             }
 
-            // Every node gets its own parameter array. TestMethodIdentifierProperty exposes it publicly, so
-            // aliasing one array across nodes would let a consumer that writes to it corrupt every other node
-            // built from the same test method.
+            // A parameterized method must keep getting its own parameter array. TestMethodIdentifierProperty
+            // exposes it publicly, so aliasing one array across nodes would let a consumer that writes to it
+            // corrupt every other node built from the same test method.
             return new TestMethodIdentifierProperty(
                 assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, [.. _parameterTypeFullNames], returnTypeFullName: string.Empty);
         }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -218,6 +218,9 @@ internal static class MSTestTestNodeConverter
         private readonly int _arity;
         private readonly string[] _parameterTypeFullNames;
 
+        // Only set for the parameterless case, where the produced property is fully immutable. See ToProperty().
+        private TestMethodIdentifierProperty? _cachedParameterlessProperty;
+
         private ParsedManagedName(string @namespace, string typeName, string methodName, int arity, string[] parameterTypeFullNames)
         {
             _namespace = @namespace;
@@ -244,15 +247,23 @@ internal static class MSTestTestNodeConverter
 
         public TestMethodIdentifierProperty ToProperty()
         {
-            // Every node gets its own parameter array. TestMethodIdentifierProperty exposes it publicly, so
-            // aliasing one array across nodes would let a consumer that writes to it corrupt every other node
-            // built from the same test method. An empty array cannot be mutated, so the common parameterless
-            // case still allocates nothing here.
-            string[] parameterTypeFullNames = _parameterTypeFullNames.Length == 0 ? _parameterTypeFullNames : [.. _parameterTypeFullNames];
-
             // AssemblyFullName and ReturnTypeFullName are not carried by the neutral model today; kept empty to
             // match the current (bridge) behavior. Populating them is a follow-up enabled by this native path.
-            return new TestMethodIdentifierProperty(assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, parameterTypeFullNames, returnTypeFullName: string.Empty);
+            if (_parameterTypeFullNames.Length == 0)
+            {
+                // Every other piece of state on the property is an immutable string or int, and an empty array
+                // cannot be mutated, so the whole property is safe to share across nodes. This is the common
+                // case (most test methods take no parameters), and the ParsedManagedName itself is cached per
+                // TestMethod, so a test that reports more than once (retries, re-runs) allocates nothing here.
+                return _cachedParameterlessProperty ??= new TestMethodIdentifierProperty(
+                    assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, _parameterTypeFullNames, returnTypeFullName: string.Empty);
+            }
+
+            // Every node gets its own parameter array. TestMethodIdentifierProperty exposes it publicly, so
+            // aliasing one array across nodes would let a consumer that writes to it corrupt every other node
+            // built from the same test method.
+            return new TestMethodIdentifierProperty(
+                assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, [.. _parameterTypeFullNames], returnTypeFullName: string.Empty);
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IConsole.cs
@@ -65,6 +65,15 @@ internal interface IConsole
 
     void Write(string? value);
 
+    /// <summary>
+    /// Writes the contents of <paramref name="value"/> without materializing them into a <see cref="string"/> first.
+    /// </summary>
+    /// <remarks>
+    /// This exists so that batched terminal output (which is accumulated in a <see cref="StringBuilder"/> and can grow
+    /// to several kilobytes) does not have to allocate a fresh string on every flush.
+    /// </remarks>
+    void Write(StringBuilder value);
+
     void Write(char value);
 
     [UnsupportedOSPlatform("android")]

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemConsole.cs
@@ -111,6 +111,23 @@ internal sealed class SystemConsole : IConsole
         }
     }
 
+    public void Write(StringBuilder value)
+    {
+        if (_suppressOutput)
+        {
+            return;
+        }
+
+#if NETCOREAPP
+        // TextWriter.Write(StringBuilder) walks the builder's chunks and writes each one as a span, so the
+        // batched output never has to be copied into a temporary string.
+        CaptureConsoleOutWriter.Write(value);
+#else
+        // netstandard2.0 / .NET Framework have no StringBuilder overload, so the string copy is unavoidable there.
+        CaptureConsoleOutWriter.Write(value.ToString());
+#endif
+    }
+
     [UnsupportedOSPlatform("android")]
     [UnsupportedOSPlatform("ios")]
     [UnsupportedOSPlatform("tvos")]

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Testing.Platform.Helpers.IConsole.Write(System.Text.StringBuilder! value) -> void
+Microsoft.Testing.Platform.Helpers.SystemConsole.Write(System.Text.StringBuilder! value) -> void
 Microsoft.Testing.Platform.Messages.AsyncConsumerDataProcessor.AsyncConsumerDataProcessor(Microsoft.Testing.Platform.Extensions.IDataConsumer! dataConsumer, Microsoft.Testing.Platform.Helpers.ITask! task, System.Threading.CancellationToken cancellationToken, System.TimeSpan canceledShutdownTimeout) -> void
 Microsoft.Testing.Platform.Messages.AsyncConsumerDataProcessor.IsConsumerRunning.get -> bool
 Microsoft.Testing.Platform.Messages.BlockingConsumerDataProcessor.BlockingConsumerDataProcessor(Microsoft.Testing.Platform.Extensions.IDataConsumer! dataConsumer, System.Threading.CancellationToken cancellationToken, System.TimeSpan canceledShutdownTimeout) -> void

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/AnsiTerminal.cs
@@ -160,7 +160,7 @@ internal sealed class AnsiTerminal : ITerminal
 
     public void StopUpdate()
     {
-        _console.Write(_stringBuilder.ToString());
+        _console.Write(_stringBuilder);
         _isBatching = false;
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SilenceDrivenHeartbeatRenderer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SilenceDrivenHeartbeatRenderer.cs
@@ -28,6 +28,11 @@ internal sealed class SilenceDrivenHeartbeatRenderer : IProgressRenderer
     // Only touched from the single rendering thread inside OnTick.
     private readonly Dictionary<long, SlowTestThresholdState> _slowTestThresholdStates = [];
 
+    // Scratch buffer for composing slow-test descriptions. Like _slowTestThresholdStates it is only touched
+    // from the single rendering thread inside OnTick, so it can be reused instead of allocating a builder
+    // (and its backing char array) for every surfaced slow test.
+    private readonly StringBuilder _slowTestDescriptionBuilder = new();
+
     private IStopwatch? _clock;
 
     // Ticks (on _clock's timeline) of the last activity (test completion) or last heartbeat emission.
@@ -174,9 +179,10 @@ internal sealed class SilenceDrivenHeartbeatRenderer : IProgressRenderer
         }
     }
 
-    private static string BuildSlowTestDescription(TestProgressState item, TestDetailState detail)
+    private string BuildSlowTestDescription(TestProgressState item, TestDetailState detail)
     {
-        var builder = new StringBuilder();
+        StringBuilder builder = _slowTestDescriptionBuilder;
+        builder.Clear();
         builder.Append(detail.Text);
         builder.Append(" (");
         builder.Append(item.AssemblyName);

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SilenceDrivenHeartbeatRenderer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/SilenceDrivenHeartbeatRenderer.cs
@@ -28,10 +28,10 @@ internal sealed class SilenceDrivenHeartbeatRenderer : IProgressRenderer
     // Only touched from the single rendering thread inside OnTick.
     private readonly Dictionary<long, SlowTestThresholdState> _slowTestThresholdStates = [];
 
-    // Scratch buffer for composing slow-test descriptions. Like _slowTestThresholdStates it is only touched
-    // from the single rendering thread inside OnTick, so it can be reused instead of allocating a builder
-    // (and its backing char array) for every surfaced slow test.
-    private readonly StringBuilder _slowTestDescriptionBuilder = new();
+    // Scratch buffer for composing slow-test descriptions, created on first use so a healthy run that never
+    // surfaces a slow test allocates nothing. Like _slowTestThresholdStates it is only touched from the single
+    // rendering thread inside OnTick, so it can be reused across reports.
+    private StringBuilder? _slowTestDescriptionBuilder;
 
     private IStopwatch? _clock;
 
@@ -181,7 +181,7 @@ internal sealed class SilenceDrivenHeartbeatRenderer : IProgressRenderer
 
     private string BuildSlowTestDescription(TestProgressState item, TestDetailState detail)
     {
-        StringBuilder builder = _slowTestDescriptionBuilder;
+        StringBuilder builder = _slowTestDescriptionBuilder ??= new StringBuilder();
         builder.Clear();
         builder.Append(detail.Text);
         builder.Append(" (");

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/Transport/DotnetTestHttpClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/Transport/DotnetTestHttpClient.cs
@@ -25,11 +25,6 @@ internal sealed class DotnetTestHttpClient : NamedPipeConnectionBase, IClient
     private readonly bool _disposeHttpClient;
     private readonly SemaphoreSlim _requestLock = new(1, 1);
     private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
-
-    // Scratch buffer for the "is there a second frame?" probe at the end of every reply. Requests are
-    // serialized by _requestLock, which is held for the whole request/response exchange, so a single
-    // instance-wide buffer can be reused instead of allocating one per request.
-    private readonly byte[] _trailingByteBuffer = new byte[1];
 #if NET9_0_OR_GREATER
     private readonly Lock _lifecycleLock = new();
 #else
@@ -164,7 +159,7 @@ internal sealed class DotnetTestHttpClient : NamedPipeConnectionBase, IClient
                     MaximumResponseFrameSize).ConfigureAwait(false)
                     ?? throw new IOException("The dotnet test HTTP gateway returned an empty or truncated response frame.");
 
-                byte[] trailingByte = _trailingByteBuffer;
+                byte[] trailingByte = new byte[1];
                 int trailingByteCount = await responseStream.ReadAsync(
                     trailingByte,
                     0,

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/Transport/DotnetTestHttpClient.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/Transport/DotnetTestHttpClient.cs
@@ -25,6 +25,11 @@ internal sealed class DotnetTestHttpClient : NamedPipeConnectionBase, IClient
     private readonly bool _disposeHttpClient;
     private readonly SemaphoreSlim _requestLock = new(1, 1);
     private readonly CancellationTokenSource _disposeCancellationTokenSource = new();
+
+    // Scratch buffer for the "is there a second frame?" probe at the end of every reply. Requests are
+    // serialized by _requestLock, which is held for the whole request/response exchange, so a single
+    // instance-wide buffer can be reused instead of allocating one per request.
+    private readonly byte[] _trailingByteBuffer = new byte[1];
 #if NET9_0_OR_GREATER
     private readonly Lock _lifecycleLock = new();
 #else
@@ -159,7 +164,7 @@ internal sealed class DotnetTestHttpClient : NamedPipeConnectionBase, IClient
                     MaximumResponseFrameSize).ConfigureAwait(false)
                     ?? throw new IOException("The dotnet test HTTP gateway returned an empty or truncated response frame.");
 
-                byte[] trailingByte = new byte[1];
+                byte[] trailingByte = _trailingByteBuffer;
                 int trailingByteCount = await responseStream.ReadAsync(
                     trailingByte,
                     0,

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -354,9 +354,9 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
 
     public void ToResultTestNode_ReusesTestMethodIdentifierInstance_ForParameterlessTestMethod()
     {
-        // A parameterless identifier is fully immutable (readonly strings plus an empty, unmutatable parameter
-        // array), so the cached parse hands back the very same property instance instead of allocating a new one
-        // for every report of the same test method (retries, re-runs, ...).
+        // A parameterless identifier is fully immutable (readonly strings plus an empty parameter array, which
+        // cannot be mutated), so the cached parse hands back the very same property instance instead of
+        // allocating a new one for every node built from the same test method.
         UnitTestElement element = CreateElement();
 
         TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -352,6 +352,34 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         result.TypeName.Should().BeSameAs(inProgress.TypeName);
     }
 
+    public void ToResultTestNode_ReusesTestMethodIdentifierInstance_ForParameterlessTestMethod()
+    {
+        // A parameterless identifier is fully immutable (readonly strings plus an empty, unmutatable parameter
+        // array), so the cached parse hands back the very same property instance instead of allocating a new one
+        // for every report of the same test method (retries, re-runs, ...).
+        UnitTestElement element = CreateElement();
+
+        TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
+            .Properties.Single<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
+            .Properties.Single<TestMethodIdentifierProperty>();
+
+        result.Should().BeSameAs(inProgress);
+    }
+
+    public void ToResultTestNode_DoesNotReuseTestMethodIdentifierInstance_ForParameterizedTestMethod()
+    {
+        // Parameterized identifiers expose a mutable array, so each node must keep getting its own property.
+        UnitTestElement element = CreateElement(managedMethodName: "MyMethod(System.String)");
+
+        TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
+            .Properties.Single<TestMethodIdentifierProperty>();
+        TestMethodIdentifierProperty result = MSTestTestNodeConverter.ToResultTestNode(element, new FrameworkTestResult { Outcome = UnitTestOutcome.Passed }, DateTimeOffset.Now, DateTimeOffset.Now, isTrxEnabled: false, new MSTestSettings())
+            .Properties.Single<TestMethodIdentifierProperty>();
+
+        result.Should().NotBeSameAs(inProgress);
+    }
+
     public void ToResultTestNode_DoesNotShareParameterTypeArray_WithInProgressNode()
     {
         // TestMethodIdentifierProperty exposes ParameterTypeFullNames publicly, so nodes must never alias one

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -1391,6 +1391,8 @@ public sealed class TerminalTestReporterTests
 
         public void Write(string? value) => _output.Append(value);
 
+        public void Write(StringBuilder value) => _output.Append(value.ToString());
+
         public void Write(char value) => _output.Append(value);
 
         public void WriteLine() => _output.AppendLine();
@@ -3678,6 +3680,10 @@ public sealed class TerminalTestReporterTests
         {
         }
 
+        public void Write(StringBuilder value)
+        {
+        }
+
         public void Write(char value)
         {
         }
@@ -3727,6 +3733,8 @@ public sealed class TerminalTestReporterTests
         }
 
         public void Write(string? value) => _output.Append(value);
+
+        public void Write(StringBuilder value) => _output.Append(value.ToString());
 
         public void Write(char value) => _output.Append(value);
 

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/CTRLPlusCCancellationTokenSourceTests.cs
@@ -181,6 +181,11 @@ public sealed class CTRLPlusCCancellationTokenSourceTests
             // do nothing
         }
 
+        public void Write(StringBuilder value)
+        {
+            // do nothing
+        }
+
         public void Write(char value)
         {
             // do nothing


### PR DESCRIPTION
Handles the remaining open **perf-improver** backlog items: the filed ticket (#10376) plus the actionable entries listed in the monthly-activity backlogs (#10381, #9604).

## Changes

### 1. Cache `TestMethodIdentifierProperty` for parameterless tests (#10376)

`ParsedManagedName.ToProperty()` is called once per node built from a `TestMethod`. For a parameterless method the property is fully immutable — readonly strings/int plus an empty array that cannot be mutated — and `ParsedManagedName` is already cached per `TestMethod` (#10366), so the several nodes one executed test produces (the in-progress node, then one result node per data row and per in-process retry attempt) now share a single property instance.

The property is built eagerly in the `ParsedManagedName` constructor into a `readonly` field rather than lazily via `??=`, so the shared instance doesn't depend on call ordering or on races between concurrent reporters. `ToProperty()` is always called on a fresh parse, so nothing is built that wouldn't have been built anyway.

Parameterized methods are deliberately unchanged: they still get a fresh property carrying a fresh copy of `ParameterTypeFullNames`, because that array is publicly exposed and must never be aliased across nodes.

### 2. Unblock `AnsiTerminal.StopUpdate()` (backlog item 3 — previously recorded as *blocked by IConsole + netstandard2.0 compat*)

`StopUpdate()` called `_stringBuilder.ToString()` on **every** flush — twice a second for cursor rendering, plus around ordinary terminal writes — and the batched progress frame is routinely kilobyte-scale. `IConsole` now has a `Write(StringBuilder)` overload; `SystemConsole` forwards it to `TextWriter.Write(StringBuilder)` on .NET, which walks the builder's chunks and writes each as a span, so no temporary string is materialised. netstandard2.0 / .NET Framework keep the `ToString()` copy behind `#if`, since the overload doesn't exist there — nothing regresses on those TFMs.

### 3. Reuse the slow-test description builder (backlog item 2)

`SilenceDrivenHeartbeatRenderer.BuildSlowTestDescription` allocated a `StringBuilder` (plus backing `char[]`) per surfaced slow test. It now reuses one lazily-created instance field, so a healthy run that never surfaces a slow test still allocates nothing. Reuse is safe for the same reason as the `_slowTestThresholdStates` dictionary next to it: both are only touched from the single rendering thread inside `OnTick`.

## Deliberately not done

- **`DotnetTestHttpClient` `new byte[1]` probe buffer** (backlog item 1). An earlier revision of this PR hoisted it to an instance field; that's been reverted. It saved one ~24-byte allocation per RPC on a path that already allocates a linked CTS, streams, `ByteArrayContent` and an `HttpRequestMessage`, and it silently coupled correctness to requests staying serialized by `_requestLock` forever. Not a good trade.
- **`OpenTelemetryResultHandler.GetFullyQualifiedName()`** (backlog item 4). One logical string build per test result, only on the OTel-enabled path. `string.Concat` with 5 operands, `string.Join` and a `StringBuilder` are all neutral-or-worse than what the compiler already emits for the interpolation.

Both are recorded as won't-fix on the tracking issues rather than churning the code.

## Tests

- New: `ToResultTestNode_ReusesTestMethodIdentifierInstance_ForParameterlessTestMethod` and `ToResultTestNode_DoesNotReuseTestMethodIdentifierInstance_ForParameterizedTestMethod` in `MSTestTestNodeConverterTests`, pinning both halves of the selective caching policy alongside the existing array-isolation test.
- The `TerminalTestReporterTests` console fakes now implement `Write(StringBuilder)`, so the whole terminal suite exercises the new flush path.
- `.\build.cmd -test` — full solution build + unit tests, **0 warnings, 0 errors** across net462, net48, net8.0, net9.0 and netstandard2.0.

## Review

Two independent review rounds were run over the diff (correctness/concurrency, plus a skeptical is-this-actually-a-win pass). Findings addressed: the lazy `??=` identity race, a stale `ParsedManagedNameCache` doc block that still claimed the property is never cached, an overstated "re-runs" comment (discovery and execution don't share a `TestMethod`), eager builder allocation on healthy runs, and the `byte[1]` trade-off above. The final round found no remaining issues.

Closes #10376
