### PR TITLE
Add ReliableTestSuite sample for building reliable test suites at scale with MSTest

### DIFF
--- a/samples/public/ReliableTestSuite/CancellableWorkTests.cs
+++ b/samples/public/ReliableTestSuite/CancellableWorkTests.cs
@@ -35,4 +35,26 @@ public sealed class CancellableWorkTests
 
         Assert.IsFalse(token.IsCancellationRequested);
     }
+
+    // Deterministic proof that the cooperative loop actually STOPS on cancellation - no timing,
+    // no waiting, no flakiness. We hand it an already-cancelled token and assert it throws the
+    // exact OperationCanceledException that TestContext's token would raise when [Timeout] fires.
+    [TestMethod]
+    public async Task PollingLoop_StopsWhenTokenAlreadyCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => RunCooperativeLoopAsync(cts.Token));
+    }
+
+    private static async Task RunCooperativeLoopAsync(CancellationToken token)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            token.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
 }

--- a/samples/public/ReliableTestSuite/CancellableWorkTests.cs
+++ b/samples/public/ReliableTestSuite/CancellableWorkTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// STEP 4 - BOUND TIME COOPERATIVELY, DON'T Thread.Sleep.
+///
+/// A test that can hang has no place in a reliable suite. [Timeout] bounds it, and
+/// CooperativeCancellation = true makes the timeout cancel TestContext.CancellationToken and
+/// wait for the test to unwind, so the work stops cleanly instead of being abandoned mid-flight
+/// (which can leak file handles or background tasks and poison later tests).
+///
+/// Note what is NOT here: Thread.Sleep or Task.Wait to "pace" the test. Blocking sleeps are a
+/// top source of slow, flaky suites; MSTEST0067 flags them. Real asynchronous waiting uses
+/// await Task.Delay with the cancellation token.
+/// </summary>
+[TestClass]
+public sealed class CancellableWorkTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    [Timeout(5_000, CooperativeCancellation = true)]
+    public async Task PollingLoop_ObservesCancellation()
+    {
+        CancellationToken token = TestContext.CancellationToken;
+
+        // A cooperative loop: it awaits (never blocks) and honors cancellation. If the timeout
+        // fires, the token is signaled and the loop exits promptly.
+        for (int i = 0; i < 3; i++)
+        {
+            await Task.Delay(10, token);
+        }
+
+        Assert.IsFalse(token.IsCancellationRequested);
+    }
+}

--- a/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
+++ b/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
@@ -19,9 +19,10 @@ namespace ReliableTestSuite;
 ///
 /// COMING IN MSTest 4.4 - the precise tool is [ResourceLock]. It names the exact resource that
 /// is shared, so the scheduler serializes only tests that declare the SAME key and lets
-/// everything else run concurrently:
+/// everything else run concurrently. The full migration is a one-for-one swap - you REMOVE
+/// [DoNotParallelize] and ADD [ResourceLock] (keeping both would just re-serialize the class):
 ///
-///     // [assembly-visible once MSTest 4.4 ships]
+///     // [compiles once MSTest 4.4 ships]
 ///     [TestClass]
 ///     [ResourceLock(WellKnownResources.EnvironmentVariables)]   // exclusive by default
 ///     public sealed class EnvironmentPricingTests { ... }
@@ -29,6 +30,14 @@ namespace ReliableTestSuite;
 /// A reader-only test could take the same key in shared mode with
 /// [ResourceLock(WellKnownResources.EnvironmentVariables, Mode = ResourceAccessMode.Read)],
 /// allowing concurrent readers while still excluding writers.
+///
+/// LIMITATIONS to be honest about:
+///   - The lock is COOPERATIVE: it only coordinates tests that opt in with the SAME key. A test
+///     that mutates the environment without declaring the lock is not held back by it.
+///   - Scope is the current TEST-HOST PROCESS. It serializes tests inside one run; it is NOT a
+///     cross-process, cross-assembly-in-separate-hosts, or distributed/cross-agent mutex.
+///   - WellKnownResources.EnvironmentVariables is a shared well-known key for process-wide
+///     environment state; any string can be used as a custom key for your own shared resource.
 ///
 /// The difference is determinism with throughput: [DoNotParallelize] trades all parallelism
 /// for safety; [ResourceLock] trades only the parallelism that is genuinely unsafe.

--- a/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
+++ b/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
@@ -34,8 +34,11 @@ namespace ReliableTestSuite;
 /// LIMITATIONS to be honest about:
 ///   - The lock is COOPERATIVE: it only coordinates tests that opt in with the SAME key. A test
 ///     that mutates the environment without declaring the lock is not held back by it.
