### PR TITLE
Bump .NET SDK for MTP artifact post-processing

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "11.0.100-preview.7.26376.106",
+    "dotnet": "11.0.100-rc.1.26402.102",
     "runtimes": {
       "dotnet": [
         "8.0.29",
@@ -24,7 +24,7 @@
     }
   },
   "sdk": {
-    "version": "11.0.100-preview.7.26376.106",
+    "version": "11.0.100-rc.1.26402.102",
     "paths": [
       ".dotnet",
       "$host$"


### PR DESCRIPTION
## Summary

Bump the pinned .NET SDK from `11.0.100-preview.7.26376.106` to `11.0.100-rc.1.26402.102`.

The previous pin predated most of the MTP artifact post-processing work in the SDK, so this repo was developing and testing its `TrxArtifactPostProcessor` against the first, un-hardened drop.

## What this gains

The SDK-side implementation landed in three commits on `dotnet/sdk` `main`:

| PR | Merged (UTC) | In the new pin? |
| --- | --- | --- |
| dotnet/sdk#55419 — Add MTP artifact post-processing | 2026-07-22 | Yes |
| dotnet/sdk#55480 — Harden MTP artifact post-processing and add an opt-out | 2026-07-27 | Yes |
| dotnet/sdk#55554 — Close SDK-side gaps in MTP artifact post-processing | 2026-07-31 | **No — not yet flowed** |

## Known gap: dotnet/sdk#55554 is not included

`11.0.100-rc.1.26402.102` does **not** contain dotnet/sdk#55554 (`00928de72`). Evidence:

- `.dotnet/sdk/11.0.100-rc.1.26402.102/.version` records VMR commit `322f5005d6589845edf1d69d55820a7d1ab9a09c`.
- `dotnet/dotnet` `src/source-manifest.json` at that VMR commit pins `sdk` to `390f04ee6f9f635962e37ca94269904320745197` (AzDO build `20260730.8`, 2026-07-31 00:25 UTC) — roughly 15 hours *before* dotnet/sdk#55554 merged.
- `GET /repos/dotnet/sdk/compare/390f04ee...00928de72` reports `status=diverged`, so the shipped SDK commit does not contain it.

Corroborating behavior: running a two-project MSTest solution through `dotnet test -- --report-trx` on this SDK does merge the reports, but does not emit the `Merging compatible artifacts produced by different test applications...` message that dotnet/sdk#55554 introduced.

A follow-up bump will be needed once a VMR build carrying `00928de72` is published.

## Note for reviewers

The version band moves from `preview.7` to `rc.1`, which is a larger jump than a date-stamp bump.

## Validation

- `.\build.cmd -bl` — succeeded, 0 warnings, 0 errors
- `.\build.cmd -test -bl` — succeeded, all unit-test projects passed, 0 warnings, 0 errors
- `.\.dotnet\dotnet.exe --version` reports `11.0.100-rc.1.26402.102`
- `.\.dotnet\dotnet.exe test --help` now lists `--no-artifact-post-processing` (added by dotnet/sdk#55480), which was absent on the previous pin
- No Arcade or package-version coordination was required; the change is limited to the two `global.json` fields