### PR TITLE
Set apphost DOTNET_ROOT in InvokeTestingPlatform

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -23,6 +23,7 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 
 ### Fixed
 
+* Make the `InvokeTestingPlatform` MSBuild target set `DOTNET_ROOT_<ARCH>` from `DOTNET_HOST_PATH` when launching a compatible apphost, matching `dotnet test` runtime resolution. Set `TestingPlatformDisableAppHostDotnetRoot` to `true` to opt out; an explicit applicable `TestingPlatformEnvironmentVariable` remains authoritative in [#10408](https://github.com/microsoft/testfx/issues/10408)
 * Fix `--report-trx` crashing with `PlatformNotSupportedException` on single-threaded WebAssembly runtimes (`browser-wasm` / `wasi-wasm`): the TRX streaming store now serializes records inline instead of starting a dedicated writer thread and draining a `BlockingCollection<T>` in [#2196](https://github.com/microsoft/testfx/issues/2196)
 * Keep the Azure DevOps and GitHub Actions slow-test reporters dormant on single-threaded WebAssembly runtimes instead of attempting to start a background scan loop that cannot run there. `ITask.RunLongRunning` throws `PlatformNotSupportedException` on `browser-wasm` / `wasi-wasm`; the reporter caught and logged it to the diagnostic log, then stayed marked active with no scan loop, so the failure was invisible outside `--diagnostic` in [#2196](https://github.com/microsoft/testfx/issues/2196)
 * Report test and session file artifacts through the simplified console output used by `browser-wasm` and `wasi-wasm`, including each artifact's display name and virtual file-system path, in [#10311](https://github.com/microsoft/testfx/issues/10311)

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.Execution.cs
@@ -94,6 +94,7 @@ public partial class InvokeTestingPlatformTask
         // begins streaming output) instead of re-parsing on every output line / failed-test request.
         _captureOutput = bool.Parse(TestingPlatformCaptureOutput.ItemSpec);
         _showTestsFailure = bool.Parse(TestingPlatformShowTestsFailure.ItemSpec);
+        AddAppHostDotnetRootEnvironmentVariable();
 
         bool returnValue = base.Execute();
         if (_toolCommand is not null)

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.ToolResolution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.ToolResolution.cs
@@ -119,6 +119,74 @@ public partial class InvokeTestingPlatformTask
         _currentProcessArchitecture == (Architecture)Enum.Parse(typeof(Architecture), TestArchitecture.ItemSpec, ignoreCase: true);
 #endif
 
+    internal void AddAppHostDotnetRootEnvironmentVariable()
+    {
+        if (TestingPlatformDisableAppHostDotnetRoot
+            || TryGetRunCommand() is null
+            || DotnetHostPath is null
+            || !File.Exists(DotnetHostPath.ItemSpec)
+            || !IsCurrentProcessArchitectureCompatible())
+        {
+            return;
+        }
+
+        string? dotnetRoot = Path.GetDirectoryName(DotnetHostPath.ItemSpec);
+        if (string.IsNullOrEmpty(dotnetRoot))
+        {
+            return;
+        }
+
+        string variableName = $"DOTNET_ROOT_{_currentProcessArchitecture.ToString().ToUpperInvariant()}";
+        if (ContainsEnvironmentVariable(variableName))
+        {
+            return;
+        }
+
+        bool isWindowsX86 = IsWindowsX86ProcessOn64BitOperatingSystem(
+            _currentProcessArchitecture,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            Environment.Is64BitOperatingSystem);
+        bool hasExplicitDotnetRoot = ContainsEnvironmentVariable("DOTNET_ROOT");
+        bool hasExplicitWindowsX86DotnetRoot = isWindowsX86 && ContainsEnvironmentVariable("DOTNET_ROOT(x86)");
+        if (hasExplicitDotnetRoot || hasExplicitWindowsX86DotnetRoot)
+        {
+            EnvironmentVariables = hasExplicitDotnetRoot && isWindowsX86 && !hasExplicitWindowsX86DotnetRoot
+                ? [$"{variableName}=", "DOTNET_ROOT(x86)=", .. EnvironmentVariables ?? []]
+                : [$"{variableName}=", .. EnvironmentVariables ?? []];
+            return;
+        }
+
+        EnvironmentVariables = [$"{variableName}={dotnetRoot}", .. EnvironmentVariables ?? []];
+        Log.LogMessage(MessageImportance.Low, $"Setting '{variableName}' to '{dotnetRoot}' for apphost runtime resolution.");
+    }
+
+    internal static bool IsWindowsX86ProcessOn64BitOperatingSystem(Architecture processArchitecture, bool isWindows, bool is64BitOperatingSystem)
+        => processArchitecture == Architecture.X86 && isWindows && is64BitOperatingSystem;
+
+    private bool ContainsEnvironmentVariable(string variableName)
+    {
+        if (EnvironmentVariables is null)
+        {
+            return false;
+        }
+
+        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        foreach (string environmentVariable in EnvironmentVariables)
+        {
+            int separatorIndex = environmentVariable.IndexOf('=');
+            if (separatorIndex > 0
+                && string.Equals(environmentVariable.Substring(0, separatorIndex), variableName, comparison))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private string? TryGetRunCommand()
     {
         // This condition specifically handles this part:

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.ToolResolution.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.ToolResolution.cs
@@ -112,20 +112,32 @@ public partial class InvokeTestingPlatformTask
         return null;
     }
 
-    private bool IsCurrentProcessArchitectureCompatible() =>
+    private bool IsCurrentProcessArchitectureCompatible()
+        => IsCurrentProcessArchitectureCompatible(_currentProcessArchitecture);
+
+    private bool IsCurrentProcessArchitectureCompatible(Architecture currentProcessArchitecture) =>
 #if NETCOREAPP
-        _currentProcessArchitecture == Enum.Parse<Architecture>(TestArchitecture.ItemSpec, ignoreCase: true);
+        currentProcessArchitecture == Enum.Parse<Architecture>(TestArchitecture.ItemSpec, ignoreCase: true);
 #else
-        _currentProcessArchitecture == (Architecture)Enum.Parse(typeof(Architecture), TestArchitecture.ItemSpec, ignoreCase: true);
+        currentProcessArchitecture == (Architecture)Enum.Parse(typeof(Architecture), TestArchitecture.ItemSpec, ignoreCase: true);
 #endif
 
     internal void AddAppHostDotnetRootEnvironmentVariable()
+        => AddAppHostDotnetRootEnvironmentVariable(
+            _currentProcessArchitecture,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            Environment.Is64BitOperatingSystem);
+
+    internal void AddAppHostDotnetRootEnvironmentVariable(
+        Architecture currentProcessArchitecture,
+        bool isWindows,
+        bool is64BitOperatingSystem)
     {
         if (TestingPlatformDisableAppHostDotnetRoot
             || TryGetRunCommand() is null
             || DotnetHostPath is null
             || !File.Exists(DotnetHostPath.ItemSpec)
-            || !IsCurrentProcessArchitectureCompatible())
+            || !IsCurrentProcessArchitectureCompatible(currentProcessArchitecture))
         {
             return;
         }
@@ -136,18 +148,18 @@ public partial class InvokeTestingPlatformTask
             return;
         }
 
-        string variableName = $"DOTNET_ROOT_{_currentProcessArchitecture.ToString().ToUpperInvariant()}";
-        if (ContainsEnvironmentVariable(variableName))
+        string variableName = $"DOTNET_ROOT_{currentProcessArchitecture.ToString().ToUpperInvariant()}";
+        if (ContainsEnvironmentVariable(variableName, isWindows))
         {
             return;
         }
 
         bool isWindowsX86 = IsWindowsX86ProcessOn64BitOperatingSystem(
-            _currentProcessArchitecture,
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
-            Environment.Is64BitOperatingSystem);
-        bool hasExplicitDotnetRoot = ContainsEnvironmentVariable("DOTNET_ROOT");
-        bool hasExplicitWindowsX86DotnetRoot = isWindowsX86 && ContainsEnvironmentVariable("DOTNET_ROOT(x86)");
+            currentProcessArchitecture,
+            isWindows,
+            is64BitOperatingSystem);
+        bool hasExplicitDotnetRoot = ContainsEnvironmentVariable("DOTNET_ROOT", isWindows);
+        bool hasExplicitWindowsX86DotnetRoot = isWindowsX86 && ContainsEnvironmentVariable("DOTNET_ROOT(x86)", isWindows);
         if (hasExplicitDotnetRoot || hasExplicitWindowsX86DotnetRoot)
         {
             EnvironmentVariables = hasExplicitDotnetRoot && isWindowsX86 && !hasExplicitWindowsX86DotnetRoot
@@ -163,14 +175,14 @@ public partial class InvokeTestingPlatformTask
     internal static bool IsWindowsX86ProcessOn64BitOperatingSystem(Architecture processArchitecture, bool isWindows, bool is64BitOperatingSystem)
         => processArchitecture == Architecture.X86 && isWindows && is64BitOperatingSystem;
 
-    private bool ContainsEnvironmentVariable(string variableName)
+    private bool ContainsEnvironmentVariable(string variableName, bool isWindows)
     {
         if (EnvironmentVariables is null)
         {
             return false;
         }
 
-        StringComparison comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        StringComparison comparison = isWindows
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/InvokeTestingPlatformTask.cs
@@ -135,6 +135,11 @@ public partial class InvokeTestingPlatformTask : Build.Utilities.ToolTask, IDisp
     public ITaskItem? DotnetHostPath { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether automatic DOTNET_ROOT_&lt;ARCH&gt; configuration is disabled for apphost launches.
+    /// </summary>
+    public bool TestingPlatformDisableAppHostDotnetRoot { get; set; }
+
+    /// <summary>
     /// Gets or sets the testing platform command line arguments.
     /// </summary>
     public ITaskItem? TestingPlatformCommandLineArguments { get; set; }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/buildMultiTargeting/Microsoft.Testing.Platform.MSBuild.targets
@@ -389,6 +389,7 @@
     <_TestArchitecture Condition="'$(_TestArchitecture)' == '' or '$(_TestArchitecture)' == 'AnyCpu'">x64</_TestArchitecture>
     <TestingPlatformShowTestsFailure Condition=" '$(TestingPlatformShowTestsFailure)' == '' ">false</TestingPlatformShowTestsFailure>
     <TestingPlatformCaptureOutput Condition=" '$(TestingPlatformCaptureOutput)' == '' " >true</TestingPlatformCaptureOutput>
+    <TestingPlatformDisableAppHostDotnetRoot Condition=" '$(TestingPlatformDisableAppHostDotnetRoot)' == '' ">false</TestingPlatformDisableAppHostDotnetRoot>
   </PropertyGroup>
 
   <Target Name="InvokeTestingPlatform" >
@@ -425,6 +426,7 @@
                                EnvironmentVariables="@(TestingPlatformEnvironmentVariable->'%(Identity)=%(Value)')"
                                VSTestCLIRunSettings="$(VSTestCLIRunSettings)"
                                TestingPlatformCaptureOutput="$(TestingPlatformCaptureOutput)"
+                               TestingPlatformDisableAppHostDotnetRoot="$(TestingPlatformDisableAppHostDotnetRoot)"
                                DotnetHostPath="$(DOTNET_HOST_PATH)" />
   </Target>
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -372,6 +372,58 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         compilationResult.AssertOutputContains("[env] MTP_ENV_INHERITED=inherited-value");
     }
 
+    [TestMethod]
+    public async Task InvokeTestingPlatform_Target_Should_Set_DotnetRoot_For_AppHost()
+    {
+        string architecture = RuntimeInformation.ProcessArchitecture.ToString();
+        string dotnetRootVariableName = $"DOTNET_ROOT_{architecture.ToUpperInvariant()}";
+        string dotnetRoot = Path.Combine(RootFinder.Find(), ".dotnet");
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            SourceCode
+            .PatchCodeWithReplace("$PlatformTarget$", $"<PlatformTarget>{architecture.ToLowerInvariant()}</PlatformTarget>")
+            .PatchCodeWithReplace("$TargetFrameworks$", $"<targetFramework>{TargetFrameworks.NetCurrent}</targetFramework>")
+            .PatchCodeWithReplace("$AssertValue$", "true")
+            .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+
+        Dictionary<string, string?> CreateEnvironmentVariables()
+            => new()
+            {
+                [dotnetRootVariableName] = null,
+            };
+
+        DotnetMuxerResult derivedResult = await DotnetCli.RunAsync(
+            $"build -t:Test -p:TestingPlatformCaptureOutput=False \"{testAsset.TargetAssetPath}\"",
+            workingDirectory: testAsset.TargetAssetPath,
+            environmentVariables: CreateEnvironmentVariables(),
+            cancellationToken: TestContext.CancellationToken);
+
+        derivedResult.AssertOutputContains($"[env] {dotnetRootVariableName}={dotnetRoot}");
+
+        DotnetMuxerResult explicitResult = await DotnetCli.RunAsync(
+            $"build -t:Test -p:TestingPlatformCaptureOutput=False -p:ExplicitDotnetRoot=\"{dotnetRoot}\" \"{testAsset.TargetAssetPath}\"",
+            workingDirectory: testAsset.TargetAssetPath,
+            environmentVariables: new Dictionary<string, string?>
+            {
+                // An inherited architecture-specific root has higher apphost precedence than DOTNET_ROOT. Use an
+                // existing directory without a dotnet installation to prove the explicit item clears this override.
+                [dotnetRootVariableName] = Path.GetTempPath(),
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        explicitResult.AssertOutputContains($"[env] DOTNET_ROOT={dotnetRoot}");
+        explicitResult.AssertOutputContains($"[env] {dotnetRootVariableName}=");
+
+        DotnetMuxerResult disabledResult = await DotnetCli.RunAsync(
+            $"build -t:Test -p:TestingPlatformCaptureOutput=False -p:TestingPlatformDisableAppHostDotnetRoot=true \"{testAsset.TargetAssetPath}\"",
+            workingDirectory: testAsset.TargetAssetPath,
+            environmentVariables: CreateEnvironmentVariables(),
+            cancellationToken: TestContext.CancellationToken);
+
+        disabledResult.AssertOutputContains($"[env] {dotnetRootVariableName}=");
+    }
+
     private const string SourceCode = """
 #file MSBuild Tests.csproj
 <Project Sdk="Microsoft.NET.Sdk">
@@ -395,6 +447,10 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         <TestingPlatformEnvironmentVariable Include="MTP_ENV_SIMPLE" Value="simple-value" />
         <!-- The value intentionally contains a ';' to prove item metadata is not subject to MSBuild's ';' splitting. -->
         <TestingPlatformEnvironmentVariable Include="MTP_ENV_WITH_SEMICOLON" Value="first;second" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <TestingPlatformEnvironmentVariable Include="DOTNET_ROOT" Value="$(ExplicitDotnetRoot)" Condition="'$(ExplicitDotnetRoot)' != ''" />
     </ItemGroup>
 
     <Import Project="UserDefinedTestTarget.targets" Condition="'$(ImportUserDefinedTestTarget)' == 'true'" />
@@ -423,12 +479,14 @@ using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.MSBuild;
 using Microsoft.Testing.Platform.Services;
+using System.Runtime.InteropServices;
 
 public class Program
 {
     public static async Task<int> Main(string[] args)
     {
-        foreach (string name in new[] { "MTP_ENV_SIMPLE", "MTP_ENV_WITH_SEMICOLON", "MTP_ENV_INHERITED" })
+        string dotnetRootArchVariableName = $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant()}";
+        foreach (string name in new[] { "MTP_ENV_SIMPLE", "MTP_ENV_WITH_SEMICOLON", "MTP_ENV_INHERITED", "DOTNET_ROOT", dotnetRootArchVariableName })
         {
             Console.WriteLine($"[env] {name}={Environment.GetEnvironmentVariable(name)}");
         }

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -114,6 +114,39 @@ public sealed class InvokeTestingPlatformTaskTests
     }
 
     [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_ExplicitDotnetRootInWindowsX86Process_ClearsBothArchitectureSpecificVariables()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.TestArchitecture = new TaskItem("X86");
+        task.EnvironmentVariables = ["DOTNET_ROOT=explicit"];
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable(Architecture.X86, isWindows: true, is64BitOperatingSystem: true);
+
+        Assert.IsNotNull(task.EnvironmentVariables);
+        Assert.HasCount(3, task.EnvironmentVariables);
+        Assert.AreEqual("DOTNET_ROOT_X86=", task.EnvironmentVariables[0]);
+        Assert.AreEqual("DOTNET_ROOT(x86)=", task.EnvironmentVariables[1]);
+        Assert.AreEqual("DOTNET_ROOT=explicit", task.EnvironmentVariables[2]);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_ExplicitWindowsX86DotnetRoot_ClearsOnlyArchitectureSpecificVariable()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.TestArchitecture = new TaskItem("X86");
+        task.EnvironmentVariables = ["DOTNET_ROOT(x86)=explicit"];
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable(Architecture.X86, isWindows: true, is64BitOperatingSystem: true);
+
+        Assert.IsNotNull(task.EnvironmentVariables);
+        Assert.HasCount(2, task.EnvironmentVariables);
+        Assert.AreEqual("DOTNET_ROOT_X86=", task.EnvironmentVariables[0]);
+        Assert.AreEqual("DOTNET_ROOT(x86)=explicit", task.EnvironmentVariables[1]);
+    }
+
+    [TestMethod]
     public void AddAppHostDotnetRootEnvironmentVariable_DoesNothingWhenDisabled()
     {
         using AppHostTaskFixture fixture = new();
@@ -192,6 +225,12 @@ public sealed class InvokeTestingPlatformTaskTests
 
         public void InvokeAddAppHostDotnetRootEnvironmentVariable()
             => AddAppHostDotnetRootEnvironmentVariable();
+
+        public void InvokeAddAppHostDotnetRootEnvironmentVariable(
+            Architecture currentProcessArchitecture,
+            bool isWindows,
+            bool is64BitOperatingSystem)
+            => AddAppHostDotnetRootEnvironmentVariable(currentProcessArchitecture, isWindows, is64BitOperatingSystem);
     }
 
     private sealed class AppHostTaskFixture : IDisposable

--- a/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.MSBuild.UnitTests/InvokeTestingPlatformTaskTests.cs
@@ -68,6 +68,107 @@ public sealed class InvokeTestingPlatformTaskTests
         Assert.DoesNotContain("normal output line", capturedStdout.ToString());
     }
 
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_AddsArchitectureSpecificVariableBeforeUserVariables()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.EnvironmentVariables = ["CUSTOM_VARIABLE=value"];
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNotNull(task.EnvironmentVariables);
+        Assert.HasCount(2, task.EnvironmentVariables);
+        Assert.AreEqual($"{GetDotnetRootArchitectureVariableName()}={fixture.DotnetRoot}", task.EnvironmentVariables[0]);
+        Assert.AreEqual("CUSTOM_VARIABLE=value", task.EnvironmentVariables[1]);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_DoesNotOverrideExplicitDotnetRoot()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.EnvironmentVariables = ["DOTNET_ROOT=explicit"];
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNotNull(task.EnvironmentVariables);
+        Assert.HasCount(2, task.EnvironmentVariables);
+        Assert.AreEqual($"{GetDotnetRootArchitectureVariableName()}=", task.EnvironmentVariables[0]);
+        Assert.AreEqual("DOTNET_ROOT=explicit", task.EnvironmentVariables[1]);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_DoesNotOverrideExplicitArchitectureSpecificDotnetRoot()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        string explicitVariable = $"{GetDotnetRootArchitectureVariableName()}=explicit";
+        task.EnvironmentVariables = [explicitVariable];
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNotNull(task.EnvironmentVariables);
+        Assert.HasCount(1, task.EnvironmentVariables);
+        Assert.AreEqual(explicitVariable, task.EnvironmentVariables[0]);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_DoesNothingWhenDisabled()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.TestingPlatformDisableAppHostDotnetRoot = true;
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNull(task.EnvironmentVariables);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_DoesNothingWithoutAppHost()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.UseAppHost = new TaskItem("false");
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNull(task.EnvironmentVariables);
+    }
+
+    [TestMethod]
+    public void AddAppHostDotnetRootEnvironmentVariable_DoesNothingForIncompatibleArchitecture()
+    {
+        using AppHostTaskFixture fixture = new();
+        TestableInvokeTestingPlatformTask task = fixture.CreateTask();
+        task.TestArchitecture = new TaskItem(RuntimeInformation.ProcessArchitecture is Architecture.X64 or Architecture.X86 ? "arm64" : "x64");
+
+        task.InvokeAddAppHostDotnetRootEnvironmentVariable();
+
+        Assert.IsNull(task.EnvironmentVariables);
+    }
+
+    [TestMethod]
+    [DataRow("X86", true, true, true)]
+    [DataRow("X86", true, false, false)]
+    [DataRow("X86", false, true, false)]
+    [DataRow("X64", true, true, false)]
+    public void IsWindowsX86ProcessOn64BitOperatingSystem_ReturnsExpectedResult(
+        string architecture,
+        bool isWindows,
+        bool is64BitOperatingSystem,
+        bool expected)
+        => Assert.AreEqual(
+            expected,
+            InvokeTestingPlatformTask.IsWindowsX86ProcessOn64BitOperatingSystem(
+                Enum.Parse<Architecture>(architecture),
+                isWindows,
+                is64BitOperatingSystem));
+
+    private static string GetDotnetRootArchitectureVariableName()
+        => $"DOTNET_ROOT_{RuntimeInformation.ProcessArchitecture.ToString().ToUpperInvariant()}";
+
     private sealed class TestableInvokeTestingPlatformTask : InvokeTestingPlatformTask
     {
         // MSBuild is the one that normally supplies the [Required] inputs; stub them out here so the test can focus
@@ -76,6 +177,7 @@ public sealed class InvokeTestingPlatformTaskTests
         public TestableInvokeTestingPlatformTask()
             : base(new StubFileSystem())
         {
+            BuildEngine = Mock.Of<IBuildEngine>();
             TargetPath = new TaskItem("MyAssembly.dll");
             TargetFramework = new TaskItem("net9.0");
             TestArchitecture = new TaskItem("x64");
@@ -87,6 +189,38 @@ public sealed class InvokeTestingPlatformTaskTests
 
         public void InvokeLogEventsFromTextOutput(string singleLine)
             => LogEventsFromTextOutput(singleLine, MessageImportance.High);
+
+        public void InvokeAddAppHostDotnetRootEnvironmentVariable()
+            => AddAppHostDotnetRootEnvironmentVariable();
+    }
+
+    private sealed class AppHostTaskFixture : IDisposable
+    {
+        private readonly string _appHostExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
+
+        public AppHostTaskFixture()
+        {
+            Directory.CreateDirectory(DotnetRoot);
+            File.WriteAllText(Path.Combine(DotnetRoot, $"apphost{_appHostExtension}"), string.Empty);
+            File.WriteAllText(Path.Combine(DotnetRoot, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet"), string.Empty);
+        }
+
+        public string DotnetRoot { get; } = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        public TestableInvokeTestingPlatformTask CreateTask()
+            => new()
+            {
+                TargetPath = new TaskItem(Path.Combine(DotnetRoot, $"apphost{_appHostExtension}")),
+                TargetDir = new TaskItem($"{DotnetRoot}{Path.DirectorySeparatorChar}"),
+                AssemblyName = new TaskItem("apphost"),
+                NativeExecutableExtension = new TaskItem(_appHostExtension),
+                UseAppHost = new TaskItem("true"),
+                IsExecutable = new TaskItem("true"),
+                TestArchitecture = new TaskItem(RuntimeInformation.ProcessArchitecture.ToString()),
+                DotnetHostPath = new TaskItem(Path.Combine(DotnetRoot, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet")),
+            };
+
+        public void Dispose() => Directory.Delete(DotnetRoot, recursive: true);
     }
 
     private sealed class StubFileSystem : IFileSystem


### PR DESCRIPTION
## Summary

- derive `DOTNET_ROOT_<ARCH>` from `DOTNET_HOST_PATH` for compatible direct apphost launches
- preserve explicit `TestingPlatformEnvironmentVariable` overrides, including clearing inherited higher-precedence roots when plain `DOTNET_ROOT` is supplied
- add the `TestingPlatformDisableAppHostDotnetRoot` opt-out and cover automatic, override, opt-out, architecture, and Windows x86 behavior

Fixes #10408
