### PR TITLE
Cover the per-provider pass running after MultipleRule (MSTEST0081)

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestFilterProviderShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestFilterProviderShouldBeValidAnalyzerTests.cs
@@ -471,7 +471,14 @@ public sealed class TestFilterProviderShouldBeValidAnalyzerTests
     }
 
     // The two attributes are distinct types, so the compiler's own duplicate-attribute check does not fire
-    // even though the adapter rejects the pair with UTA079.
+    // even though the adapter rejects the pair with UTA079. This mixed pair is in fact the *only* shape that
+    // can reach MultipleRule from well-formed C#: both attributes are AllowMultiple = false, and Roslyn keys
+    // its duplicate check off the original definition, so a same-shape pair - two 'typeof' registrations, or
+    // two 'TestFilterProvider<T>' registrations, even with different T - is rejected as CS0579 and never
+    // reaches the adapter. Those two shapes are deliberately untested: MSTEST0081 does still fire on them
+    // (Roslyn keeps both attributes in the symbol model despite the duplicate error), but it reports the same
+    // defect CS0579 already reports, through the same analyzer branch this test covers - so such a test would
+    // add no coverage while pinning the analyzer's behavior on input that cannot compile.
     [TestMethod]
     public async Task WhenGenericAndNonGenericProvidersAreCombined_Diagnostic()
     {
@@ -494,6 +501,38 @@ public sealed class TestFilterProviderShouldBeValidAnalyzerTests
             code,
             VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.MultipleRule).WithLocation(0),
             VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.MultipleRule).WithLocation(1));
+    }
+
+    // MultipleRule and the per-provider rules are reported by two separate loops over the same set
+    // (AnalyzeCompilation), and the second one is not gated on the first. Every other multiple-provider test
+    // registers only valid filters, so nothing pins that the per-provider pass still runs once MultipleRule has
+    // fired: short-circuiting after the MultipleRule loop would leave them all green while silently hiding every
+    // other MSTEST0081 sub-rule from any assembly with more than one provider. Hence one registration here is
+    // also invalid on its own, so the assembly must report both MultipleRule twice and NotATestFilterRule once.
+    [TestMethod]
+    public async Task WhenMultipleProvidersAreRegisteredAndOneIsInvalid_Diagnostic()
+    {
+        string code = Header + """
+            [assembly: {|#0:TestFilterProvider(typeof(NotAFilter))|}]
+            [assembly: {|#1:TestFilterProvider<MyFilter>|}]
+
+            public sealed class NotAFilter
+            {
+            }
+
+            public sealed class MyFilter : ITestFilter
+            {
+                public TestFilterResult Filter(TestFilterContext context) => TestFilterResult.Run;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.MultipleRule).WithLocation(0),
+            VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.MultipleRule).WithLocation(1),
+            VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.NotATestFilterRule)
+                .WithLocation(0)
+                .WithArguments("NotAFilter"));
     }
 #endif
 }


### PR DESCRIPTION
Closes #10378

## What this covers

MSTEST0081''s `MultipleRule` and its per-provider rules are reported by **two separate loops** over the same provider set in `AnalyzeCompilation`, and the second is not gated on the first:

```csharp
if (providers.Length > 1)
{
    foreach (AttributeData provider in providers) { Report(context, provider, MultipleRule); }
}

foreach (AttributeData provider in providers) { AnalyzeProvider(...); }
```

Every existing multiple-provider test registers only *valid* filters, so nothing pinned that the per-provider pass still runs once `MultipleRule` has fired. Short-circuiting after the `MultipleRule` loop would leave the entire suite green while silently hiding every other MSTEST0081 sub-rule from any assembly registering more than one provider.

`WhenMultipleProvidersAreRegisteredAndOneIsInvalid_Diagnostic` registers one invalid + one valid provider and expects `MultipleRule` twice plus `NotATestFilterRule` once.

**Verified by mutation:** adding `return;` after the `MultipleRule` loop fails *only* this test (1 of 26 in the class) — no pre-existing test notices.

## Note: the issue''s premise was incorrect

#10378 asked for two tests — two non-generic registrations, and two generic registrations — on the stated basis that `TestFilterProviderAttribute` is `AllowMultiple = true` so both shapes compile cleanly.

Both attributes are actually declared `AllowMultiple = false`, and Roslyn keys its duplicate-attribute check off the **original definition** — so even `TestFilterProvider<A>` + `TestFilterProvider<B>`, despite being distinct constructed types, is rejected as `CS0579`.

I implemented both tests first and confirmed this empirically. They passed once `CS0579` was asserted, but they were not worth keeping:

- **They added no coverage.** The pre-existing `WhenGenericAndNonGenericProvidersAreCombined_Diagnostic` already covers the `providers.Length > 1` branch; deleting that branch fails the pre-existing test identically.
- **They pinned analyzer behavior on input that cannot compile**, since the mixed generic/non-generic pair is the only shape that reaches `MultipleRule` from well-formed C#.

So instead of the literal ask, this PR delivers the multiple-provider coverage that was genuinely missing, and records the `AllowMultiple` / `CS0579` finding as a comment on the mixed-form test so the next person does not re-derive it.

## Validation

Full `MSTest.Analyzers.UnitTests` suite: **net8.0 1686/1686**, **net472 1629/1629**. Build clean, 0 warnings. No production code changed.
