### PR TITLE
Clear the efficiency-improver backlog: OTel tags and analyzer member lookup

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/DynamicDataShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/DynamicDataShouldBeValidAnalyzer.cs
@@ -179,20 +179,36 @@ public sealed class DynamicDataShouldBeValidAnalyzer : DiagnosticAnalyzer
                 return (null, false);
             }
 
-            ISymbol? potentialProperty = potentialMembers.FirstOrDefault(m => m.Kind == SymbolKind.Property);
-            if (potentialProperty is not null)
+            // Single pass over the members: a property always wins, otherwise the first method is used and
+            // more than one method is an error. Doing this with FirstOrDefault + Where().ToImmutableArray()
+            // scanned the members twice and allocated an array per [DynamicData] attribute per compilation.
+            ISymbol? firstMethod = null;
+            bool hasMultipleMethods = false;
+            foreach (ISymbol member in potentialMembers)
             {
-                return (potentialProperty, false);
+                switch (member.Kind)
+                {
+                    case SymbolKind.Property:
+                        return (member, false);
+
+                    case SymbolKind.Method:
+                        if (firstMethod is null)
+                        {
+                            firstMethod = member;
+                        }
+                        else
+                        {
+                            hasMultipleMethods = true;
+                        }
+
+                        break;
+                }
             }
 
-            var candidateMethods = potentialMembers.Where(m => m.Kind == SymbolKind.Method).ToImmutableArray();
-            if (candidateMethods.Length > 1)
-            {
-                // If there are multiple methods with the same name, report a diagnostic. This is not a supported scenario.
-                return (null, true);
-            }
-
-            return (candidateMethods.IsEmpty ? potentialMembers[0] : candidateMethods[0], false);
+            // If there are multiple methods with the same name, report a diagnostic. This is not a supported scenario.
+            return hasMultipleMethods
+                ? (null, true)
+                : (firstMethod ?? potentialMembers[0], false);
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Telemetry/OpenTelemetryResultHandler.cs
@@ -318,7 +318,35 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
             }
         }
 
-        if (testNode.Properties.SingleOrDefault<TestMethodIdentifierProperty>() is { } identifierProperty)
+        // Single pass over the property bag for the two singleton properties below: two separate
+        // SingleOrDefault<T>() calls walked the whole bag once each.
+        TestMethodIdentifierProperty? identifierProperty = null;
+        TestFileLocationProperty? testLocationProperty = null;
+        PropertyBag.PropertyBagEnumerator enumerator = testNode.Properties.GetStructEnumerator();
+        while (enumerator.MoveNext())
+        {
+            switch (enumerator.Current)
+            {
+                case TestMethodIdentifierProperty identifier:
+                    if (identifierProperty is not null)
+                    {
+                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(TestMethodIdentifierProperty)}'.");
+                    }
+
+                    identifierProperty = identifier;
+                    break;
+                case TestFileLocationProperty location:
+                    if (testLocationProperty is not null)
+                    {
+                        throw new InvalidOperationException($"Found multiple properties of type '{typeof(TestFileLocationProperty)}'.");
+                    }
+
+                    testLocationProperty = location;
+                    break;
+            }
+        }
+
+        if (identifierProperty is not null)
         {
             // code.function.name is defined as the *fully qualified* name; there is no separate namespace
             // attribute (code.namespace is deprecated upstream).
@@ -335,7 +363,7 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
             }
         }
 
-        if (testNode.Properties.SingleOrDefault<TestFileLocationProperty>() is { } testLocationProperty)
+        if (testLocationProperty is not null)
         {
             yield return new(TestingPlatformSemanticConventions.Attributes.CodeFilePath, testLocationProperty.FilePath);
             yield return new(TestingPlatformSemanticConventions.Attributes.CodeLineNumber, testLocationProperty.LineSpan.Start.Line);
@@ -348,8 +376,16 @@ internal sealed class OpenTelemetryResultHandler : IDisposable
             }
         }
 