-///   - Scope is the current TEST-HOST PROCESS. It serializes tests inside one run; it is NOT a
-///     cross-process, cross-assembly-in-separate-hosts, or distributed/cross-agent mutex.
+///   - Scope is a single TEST SOURCE (assembly). The adapter creates a separate lock manager per
+///     source, so matching keys serialize only the parallel tests WITHIN this assembly's run; they
+///     do NOT coordinate tests in a different assembly, even when both run in the same test-host
+///     process. It is not a cross-assembly, cross-process, or distributed/cross-agent mutex - don't
+///     rely on it for global state shared across assemblies.
 ///   - WellKnownResources.EnvironmentVariables is a shared well-known key for process-wide
 ///     environment state; any string can be used as a custom key for your own shared resource.
 ///

--- a/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
+++ b/samples/public/ReliableTestSuite/EnvironmentPricingTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// STEP 2 - COORDINATE WHAT YOU CANNOT ELIMINATE.
+///
+/// These tests mutate a process-wide environment variable, so unlike the file tests they DO
+/// share state with every other test in the process. Left unguarded under method-level
+/// parallelization, one test's write would race another's read - the classic flaky failure.
+///
+/// TODAY (shipped MSTest): the blunt-but-correct tool is [DoNotParallelize]. It guarantees the
+/// class runs with nothing else, but it is all-or-nothing: the class is serialized against the
+/// ENTIRE suite and deferred to the end of the run, even against tests that never touch the
+/// environment.
+///
+/// COMING IN MSTest 4.4 - the precise tool is [ResourceLock]. It names the exact resource that
+/// is shared, so the scheduler serializes only tests that declare the SAME key and lets
+/// everything else run concurrently:
+///
+///     // [assembly-visible once MSTest 4.4 ships]
+///     [TestClass]
+///     [ResourceLock(WellKnownResources.EnvironmentVariables)]   // exclusive by default
+///     public sealed class EnvironmentPricingTests { ... }
+///
+/// A reader-only test could take the same key in shared mode with
+/// [ResourceLock(WellKnownResources.EnvironmentVariables, Mode = ResourceAccessMode.Read)],
+/// allowing concurrent readers while still excluding writers.
+///
+/// The difference is determinism with throughput: [DoNotParallelize] trades all parallelism
+/// for safety; [ResourceLock] trades only the parallelism that is genuinely unsafe.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public sealed class EnvironmentPricingTests
+{
+    [TestInitialize]
+    public void ClearRate()
+        => Environment.SetEnvironmentVariable(PricingCalculator.TaxRateVariable, null);
+
+    [TestCleanup]
+    public void ResetRate()
+        => Environment.SetEnvironmentVariable(PricingCalculator.TaxRateVariable, null);
+
+    [TestMethod]
+    public void NoRateConfigured_ReturnsAmountUnchanged()
+    {
+        Assert.AreEqual(100m, PricingCalculator.ApplyTax(100m));
+    }
+
+    [TestMethod]
+    public void RateConfigured_AppliesTax()
+    {
+        Environment.SetEnvironmentVariable(
+            PricingCalculator.TaxRateVariable,
+            0.2m.ToString(CultureInfo.InvariantCulture));
+
+        Assert.AreEqual(120m, PricingCalculator.ApplyTax(100m));
+    }
+}

--- a/samples/public/ReliableTestSuite/FlakyDependencyTests.cs
+++ b/samples/public/ReliableTestSuite/FlakyDependencyTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// STEP 5 - RETRY IS CONTAINMENT, NOT A FIX.
+///
+/// [Retry] re-runs a failed test up to N times. Read that plainly: it makes a nondeterministic
+/// test PASS more often - it does not make it deterministic. Every previous step in this sample
+/// removes a source of nondeterminism (isolation, resource coordination, declarative gating,
+/// cooperative timeouts). Retry is the last resort for residual flakiness you have not yet been
+/// able to eliminate - for example a genuinely external dependency you do not control.
+///
+/// Use it deliberately and visibly, never as the default. Under Microsoft.Testing.Platform each
+/// attempt is reported, so a retried test still shows up as "flaky" rather than a clean green -
+/// that visibility is the point. If you find yourself adding [Retry] to hide a race in your OWN
+/// code, stop and fix the race; the earlier steps are how.
+///
+/// (Also distinct from the Microsoft.Testing.Extensions.Retry orchestrator's
+/// --retry-failed-tests, which re-runs failed tests in a fresh host process. If you combine
+/// them, the attempt counts multiply.)
+/// </summary>
+[TestClass]
+public sealed class FlakyDependencyTests
+{
+    private static int s_attempts;
+
+    // Simulates a flaky *external* dependency (e.g. a remote service) that fails the first time
+    // and then succeeds. In real code the earlier steps cannot remove this - it is outside the
+    // process - so retry is the honest containment tool.
+    private static bool CallExternalService()
+        => Interlocked.Increment(ref s_attempts) >= 2;
+
+    [TestMethod]
+    [Retry(3, MillisecondsDelayBetweenRetries = 50, BackoffType = DelayBackoffType.Exponential)]
+    public void ExternalCall_EventuallySucceeds()
+    {
+        // NOTE: this passing on retry does NOT make the dependency deterministic. It contains
+        // the flakiness so unrelated tests are not blocked; the durable fix is a test double.
+        Assert.IsTrue(CallExternalService(), "External dependency was not available on this attempt.");
+    }
+}

