### PR TITLE
Fix Japanese retried test count

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -314,7 +314,7 @@
       </trans-unit>
       <trans-unit id="RetriedTestsAndRuns">
         <source>{0} test(s), {1} extra run(s)</source>
-        <target state="translated">{0} 回のテスト、{1} 回の追加実行</target>
+        <target state="translated">{0} 件のテスト、{1} 回の追加実行</target>
         <note>{0} is the number of distinct tests that were retried. {1} is the number of additional executions those retries caused. Rendered after the 'retried:' label. The '(s)' suffix follows the existing convention used elsewhere in the platform for counts that may be one.</note>
       </trans-unit>
       <trans-unit id="RunningTestsFrom">


### PR DESCRIPTION
PR #10399 used the occurrence counter `回` for both placeholders in the retry summary, even though `{0}` counts distinct tests and `{1}` counts additional executions.

Use `件` for the distinct-test count and retain `回` for extra runs.