-        foreach (TestMetadataProperty metadata in testNode.Properties.OfType<TestMetadataProperty>())
+        // The metadata is yielded after the blocks above, so it needs its own pass. OfType<TestMetadataProperty>()
+        // would materialize a TProperty[] just to enumerate it once; the struct enumerator allocates nothing.
+        PropertyBag.PropertyBagEnumerator metadataEnumerator = testNode.Properties.GetStructEnumerator();
+        while (metadataEnumerator.MoveNext())
         {
+            if (metadataEnumerator.Current is not TestMetadataProperty metadata)
+            {
+                continue;
+            }
+
             yield return new KeyValuePair<string, object?>($"{TestingPlatformSemanticConventions.Attributes.TestMetadataPrefix}{metadata.Key}", metadata.Value);
             if (_options.EmitLegacyAttributes)
             {

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Telemetry/OpenTelemetryResultHandlerTests.cs
@@ -721,6 +721,29 @@ public sealed class OpenTelemetryResultHandlerTests : IDisposable
     }
 
     private IEnumerable<KeyValuePair<string, object?>>? CaptureInProgressTags(TestMethodIdentifierProperty identifierProperty)
+        => CaptureInProgressTags(new PropertyBag(identifierProperty));
+
+    [TestMethod]
+    public void NotifyInProgress_WithDuplicateIdentifierProperty_Throws()
+    {
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(() => CaptureInProgressTags(new PropertyBag(
+            new TestMethodIdentifierProperty("MyAssembly", "My.Namespace", "MyClass", "MyMethod", 0, [], "void"),
+            new TestMethodIdentifierProperty("MyAssembly", "My.Namespace", "MyClass", "MyOtherMethod", 0, [], "void"))));
+
+        Assert.AreEqual($"Found multiple properties of type '{typeof(TestMethodIdentifierProperty)}'.", exception.Message);
+    }
+
+    [TestMethod]
+    public void NotifyInProgress_WithDuplicateFileLocationProperty_Throws()
+    {
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(() => CaptureInProgressTags(new PropertyBag(
+            new TestFileLocationProperty("first.cs", new LinePositionSpan(new LinePosition(1, 0), new LinePosition(2, 0))),
+            new TestFileLocationProperty("second.cs", new LinePositionSpan(new LinePosition(3, 0), new LinePosition(4, 0))))));
+
+        Assert.AreEqual($"Found multiple properties of type '{typeof(TestFileLocationProperty)}'.", exception.Message);
+    }
+
+    private IEnumerable<KeyValuePair<string, object?>>? CaptureInProgressTags(PropertyBag properties)
     {
         IEnumerable<KeyValuePair<string, object?>>? capturedTags = null;
         _otelService.Setup(s => s.StartActivity(
@@ -736,7 +759,7 @@ public sealed class OpenTelemetryResultHandlerTests : IDisposable
             {
                 Uid = new TestNodeUid("fqn"),
                 DisplayName = "Test",
-                Properties = new PropertyBag(identifierProperty),
+                Properties = properties,
             },
             null);
 


### PR DESCRIPTION
Companion to #10384, which cleared the `[perf-improver]` backlog. This does the same for the `[efficiency-improver]` one tracked in #10382 / #10377.

Two of the code-level items are worth acting on; the rest are closed out as won't-fix on the issue itself, with reasons.

### `OpenTelemetryResultHandler.GetTestInitialInfo`

Walked the property bag three times per test on the OTel path: `SingleOrDefault<TestMethodIdentifierProperty>`, `SingleOrDefault<TestFileLocationProperty>` and `OfType<TestMetadataProperty>`. The last one materializes a `TProperty[]` purely to enumerate it once.

It now uses the struct enumerator: one pass for the two singleton properties, one for the metadata. The metadata pass has to stay separate because those tags are emitted *after* the identifier and file-location blocks, and buffering them to fold it into a single pass would reintroduce the very allocation being removed. Two walks instead of three, and no array.

The duplicate-property detection `SingleOrDefault` gave for free is kept explicitly - same shape as the guards `SetResultDetails` already has right below - and is now covered by two tests. It is reachable: `PropertyBag` only rejects duplicate property *instances*, not two distinct instances of the same type.

### `DynamicDataShouldBeValidAnalyzer.TryGetMemberCore`

Scanned the candidate members twice (`FirstOrDefault` for a property, then `Where(...).ToImmutableArray()` for the methods) and allocated an `ImmutableArray` per `[DynamicData]` attribute. A single `switch` over the members now resolves the property, the first method, and the more-than-one-method case in one pass. The backlog entry called this "compile-time only", but analyzers re-run on every keystroke in the IDE, so it is not.

### Backlog items deliberately not taken

Documented on #10382 rather than changed here:

- **`TerminalTestReporter.TotalTests`** - the entry claims `_assemblies.Values.Sum()` runs "on every display refresh". It does not: the property has no callers in `src/` at all, only in unit tests. Progress rendering and the summary compute their totals separately. Nothing to fix.
- **`OpenTelemetryResultHandler.GetSuiteName`** - merging its walk into `SetResultDetails` would mean reordering the metric emission relative to span tagging and buffering the metadata/artifact properties. It is a non-allocating walk over a handful of properties on an opt-in path.
- **`TestExecutionManager` MethodLevel `Select(t => new[] { t })`** - the queue element type is `IEnumerable<UnitTestElement>`; removing the one-element array means changing that type. One-time setup allocation, not worth the churn.
- **CI output-byte-count health metric** - infrastructure proposal, needs a maintainer decision rather than a PR.

### Validation

`Microsoft.Testing.Platform.UnitTests` (2024 + the 2 new tests) and `MSTest.Analyzers.UnitTests` (1688) all pass; full `build.cmd` is clean with 0 warnings.