--- a/samples/public/ReliableTestSuite/FlakyDependencyTests.cs
+++ b/samples/public/ReliableTestSuite/FlakyDependencyTests.cs
@@ -8,14 +8,17 @@ namespace ReliableTestSuite;
 ///
 /// [Retry] re-runs a failed test up to N times. Read that plainly: it makes a nondeterministic
 /// test PASS more often - it does not make it deterministic. Every previous step in this sample
-/// removes a source of nondeterminism (isolation, resource coordination, declarative gating,
-/// cooperative timeouts). Retry is the last resort for residual flakiness you have not yet been
-/// able to eliminate - for example a genuinely external dependency you do not control.
+/// addresses a source of nondeterminism at its root (isolation, resource coordination) or makes
+/// the failure honest and bounded (declarative gating, cooperative timeouts). Retry is the last
+/// resort for residual flakiness you have not yet been able to eliminate - for example a
+/// genuinely external dependency you do not control.
 ///
-/// Use it deliberately and visibly, never as the default. Under Microsoft.Testing.Platform each
-/// attempt is reported, so a retried test still shows up as "flaky" rather than a clean green -
-/// that visibility is the point. If you find yourself adding [Retry] to hide a race in your OWN
-/// code, stop and fix the race; the earlier steps are how.
+/// Use it deliberately and visibly, never as the default. On MSTest 4.4+ under
+/// Microsoft.Testing.Platform each attempt is reported, so a retried test surfaces as "flaky"
+/// rather than a clean green - that visibility is the point. (On 4.3.x a retried-then-passed
+/// test reports as an ordinary pass, so the retry is easier to forget it is there.) If you find
+/// yourself adding [Retry] to hide a race in your OWN code, stop and fix the race; the earlier
+/// steps are how.
 ///
 /// (Also distinct from the Microsoft.Testing.Extensions.Retry orchestrator's
 /// --retry-failed-tests, which re-runs failed tests in a fresh host process. If you combine
