### PR TITLE
Add analyzer edge-case tests

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestMethodOverDataTestMethodAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferTestMethodOverDataTestMethodAnalyzerTests.cs
@@ -272,4 +272,29 @@ public sealed class PreferTestMethodOverDataTestMethodAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, code);
     }
+
+    [TestMethod]
+    public async Task WhenMethodUsesCustomAttributeInheritingDataTestMethod_NoDiagnosticOnMethod()
+    {
+        // AnalyzeMethod uses strict symbol equality, so only the custom attribute declaration is
+        // diagnosed by AnalyzeNamedType; applying the derived attribute does not add a diagnostic.
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            internal class [|MyDataTestMethodAttribute|] : DataTestMethodAttribute
+            {
+            }
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [MyDataTestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UseCancellationTokenPropertyAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UseCancellationTokenPropertyAnalyzerTests.cs
@@ -337,4 +337,29 @@ public sealed class UseCancellationTokenPropertyAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(code, fixedCode);
     }
+
+    [TestMethod]
+    public async Task WhenCancellationTokenSourceIsUsedWithCancelMethod_ShouldReportDiagnosticWithNoFix()
+    {
+        // The analyzer fires on any access to TestContext.CancellationTokenSource (not just .Token).
+        // The fixer only handles the .CancellationTokenSource.Token pattern, so calling .Cancel()
+        // produces a diagnostic but no code fix is offered.
+        const string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                public TestContext TestContext { get; set; }
+
+                [TestMethod]
+                public void MyTest()
+                {
+                    [|TestContext.CancellationTokenSource|].Cancel();
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
 }


### PR DESCRIPTION
## Summary

- verify MSTEST0054 reports `TestContext.CancellationTokenSource.Cancel()` without offering an invalid code fix
- verify MSTEST0044 does not report a method-level diagnostic for attributes derived from `DataTestMethodAttribute`
- preserve the existing direct-inheritance diagnostic on the custom attribute declaration

Fixes #10388

## Validation

- targeted analyzer regression tests (`2/2` passed)
- full repository build