### PR TITLE
Warn that adding a reporter file needs a dotnet/sdk manifest append

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
@@ -12,6 +12,19 @@
       eng/vendored-files.json manifest; a scheduled workflow there opens an issue whenever these upstream files
       change, so any change here may require a coordinated port in dotnet/sdk (see dotnet/sdk eng/vendored-files.md).
 
+    ADDING A FILE HERE ALSO NEEDS A dotnet/sdk MANIFEST CHANGE
+      The reporter Include below is a *glob*, so a new file in this folder joins the contract automatically and the
+      build stays green. dotnet/sdk's eng/vendored-files.json instead enumerates each upstream path by hand, and its
+      drift workflow only watches the paths it lists. A file added here is therefore not merely unported downstream,
+      it is INVISIBLE there: later edits to it raise no drift issue at all. Renames and deletions do not have this
+      problem - the tracked path then 404s and the workflow reports 'upstream path missing' - so additions are the
+      one asymmetric case, and the one that fails silently.
+
+      So when you add a file to this folder, also append it to the dotnet-test-terminal-reporter entry in that
+      manifest. Append, never insert: the workflow keys its tracking issues on the source's position in the array
+      (its hidden 'vendored-sync:id={id}:{source-index}' issue marker), so reordering re-points open issues at the
+      wrong file. Splitting TerminalTestReporter.Summary.cs into partials hit exactly this; see #10390.
+
     SCOPE
       The set is the reporter + its rendering/state types + the small platform abstractions it depends on
       (IConsole/IStopwatch/IColor/System* + ILogger/LogLevel/LoggingExtensions/NopLogger +


### PR DESCRIPTION
Records, in the file testfx contributors actually touch, that adding a reporter source file needs a coordinated `dotnet/sdk` manifest change. Follow-up to #10387 / #10390. Comment-only — no build behavior changes.

### Why

`TerminalReporterContract.props` already tells contributors that the reporter is hard-forked into `dotnet/sdk` and that "any change here may require a coordinated port". That covers *edits*. It does not cover *additions*, which behave differently and fail silently:

- **Our side globs.** `Include="$(MSBuildThisFileDirectory)*.cs"` picks up a new partial automatically, and the standalone contract test project keeps compiling. Nothing signals that anything is owed downstream.
- **Their side enumerates.** `eng/vendored-files.json` lists each upstream path by hand and the drift workflow only watches the paths it lists. So a file we add isn't merely unported — it's **invisible**: later edits to it raise no drift issue at all.

That asymmetry is specific to additions. I read `check_vendored_files.py` to confirm the other cases are fine: a rename or delete makes the tracked path 404, which the script maps to `status="missing"` → an "upstream path missing" issue. Additions are the one silent case.

This is not hypothetical — it's precisely what #10387 caused, and it took a manual audit to notice. The note also records the **append-never-insert** rule, because the bot's issue identity is the source's *array index* (`vendored-sync:id={id}:{source-index}`); sorting a new entry into the list silently re-points existing open drift issues at the wrong file. I hit that myself while fixing the manifest and only caught it by running the checker before and after.

### Note

While writing this I initially pasted the literal marker `<!-- ... -->` into the XML comment, which terminated it early and made the file invalid XML. Caught by parsing the file; the committed version quotes the marker without the delimiters. Worth mentioning because MSBuild's own error for this is not obvious.

### Validation

- `[xml]` parses the file, and no `--` sequence remains inside any comment block.
- `Microsoft.Testing.Platform.TerminalReporterContract.UnitTests` (the project that imports this props) builds and passes on `net8.0` and `net9.0` — **0 warnings**.
- File encoding, trailing newline and whitespace unchanged; diff is +13/-0.

### Related

The `dotnet/sdk` half is [dotnet/sdk#55564](https://github.com/dotnet/sdk/pull/55564), which appends the four new partials to the manifest and documents the same append-only rule there. This PR is the mirror note on the source-of-truth side, so the requirement is visible before someone adds the next partial rather than after.