@@ -26,9 +29,10 @@ public sealed class FlakyDependencyTests
 {
     private static int s_attempts;
 
-    // Simulates a flaky *external* dependency (e.g. a remote service) that fails the first time
-    // and then succeeds. In real code the earlier steps cannot remove this - it is outside the
-    // process - so retry is the honest containment tool.
+    // A SCRIPTED teaching fixture, not real flakiness: a static counter makes attempt #1 "fail"
+    // and attempt #2 "succeed" so the sample deterministically exercises the retry path. It
+    // stands in for a flaky *external* dependency (e.g. a remote service) that the earlier steps
+    // cannot remove because it lives outside the process - which is when retry is the honest tool.
     private static bool CallExternalService()
         => Interlocked.Increment(ref s_attempts) >= 2;
 

--- a/samples/public/ReliableTestSuite/GlobalFixtures.cs
+++ b/samples/public/ReliableTestSuite/GlobalFixtures.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// Per-assembly setup/teardown that runs once, regardless of how many test classes exist.
+/// [GlobalTestInitialize]/[GlobalTestCleanup] methods must be public static and take a
+/// TestContext. Unlike [AssemblyInitialize], they are not tied to a single class, so shared
+/// suite-wide bootstrapping lives in one obvious place.
+/// </summary>
+[TestClass]
+public static class GlobalFixtures
+{
+    [GlobalTestInitialize]
+    public static void SuiteSetup(TestContext context)
+        => context.WriteLine("Reliable suite starting - environment is deterministic from here.");
+
+    [GlobalTestCleanup]
+    public static void SuiteTeardown(TestContext context)
+        => context.WriteLine("Reliable suite finished.");
+}

--- a/samples/public/ReliableTestSuite/GlobalFixtures.cs
+++ b/samples/public/ReliableTestSuite/GlobalFixtures.cs
@@ -4,19 +4,42 @@
 namespace ReliableTestSuite;
 
 /// <summary>
-/// Per-assembly setup/teardown that runs once, regardless of how many test classes exist.
-/// [GlobalTestInitialize]/[GlobalTestCleanup] methods must be public static and take a
-/// TestContext. Unlike [AssemblyInitialize], they are not tied to a single class, so shared
-/// suite-wide bootstrapping lives in one obvious place.
+/// SUITE-WIDE FIXTURES - and the distinction people most often get wrong.
+///
+/// There are two assembly-scoped lifecycle hooks, and they run at very different cadences:
+///
+///   [AssemblyInitialize] / [AssemblyCleanup] run exactly ONCE per assembly - before the first
+///   test starts and after the last test finishes. This is where once-only suite bootstrapping
+///   belongs (start a shared server, seed a database, warm a cache). [AssemblyInitialize] takes a
+///   TestContext; [AssemblyCleanup] may optionally take one.
+///
+///   [GlobalTestInitialize] / [GlobalTestCleanup] are the assembly-wide equivalent of
+///   [TestInitialize] / [TestCleanup]: they run before and after EVERY test in the assembly,
+///   independent of any single class. Use them to reset ambient state per test - NOT for
+///   once-only setup. Both must be public static and take a TestContext.
+///
+/// Putting expensive once-only work in a per-test hook (or expecting once-per-run semantics from
+/// [GlobalTestInitialize]) is a classic scaling mistake; naming both here makes the difference
+/// explicit so a reader copies the right one.
 /// </summary>
 [TestClass]
 public static class GlobalFixtures
 {
-    [GlobalTestInitialize]
+    // Runs ONCE, before any test - the right home for suite-wide bootstrapping.
+    [AssemblyInitialize]
     public static void SuiteSetup(TestContext context)
-        => context.WriteLine("Reliable suite starting - environment is deterministic from here.");
+        => context.WriteLine("Reliable suite starting - shared bootstrapping happens here, once.");
 
-    [GlobalTestCleanup]
+    // Runs ONCE, after every test has finished.
+    [AssemblyCleanup]
     public static void SuiteTeardown(TestContext context)
         => context.WriteLine("Reliable suite finished.");
+
+    // Runs before EVERY test (assembly-wide [TestInitialize]). Keep it cheap and idempotent; it
+    // is not the place for once-only work. Here it is a no-op that documents the cadence.
+    [GlobalTestInitialize]
+    public static void BeforeEachTest(TestContext context)
+    {
+        // Per-test hook: e.g. reset a piece of ambient state so no test inherits another's leftovers.
+    }
 }

--- a/samples/public/ReliableTestSuite/OrderExportTests.cs
+++ b/samples/public/ReliableTestSuite/OrderExportTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// STEP 1 - ELIMINATE BEFORE YOU LOCK.
+///
+/// These tests all write files, yet they need no [ResourceLock] and no [DoNotParallelize].
+/// The reason: each test writes into its OWN unique directory, created in [TestInitialize] and
+/// removed in [TestCleanup]. There is no shared resource to contend on, so the scheduler is free
+/// to run every method concurrently. The cheapest concurrency bug is the one that cannot exist
+/// because nothing is shared.
+///
+/// (On MSTest 4.4+, TestContext.TestTempDirectory gives you a per-test folder the platform
+/// manages for you, removing even this bookkeeping.)
+/// </summary>
+[TestClass]
+public sealed class OrderExportTests
+{
+    private string _tempDir = null!;
+
+    [TestInitialize]
+    public void CreateUniqueDirectory()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "ReliableSuite", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [TestCleanup]
+    public void RemoveUniqueDirectory()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ExportsSingleOrder()
+    {
+        string path = Path.Combine(_tempDir, "orders.csv");
+
+        OrderExporter.ExportCsv([new Order(1, "Contoso", 42.00m)], path);
+
+        string[] lines = File.ReadAllLines(path);
+        Assert.HasCount(2, lines);
+        Assert.AreEqual("Id,Customer,Total", lines[0]);
+        Assert.Contains("Contoso", lines[1]);
+    }
+
+    [TestMethod]
+    public void ExportsMultipleOrders()
+    {
+        string path = Path.Combine(_tempDir, "orders.csv");
+
+        OrderExporter.ExportCsv(
+            [new Order(1, "Contoso", 10m), new Order(2, "Fabrikam", 20m)],
+            path);
+
+        string[] lines = File.ReadAllLines(path);
+        Assert.HasCount(3, lines);
+    }
+
+    [TestMethod]
+    public void ExportsEmptySequence()
+    {
+        string path = Path.Combine(_tempDir, "orders.csv");
+
+        OrderExporter.ExportCsv([], path);
+
+        string[] lines = File.ReadAllLines(path);
+        Assert.HasCount(1, lines);
+    }
+}

--- a/samples/public/ReliableTestSuite/OrderExportTests.cs
+++ b/samples/public/ReliableTestSuite/OrderExportTests.cs
@@ -46,7 +46,9 @@ public sealed class OrderExportTests
         string[] lines = File.ReadAllLines(path);
         Assert.HasCount(2, lines);
         Assert.AreEqual("Id,Customer,Total", lines[0]);
-        Assert.Contains("Contoso", lines[1]);
+        // Assert the WHOLE row, not just a substring: a culture-dependent decimal (42,00) would
+        // change this shape and must fail the test rather than slip through.
+        Assert.AreEqual("1,Contoso,42.00", lines[1]);
     }
 
     [TestMethod]

--- a/samples/public/ReliableTestSuite/PlatformSpecificTests.cs
+++ b/samples/public/ReliableTestSuite/PlatformSpecificTests.cs
@@ -19,21 +19,23 @@ public sealed class PlatformSpecificTests
     // Runs only on Windows. On Linux/macOS this is reported as not-run, not as a hollow pass.
     [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
-    public void UsesWindowsOnlyPath()
+    public void UsesWindowsPathSemantics()
     {
-        Assert.IsTrue(OperatingSystem.IsWindows());
+        // Stands in for genuinely Windows-specific behavior (rather than re-asserting the OS):
+        // the path separator is '\' and path comparison is case-insensitive.
+        Assert.AreEqual('\\', Path.DirectorySeparatorChar);
+        Assert.IsTrue(string.Equals(@"C:\Temp", @"c:\temp", StringComparison.OrdinalIgnoreCase));
     }
 
-    // Skips a timing-sensitive check when running under CI (ConditionMode.Exclude), where
-    // shared/throttled agents make it flaky - without pretending it passed locally.
+    // Excluded on CI (ConditionMode.Exclude) for a REAL environmental reason: this check needs an
+    // interactive desktop session that headless CI agents do not have. That is honest gating.
+    // Excluding a test merely because it is FLAKY on CI would be hiding the flake - the earlier
+    // rungs (isolate, coordinate, bound) are how you fix that instead of muting it.
     [TestMethod]
     [CICondition(ConditionMode.Exclude)]
-    public void TimingSensitiveCheck_NotOnCI()
+    public void InteractiveOnlyCheck_NotOnHeadlessCI()
     {
-        // A real check that would be timing-flaky on shared CI agents.
-        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-        stopwatch.Stop();
-        Assert.IsFalse(stopwatch.IsRunning);
+        Assert.IsTrue(Environment.UserInteractive);
     }
 
     // Runs only when 'dotnet' is resolvable on PATH. Gating on tool availability beats a

--- a/samples/public/ReliableTestSuite/PlatformSpecificTests.cs
+++ b/samples/public/ReliableTestSuite/PlatformSpecificTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// STEP 3 - GATE ENVIRONMENT-SPECIFIC TESTS DECLARATIVELY.
+///
+/// A common source of "works on my machine" flakiness is a test that silently early-returns
+/// (or worse, does nothing) when it is on the wrong OS, off CI, or when a required tool is
+/// missing. That reports a false PASS. Condition attributes instead mark the test as NOT RUN
+/// for the right reason, so the run summary tells the truth.
+///
+/// Conditions of the SAME group are OR'd; conditions in DIFFERENT groups are AND'd.
+/// </summary>
+[TestClass]
+public sealed class PlatformSpecificTests
+{
+    // Runs only on Windows. On Linux/macOS this is reported as not-run, not as a hollow pass.
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void UsesWindowsOnlyPath()
+    {
+        Assert.IsTrue(OperatingSystem.IsWindows());
+    }
+
+    // Skips a timing-sensitive check when running under CI (ConditionMode.Exclude), where
+    // shared/throttled agents make it flaky - without pretending it passed locally.
+    [TestMethod]
+    [CICondition(ConditionMode.Exclude)]
+    public void TimingSensitiveCheck_NotOnCI()
+    {
+        // A real check that would be timing-flaky on shared CI agents.
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        stopwatch.Stop();
+        Assert.IsFalse(stopwatch.IsRunning);
+    }
+
+    // Runs only when 'dotnet' is resolvable on PATH. Gating on tool availability beats a
+    // try/catch that swallows a missing-tool error and reports success.
+    [TestMethod]
+    [ExecutableCondition("dotnet")]
+    public void RequiresDotnetCli()
+    {
+        string? path = Environment.GetEnvironmentVariable("PATH");
+        Assert.IsNotNull(path);
+    }
+}

--- a/samples/public/ReliableTestSuite/README.md
+++ b/samples/public/ReliableTestSuite/README.md
@@ -37,17 +37,23 @@ re-serialize the class).
 
 - It is **cooperative** — it only coordinates tests that opt in with the **same** key. A test that
   touches the resource without declaring the lock is not held back.
-- Its scope is the current **test-host process**. It serializes tests within one run; it is not a
-  cross-process or distributed/cross-agent mutex.
+- Its scope is a single **test source (assembly)**. The adapter creates a separate lock manager per
+  source, so matching keys serialize only the parallel tests *within one assembly's* run — they do
+  **not** coordinate tests in a *different* assembly, even when both run in the same test-host
+  process. It is not a cross-assembly, cross-process, or distributed/cross-agent mutex, so don't rely
+  on it for global state shared across assemblies.
 
 ## What to expect when you run it
 
-- **10 tests pass** locally on Windows. Some condition-gated tests report **not run** (rather than a
+- **11 tests pass** locally on Windows. Some condition-gated tests report **not run** (rather than a
   hollow pass) depending on your environment — e.g. `UsesWindowsPathSemantics` runs only on Windows,
   and `InteractiveOnlyCheck_NotOnHeadlessCI` is excluded on CI.
-- The banner prints the worker count, parallel scope, and the **random-order seed**. To reproduce a
-  specific failing order, reuse the reported seed. In CI you should **rotate the seed** (or leave it
-  unset) so runs keep exploring new orderings instead of freezing on one.
+- The banner prints the worker count, parallel scope, and the **random-order seed**. The seed
+  reproduces the shuffled *queue order*, not the exact concurrent interleaving: with multiple workers
+  dequeuing and running tests in parallel, timing-dependent races can still vary run-to-run under the
+  same seed. To reproduce a race deterministically, reduce parallelism (or serialize the suspects)
+  first, then use the seed to pin the order. In CI you should **rotate the seed** (or leave it unset)
+  so runs keep exploring new orderings instead of freezing on one.
 - On **MSTest 4.4+** a retried test surfaces as *flaky*; on the pinned 4.3.x a retried-then-passed
   test reports as an ordinary pass.
 

--- a/samples/public/ReliableTestSuite/README.md
+++ b/samples/public/ReliableTestSuite/README.md
@@ -1,0 +1,38 @@
+# Reliable test suites at scale with MSTest
+
+A single coherent sample that shows how to make a **parallel** MSTest suite reliable by
+*engineering determinism* instead of *re-rolling the dice with retries*.
+
+The project opts into method-level parallelization (`MSTestParallelizeScope=MethodLevel` in the
+`.csproj`). MSTest does not parallelize by default; turning it on is what surfaces latent
+shared-state bugs. Each file then demonstrates one rung of the reliability ladder:
+
+| File | Technique | Why it matters |
+| --- | --- | --- |
+| `OrderExportTests.cs` | **Eliminate** — per-test unique temp directory | No shared resource ⇒ no lock needed ⇒ full parallelism. The cheapest concurrency bug is the one that cannot exist. (MSTest 4.4 adds `TestContext.TestTempDirectory` so the platform manages this for you.) |
+| `EnvironmentPricingTests.cs` | **Coordinate** — `[DoNotParallelize]` today, `[ResourceLock(WellKnownResources.EnvironmentVariables)]` in MSTest 4.4 | Genuinely process-global state must be serialized. `[ResourceLock]` serializes *only* the tests that share the named resource, not the whole suite. |
+| `PlatformSpecificTests.cs` | **Gate** — `[OSCondition]`, `[CICondition]`, `[ExecutableCondition]` | A test that silently early-returns on the wrong OS reports a false pass. Conditions report *not run* for the right reason. |
+| `CancellableWorkTests.cs` | **Bound time** — `[Timeout(CooperativeCancellation = true)]` + `TestContext.CancellationToken` | A test that can hang has no place in a reliable suite; cooperative cancellation stops the work cleanly. No `Thread.Sleep`. |
+| `FlakyDependencyTests.cs` | **Contain** — `[Retry]` | Retry makes a nondeterministic test pass more often; it does **not** make it deterministic. Last resort for residual, external flakiness only. |
+| `testconfig.json` | **Expose** — `randomizeTestOrder` + fixed seed | Random order surfaces hidden inter-test ordering dependencies; the reported seed makes any failure reproducible. |
+| `GlobalFixtures.cs` | **Bootstrap** — `[GlobalTestInitialize]` / `[GlobalTestCleanup]` | One obvious place for suite-wide setup/teardown, independent of any single class. |
+
+## The thesis
+
+**Determinism is a property you engineer, not a dice roll you re-roll.** Work down the ladder in
+order: eliminate sharing, isolate what is left, coordinate the truly-global remainder with named
+resource locks, and only then contain whatever residual nondeterminism you could not remove.
+`[Retry]` sits at the bottom on purpose.
+
+## `[ResourceLock]` note
+
+`[ResourceLock]` and `WellKnownResources` ship in **MSTest 4.4**. This sample pins the shipped
+`MSTest.Sdk` (see `../global.json`), so it demonstrates the coordination step with the
+shipped-today `[DoNotParallelize]` and shows the exact `[ResourceLock]` upgrade in the comments of
+`EnvironmentPricingTests.cs`.
+
+## Run it
+
+```console
+dotnet run
+```

--- a/samples/public/ReliableTestSuite/README.md
+++ b/samples/public/ReliableTestSuite/README.md
@@ -15,7 +15,7 @@ shared-state bugs. Each file then demonstrates one rung of the reliability ladde
 | `CancellableWorkTests.cs` | **Bound time** — `[Timeout(CooperativeCancellation = true)]` + `TestContext.CancellationToken` | A test that can hang has no place in a reliable suite; cooperative cancellation stops the work cleanly. No `Thread.Sleep`. |
 | `FlakyDependencyTests.cs` | **Contain** — `[Retry]` | Retry makes a nondeterministic test pass more often; it does **not** make it deterministic. Last resort for residual, external flakiness only. |
 | `testconfig.json` | **Expose** — `randomizeTestOrder` + fixed seed | Random order surfaces hidden inter-test ordering dependencies; the reported seed makes any failure reproducible. |
-| `GlobalFixtures.cs` | **Bootstrap** — `[GlobalTestInitialize]` / `[GlobalTestCleanup]` | One obvious place for suite-wide setup/teardown, independent of any single class. |
+| `GlobalFixtures.cs` | **Bootstrap** — `[AssemblyInitialize]`/`[AssemblyCleanup]` (once per run) vs `[GlobalTestInitialize]`/`[GlobalTestCleanup]` (before/after **every** test) | Suite-wide setup has two cadences and mixing them up is a classic scaling bug: once-only work (start a server, seed a DB) goes in `[AssemblyInitialize]`; per-test ambient reset goes in the global test hooks. |
 
 ## The thesis
 
@@ -27,9 +27,29 @@ resource locks, and only then contain whatever residual nondeterminism you could
 ## `[ResourceLock]` note
 
 `[ResourceLock]` and `WellKnownResources` ship in **MSTest 4.4**. This sample pins the shipped
-`MSTest.Sdk` (see `../global.json`), so it demonstrates the coordination step with the
-shipped-today `[DoNotParallelize]` and shows the exact `[ResourceLock]` upgrade in the comments of
-`EnvironmentPricingTests.cs`.
+`MSTest.Sdk` **4.3.x** (see `../global.json` and `../Directory.Build.props`), so it demonstrates the
+coordination step with the shipped-today `[DoNotParallelize]` and shows the exact `[ResourceLock]`
+upgrade in the comments of `EnvironmentPricingTests.cs`. The migration is a one-for-one swap:
+**remove** `[DoNotParallelize]` and **add** `[ResourceLock(...)]` (keeping both would just
+re-serialize the class).
+
+`[ResourceLock]` limitations worth stating up front:
+
+- It is **cooperative** — it only coordinates tests that opt in with the **same** key. A test that
+  touches the resource without declaring the lock is not held back.
+- Its scope is the current **test-host process**. It serializes tests within one run; it is not a
+  cross-process or distributed/cross-agent mutex.
+
+## What to expect when you run it
+
+- **10 tests pass** locally on Windows. Some condition-gated tests report **not run** (rather than a
+  hollow pass) depending on your environment — e.g. `UsesWindowsPathSemantics` runs only on Windows,
+  and `InteractiveOnlyCheck_NotOnHeadlessCI` is excluded on CI.
+- The banner prints the worker count, parallel scope, and the **random-order seed**. To reproduce a
+  specific failing order, reuse the reported seed. In CI you should **rotate the seed** (or leave it
+  unset) so runs keep exploring new orderings instead of freezing on one.
+- On **MSTest 4.4+** a retried test surfaces as *flaky*; on the pinned 4.3.x a retried-then-passed
+  test reports as an ordinary pass.
 
 ## Run it
 

--- a/samples/public/ReliableTestSuite/ReliableTestSuite.csproj
+++ b/samples/public/ReliableTestSuite/ReliableTestSuite.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="MSTest.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!--
+      Opt in to parallelization. MSTest does NOT run tests in parallel by default.
+      This MSBuild knob emits [assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]
+      for us (see MSTest.TestAdapter's Parallelize.targets), so every [TestMethod] in the
+      assembly becomes a candidate to run concurrently - which is exactly what turns latent
+      shared-state bugs into visible failures. The whole point of this sample is to make that
+      parallelism SAFE rather than to avoid it.
+    -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
+  </PropertyGroup>
+
+</Project>

--- a/samples/public/ReliableTestSuite/src/OrderExporter.cs
+++ b/samples/public/ReliableTestSuite/src/OrderExporter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
+
 namespace ReliableTestSuite;
 
 /// <summary>
@@ -8,6 +10,11 @@ namespace ReliableTestSuite;
 /// Crucially, the path is a parameter - the exporter owns no ambient/global state, so two
 /// callers writing to two different paths never interfere. That property is what lets the
 /// tests below run in parallel with no lock at all.
+///
+/// Note the InvariantCulture formatting of the decimal below. Owning no ambient state also means
+/// not depending on the ambient CULTURE: with a default '$"{order.Total}"' interpolation the
+/// output would change shape on a comma-decimal machine (42.00 -> 42,00), corrupting the CSV.
+/// Determinism is engineered here too, not assumed.
 /// </summary>
 public static class OrderExporter
 {
@@ -17,7 +24,9 @@ public static class OrderExporter
         writer.WriteLine("Id,Customer,Total");
         foreach (Order order in orders)
         {
-            writer.WriteLine($"{order.Id},{order.Customer},{order.Total}");
+            writer.WriteLine(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{order.Id},{order.Customer},{order.Total}"));
         }
     }
 }

--- a/samples/public/ReliableTestSuite/src/OrderExporter.cs
+++ b/samples/public/ReliableTestSuite/src/OrderExporter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// A minimal "system under test": exports orders to a CSV file at a caller-supplied path.
+/// Crucially, the path is a parameter - the exporter owns no ambient/global state, so two
+/// callers writing to two different paths never interfere. That property is what lets the
+/// tests below run in parallel with no lock at all.
+/// </summary>
+public static class OrderExporter
+{
+    public static void ExportCsv(IEnumerable<Order> orders, string filePath)
+    {
+        using var writer = new StreamWriter(filePath);
+        writer.WriteLine("Id,Customer,Total");
+        foreach (Order order in orders)
+        {
+            writer.WriteLine($"{order.Id},{order.Customer},{order.Total}");
+        }
+    }
+}
+
+public sealed record Order(int Id, string Customer, decimal Total);

--- a/samples/public/ReliableTestSuite/src/PricingCalculator.cs
+++ b/samples/public/ReliableTestSuite/src/PricingCalculator.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+
+namespace ReliableTestSuite;
+
+/// <summary>
+/// A calculator that reads its tax rate from a process-wide environment variable. Unlike
+/// <see cref="OrderExporter"/>, this type reaches into genuinely global state: every test in
+/// the process shares one copy of the environment block. This is the case that CANNOT be made
+/// safe by isolation alone - it must be coordinated (see EnvironmentPricingTests).
+/// </summary>
+public static class PricingCalculator
+{
+    public const string TaxRateVariable = "RELIABLE_SUITE_TAX_RATE";
+
+    public static decimal ApplyTax(decimal amount)
+    {
+        string? raw = Environment.GetEnvironmentVariable(TaxRateVariable);
+        decimal rate = raw is null
+            ? 0m
+            : decimal.Parse(raw, CultureInfo.InvariantCulture);
+        return amount + (amount * rate);
+    }
+}

--- a/samples/public/ReliableTestSuite/testconfig.json
+++ b/samples/public/ReliableTestSuite/testconfig.json
@@ -1,0 +1,8 @@
+{
+  "mstest": {
+    "execution": {
+      "randomizeTestOrder": true,
+      "randomTestOrderSeed": 12345
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

A new `samples/public/ReliableTestSuite/` sample: one coherent, parallel MSTest suite that teaches how to make a suite reliable **at scale** by *engineering determinism* rather than *re-rolling the dice with retries*.

The sample turns on method-level parallelization (`MSTestParallelizeScope=MethodLevel`) — which is what surfaces latent shared-state bugs — and walks a **reliability ladder**, one rung per file:

| File | Rung | Technique |
| --- | --- | --- |
| `OrderExportTests.cs` | **Eliminate** | Per-test unique temp directory → no shared resource, no lock, full parallelism |
| `EnvironmentPricingTests.cs` | **Coordinate** | `[DoNotParallelize]` today; the exact `[ResourceLock(WellKnownResources.EnvironmentVariables)]` migration shown in comments for MSTest 4.4 |
| `PlatformSpecificTests.cs` | **Gate** | `[OSCondition]`, `[CICondition]`, `[ExecutableCondition]` report *not run* for the right reason instead of a false pass |
| `CancellableWorkTests.cs` | **Bound time** | `[Timeout(CooperativeCancellation = true)]` + `TestContext.CancellationToken`, no `Thread.Sleep` |
| `FlakyDependencyTests.cs` | **Contain** | `[Retry]` as a deliberate last resort — containment, not a fix |
| `testconfig.json` | **Expose** | `randomizeTestOrder` + reported seed |
| `GlobalFixtures.cs` | **Bootstrap** | `[AssemblyInitialize]`/`[AssemblyCleanup]` (once) vs `[GlobalTestInitialize]`/`[GlobalTestCleanup]` (per test) |

**Thesis:** determinism is a property you engineer, not a dice roll you re-roll. `[ResourceLock]` (the precise alternative to the all-or-nothing `[DoNotParallelize]`) is the centerpiece; retry sits at the bottom of the ladder on purpose.

## Versioning

The sample pins the **shipped `MSTest.Sdk` 4.3.x** (`samples/public/global.json`, `samples/public/Directory.Build.props`). `[ResourceLock]`/`WellKnownResources` ship in **4.4**, so they are demonstrated in comments with the full `[DoNotParallelize]` → `[ResourceLock]` swap and documented limitations (cooperative, same-key, test-host-process scope). No unreleased API is compiled.

## Review

Went through three code-review passes (general code review, MSTest expert review, design review) and folded in the findings: corrected once-per-run vs per-test fixture semantics, made the CSV export culture-invariant with a full-row assertion, replaced a flake-hiding CI-condition example with an honest environmental exclude, added a deterministic cancellation-observing test, and marked per-attempt retry "flaky" reporting as 4.4+ behavior.

## Verification

- `dotnet build` → **0 warnings, 0 errors**
- `dotnet run` → **11/11 tests pass**; `Workers: 32, Scope: MethodLevel`; random order enabled with reported seed

## Notes

- Opened as **draft**; no publication date. The accompanying blog post is kept as a session artifact and is **not** part of this PR.