### PR TITLE
Publish Azure DevOps retry attempts as sub-results

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsConstants.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsConstants.cs
@@ -49,6 +49,62 @@ internal static class AzureDevOpsConstants
     public const string TestRunIdEnvironmentVariableName = "TESTINGPLATFORM_AZUREDEVOPS_TESTRUNID";
 
     /// <summary>
+    /// Name of the environment variable that carries the path of the file mapping each published test to the
+    /// Azure DevOps result id it was created under, so that a later attempt of the same test updates that
+    /// result instead of publishing a second one for the same test.
+    /// </summary>
+    /// <remarks>
+    /// Set by <see cref="AzureDevOpsTestRunOrchestratorLifetime"/> next to
+    /// <see cref="TestRunIdEnvironmentVariableName"/>. It is a separate variable rather than another field of
+    /// that one on purpose: a process running an older version parses the run id value positionally and
+    /// would reject a longer form, which would send it off to create a run of its own and undo the
+    /// one-run-per-build guarantee. An unknown extra variable is simply ignored instead.
+    /// <para>
+    /// The path (rather than just a directory) comes from the orchestrator because each attempt is given its
+    /// own results directory, so the attempts share no directory of their own. Carrying it also scopes the
+    /// map to a single orchestration: test hosts that merely run alongside each other never see it and keep
+    /// publishing independent results.
+    /// </para>
+    /// <para>
+    /// The value is <c>&lt;buildId&gt;:&lt;path&gt;</c>, with the build id guarding against a stale value
+    /// inherited from an earlier build on a reused agent, exactly as for the run id.
+    /// </para>
+    /// </remarks>
+    public const string ResultMapPathEnvironmentVariableName = "TESTINGPLATFORM_AZUREDEVOPS_RESULTMAP";
+
+    /// <summary>
+    /// Formats the handoff value that tells descendant processes where the result map lives.
+    /// </summary>
+    public static string FormatResultMapPath(int buildId, string path)
+        => $"{buildId.ToString(CultureInfo.InvariantCulture)}:{path}";
+
+    /// <summary>
+    /// Returns the result map path established by an ancestor process for <paramref name="buildId"/>, or
+    /// <see langword="null"/> when there is no map to join.
+    /// </summary>
+    /// <remarks>
+    /// Only the first separator is significant, so a Windows path keeps its drive letter. Anything
+    /// malformed or belonging to another build is treated as absent, which means results are published
+    /// individually — the behaviour that predates reruns, rather than a loss.
+    /// </remarks>
+    public static string? TryGetInheritedResultMapPath(IEnvironment environment, int buildId)
+    {
+        string? value = environment.GetEnvironmentVariable(ResultMapPathEnvironmentVariableName);
+        if (value is null || value.Length == 0)
+        {
+            return null;
+        }
+
+        int separatorIndex = value.IndexOf(':');
+        return separatorIndex <= 0
+            || !int.TryParse(value[..separatorIndex], NumberStyles.Integer, CultureInfo.InvariantCulture, out int inheritedBuildId)
+            || inheritedBuildId != buildId
+            || separatorIndex + 1 >= value.Length
+                ? null
+                : value[(separatorIndex + 1)..];
+    }
+
+    /// <summary>
     /// Formats the handoff value that tells descendant processes which run to publish into.
     /// </summary>
     public static string FormatInheritedTestRunId(int buildId, int runId)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;
@@ -15,6 +15,24 @@ internal static class AzureDevOpsLivePublishingConstants
     public const int MaxRunNameLength = 256;
     public const string NotExecutedTestOutcome = "NotExecuted";
     public const string PassedTestOutcome = "Passed";
+
+    /// <summary>
+    /// Value of <c>resultGroupType</c> that tells Azure DevOps a result is the parent of several attempts
+    /// of the same test rather than a leaf result.
+    /// </summary>
+    /// <remarks>
+    /// Azure DevOps serializes <c>ResultGroupType</c> in camelCase on the wire, so the literal is
+    /// <c>rerun</c> and not <c>Rerun</c>.
+    /// </remarks>
+    public const string RerunResultGroupType = "rerun";
+
+    /// <summary>Maximum number of sub-results Azure DevOps accepts under a single result.</summary>
+    /// <remarks>
+    /// Matches the limit the Azure Pipelines agent enforces client-side before publishing, where exceeding
+    /// it truncates rather than fails. A retry sequence never approaches this, so the cap only guards
+    /// against an unbounded attempt history.
+    /// </remarks>
+    public const int MaxSubResultsPerResult = 1000;
 
     /// <summary>Maximum size (in bytes) of a single attachment uploaded to Azure DevOps. Files larger than this are skipped.</summary>
     public const long MaxAttachmentSizeBytes = 16L * 1024 * 1024;
@@ -74,6 +92,48 @@ internal sealed record AzureDevOpsTestCaseResult(
     [property: JsonPropertyName("errorMessage")] string? ErrorMessage,
     [property: JsonPropertyName("stackTrace")] string? StackTrace,
     [property: JsonPropertyName("startedDate")] DateTimeOffset? StartedDate,
+    [property: JsonPropertyName("completedDate")] DateTimeOffset? CompletedDate)
+{
+    /// <summary>
+    /// Gets the id Azure DevOps assigned to this result, set only when updating an already published result.
+    /// </summary>
+    /// <remarks>
+    /// Declared as properties rather than positional parameters so that adding them does not change the
+    /// record's constructor and deconstructor signatures. All three are absent from a freshly created
+    /// result and are only populated when a retry attempt turns an existing result into a rerun.
+    /// </remarks>
+    [JsonPropertyName("id")]
+    public int? Id { get; init; }
+
+    /// <summary>
+    /// Gets the hierarchy type of the result; <see cref="AzureDevOpsLivePublishingConstants.RerunResultGroupType"/>
+    /// marks it as the parent of several attempts.
+    /// </summary>
+    [JsonPropertyName("resultGroupType")]
+    public string? ResultGroupType { get; init; }
+
+    /// <summary>Gets the individual attempts of this test, oldest first.</summary>
+    [JsonPropertyName("subResults")]
+    public IReadOnlyList<AzureDevOpsTestSubResult>? SubResults { get; init; }
+}
+
+/// <summary>
+/// One attempt of a test that ran more than once, published under the parent result rather than as a
+/// result of its own.
+/// </summary>
+/// <remarks>
+/// <see cref="SequenceId"/> is the attempt ordinal. Azure DevOps documents it only as an "index number",
+/// with no stated requirement to be 1-based or contiguous, but the agent's own publisher emits it that way
+/// and the Tests tab orders attempts by it, so this extension does the same.
+/// </remarks>
+internal sealed record AzureDevOpsTestSubResult(
+    [property: JsonPropertyName("sequenceId")] int SequenceId,
+    [property: JsonPropertyName("displayName")] string DisplayName,
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("durationInMs")] long? DurationInMs,
+    [property: JsonPropertyName("errorMessage")] string? ErrorMessage,
+    [property: JsonPropertyName("stackTrace")] string? StackTrace,
+    [property: JsonPropertyName("startedDate")] DateTimeOffset? StartedDate,
     [property: JsonPropertyName("completedDate")] DateTimeOffset? CompletedDate);
 
 /// <summary>A test case result bundled with optional attachments to upload after the result is published.</summary>
@@ -112,6 +172,18 @@ internal sealed class AzureDevOpsTestResultAttachment
 
     public static AzureDevOpsTestResultAttachment FromString(string content, string fileName, string attachmentType, string? comment = null)
         => new(fileName, attachmentType, comment, filePath: null, inlineContent: content);
+
+    /// <summary>
+    /// Returns a copy of this attachment published under a different file name.
+    /// </summary>
+    /// <remarks>
+    /// Every attempt of a rerun uploads its attachments against the same parent result, where Azure DevOps
+    /// accumulates rather than replaces them. Two attempts would therefore both contribute a
+    /// <c>stdout.log</c>, leaving no way to tell which attempt produced which. Renaming per attempt keeps
+    /// them distinguishable without needing a sub-result id we cannot reliably obtain.
+    /// </remarks>
+    public AzureDevOpsTestResultAttachment WithFileName(string fileName)
+        => new(fileName, AttachmentType, Comment, FilePath, InlineContent);
 }
 
 internal sealed record AzureDevOpsTestResultsPublisherOptions(

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -117,6 +117,8 @@ internal sealed class AzureDevOpsResultIdStore
             [ToSubResult(result, sequenceId: 1)])
         {
             TotalDurationInMs = result.DurationInMs,
+            StartedDate = result.StartedDate,
+            CompletedDate = result.CompletedDate,
         };
         _hasUnsavedChanges = true;
     }
@@ -158,12 +160,16 @@ internal sealed class AzureDevOpsResultIdStore
     public void RecordAttempts(
         AzureDevOpsPublishedResult published,
         IReadOnlyList<AzureDevOpsTestSubResult> attempts,
-        long? totalDurationInMs)
+        long? totalDurationInMs,
+        DateTimeOffset? startedDate,
+        DateTimeOffset? completedDate)
     {
         _results[CreateKey(published.Storage, published.Name, published.Title)] = published with
         {
             Attempts = attempts,
             TotalDurationInMs = totalDurationInMs,
+            StartedDate = startedDate,
+            CompletedDate = completedDate,
         };
         _hasUnsavedChanges = true;
         _hasAdvancedExistingHistory = true;
@@ -243,6 +249,8 @@ internal sealed class AzureDevOpsResultIdStore
                 entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Title, published.Id, published.Attempts)
                 {
                     TotalDurationInMs = published.TotalDurationInMs,
+                    StartedDate = published.StartedDate,
+                    CompletedDate = published.CompletedDate,
                 };
             }
 
@@ -363,6 +371,8 @@ internal sealed class AzureDevOpsResultIdStore
                         _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts)
                         {
                             TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
+                            StartedDate = entry.StartedDate ?? GetEarliestStartedDate(entry.Attempts),
+                            CompletedDate = entry.CompletedDate ?? GetLatestCompletedDate(entry.Attempts),
                         };
                         keyByResultId[entry.Id] = key;
                         resultIdByKey[key] = entry.Id;
@@ -428,6 +438,12 @@ internal sealed class AzureDevOpsResultIdStore
                 ? left
                 : right.Value > long.MaxValue - left.Value ? long.MaxValue : left.Value + right.Value;
 
+    private static DateTimeOffset? GetEarliestStartedDate(IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+        => attempts.Where(attempt => attempt.StartedDate is not null).Min(attempt => attempt.StartedDate);
+
+    private static DateTimeOffset? GetLatestCompletedDate(IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+        => attempts.Where(attempt => attempt.CompletedDate is not null).Max(attempt => attempt.CompletedDate);
+
     private void TryDeleteFile(string path)
     {
         try
@@ -481,6 +497,10 @@ internal sealed record AzureDevOpsPublishedResult(
     IReadOnlyList<AzureDevOpsTestSubResult> Attempts)
 {
     public long? TotalDurationInMs { get; init; }
+
+    public DateTimeOffset? StartedDate { get; init; }
+
+    public DateTimeOffset? CompletedDate { get; init; }
 }
 
 /// <summary>
@@ -500,6 +520,12 @@ internal sealed record AzureDevOpsResultMapEntry(
 {
     [JsonPropertyName("totalDurationInMs")]
     public long? TotalDurationInMs { get; init; }
+
+    [JsonPropertyName("startedDate")]
+    public DateTimeOffset? StartedDate { get; init; }
+
+    [JsonPropertyName("completedDate")]
+    public DateTimeOffset? CompletedDate { get; init; }
 }
 
 /// <summary>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -132,6 +132,18 @@ internal sealed class AzureDevOpsResultIdStore
     }
 
     /// <summary>
+    /// Removes history that can no longer be safely persisted after an ambiguous PATCH failure.
+    /// </summary>
+    /// <remarks>
+    /// The persisted map was deleted before PATCH. If the request then fails after reaching Azure DevOps,
+    /// retaining the pre-PATCH history would let a later save resurrect stale state and overwrite an
+    /// accepted attempt. The result remains in Azure DevOps; forgetting it here makes the next publish use
+    /// a separate POST instead.
+    /// </remarks>
+    public void Forget(AzureDevOpsPublishedResult published)
+        => _results.Remove(CreateKey(published.Storage, published.Name));
+
+    /// <summary>
     /// Removes the persisted map before an existing result is updated.
     /// </summary>
     /// <remarks>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -273,11 +273,12 @@ internal sealed class AzureDevOpsResultIdStore
                 return;
             }
 
-            foreach (AzureDevOpsResultMapEntry entry in map.Results)
+            foreach (AzureDevOpsResultMapEntry? entry in map.Results)
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
                 // annotated: a truncated or hand-edited file can yield nulls and non-positive ids.
-                if (entry.Id > 0
+                if (entry is not null
+                    && entry.Id > 0
                     && entry.Storage is { Length: > 0 } storage
                     && entry.Name is { Length: > 0 } name
                     && entry.Title is { Length: > 0 } title

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -53,8 +53,8 @@ internal sealed class AzureDevOpsResultIdStore
     private readonly int _buildId;
     private readonly int _runId;
 
-    // Keyed by (storage, name) because automatedTestName is TestNode.Uid.Value, which is only unique
-    // within a test application: two assemblies in one build can legitimately use the same uid.
+    // Keyed by (storage, name, title): automatedTestName is TestNode.Uid.Value, which can be shared by
+    // several folded data-driven rows. The title carries the row identity within that test application.
     private readonly Dictionary<string, AzureDevOpsPublishedResult> _results = [];
 
     private bool _hasUnsavedChanges;
@@ -83,7 +83,7 @@ internal sealed class AzureDevOpsResultIdStore
     /// Returns what is already published for a test, or <see langword="null"/> when this build has not seen it.
     /// </summary>
     public AzureDevOpsPublishedResult? TryGet(AzureDevOpsTestCaseResult result)
-        => _results.TryGetValue(CreateKey(result.AutomatedTestStorage, result.AutomatedTestName), out AzureDevOpsPublishedResult? published)
+        => _results.TryGetValue(CreateKey(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle), out AzureDevOpsPublishedResult? published)
             ? published
             : null;
 
@@ -92,8 +92,8 @@ internal sealed class AzureDevOpsResultIdStore
     /// </summary>
     public void RecordCreated(AzureDevOpsTestCaseResult result, int resultId)
     {
-        _results[CreateKey(result.AutomatedTestStorage, result.AutomatedTestName)] =
-            new AzureDevOpsPublishedResult(result.AutomatedTestStorage, result.AutomatedTestName, resultId, [ToSubResult(result, sequenceId: 1)]);
+        _results[CreateKey(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle)] =
+            new AzureDevOpsPublishedResult(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle, resultId, [ToSubResult(result, sequenceId: 1)]);
         _hasUnsavedChanges = true;
     }
 
@@ -126,7 +126,7 @@ internal sealed class AzureDevOpsResultIdStore
     /// </summary>
     public void RecordAttempts(AzureDevOpsPublishedResult published, IReadOnlyList<AzureDevOpsTestSubResult> attempts)
     {
-        _results[CreateKey(published.Storage, published.Name)] = published with { Attempts = attempts };
+        _results[CreateKey(published.Storage, published.Name, published.Title)] = published with { Attempts = attempts };
         _hasUnsavedChanges = true;
         _hasAdvancedExistingHistory = true;
     }
@@ -141,7 +141,7 @@ internal sealed class AzureDevOpsResultIdStore
     /// a separate POST instead.
     /// </remarks>
     public void Forget(AzureDevOpsPublishedResult published)
-        => _results.Remove(CreateKey(published.Storage, published.Name));
+        => _results.Remove(CreateKey(published.Storage, published.Name, published.Title));
 
     /// <summary>
     /// Removes the persisted map before an existing result is updated.
@@ -202,7 +202,7 @@ internal sealed class AzureDevOpsResultIdStore
             int index = 0;
             foreach (AzureDevOpsPublishedResult published in _results.Values)
             {
-                entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Id, published.Attempts);
+                entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Title, published.Id, published.Attempts);
             }
 
             string json = JsonSerializer.Serialize(new AzureDevOpsResultMapFile(_buildId, _runId, entries), JsonSerializerOptions);
@@ -277,10 +277,13 @@ internal sealed class AzureDevOpsResultIdStore
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
                 // annotated: a truncated or hand-edited file can yield nulls and non-positive ids.
-                if (entry is { Id: > 0, Storage: { Length: > 0 } storage, Name: { Length: > 0 } name }
+                if (entry.Id > 0
+                    && entry.Storage is { Length: > 0 } storage
+                    && entry.Name is { Length: > 0 } name
+                    && entry.Title is { Length: > 0 } title
                     && IsValidAttemptHistory(entry.Attempts))
                 {
-                    _results[CreateKey(storage, name)] = new AzureDevOpsPublishedResult(storage, name, entry.Id, entry.Attempts);
+                    _results[CreateKey(storage, name, title)] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts);
                 }
             }
         }
@@ -308,6 +311,7 @@ internal sealed class AzureDevOpsResultIdStore
             if (attempt is null
                 || attempt.SequenceId <= previousSequenceId
                 || attempt.DisplayName is null
+                || attempt.DurationInMs is < 0
                 || attempt.Outcome is not (
                     AzureDevOpsLivePublishingConstants.PassedTestOutcome
                     or AzureDevOpsLivePublishingConstants.FailedTestOutcome
@@ -363,14 +367,15 @@ internal sealed class AzureDevOpsResultIdStore
     /// character, including whatever separator we might otherwise pick, and two different tests must never
     /// produce the same key or one would be published as a rerun of the other.
     /// </remarks>
-    private static string CreateKey(string storage, string name)
-        => $"{storage.Length.ToString(CultureInfo.InvariantCulture)}:{storage.ToLowerInvariant()}:{name}";
+    private static string CreateKey(string storage, string name, string title)
+        => $"{storage.Length.ToString(CultureInfo.InvariantCulture)}:{storage.ToLowerInvariant()}:{name.Length.ToString(CultureInfo.InvariantCulture)}:{name}:{title}";
 }
 
 /// <summary>A test already published to the run, with every attempt seen so far.</summary>
 internal sealed record AzureDevOpsPublishedResult(
     string Storage,
     string Name,
+    string Title,
     int Id,
     IReadOnlyList<AzureDevOpsTestSubResult> Attempts);
 
@@ -385,6 +390,7 @@ internal sealed record AzureDevOpsPublishedResult(
 internal sealed record AzureDevOpsResultMapEntry(
     [property: JsonPropertyName("storage")] string? Storage,
     [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("title")] string? Title,
     [property: JsonPropertyName("id")] int Id,
     [property: JsonPropertyName("attempts")] IReadOnlyList<AzureDevOpsTestSubResult>? Attempts);
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -108,7 +108,8 @@ internal sealed class AzureDevOpsResultIdStore
     /// </remarks>
     public static IReadOnlyList<AzureDevOpsTestSubResult> BuildNextAttempts(AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResult result)
     {
-        List<AzureDevOpsTestSubResult> attempts = [.. published.Attempts, ToSubResult(result, published.Attempts.Count + 1)];
+        int nextSequenceId = published.Attempts.Count == 0 ? 1 : published.Attempts[^1].SequenceId + 1;
+        List<AzureDevOpsTestSubResult> attempts = [.. published.Attempts, ToSubResult(result, nextSequenceId)];
 
         // Azure DevOps caps sub-results per result; keep the most recent attempts because they are the ones
         // that explain the parent outcome. A retry sequence never gets close to this.

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -403,6 +403,7 @@ internal sealed class AzureDevOpsResultIdStore
         {
             if (attempt is null
                 || attempt.SequenceId <= previousSequenceId
+                || attempt.SequenceId == int.MaxValue
                 || attempt.DisplayName is null
                 || attempt.DurationInMs is < 0
                 || attempt.Outcome is not (

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -154,13 +154,11 @@ internal sealed class AzureDevOpsResultIdStore
     /// </remarks>
     public bool TryInvalidatePersistedMap()
     {
-        if (!_fileSystem.ExistFile(_filePath))
-        {
-            return true;
-        }
-
         try
         {
+            // DeleteFile is a no-op when the file is absent. Do not probe with ExistFile first: File.Exists
+            // also returns false for access and path errors, which would fail this safety gate open and
+            // allow PATCH to proceed while stale history may still be present.
             _fileSystem.DeleteFile(_filePath);
             return true;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -114,7 +114,10 @@ internal sealed class AzureDevOpsResultIdStore
             result.AutomatedTestName,
             result.TestCaseTitle,
             resultId,
-            [ToSubResult(result, sequenceId: 1)]);
+            [ToSubResult(result, sequenceId: 1)])
+        {
+            TotalDurationInMs = result.DurationInMs,
+        };
         _hasUnsavedChanges = true;
     }
 
@@ -143,11 +146,25 @@ internal sealed class AzureDevOpsResultIdStore
     }
 
     /// <summary>
+    /// Returns the total duration after <paramref name="result"/> is added, including attempts no longer
+    /// retained in the capped sub-result list.
+    /// </summary>
+    public static long? BuildNextTotalDuration(AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResult result)
+        => AddDurations(published.TotalDurationInMs ?? SumDurations(published.Attempts), result.DurationInMs);
+
+    /// <summary>
     /// Records an attempt history that Azure DevOps has accepted.
     /// </summary>
-    public void RecordAttempts(AzureDevOpsPublishedResult published, IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+    public void RecordAttempts(
+        AzureDevOpsPublishedResult published,
+        IReadOnlyList<AzureDevOpsTestSubResult> attempts,
+        long? totalDurationInMs)
     {
-        _results[CreateKey(published.Storage, published.Name, published.Title)] = published with { Attempts = attempts };
+        _results[CreateKey(published.Storage, published.Name, published.Title)] = published with
+        {
+            Attempts = attempts,
+            TotalDurationInMs = totalDurationInMs,
+        };
         _hasUnsavedChanges = true;
         _hasAdvancedExistingHistory = true;
     }
@@ -223,7 +240,10 @@ internal sealed class AzureDevOpsResultIdStore
             int index = 0;
             foreach (AzureDevOpsPublishedResult published in _results.Values)
             {
-                entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Title, published.Id, published.Attempts);
+                entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Title, published.Id, published.Attempts)
+                {
+                    TotalDurationInMs = published.TotalDurationInMs,
+                };
             }
 
             string json = JsonSerializer.Serialize(new AzureDevOpsResultMapFile(_buildId, _runId, entries), JsonSerializerOptions);
@@ -333,7 +353,17 @@ internal sealed class AzureDevOpsResultIdStore
                     }
                     else
                     {
-                        _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts);
+                        long? retainedDuration = SumDurations(entry.Attempts);
+                        if (entry.TotalDurationInMs is < 0
+                            || (entry.TotalDurationInMs is { } totalDuration && retainedDuration is { } retained && totalDuration < retained))
+                        {
+                            continue;
+                        }
+
+                        _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts)
+                        {
+                            TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
+                        };
                         keyByResultId[entry.Id] = key;
                         resultIdByKey[key] = entry.Id;
                     }
@@ -379,6 +409,24 @@ internal sealed class AzureDevOpsResultIdStore
 
         return true;
     }
+
+    private static long? SumDurations(IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+    {
+        long? total = null;
+        foreach (AzureDevOpsTestSubResult attempt in attempts)
+        {
+            total = AddDurations(total, attempt.DurationInMs);
+        }
+
+        return total;
+    }
+
+    private static long? AddDurations(long? left, long? right)
+        => left is null
+            ? right
+            : right is null
+                ? left
+                : right.Value > long.MaxValue - left.Value ? long.MaxValue : left.Value + right.Value;
 
     private void TryDeleteFile(string path)
     {
@@ -430,7 +478,10 @@ internal sealed record AzureDevOpsPublishedResult(
     string Name,
     string Title,
     int Id,
-    IReadOnlyList<AzureDevOpsTestSubResult> Attempts);
+    IReadOnlyList<AzureDevOpsTestSubResult> Attempts)
+{
+    public long? TotalDurationInMs { get; init; }
+}
 
 /// <summary>
 /// On-disk shape of one map entry.
@@ -445,7 +496,11 @@ internal sealed record AzureDevOpsResultMapEntry(
     [property: JsonPropertyName("name")] string? Name,
     [property: JsonPropertyName("title")] string? Title,
     [property: JsonPropertyName("id")] int Id,
-    [property: JsonPropertyName("attempts")] IReadOnlyList<AzureDevOpsTestSubResult>? Attempts);
+    [property: JsonPropertyName("attempts")] IReadOnlyList<AzureDevOpsTestSubResult>? Attempts)
+{
+    [JsonPropertyName("totalDurationInMs")]
+    public long? TotalDurationInMs { get; init; }
+}
 
 /// <summary>
 /// On-disk shape of the result map.

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -60,6 +60,7 @@ internal sealed class AzureDevOpsResultIdStore
 
     private bool _hasUnsavedChanges;
     private bool _hasAdvancedExistingHistory;
+    private bool _canPersist = true;
 
     private AzureDevOpsResultIdStore(IFileSystem fileSystem, ILogger logger, string filePath, int buildId, int runId)
     {
@@ -232,7 +233,7 @@ internal sealed class AzureDevOpsResultIdStore
     {
         // Nothing was published, so there is nothing for the next attempt to merge into. Writing an empty
         // map would only leave a file behind in the results directory.
-        if (!_hasUnsavedChanges)
+        if (!_hasUnsavedChanges || !_canPersist)
         {
             return;
         }
@@ -314,17 +315,17 @@ internal sealed class AzureDevOpsResultIdStore
             string content = await _fileSystem.ReadAllTextAsync(_filePath).ConfigureAwait(false);
             AzureDevOpsResultMapFile? map = JsonSerializer.Deserialize<AzureDevOpsResultMapFile>(content, JsonSerializerOptions);
 
-            // Result ids are scoped by run, not only by build. A map left behind by another run would
-            // address unrelated results even when it belongs to the same build (for example after a
-            // crashed orchestration whose process id was later reused). Start over instead.
+            // Result ids are scoped by run, not only by build. A map left behind by another run is foreign
+            // state: ignore it and never overwrite its path when this session later creates results.
             if (map?.Results is null || map.BuildId != _buildId || map.RunId != _runId)
             {
+                _canPersist = false;
                 return;
             }
 
-            Dictionary<int, string> keyByResultId = [];
-            Dictionary<string, int> resultIdByKey = [];
-            HashSet<int> ambiguousResultIds = [];
+            var candidates = new List<(AzureDevOpsResultMapEntry Entry, string Key, long? RetainedDuration)>();
+            Dictionary<string, int> keyCounts = [];
+            Dictionary<int, int> resultIdCounts = [];
             foreach (AzureDevOpsResultMapEntry? entry in map.Results)
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
@@ -337,47 +338,33 @@ internal sealed class AzureDevOpsResultIdStore
                     && IsValidAttemptHistory(entry.Attempts))
                 {
                     string key = CreateKey(storage, name, title);
-                    if (ambiguousResultIds.Contains(entry.Id) || _ambiguousKeys.Contains(key))
+                    long? retainedDuration = SumDurations(entry.Attempts);
+                    if (entry.TotalDurationInMs is < 0
+                        || (entry.TotalDurationInMs is { } totalDuration && retainedDuration is { } retained && totalDuration < retained))
                     {
                         continue;
                     }
 
-                    if (keyByResultId.TryGetValue(entry.Id, out string? previousKey))
-                    {
-                        _results.Remove(previousKey);
-                        resultIdByKey.Remove(previousKey);
-                        _ambiguousKeys.Add(previousKey);
-                        _ambiguousKeys.Add(key);
-                        ambiguousResultIds.Add(entry.Id);
-                    }
-                    else if (resultIdByKey.TryGetValue(key, out int previousResultId))
-                    {
-                        _results.Remove(key);
-                        keyByResultId.Remove(previousResultId);
-                        resultIdByKey.Remove(key);
-                        _ambiguousKeys.Add(key);
-                        ambiguousResultIds.Add(previousResultId);
-                        ambiguousResultIds.Add(entry.Id);
-                    }
-                    else
-                    {
-                        long? retainedDuration = SumDurations(entry.Attempts);
-                        if (entry.TotalDurationInMs is < 0
-                            || (entry.TotalDurationInMs is { } totalDuration && retainedDuration is { } retained && totalDuration < retained))
-                        {
-                            continue;
-                        }
-
-                        _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts)
-                        {
-                            TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
-                            StartedDate = entry.StartedDate ?? GetEarliestStartedDate(entry.Attempts),
-                            CompletedDate = entry.CompletedDate ?? GetLatestCompletedDate(entry.Attempts),
-                        };
-                        keyByResultId[entry.Id] = key;
-                        resultIdByKey[key] = entry.Id;
-                    }
+                    candidates.Add((entry, key, retainedDuration));
+                    keyCounts[key] = keyCounts.TryGetValue(key, out int keyCount) ? keyCount + 1 : 1;
+                    resultIdCounts[entry.Id] = resultIdCounts.TryGetValue(entry.Id, out int idCount) ? idCount + 1 : 1;
                 }
+            }
+
+            foreach ((AzureDevOpsResultMapEntry entry, string key, long? retainedDuration) in candidates)
+            {
+                if (keyCounts[key] != 1 || resultIdCounts[entry.Id] != 1)
+                {
+                    _ambiguousKeys.Add(key);
+                    continue;
+                }
+
+                _results[key] = new AzureDevOpsPublishedResult(entry.Storage!, entry.Name!, entry.Title!, entry.Id, entry.Attempts!)
+                {
+                    TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
+                    StartedDate = entry.StartedDate ?? GetEarliestStartedDate(entry.Attempts!),
+                    CompletedDate = entry.CompletedDate ?? GetLatestCompletedDate(entry.Attempts!),
+                };
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -294,6 +294,9 @@ internal sealed class AzureDevOpsResultIdStore
                 return;
             }
 
+            Dictionary<int, string> keyByResultId = [];
+            Dictionary<string, int> resultIdByKey = [];
+            HashSet<int> ambiguousResultIds = [];
             foreach (AzureDevOpsResultMapEntry? entry in map.Results)
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
@@ -306,13 +309,33 @@ internal sealed class AzureDevOpsResultIdStore
                     && IsValidAttemptHistory(entry.Attempts))
                 {
                     string key = CreateKey(storage, name, title);
-                    if (_results.Remove(key))
+                    if (ambiguousResultIds.Contains(entry.Id) || _ambiguousKeys.Contains(key))
                     {
-                        _ambiguousKeys.Add(key);
+                        continue;
                     }
-                    else if (!_ambiguousKeys.Contains(key))
+
+                    if (keyByResultId.TryGetValue(entry.Id, out string? previousKey))
+                    {
+                        _results.Remove(previousKey);
+                        resultIdByKey.Remove(previousKey);
+                        _ambiguousKeys.Add(previousKey);
+                        _ambiguousKeys.Add(key);
+                        ambiguousResultIds.Add(entry.Id);
+                    }
+                    else if (resultIdByKey.TryGetValue(key, out int previousResultId))
+                    {
+                        _results.Remove(key);
+                        keyByResultId.Remove(previousResultId);
+                        resultIdByKey.Remove(key);
+                        _ambiguousKeys.Add(key);
+                        ambiguousResultIds.Add(previousResultId);
+                        ambiguousResultIds.Add(entry.Id);
+                    }
+                    else
                     {
                         _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts);
+                        keyByResultId[entry.Id] = key;
+                        resultIdByKey[key] = entry.Id;
                     }
                 }
             }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -51,27 +51,30 @@ internal sealed class AzureDevOpsResultIdStore
     private readonly ILogger _logger;
     private readonly string _filePath;
     private readonly int _buildId;
+    private readonly int _runId;
 
     // Keyed by (storage, name) because automatedTestName is TestNode.Uid.Value, which is only unique
     // within a test application: two assemblies in one build can legitimately use the same uid.
     private readonly Dictionary<string, AzureDevOpsPublishedResult> _results = [];
 
     private bool _hasUnsavedChanges;
+    private bool _hasAdvancedExistingHistory;
 
-    private AzureDevOpsResultIdStore(IFileSystem fileSystem, ILogger logger, string filePath, int buildId)
+    private AzureDevOpsResultIdStore(IFileSystem fileSystem, ILogger logger, string filePath, int buildId, int runId)
     {
         _fileSystem = fileSystem;
         _logger = logger;
         _filePath = filePath;
         _buildId = buildId;
+        _runId = runId;
     }
 
     /// <summary>
     /// Opens the store at <paramref name="filePath"/>, reading any state earlier attempts left behind.
     /// </summary>
-    public static async Task<AzureDevOpsResultIdStore> OpenAsync(IFileSystem fileSystem, ILogger logger, string filePath, int buildId)
+    public static async Task<AzureDevOpsResultIdStore> OpenAsync(IFileSystem fileSystem, ILogger logger, string filePath, int buildId, int runId)
     {
-        AzureDevOpsResultIdStore store = new(fileSystem, logger, filePath, buildId);
+        AzureDevOpsResultIdStore store = new(fileSystem, logger, filePath, buildId, runId);
         await store.LoadAsync().ConfigureAwait(false);
         return store;
     }
@@ -124,6 +127,35 @@ internal sealed class AzureDevOpsResultIdStore
     {
         _results[CreateKey(published.Storage, published.Name)] = published with { Attempts = attempts };
         _hasUnsavedChanges = true;
+        _hasAdvancedExistingHistory = true;
+    }
+
+    /// <summary>
+    /// Removes the persisted map before an existing result is updated.
+    /// </summary>
+    /// <remarks>
+    /// PATCH changes server history in place. If the process dies after Azure DevOps accepts it but before
+    /// the updated map is saved, an old map would let the next attempt replace that history with stale data.
+    /// Deleting first closes that crash window. When deletion is impossible the caller must avoid PATCH and
+    /// create a separate result instead — duplicates are preferable to losing an accepted attempt.
+    /// </remarks>
+    public bool TryInvalidatePersistedMap()
+    {
+        if (!_fileSystem.ExistFile(_filePath))
+        {
+            return true;
+        }
+
+        try
+        {
+            _fileSystem.DeleteFile(_filePath);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {_filePath}: {ex.Message}");
+            return false;
+        }
     }
 
     /// <summary>
@@ -162,7 +194,7 @@ internal sealed class AzureDevOpsResultIdStore
                 entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Id, published.Attempts);
             }
 
-            string json = JsonSerializer.Serialize(new AzureDevOpsResultMapFile(_buildId, entries), JsonSerializerOptions);
+            string json = JsonSerializer.Serialize(new AzureDevOpsResultMapFile(_buildId, _runId, entries), JsonSerializerOptions);
 
             using (IFileStream stream = _fileSystem.NewFileStream(temporaryFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
             using (StreamWriter writer = new(stream.Stream, Utf8EncodingWithoutBom, 1024, leaveOpen: true))
@@ -178,10 +210,21 @@ internal sealed class AzureDevOpsResultIdStore
 
             _fileSystem.MoveFile(temporaryFilePath, _filePath, overwrite: true);
             _hasUnsavedChanges = false;
+            _hasAdvancedExistingHistory = false;
         }
         catch (Exception ex)
         {
             TryDeleteFile(temporaryFilePath);
+
+            // TryInvalidatePersistedMap removes the old map before any PATCH, so this is normally absent.
+            // Keep a still-valid old map after create-only changes: the new results may be duplicated on
+            // the next attempt, but previously known results can still merge correctly. If an existing
+            // history somehow advanced without prior invalidation, remove it rather than risk data loss.
+            if (_hasAdvancedExistingHistory)
+            {
+                TryDeleteFile(_filePath);
+            }
+
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToWriteCoordinationFile} {_filePath}: {ex.Message}");
         }
     }
@@ -211,9 +254,10 @@ internal sealed class AzureDevOpsResultIdStore
             string content = await _fileSystem.ReadAllTextAsync(_filePath).ConfigureAwait(false);
             AzureDevOpsResultMapFile? map = JsonSerializer.Deserialize<AzureDevOpsResultMapFile>(content, JsonSerializerOptions);
 
-            // A map left behind by an unrelated build would send this build's updates at results that
-            // belong to somebody else's run, which Azure DevOps rejects. Start over instead.
-            if (map?.Results is null || map.BuildId != _buildId)
+            // Result ids are scoped by run, not only by build. A map left behind by another run would
+            // address unrelated results even when it belongs to the same build (for example after a
+            // crashed orchestration whose process id was later reused). Start over instead.
+            if (map?.Results is null || map.BuildId != _buildId || map.RunId != _runId)
             {
                 return;
             }
@@ -306,9 +350,11 @@ internal sealed record AzureDevOpsResultMapEntry(
 /// On-disk shape of the result map.
 /// </summary>
 /// <remarks>
-/// Unknown members are ignored on read, so a newer process can add fields without breaking an older one
-/// that takes part in the same build.
+/// Unknown members are ignored on read, so additive fields remain forward-compatible. The build and run
+/// ids are required discriminators: a map that predates either one is deliberately ignored, because result
+/// ids are only meaningful within the run that created them.
 /// </remarks>
 internal sealed record AzureDevOpsResultMapFile(
     [property: JsonPropertyName("buildId")] int BuildId,
+    [property: JsonPropertyName("runId")] int RunId,
     [property: JsonPropertyName("results")] IReadOnlyList<AzureDevOpsResultMapEntry>? Results);

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -209,7 +209,7 @@ internal sealed class AzureDevOpsResultIdStore
 #endif
             }
 
-            _fileSystem.MoveFile(temporaryFilePath, _filePath, overwrite: true);
+            _fileSystem.ReplaceFile(temporaryFilePath, _filePath);
             _hasUnsavedChanges = false;
             _hasAdvancedExistingHistory = false;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Security;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -207,7 +208,7 @@ internal sealed class AzureDevOpsResultIdStore
             _fileSystem.DeleteFile(_filePath);
             return true;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
         {
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {_filePath}: {ex.Message}");
             return false;
@@ -334,10 +335,20 @@ internal sealed class AzureDevOpsResultIdStore
                     && entry.Id > 0
                     && entry.Storage is { Length: > 0 } storage
                     && entry.Name is { Length: > 0 } name
-                    && entry.Title is { Length: > 0 } title
-                    && IsValidAttemptHistory(entry.Attempts))
+                    && entry.Title is { Length: > 0 } title)
                 {
                     string key = CreateKey(storage, name, title);
+                    keyCounts[key] = keyCounts.TryGetValue(key, out int keyCount) ? keyCount + 1 : 1;
+                    resultIdCounts[entry.Id] = resultIdCounts.TryGetValue(entry.Id, out int idCount) ? idCount + 1 : 1;
+
+                    // Count usable identities before validating payload fields. An invalid entry still
+                    // makes its key and result id ambiguous; accepting another entry that claims either
+                    // would guess ownership from untrusted data.
+                    if (!IsValidAttemptHistory(entry.Attempts))
+                    {
+                        continue;
+                    }
+
                     long? retainedDuration = SumDurations(entry.Attempts);
                     if (entry.TotalDurationInMs is < 0
                         || (entry.TotalDurationInMs is { } totalDuration && retainedDuration is { } retained && totalDuration < retained))
@@ -346,8 +357,6 @@ internal sealed class AzureDevOpsResultIdStore
                     }
 
                     candidates.Add((entry, key, retainedDuration));
-                    keyCounts[key] = keyCounts.TryGetValue(key, out int keyCount) ? keyCount + 1 : 1;
-                    resultIdCounts[entry.Id] = resultIdCounts.TryGetValue(entry.Id, out int idCount) ? idCount + 1 : 1;
                 }
             }
 
@@ -367,7 +376,7 @@ internal sealed class AzureDevOpsResultIdStore
                 };
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException or JsonException)
         {
             // Degrade to an empty map: every test looks unseen and is published as its own result, which
             // is the behaviour that predates reruns. Losing the merge is acceptable; losing results is not.
@@ -441,7 +450,7 @@ internal sealed class AzureDevOpsResultIdStore
                 _fileSystem.DeleteFile(path);
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
         {
             // Leaving a temporary file behind is harmless; it is never read.
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -1,0 +1,314 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+
+namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
+
+/// <summary>
+/// Remembers which Azure DevOps result id a test was published under, and the attempts published so far,
+/// so that a later attempt of the same test updates that result instead of adding a second one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The mapping has to cross process boundaries: each <c>--retry-failed-tests</c> attempt runs in its own
+/// test host, so the process that publishes attempt 2 is not the one that published attempt 1. Environment
+/// variables cannot carry it because they are fixed at launch and flow parent-to-child, whereas this is
+/// sibling-to-sibling and produced after launch. A file is therefore the only viable channel.
+/// </para>
+/// <para>
+/// The file deliberately does not live in <see cref="AzureDevOpsPublishConfiguration.ResultsDirectory"/>:
+/// the retry orchestrator gives every attempt its own results directory, so a file written there would be
+/// invisible to the next attempt. The orchestrator picks the path instead and hands it down, which also
+/// scopes the map to one orchestration — two test hosts that merely run concurrently (for example the same
+/// assembly multi-targeted) get different maps and keep publishing independent results, exactly as before.
+/// </para>
+/// <para>
+/// Reads and writes are tolerant by design. Anything unreadable is treated as an empty map, which degrades
+/// to today's behaviour of one result per attempt rather than losing a result. Writes go through a
+/// temporary file so an interrupted write cannot leave a torn map behind.
+/// </para>
+/// <para>
+/// Not thread-safe: the publisher only touches it while holding its flush semaphore, and the attempts of
+/// one orchestration are sequential, so there is never more than one writer.
+/// </para>
+/// </remarks>
+internal sealed class AzureDevOpsResultIdStore
+{
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly UTF8Encoding Utf8EncodingWithoutBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger _logger;
+    private readonly string _filePath;
+    private readonly int _buildId;
+
+    // Keyed by (storage, name) because automatedTestName is TestNode.Uid.Value, which is only unique
+    // within a test application: two assemblies in one build can legitimately use the same uid.
+    private readonly Dictionary<string, AzureDevOpsPublishedResult> _results = [];
+
+    private bool _hasUnsavedChanges;
+
+    private AzureDevOpsResultIdStore(IFileSystem fileSystem, ILogger logger, string filePath, int buildId)
+    {
+        _fileSystem = fileSystem;
+        _logger = logger;
+        _filePath = filePath;
+        _buildId = buildId;
+    }
+
+    /// <summary>
+    /// Opens the store at <paramref name="filePath"/>, reading any state earlier attempts left behind.
+    /// </summary>
+    public static async Task<AzureDevOpsResultIdStore> OpenAsync(IFileSystem fileSystem, ILogger logger, string filePath, int buildId)
+    {
+        AzureDevOpsResultIdStore store = new(fileSystem, logger, filePath, buildId);
+        await store.LoadAsync().ConfigureAwait(false);
+        return store;
+    }
+
+    /// <summary>
+    /// Returns what is already published for a test, or <see langword="null"/> when this build has not seen it.
+    /// </summary>
+    public AzureDevOpsPublishedResult? TryGet(AzureDevOpsTestCaseResult result)
+        => _results.TryGetValue(CreateKey(result.AutomatedTestStorage, result.AutomatedTestName), out AzureDevOpsPublishedResult? published)
+            ? published
+            : null;
+
+    /// <summary>
+    /// Records the result id Azure DevOps assigned to a newly created result, along with its first attempt.
+    /// </summary>
+    public void RecordCreated(AzureDevOpsTestCaseResult result, int resultId)
+    {
+        _results[CreateKey(result.AutomatedTestStorage, result.AutomatedTestName)] =
+            new AzureDevOpsPublishedResult(result.AutomatedTestStorage, result.AutomatedTestName, resultId, [ToSubResult(result, sequenceId: 1)]);
+        _hasUnsavedChanges = true;
+    }
+
+    /// <summary>
+    /// Builds what the attempt history would become if <paramref name="result"/> were published, without
+    /// recording it.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="RecordAttempts"/> so the map is only advanced once Azure DevOps has
+    /// accepted the update. Recording first would double-count the attempt when a failed update is retried,
+    /// leaving the same execution listed twice under the test.
+    /// </remarks>
+    public static IReadOnlyList<AzureDevOpsTestSubResult> BuildNextAttempts(AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResult result)
+    {
+        List<AzureDevOpsTestSubResult> attempts = [.. published.Attempts, ToSubResult(result, published.Attempts.Count + 1)];
+
+        // Azure DevOps caps sub-results per result; keep the most recent attempts because they are the ones
+        // that explain the parent outcome. A retry sequence never gets close to this.
+        if (attempts.Count > AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult)
+        {
+            attempts.RemoveRange(0, attempts.Count - AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult);
+        }
+
+        return attempts;
+    }
+
+    /// <summary>
+    /// Records an attempt history that Azure DevOps has accepted.
+    /// </summary>
+    public void RecordAttempts(AzureDevOpsPublishedResult published, IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+    {
+        _results[CreateKey(published.Storage, published.Name)] = published with { Attempts = attempts };
+        _hasUnsavedChanges = true;
+    }
+
+    /// <summary>
+    /// Persists the map for the next attempt, tolerating any failure to write.
+    /// </summary>
+    /// <remarks>
+    /// Called once per session rather than after every publish: only another process reads the file, and
+    /// the attempts of one orchestration never overlap, so writing it more often would rewrite the whole
+    /// map repeatedly for no benefit.
+    /// <para>
+    /// The results this describes are already in Azure DevOps, so a failed write only costs the next
+    /// attempt the ability to merge into them — it publishes its own result instead, which is what happened
+    /// before reruns were expressed at all. Failing the run over it would be far worse.
+    /// </para>
+    /// </remarks>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "The map payload type is internal, fixed, and controlled by this extension.")]
+    [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "The map payload type is internal, fixed, and controlled by this extension.")]
+    public async Task SaveAsync(CancellationToken cancellationToken)
+    {
+        // Nothing was published, so there is nothing for the next attempt to merge into. Writing an empty
+        // map would only leave a file behind in the results directory.
+        if (!_hasUnsavedChanges)
+        {
+            return;
+        }
+
+        // A temporary file next to the target keeps the move on the same volume, so it stays atomic.
+        string temporaryFilePath = $"{_filePath}.{Guid.NewGuid():N}.tmp";
+
+        try
+        {
+            var entries = new AzureDevOpsResultMapEntry[_results.Count];
+            int index = 0;
+            foreach (AzureDevOpsPublishedResult published in _results.Values)
+            {
+                entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Id, published.Attempts);
+            }
+
+            string json = JsonSerializer.Serialize(new AzureDevOpsResultMapFile(_buildId, entries), JsonSerializerOptions);
+
+            using (IFileStream stream = _fileSystem.NewFileStream(temporaryFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (StreamWriter writer = new(stream.Stream, Utf8EncodingWithoutBom, 1024, leaveOpen: true))
+            {
+#if NET
+                await writer.WriteAsync(json.AsMemory(), cancellationToken).ConfigureAwait(false);
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+#else
+                await writer.WriteAsync(json).ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+#endif
+            }
+
+            _fileSystem.MoveFile(temporaryFilePath, _filePath, overwrite: true);
+            _hasUnsavedChanges = false;
+        }
+        catch (Exception ex)
+        {
+            TryDeleteFile(temporaryFilePath);
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToWriteCoordinationFile} {_filePath}: {ex.Message}");
+        }
+    }
+
+    private static AzureDevOpsTestSubResult ToSubResult(AzureDevOpsTestCaseResult result, int sequenceId)
+        => new(
+            sequenceId,
+            result.TestCaseTitle,
+            result.Outcome,
+            result.DurationInMs,
+            result.ErrorMessage,
+            result.StackTrace,
+            result.StartedDate,
+            result.CompletedDate);
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "The map payload type is internal, fixed, and controlled by this extension.")]
+    [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "The map payload type is internal, fixed, and controlled by this extension.")]
+    private async Task LoadAsync()
+    {
+        try
+        {
+            if (!_fileSystem.ExistFile(_filePath))
+            {
+                return;
+            }
+
+            string content = await _fileSystem.ReadAllTextAsync(_filePath).ConfigureAwait(false);
+            AzureDevOpsResultMapFile? map = JsonSerializer.Deserialize<AzureDevOpsResultMapFile>(content, JsonSerializerOptions);
+
+            // A map left behind by an unrelated build would send this build's updates at results that
+            // belong to somebody else's run, which Azure DevOps rejects. Start over instead.
+            if (map?.Results is null || map.BuildId != _buildId)
+            {
+                return;
+            }
+
+            foreach (AzureDevOpsResultMapEntry entry in map.Results)
+            {
+                // Entries come from disk, so nothing about them is guaranteed however the record is
+                // annotated: a truncated or hand-edited file can yield nulls and non-positive ids.
+                if (entry is { Id: > 0, Storage: { Length: > 0 } storage, Name: { Length: > 0 } name })
+                {
+                    _results[CreateKey(storage, name)] = new AzureDevOpsPublishedResult(storage, name, entry.Id, entry.Attempts ?? []);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // Degrade to an empty map: every test looks unseen and is published as its own result, which
+            // is the behaviour that predates reruns. Losing the merge is acceptable; losing results is not.
+            _results.Clear();
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToReadCoordinationFile} {_filePath}: {ex.Message}");
+        }
+    }
+
+    private void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (_fileSystem.ExistFile(path))
+            {
+                _fileSystem.DeleteFile(path);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Leaving a temporary file behind is harmless; it is never read.
+        }
+    }
+
+    /// <summary>
+    /// Logs a warning, swallowing any failure from the logging providers, for the same reason the
+    /// coordinator does: every caller here is already on a recovery path.
+    /// </summary>
+    private void TryLogWarning(string message)
+    {
+        try
+        {
+            _logger.LogWarning(message);
+        }
+        catch (Exception)
+        {
+            // There is nowhere left to report this: the diagnostic logger is the fallback sink.
+        }
+    }
+
+    /// <summary>
+    /// Compares map keys the way Azure DevOps matches the underlying fields: the storage is a file name, so
+    /// it is matched case-insensitively, while the test name is matched exactly.
+    /// </summary>
+    /// <remarks>
+    /// The storage is length-prefixed so that the two parts cannot run together: a test uid may contain any
+    /// character, including whatever separator we might otherwise pick, and two different tests must never
+    /// produce the same key or one would be published as a rerun of the other.
+    /// </remarks>
+    private static string CreateKey(string storage, string name)
+        => $"{storage.Length.ToString(CultureInfo.InvariantCulture)}:{storage.ToLowerInvariant()}:{name}";
+}
+
+/// <summary>A test already published to the run, with every attempt seen so far.</summary>
+internal sealed record AzureDevOpsPublishedResult(
+    string Storage,
+    string Name,
+    int Id,
+    IReadOnlyList<AzureDevOpsTestSubResult> Attempts);
+
+/// <summary>
+/// On-disk shape of one map entry.
+/// </summary>
+/// <remarks>
+/// Carries its key as ordinary fields rather than being a JSON object keyed by test name, because a test
+/// uid can contain any character and would otherwise need escaping. Every member is nullable because the
+/// file is untrusted input.
+/// </remarks>
+internal sealed record AzureDevOpsResultMapEntry(
+    [property: JsonPropertyName("storage")] string? Storage,
+    [property: JsonPropertyName("name")] string? Name,
+    [property: JsonPropertyName("id")] int Id,
+    [property: JsonPropertyName("attempts")] IReadOnlyList<AzureDevOpsTestSubResult>? Attempts);
+
+/// <summary>
+/// On-disk shape of the result map.
+/// </summary>
+/// <remarks>
+/// Unknown members are ignored on read, so a newer process can add fields without breaking an older one
+/// that takes part in the same build.
+/// </remarks>
+internal sealed record AzureDevOpsResultMapFile(
+    [property: JsonPropertyName("buildId")] int BuildId,
+    [property: JsonPropertyName("results")] IReadOnlyList<AzureDevOpsResultMapEntry>? Results);

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -267,9 +267,10 @@ internal sealed class AzureDevOpsResultIdStore
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
                 // annotated: a truncated or hand-edited file can yield nulls and non-positive ids.
-                if (entry is { Id: > 0, Storage: { Length: > 0 } storage, Name: { Length: > 0 } name })
+                if (entry is { Id: > 0, Storage: { Length: > 0 } storage, Name: { Length: > 0 } name }
+                    && IsValidAttemptHistory(entry.Attempts))
                 {
-                    _results[CreateKey(storage, name)] = new AzureDevOpsPublishedResult(storage, name, entry.Id, entry.Attempts ?? []);
+                    _results[CreateKey(storage, name)] = new AzureDevOpsPublishedResult(storage, name, entry.Id, entry.Attempts);
                 }
             }
         }
@@ -280,6 +281,36 @@ internal sealed class AzureDevOpsResultIdStore
             _results.Clear();
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToReadCoordinationFile} {_filePath}: {ex.Message}");
         }
+    }
+
+    private static bool IsValidAttemptHistory([NotNullWhen(true)] IReadOnlyList<AzureDevOpsTestSubResult>? attempts)
+    {
+        if (attempts is null
+            || attempts.Count == 0
+            || attempts.Count > AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult)
+        {
+            return false;
+        }
+
+        int previousSequenceId = 0;
+        foreach (AzureDevOpsTestSubResult attempt in attempts)
+        {
+            if (attempt is null
+                || attempt.SequenceId <= previousSequenceId
+                || attempt.DisplayName is null
+                || attempt.Outcome is not (
+                    AzureDevOpsLivePublishingConstants.PassedTestOutcome
+                    or AzureDevOpsLivePublishingConstants.FailedTestOutcome
+                    or AzureDevOpsLivePublishingConstants.NotExecutedTestOutcome
+                    or AzureDevOpsLivePublishingConstants.AbortedTestOutcome))
+            {
+                return false;
+            }
+
+            previousSequenceId = attempt.SequenceId;
+        }
+
+        return true;
     }
 
     private void TryDeleteFile(string path)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -56,6 +56,7 @@ internal sealed class AzureDevOpsResultIdStore
     // Keyed by (storage, name, title): automatedTestName is TestNode.Uid.Value, which can be shared by
     // several folded data-driven rows. The title carries the row identity within that test application.
     private readonly Dictionary<string, AzureDevOpsPublishedResult> _results = [];
+    private readonly HashSet<string> _ambiguousKeys = [];
 
     private bool _hasUnsavedChanges;
     private bool _hasAdvancedExistingHistory;
@@ -92,8 +93,28 @@ internal sealed class AzureDevOpsResultIdStore
     /// </summary>
     public void RecordCreated(AzureDevOpsTestCaseResult result, int resultId)
     {
-        _results[CreateKey(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle)] =
-            new AzureDevOpsPublishedResult(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle, resultId, [ToSubResult(result, sequenceId: 1)]);
+        string key = CreateKey(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle);
+        if (_ambiguousKeys.Contains(key))
+        {
+            return;
+        }
+
+        if (_results.Remove(key))
+        {
+            // A folded data-driven test may legally give two rows the same display name. The platform does
+            // not expose a stable row id that survives the next process, and matching by completion order
+            // could attach history to the wrong row. Forget both mappings so later attempts use safe POSTs.
+            _ambiguousKeys.Add(key);
+            _hasUnsavedChanges = true;
+            return;
+        }
+
+        _results[key] = new AzureDevOpsPublishedResult(
+            result.AutomatedTestStorage,
+            result.AutomatedTestName,
+            result.TestCaseTitle,
+            resultId,
+            [ToSubResult(result, sequenceId: 1)]);
         _hasUnsavedChanges = true;
     }
 
@@ -284,7 +305,15 @@ internal sealed class AzureDevOpsResultIdStore
                     && entry.Title is { Length: > 0 } title
                     && IsValidAttemptHistory(entry.Attempts))
                 {
-                    _results[CreateKey(storage, name, title)] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts);
+                    string key = CreateKey(storage, name, title);
+                    if (_results.Remove(key))
+                    {
+                        _ambiguousKeys.Add(key);
+                    }
+                    else if (!_ambiguousKeys.Contains(key))
+                    {
+                        _results[key] = new AzureDevOpsPublishedResult(storage, name, title, entry.Id, entry.Attempts);
+                    }
                 }
             }
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -331,15 +331,25 @@ internal sealed class AzureDevOpsResultIdStore
             {
                 // Entries come from disk, so nothing about them is guaranteed however the record is
                 // annotated: a truncated or hand-edited file can yield nulls and non-positive ids.
-                if (entry is not null
-                    && entry.Id > 0
+                if (entry is null)
+                {
+                    continue;
+                }
+
+                // A malformed key still makes a positive server result id ambiguous. Count IDs before
+                // validating any other field so a later well-formed entry cannot claim that same result.
+                if (entry.Id > 0)
+                {
+                    resultIdCounts[entry.Id] = resultIdCounts.TryGetValue(entry.Id, out int idCount) ? idCount + 1 : 1;
+                }
+
+                if (entry.Id > 0
                     && entry.Storage is { Length: > 0 } storage
                     && entry.Name is { Length: > 0 } name
                     && entry.Title is { Length: > 0 } title)
                 {
                     string key = CreateKey(storage, name, title);
                     keyCounts[key] = keyCounts.TryGetValue(key, out int keyCount) ? keyCount + 1 : 1;
-                    resultIdCounts[entry.Id] = resultIdCounts.TryGetValue(entry.Id, out int idCount) ? idCount + 1 : 1;
 
                     // Count usable identities before validating payload fields. An invalid entry still
                     // makes its key and result id ambiguous; accepting another entry that claims either

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
@@ -33,6 +33,13 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
 
+    private static readonly JsonSerializerOptions UpdateJsonSerializerOptions = new()
+    {
+        // PATCH must send null outcome details explicitly so a passing retry clears the error and stack
+        // trace left by the prior failed attempt. Omitting them would leave those server fields unchanged.
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
     private static readonly HttpClient SharedHttpClient = CreateHttpClient();
 
     private readonly HttpClient _httpClient;
@@ -145,7 +152,8 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
             PatchMethod,
             BuildResultsUri(configuration.CollectionUri, configuration.Project, runId),
             configuration.AccessToken,
-            results);
+            results,
+            UpdateJsonSerializerOptions);
 
         await SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
@@ -304,10 +312,18 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
 
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "Payload types are internal, fixed, and controlled by this extension.")]
     [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Payload types are internal, fixed, and controlled by this extension.")]
-    private static HttpRequestMessage CreateRequest<TPayload>(HttpMethod method, Uri uri, string accessToken, TPayload payload)
+    private static HttpRequestMessage CreateRequest<TPayload>(
+        HttpMethod method,
+        Uri uri,
+        string accessToken,
+        TPayload payload,
+        JsonSerializerOptions? jsonSerializerOptions = null)
     {
         HttpRequestMessage request = CreateRequest(method, uri, accessToken);
-        request.Content = new StringContent(JsonSerializer.Serialize(payload, JsonSerializerOptions), Encoding.UTF8, "application/json");
+        request.Content = new StringContent(
+            JsonSerializer.Serialize(payload, jsonSerializerOptions ?? JsonSerializerOptions),
+            Encoding.UTF8,
+            "application/json");
         return request;
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
@@ -130,6 +130,26 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
         }
     }
 
+    /// <summary>
+    /// Updates results that were already published to the run, folding a further attempt of the same test
+    /// into the result that represents it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does not surface the response body. Azure DevOps returns the updated results, but the
+    /// caller already knows the ids it sent (that is how it addressed them), and the sub-result ids in the
+    /// response are not needed: attachments for every attempt are uploaded against the parent result.
+    /// </remarks>
+    public async Task UpdateTestResultsAsync(AzureDevOpsPublishConfiguration configuration, int runId, IReadOnlyList<AzureDevOpsTestCaseResult> results, CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = CreateRequest(
+            PatchMethod,
+            BuildResultsUri(configuration.CollectionUri, configuration.Project, runId),
+            configuration.AccessToken,
+            results);
+
+        await SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task UploadTestResultAttachmentAsync(AzureDevOpsPublishConfiguration configuration, int runId, int testCaseResultId, AzureDevOpsTestResultAttachment attachment, CancellationToken cancellationToken)
     {
         AttachmentRequest? payload = TryBuildAttachmentRequest(attachment);

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -166,7 +166,13 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 if (creations.Count > 0 && !await TryCreateResultsAsync(creations, deferredAttachments, cancellationToken).ConfigureAwait(false))
                 {
                     // Nothing in this batch reached Azure DevOps: the creations failed, and the updates were
-                    // not attempted. Requeue the batch as it was, so the next flush retries it in order.
+                    // not attempted. Release every parent claimed while classifying this untouched batch,
+                    // then requeue it as it was so the next flush can retry the intended update path.
+                    foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updateCandidates)
+                    {
+                        _claimedResultIds.Remove(published.Id);
+                    }
+
                     RequeueUnsafe(batch);
                     return;
                 }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -280,6 +280,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 Id = updates[i].Published.Id,
                 ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
                 SubResults = attemptHistories[i],
+                DurationInMs = SumDurations(attemptHistories[i]),
             };
         }
 
@@ -365,6 +366,24 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         }
 
         return renamed;
+    }
+
+    private static long? SumDurations(IReadOnlyList<AzureDevOpsTestSubResult> attempts)
+    {
+        long total = 0;
+        bool hasDuration = false;
+        foreach (AzureDevOpsTestSubResult attempt in attempts)
+        {
+            if (attempt.DurationInMs is not { } duration)
+            {
+                continue;
+            }
+
+            hasDuration = true;
+            total = duration > long.MaxValue - total ? long.MaxValue : total + duration;
+        }
+
+        return hasDuration ? total : null;
     }
 
     private async Task UploadAttachmentsForResultAsync(int testCaseResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> attachments, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -187,7 +187,15 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 {
                     RequeueUnsafe([.. updates.Select(update => update.Attempt)]);
                     await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);
-                    return;
+                    if (!force)
+                    {
+                        return;
+                    }
+
+                    // TryUpdateResultsAsync forgot the ambiguous mappings before requeueing. A forced
+                    // session-end flush has no later opportunity, so immediately loop and reclassify these
+                    // attempts as safe creates. Background flushes return to preserve the retry backoff.
+                    continue;
                 }
 
                 await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -234,14 +234,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         // interrupts the best-effort attachment phase.
         for (int i = 0; i < batch.Count; i++)
         {
-            // The retry orchestrator only schedules failed/aborted tests again. Passed and skipped tests
-            // can never be looked up by a later attempt, so retaining them would make memory and map size
-            // grow with the whole suite even when no retry runs.
-            if (_resultIdStore is not null
-                && batch[i].Result.Outcome is AzureDevOpsLivePublishingConstants.FailedTestOutcome or AzureDevOpsLivePublishingConstants.AbortedTestOutcome)
-            {
-                _resultIdStore.RecordCreated(batch[i].Result, resultIds[i]);
-            }
+            // Folded data-driven rows share one uid. A failure in any row retries the whole uid, including
+            // rows that passed or were skipped, so every row must retain its own result id and history.
+            _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
 
             if (batch[i].Attachments.Count > 0)
             {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -168,7 +168,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     // Nothing in this batch reached Azure DevOps: the creations failed, and the updates were
                     // not attempted. Release every parent claimed while classifying this untouched batch,
                     // then requeue it as it was so the next flush can retry the intended update path.
-                    foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updateCandidates)
+                    foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updates)
                     {
                         _claimedResultIds.Remove(published.Id);
                     }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -277,7 +277,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
             if (batch[i].Attachments.Count > 0)
             {
-                deferredAttachments.Add((resultIds[i], batch[i].Attachments));
+                deferredAttachments.Add((
+                    resultIds[i],
+                    _resultIdStore is null ? batch[i].Attachments : RenameForAttempt(batch[i].Attachments, attemptNumber: 1)));
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -273,7 +273,11 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         {
             // Folded data-driven rows share one uid. A failure in any row retries the whole uid, including
             // rows that passed or were skipped, so every row must retain its own result id and history.
-            _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
+            if (_resultIdStore is not null)
+            {
+                _resultIdStore.RecordCreated(batch[i].Result, resultIds[i]);
+                _claimedResultIds.Add(resultIds[i]);
+            }
 
             if (batch[i].Attachments.Count > 0)
             {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -127,6 +127,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 // orchestrated run has a store, so an ordinary run takes the create path for everything.
                 List<AzureDevOpsTestCaseResultWithAttachments> creations = [];
                 List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates = [];
+                List<(int ResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments = [];
                 foreach (AzureDevOpsTestCaseResultWithAttachments item in batch)
                 {
                     if (_resultIdStore?.TryGet(item.Result) is { } published)
@@ -139,7 +140,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     }
                 }
 
-                if (creations.Count > 0 && !await TryCreateResultsAsync(creations, cancellationToken).ConfigureAwait(false))
+                if (creations.Count > 0 && !await TryCreateResultsAsync(creations, deferredAttachments, cancellationToken).ConfigureAwait(false))
                 {
                     // Nothing in this batch reached Azure DevOps: the creations failed, and the updates were
                     // not attempted. Requeue the batch as it was, so the next flush retries it in order.
@@ -153,17 +154,21 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     // stale history for the next attempt to replay. Create separate results instead: less
                     // tidy, but every execution remains represented.
                     List<AzureDevOpsTestCaseResultWithAttachments> updateFallbacks = [.. updates.Select(update => update.Attempt)];
-                    if (!await TryCreateResultsAsync(updateFallbacks, cancellationToken).ConfigureAwait(false))
+                    if (!await TryCreateResultsAsync(updateFallbacks, deferredAttachments, cancellationToken).ConfigureAwait(false))
                     {
                         RequeueUnsafe(updateFallbacks);
+                        await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);
                         return;
                     }
                 }
-                else if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, cancellationToken).ConfigureAwait(false))
+                else if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, deferredAttachments, cancellationToken).ConfigureAwait(false))
                 {
                     RequeueUnsafe([.. updates.Select(update => update.Attempt)]);
+                    await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);
                     return;
                 }
+
+                await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);
             }
         }
         finally
@@ -179,7 +184,10 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
     /// <returns>
     /// <see langword="false"/> when the batch did not reach Azure DevOps and the caller should requeue it.
     /// </returns>
-    private async Task<bool> TryCreateResultsAsync(List<AzureDevOpsTestCaseResultWithAttachments> batch, CancellationToken cancellationToken)
+    private async Task<bool> TryCreateResultsAsync(
+        List<AzureDevOpsTestCaseResultWithAttachments> batch,
+        List<(int ResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments,
+        CancellationToken cancellationToken)
     {
         IReadOnlyList<int>? resultIds;
         try
@@ -227,11 +235,10 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         for (int i = 0; i < batch.Count; i++)
         {
             _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
-        }
-
-        for (int i = 0; i < batch.Count; i++)
-        {
-            await UploadAttachmentsForResultAsync(resultIds[i], batch[i].Attachments, cancellationToken).ConfigureAwait(false);
+            if (batch[i].Attachments.Count > 0)
+            {
+                deferredAttachments.Add((resultIds[i], batch[i].Attachments));
+            }
         }
 
         return true;
@@ -250,6 +257,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
     /// </remarks>
     private async Task<bool> TryUpdateResultsAsync(
         List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates,
+        List<(int ResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments,
         CancellationToken cancellationToken)
     {
         var parents = new AzureDevOpsTestCaseResult[updates.Count];
@@ -293,13 +301,25 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         for (int i = 0; i < updates.Count; i++)
         {
-            await UploadAttachmentsForResultAsync(
-                updates[i].Published.Id,
-                RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i][^1].SequenceId),
-                cancellationToken).ConfigureAwait(false);
+            if (updates[i].Attempt.Attachments.Count > 0)
+            {
+                deferredAttachments.Add((
+                    updates[i].Published.Id,
+                    RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i][^1].SequenceId)));
+            }
         }
 
         return true;
+    }
+
+    private async Task UploadDeferredAttachmentsAsync(
+        List<(int ResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments,
+        CancellationToken cancellationToken)
+    {
+        foreach ((int resultId, IReadOnlyList<AzureDevOpsTestResultAttachment> attachments) in deferredAttachments)
+        {
+            await UploadAttachmentsForResultAsync(resultId, attachments, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -122,87 +122,229 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     return;
                 }
 
-                IReadOnlyList<int>? resultIds;
-                try
+                // A test this build already published is a further attempt at it, not a new test, so it
+                // updates that result instead of adding a second one for the same test. Only an
+                // orchestrated run has a store, so an ordinary run takes the create path for everything.
+                List<AzureDevOpsTestCaseResultWithAttachments> creations = [];
+                List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates = [];
+                foreach (AzureDevOpsTestCaseResultWithAttachments item in batch)
                 {
-                    if (_coordinatedRun is not null && _runIdCoordinator is not null)
+                    if (_resultIdStore?.TryGet(item.Result) is { } published)
                     {
-                        await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
+                        updates.Add((published, item));
                     }
-
-                    var resultsOnly = new AzureDevOpsTestCaseResult[batch.Count];
-                    for (int i = 0; i < batch.Count; i++)
+                    else
                     {
-                        resultsOnly[i] = batch[i].Result;
+                        creations.Add(item);
                     }
-
-                    resultIds = await _client.PublishTestResultsAsync(_publishConfiguration, CurrentRunId.Value, resultsOnly, cancellationToken).ConfigureAwait(false);
-                    _lastFlushTime = _clock.UtcNow;
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
-                {
-                    // Transport/HTTP failure — AzDO may not have accepted the batch, so it's safe to
-                    // requeue and retry. Push results in reverse so Pop retries them in batch order.
-                    for (int i = batch.Count - 1; i >= 0; i--)
-                    {
-                        _retryResults.Push(batch[i]);
-                    }
 
-                    // Reset the interval countdown so a transient failure does not cause a tight retry loop.
-                    _lastFlushTime = _clock.UtcNow;
-                    TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
+                if (creations.Count > 0 && !await TryCreateResultsAsync(creations, cancellationToken).ConfigureAwait(false))
+                {
+                    // Nothing in this batch reached Azure DevOps: the creations failed, and the updates were
+                    // not attempted. Requeue the batch as it was, so the next flush retries it in order.
+                    RequeueUnsafe(batch);
                     return;
                 }
 
-                // POST succeeded. If we couldn't parse the response we cannot upload result-level
-                // attachments for this batch, but we MUST NOT republish (that would create duplicate
-                // result rows in AzDO). Continue with the next batch.
-                if (resultIds is null)
+                if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, cancellationToken).ConfigureAwait(false))
                 {
-                    if (BatchHasAttachments(batch))
-                    {
-                        Interlocked.Add(ref _failedAttachmentCount, CountAttachments(batch));
-                        TryLogWarning(AzureDevOpsResources.AzureDevOpsLivePublishingResultIdParseFailedWarning);
-                    }
-
-                    continue;
-                }
-
-                for (int i = 0; i < batch.Count; i++)
-                {
-                    if (batch[i].Attachments.Count == 0)
-                    {
-                        continue;
-                    }
-
-                    try
-                    {
-                        if (_coordinatedRun is not null && _runIdCoordinator is not null)
-                        {
-                            await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
-                        }
-
-                        await UploadResultAttachmentsAsync(resultIds[i], batch[i].Attachments, cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        // Individual upload failures are already counted inside UploadResultAttachmentsAsync
-                        // (whose logging is non-throwing), so reaching here means RenewLeaseAsync threw and no
-                        // upload was attempted at all. Count the whole set, otherwise these attachments are
-                        // dropped uncounted and the end-of-session summary under-reports.
-                        Interlocked.Add(ref _failedAttachmentCount, batch[i].Attachments.Count);
-                        TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingResultAttachmentFailed} {ex.Message}");
-                    }
+                    RequeueUnsafe([.. updates.Select(update => update.Attempt)]);
+                    return;
                 }
             }
         }
         finally
         {
             _flushSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Publishes results Azure DevOps has not seen in this build yet, recording the ids it assigns them so
+    /// that a later attempt can update them.
+    /// </summary>
+    /// <returns>
+    /// <see langword="false"/> when the batch did not reach Azure DevOps and the caller should requeue it.
+    /// </returns>
+    private async Task<bool> TryCreateResultsAsync(List<AzureDevOpsTestCaseResultWithAttachments> batch, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<int>? resultIds;
+        try
+        {
+            if (_coordinatedRun is not null && _runIdCoordinator is not null)
+            {
+                await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
+            }
+
+            var resultsOnly = new AzureDevOpsTestCaseResult[batch.Count];
+            for (int i = 0; i < batch.Count; i++)
+            {
+                resultsOnly[i] = batch[i].Result;
+            }
+
+            resultIds = await _client.PublishTestResultsAsync(_publishConfiguration!, CurrentRunId!.Value, resultsOnly, cancellationToken).ConfigureAwait(false);
+            _lastFlushTime = _clock.UtcNow;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Transport/HTTP failure — AzDO may not have accepted the batch, so it's safe to requeue and
+            // retry. Reset the interval countdown so a transient failure does not cause a tight retry loop.
+            _lastFlushTime = _clock.UtcNow;
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
+            return false;
+        }
+
+        // POST succeeded. If we couldn't parse the response we cannot upload result-level attachments for
+        // this batch, nor remember the ids for a later attempt, but we MUST NOT republish (that would
+        // create duplicate result rows in AzDO).
+        if (resultIds is null)
+        {
+            if (BatchHasAttachments(batch))
+            {
+                Interlocked.Add(ref _failedAttachmentCount, CountAttachments(batch));
+                TryLogWarning(AzureDevOpsResources.AzureDevOpsLivePublishingResultIdParseFailedWarning);
+            }
+
+            return true;
+        }
+
+        for (int i = 0; i < batch.Count; i++)
+        {
+            _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
+            await UploadAttachmentsForResultAsync(resultIds[i], batch[i].Attachments, cancellationToken).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Folds further attempts into the results that already represent those tests, so that one test that
+    /// ran several times stays one result with the attempts recorded underneath it.
+    /// </summary>
+    /// <remarks>
+    /// The parent takes the latest attempt's outcome and detail, because that is the outcome the test
+    /// ultimately had and the one the pipeline's own exit code already reflects — a test rescued by a retry
+    /// should stop being reported as failed. Azure DevOps computes run metrics from the parent, so this is
+    /// also what decides whether the run is counted as passing. The earlier attempts are not lost: they
+    /// stay visible as sub-results, which is what makes the flakiness apparent.
+    /// </remarks>
+    private async Task<bool> TryUpdateResultsAsync(
+        List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates,
+        CancellationToken cancellationToken)
+    {
+        var parents = new AzureDevOpsTestCaseResult[updates.Count];
+        var attemptHistories = new IReadOnlyList<AzureDevOpsTestSubResult>[updates.Count];
+        for (int i = 0; i < updates.Count; i++)
+        {
+            // Built but not recorded yet: the map may only advance once Azure DevOps has accepted the
+            // update, otherwise retrying a failed update would list the same execution twice.
+            attemptHistories[i] = AzureDevOpsResultIdStore.BuildNextAttempts(updates[i].Published, updates[i].Attempt.Result);
+            parents[i] = updates[i].Attempt.Result with
+            {
+                Id = updates[i].Published.Id,
+                ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
+                SubResults = attemptHistories[i],
+            };
+        }
+
+        try
+        {
+            if (_coordinatedRun is not null && _runIdCoordinator is not null)
+            {
+                await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
+            }
+
+            await _client.UpdateTestResultsAsync(_publishConfiguration!, CurrentRunId!.Value, parents, cancellationToken).ConfigureAwait(false);
+            _lastFlushTime = _clock.UtcNow;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _lastFlushTime = _clock.UtcNow;
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
+            return false;
+        }
+
+        for (int i = 0; i < updates.Count; i++)
+        {
+            _resultIdStore!.RecordAttempts(updates[i].Published, attemptHistories[i]);
+            await UploadAttachmentsForResultAsync(
+                updates[i].Published.Id,
+                RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i].Count),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Qualifies attachment names with the attempt that produced them.
+    /// </summary>
+    /// <remarks>
+    /// Every attempt uploads against the same parent result, where Azure DevOps accumulates attachments
+    /// rather than replacing them, so two attempts would otherwise both contribute a <c>stdout.log</c> with
+    /// no way to tell them apart.
+    /// </remarks>
+    private static IReadOnlyList<AzureDevOpsTestResultAttachment> RenameForAttempt(IReadOnlyList<AzureDevOpsTestResultAttachment> attachments, int attemptNumber)
+    {
+        if (attachments.Count == 0)
+        {
+            return attachments;
+        }
+
+        var renamed = new AzureDevOpsTestResultAttachment[attachments.Count];
+        for (int i = 0; i < attachments.Count; i++)
+        {
+            string fileName = attachments[i].FileName;
+            string extension = Path.GetExtension(fileName);
+            renamed[i] = attachments[i].WithFileName(
+                $"{Path.GetFileNameWithoutExtension(fileName)}.attempt-{attemptNumber.ToString(CultureInfo.InvariantCulture)}{extension}");
+        }
+
+        return renamed;
+    }
+
+    private async Task UploadAttachmentsForResultAsync(int testCaseResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> attachments, CancellationToken cancellationToken)
+    {
+        if (attachments.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_coordinatedRun is not null && _runIdCoordinator is not null)
+            {
+                await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
+            }
+
+            await UploadResultAttachmentsAsync(testCaseResultId, attachments, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Individual upload failures are already counted inside UploadResultAttachmentsAsync (whose
+            // logging is non-throwing), so reaching here means RenewLeaseAsync threw and no upload was
+            // attempted at all. Count the whole set, otherwise these attachments are dropped uncounted and
+            // the end-of-session summary under-reports.
+            Interlocked.Add(ref _failedAttachmentCount, attachments.Count);
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingResultAttachmentFailed} {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Returns results to the front of the queue so the next flush retries them in their original order.
+    /// </summary>
+    /// <remarks>Call only while holding <see cref="_flushSemaphore"/>.</remarks>
+    private void RequeueUnsafe(IReadOnlyList<AzureDevOpsTestCaseResultWithAttachments> batch)
+    {
+        // Pushed in reverse so Pop yields them in batch order.
+        for (int i = batch.Count - 1; i >= 0; i--)
+        {
+            _retryResults.Push(batch[i]);
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -152,12 +152,13 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates = [];
                 foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments attempt) in updateCandidates)
                 {
-                    if (candidateCountsByResultId[published.Id] == 1)
+                    if (candidateCountsByResultId[published.Id] == 1 && _claimedResultIds.Add(published.Id))
                     {
                         updates.Add((published, attempt));
                     }
                     else
                     {
+                        _claimedResultIds.Add(published.Id);
                         creations.Add(attempt);
                     }
                 }
@@ -295,17 +296,19 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
     {
         var parents = new AzureDevOpsTestCaseResult[updates.Count];
         var attemptHistories = new IReadOnlyList<AzureDevOpsTestSubResult>[updates.Count];
+        long?[] totalDurations = new long?[updates.Count];
         for (int i = 0; i < updates.Count; i++)
         {
             // Built but not recorded yet: the map may only advance once Azure DevOps has accepted the
             // update, otherwise retrying a failed update would list the same execution twice.
             attemptHistories[i] = AzureDevOpsResultIdStore.BuildNextAttempts(updates[i].Published, updates[i].Attempt.Result);
+            totalDurations[i] = AzureDevOpsResultIdStore.BuildNextTotalDuration(updates[i].Published, updates[i].Attempt.Result);
             parents[i] = updates[i].Attempt.Result with
             {
                 Id = updates[i].Published.Id,
                 ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
                 SubResults = attemptHistories[i],
-                DurationInMs = SumDurations(attemptHistories[i]),
+                DurationInMs = totalDurations[i],
             };
         }
 
@@ -340,7 +343,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         // canceled, otherwise only a prefix of the accepted updates would survive into the next attempt.
         for (int i = 0; i < updates.Count; i++)
         {
-            _resultIdStore!.RecordAttempts(updates[i].Published, attemptHistories[i]);
+            _resultIdStore!.RecordAttempts(updates[i].Published, attemptHistories[i], totalDurations[i]);
         }
 
         for (int i = 0; i < updates.Count; i++)
@@ -391,24 +394,6 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         }
 
         return renamed;
-    }
-
-    private static long? SumDurations(IReadOnlyList<AzureDevOpsTestSubResult> attempts)
-    {
-        long total = 0;
-        bool hasDuration = false;
-        foreach (AzureDevOpsTestSubResult attempt in attempts)
-        {
-            if (attempt.DurationInMs is not { } duration)
-            {
-                continue;
-            }
-
-            hasDuration = true;
-            total = duration > long.MaxValue - total ? long.MaxValue : total + duration;
-        }
-
-        return hasDuration ? total : null;
     }
 
     private async Task UploadAttachmentsForResultAsync(int testCaseResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> attachments, CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -297,18 +297,24 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         var parents = new AzureDevOpsTestCaseResult[updates.Count];
         var attemptHistories = new IReadOnlyList<AzureDevOpsTestSubResult>[updates.Count];
         long?[] totalDurations = new long?[updates.Count];
+        var startedDates = new DateTimeOffset?[updates.Count];
+        var completedDates = new DateTimeOffset?[updates.Count];
         for (int i = 0; i < updates.Count; i++)
         {
             // Built but not recorded yet: the map may only advance once Azure DevOps has accepted the
             // update, otherwise retrying a failed update would list the same execution twice.
             attemptHistories[i] = AzureDevOpsResultIdStore.BuildNextAttempts(updates[i].Published, updates[i].Attempt.Result);
             totalDurations[i] = AzureDevOpsResultIdStore.BuildNextTotalDuration(updates[i].Published, updates[i].Attempt.Result);
+            startedDates[i] = Min(updates[i].Published.StartedDate, updates[i].Attempt.Result.StartedDate);
+            completedDates[i] = Max(updates[i].Published.CompletedDate, updates[i].Attempt.Result.CompletedDate);
             parents[i] = updates[i].Attempt.Result with
             {
                 Id = updates[i].Published.Id,
                 ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
                 SubResults = attemptHistories[i],
                 DurationInMs = totalDurations[i],
+                StartedDate = startedDates[i],
+                CompletedDate = completedDates[i],
             };
         }
 
@@ -343,7 +349,12 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         // canceled, otherwise only a prefix of the accepted updates would survive into the next attempt.
         for (int i = 0; i < updates.Count; i++)
         {
-            _resultIdStore!.RecordAttempts(updates[i].Published, attemptHistories[i], totalDurations[i]);
+            _resultIdStore!.RecordAttempts(
+                updates[i].Published,
+                attemptHistories[i],
+                totalDurations[i],
+                startedDates[i],
+                completedDates[i]);
         }
 
         for (int i = 0; i < updates.Count; i++)
@@ -395,6 +406,12 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         return renamed;
     }
+
+    private static DateTimeOffset? Min(DateTimeOffset? left, DateTimeOffset? right)
+        => left is null ? right : right is null || left <= right ? left : right;
+
+    private static DateTimeOffset? Max(DateTimeOffset? left, DateTimeOffset? right)
+        => left is null ? right : right is null || left >= right ? left : right;
 
     private async Task UploadAttachmentsForResultAsync(int testCaseResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> attachments, CancellationToken cancellationToken)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -295,7 +295,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         {
             await UploadAttachmentsForResultAsync(
                 updates[i].Published.Id,
-                RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i].Count),
+                RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i][^1].SequenceId),
                 cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -187,7 +187,15 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     {
                         RequeueUnsafe(updateFallbacks);
                         await UploadDeferredAttachmentsAsync(deferredAttachments, cancellationToken).ConfigureAwait(false);
-                        return;
+                        if (!force)
+                        {
+                            return;
+                        }
+
+                        // The claim is retained because the persisted map could not be invalidated. On the
+                        // next forced iteration it makes this item ambiguous, so it is reclassified as a
+                        // plain creation. A subsequent create failure returns through the normal branch.
+                        continue;
                     }
                 }
                 else if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, deferredAttachments, cancellationToken).ConfigureAwait(false))

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -126,17 +126,39 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 // updates that result instead of adding a second one for the same test. Only an
                 // orchestrated run has a store, so an ordinary run takes the create path for everything.
                 List<AzureDevOpsTestCaseResultWithAttachments> creations = [];
-                List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates = [];
+                List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updateCandidates = [];
                 List<(int ResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments = [];
                 foreach (AzureDevOpsTestCaseResultWithAttachments item in batch)
                 {
                     if (_resultIdStore?.TryGet(item.Result) is { } published)
                     {
-                        updates.Add((published, item));
+                        updateCandidates.Add((published, item));
                     }
                     else
                     {
                         creations.Add(item);
+                    }
+                }
+
+                // The store is unchanged while classifying a batch, so two current rows can resolve to the
+                // same persisted parent (for example when a formerly unique folded data row is duplicated).
+                // Never PATCH a guessed parent twice; ambiguous rows degrade to independent creates.
+                Dictionary<int, int> candidateCountsByResultId = [];
+                foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updateCandidates)
+                {
+                    candidateCountsByResultId[published.Id] = candidateCountsByResultId.TryGetValue(published.Id, out int count) ? count + 1 : 1;
+                }
+
+                List<(AzureDevOpsPublishedResult Published, AzureDevOpsTestCaseResultWithAttachments Attempt)> updates = [];
+                foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments attempt) in updateCandidates)
+                {
+                    if (candidateCountsByResultId[published.Id] == 1)
+                    {
+                        updates.Add((published, attempt));
+                    }
+                    else
+                    {
+                        creations.Add(attempt);
                     }
                 }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -234,7 +234,15 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         // interrupts the best-effort attachment phase.
         for (int i = 0; i < batch.Count; i++)
         {
-            _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
+            // The retry orchestrator only schedules failed/aborted tests again. Passed and skipped tests
+            // can never be looked up by a later attempt, so retaining them would make memory and map size
+            // grow with the whole suite even when no retry runs.
+            if (_resultIdStore is not null
+                && batch[i].Result.Outcome is AzureDevOpsLivePublishingConstants.FailedTestOutcome or AzureDevOpsLivePublishingConstants.AbortedTestOutcome)
+            {
+                _resultIdStore.RecordCreated(batch[i].Result, resultIds[i]);
+            }
+
             if (batch[i].Attachments.Count > 0)
             {
                 deferredAttachments.Add((resultIds[i], batch[i].Attachments));

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -285,8 +285,18 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             await _client.UpdateTestResultsAsync(_publishConfiguration!, CurrentRunId!.Value, parents, cancellationToken).ConfigureAwait(false);
             _lastFlushTime = _clock.UtcNow;
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex)
         {
+            foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updates)
+            {
+                _resultIdStore!.Forget(published);
+            }
+
+            if (ex is OperationCanceledException)
+            {
+                throw;
+            }
+
             _lastFlushTime = _clock.UtcNow;
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
             return false;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -147,7 +147,19 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     return;
                 }
 
-                if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, cancellationToken).ConfigureAwait(false))
+                if (updates.Count > 0 && !_resultIdStore!.TryInvalidatePersistedMap())
+                {
+                    // The old map cannot be removed, so a successful PATCH followed by a crash could leave
+                    // stale history for the next attempt to replay. Create separate results instead: less
+                    // tidy, but every execution remains represented.
+                    List<AzureDevOpsTestCaseResultWithAttachments> updateFallbacks = [.. updates.Select(update => update.Attempt)];
+                    if (!await TryCreateResultsAsync(updateFallbacks, cancellationToken).ConfigureAwait(false))
+                    {
+                        RequeueUnsafe(updateFallbacks);
+                        return;
+                    }
+                }
+                else if (updates.Count > 0 && !await TryUpdateResultsAsync(updates, cancellationToken).ConfigureAwait(false))
                 {
                     RequeueUnsafe([.. updates.Select(update => update.Attempt)]);
                     return;
@@ -209,9 +221,16 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             return true;
         }
 
+        // Record the whole accepted batch before any cancellable attachment upload. Azure DevOps accepted
+        // every result in one operation, so the map must describe all of them even if cancellation
+        // interrupts the best-effort attachment phase.
         for (int i = 0; i < batch.Count; i++)
         {
             _resultIdStore?.RecordCreated(batch[i].Result, resultIds[i]);
+        }
+
+        for (int i = 0; i < batch.Count; i++)
+        {
             await UploadAttachmentsForResultAsync(resultIds[i], batch[i].Attachments, cancellationToken).ConfigureAwait(false);
         }
 
@@ -265,9 +284,15 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             return false;
         }
 
+        // The PATCH accepted the whole batch. Advance every history before an attachment upload can be
+        // canceled, otherwise only a prefix of the accepted updates would survive into the next attempt.
         for (int i = 0; i < updates.Count; i++)
         {
             _resultIdStore!.RecordAttempts(updates[i].Published, attemptHistories[i]);
+        }
+
+        for (int i = 0; i < updates.Count; i++)
+        {
             await UploadAttachmentsForResultAsync(
                 updates[i].Published.Id,
                 RenameForAttempt(updates[i].Attempt.Attachments, attemptHistories[i].Count),

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
@@ -163,7 +163,12 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
             // the same test. Absent (a run with no orchestrator) means every result is simply created.
             if (AzureDevOpsConstants.TryGetInheritedResultMapPath(_environment, publishConfiguration.BuildId) is { } resultMapPath)
             {
-                _resultIdStore = await AzureDevOpsResultIdStore.OpenAsync(_fileSystem, _logger, resultMapPath, publishConfiguration.BuildId).ConfigureAwait(false);
+                _resultIdStore = await AzureDevOpsResultIdStore.OpenAsync(
+                    _fileSystem,
+                    _logger,
+                    resultMapPath,
+                    publishConfiguration.BuildId,
+                    CurrentRunId.Value).ConfigureAwait(false);
             }
 
             // Results stream into the run as tests complete, but the build's Tests tab only lists the run

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
@@ -39,6 +39,8 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
     private AzureDevOpsPublishConfiguration? _publishConfiguration;
     private AzureDevOpsRunIdCoordinator? _runIdCoordinator;
     private AzureDevOpsCoordinatedRun? _coordinatedRun;
+    // Mutate only while holding _flushSemaphore.
+    private AzureDevOpsResultIdStore? _resultIdStore;
     private DateTimeOffset _lastFlushTime;
     private CancellationTokenSource? _backgroundFlushCts;
     private Task? _backgroundFlushTask;
@@ -156,6 +158,14 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
                     testSessionContext.CancellationToken).ConfigureAwait(false);
             CurrentRunId = _coordinatedRun.RunId;
 
+            // An orchestrator also hands down where the result map lives, which is what lets a retry
+            // attempt update the result an earlier attempt created rather than publish a second one for
+            // the same test. Absent (a run with no orchestrator) means every result is simply created.
+            if (AzureDevOpsConstants.TryGetInheritedResultMapPath(_environment, publishConfiguration.BuildId) is { } resultMapPath)
+            {
+                _resultIdStore = await AzureDevOpsResultIdStore.OpenAsync(_fileSystem, _logger, resultMapPath, publishConfiguration.BuildId).ConfigureAwait(false);
+            }
+
             // Results stream into the run as tests complete, but the build's Tests tab only lists the run
             // once it is finalized. Point users at the run itself so they can watch results arrive live,
             // and say when the Tests tab catches up so an empty tab mid-run is not mistaken for a failure.
@@ -185,6 +195,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
             // those must be reported, not rethrown as if the user had canceled.
             _publishConfiguration = null;
             _coordinatedRun = null;
+            _resultIdStore = null;
             CurrentRunId = null;
             await WarnAsync($"{AzureDevOpsResources.AzureDevOpsLivePublishingCreateRunFailed} {ex.Message}", testSessionContext.CancellationToken).ConfigureAwait(false);
         }
@@ -338,6 +349,17 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
+        }
+
+        // Hand the map to the next attempt. Written once, here, rather than after every batch: only
+        // another process ever reads it, and no other process runs while this one does — the orchestrator
+        // runs attempts one at a time. Saving per batch would rewrite the whole map on each flush, which is
+        // quadratic in the number of tests and would be paid by every run, including those that never
+        // retry anything. If this process dies before reaching here the map is simply absent, and the next
+        // attempt publishes its own results: degraded, not lost.
+        if (_resultIdStore is not null)
+        {
+            await _resultIdStore.SaveAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         // The session-end flush is the last chance to publish: nothing drains the retry queue after

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
@@ -35,6 +35,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
     private readonly ConcurrentQueue<AzureDevOpsTestCaseResultWithAttachments> _pendingResults = new();
     private readonly ConcurrentQueue<AzureDevOpsTestResultAttachment> _pendingRunAttachments = new();
     private readonly SemaphoreSlim _flushSemaphore = new(1, 1);
+    // Mutate only while holding _flushSemaphore. One persisted parent may be updated at most once per
+    // test-host attempt; a later duplicate is ambiguous and falls back to a separate create.
+    private readonly HashSet<int> _claimedResultIds = [];
 
     private AzureDevOpsPublishConfiguration? _publishConfiguration;
     private AzureDevOpsRunIdCoordinator? _runIdCoordinator;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.cs
@@ -153,8 +153,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
             // must span every attempt. When that happened, join the existing run: this process neither
             // created it nor can tell whether it is the last one to publish into it, so it must not
             // complete it either. See AzureDevOpsTestRunOrchestratorLifetime.
-            _coordinatedRun = AzureDevOpsConstants.TryGetInheritedTestRunId(_environment, publishConfiguration.BuildId) is { } inheritedRunId
-                ? AzureDevOpsRunIdCoordinator.CreateInheritedRun(inheritedRunId, publishConfiguration)
+            int? inheritedRunId = AzureDevOpsConstants.TryGetInheritedTestRunId(_environment, publishConfiguration.BuildId);
+            _coordinatedRun = inheritedRunId is { } inheritedId
+                ? AzureDevOpsRunIdCoordinator.CreateInheritedRun(inheritedId, publishConfiguration)
                 : await _runIdCoordinator.AcquireRunAsync(
                     publishConfiguration,
                     cancellationToken => _client.CreateTestRunAsync(publishConfiguration, cancellationToken),
@@ -164,7 +165,8 @@ internal sealed partial class AzureDevOpsTestResultsPublisher : IDataConsumer, I
             // An orchestrator also hands down where the result map lives, which is what lets a retry
             // attempt update the result an earlier attempt created rather than publish a second one for
             // the same test. Absent (a run with no orchestrator) means every result is simply created.
-            if (AzureDevOpsConstants.TryGetInheritedResultMapPath(_environment, publishConfiguration.BuildId) is { } resultMapPath)
+            if (inheritedRunId is not null
+                && AzureDevOpsConstants.TryGetInheritedResultMapPath(_environment, publishConfiguration.BuildId) is { } resultMapPath)
             {
                 _resultIdStore = await AzureDevOpsResultIdStore.OpenAsync(
                     _fileSystem,

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
@@ -158,11 +158,11 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
 
             // Attempts publish into one run but run in separate processes with separate results
             // directories, so the mapping from test to result id needs a location they all agree on and
-            // that only they can see. Naming it after this process keeps two orchestrations of the same
-            // build apart, so neither merges the other's results into a rerun.
+            // that only they can see. A random orchestration id keeps two orchestrations of the same build
+            // apart even if an agent reuses a process id after a crash.
             _resultMapPath = Path.Combine(
                 publishConfiguration.ResultsDirectory,
-                $"azdo-results.{publishConfiguration.BuildId.ToString(CultureInfo.InvariantCulture)}.{_environment.ProcessId.ToString(CultureInfo.InvariantCulture)}.json");
+                $"azdo-results.{publishConfiguration.BuildId.ToString(CultureInfo.InvariantCulture)}.{Guid.NewGuid():N}.json");
             _environment.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, AzureDevOpsConstants.FormatResultMapPath(publishConfiguration.BuildId, _resultMapPath));
 
             // Only the process that created the run announces it; the others share the same id and would

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Security;
+
 using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
 using Microsoft.Testing.Extensions.Reporting;
 using Microsoft.Testing.Platform.CommandLine;
@@ -278,7 +280,7 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
                 _fileSystem.DeleteFile(path);
             }
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
         {
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {path}: {ex.Message}");
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
@@ -163,7 +163,15 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
             _resultMapPath = Path.Combine(
                 publishConfiguration.ResultsDirectory,
                 $"azdo-results.{publishConfiguration.BuildId.ToString(CultureInfo.InvariantCulture)}.{Guid.NewGuid():N}.json");
-            _environment.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, AzureDevOpsConstants.FormatResultMapPath(publishConfiguration.BuildId, _resultMapPath));
+            try
+            {
+                _environment.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, AzureDevOpsConstants.FormatResultMapPath(publishConfiguration.BuildId, _resultMapPath));
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                _resultMapPath = null;
+                TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingResultMapHandoffFailed} {ex.Message}");
+            }
 
             // Only the process that created the run announces it; the others share the same id and would
             // just repeat the same line.
@@ -207,8 +215,14 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
 
         // Stop handing the run id to any process started later: the run is about to be closed, and a
         // straggler publishing into a completed run would be rejected by Azure DevOps.
-        TrySetEnvironmentVariable(AzureDevOpsConstants.TestRunIdEnvironmentVariableName, null);
-        TrySetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, null);
+        TrySetEnvironmentVariable(
+            AzureDevOpsConstants.TestRunIdEnvironmentVariableName,
+            null,
+            AzureDevOpsResources.AzureDevOpsLivePublishingRunIdHandoffFailed);
+        TrySetEnvironmentVariable(
+            AzureDevOpsConstants.ResultMapPathEnvironmentVariableName,
+            null,
+            AzureDevOpsResources.AzureDevOpsLivePublishingResultMapHandoffFailed);
 
         // The map only has meaning for the run being closed, and it lives in the results directory, which
         // is published as a build artifact. Removing it keeps an internal coordination file out of the
@@ -277,7 +291,7 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
     /// Called from teardown, where the host may refuse the write (a <c>SecurityException</c> on
     /// .NET Framework). Failing to withdraw the handoff is far less harmful than failing the run.
     /// </remarks>
-    private void TrySetEnvironmentVariable(string name, string? value)
+    private void TrySetEnvironmentVariable(string name, string? value, string failureMessage)
     {
         try
         {
@@ -285,7 +299,7 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
         }
         catch (Exception ex)
         {
-            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingRunIdHandoffFailed} {ex.Message}");
+            TryLogWarning($"{failureMessage} {ex.Message}");
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
@@ -50,6 +50,7 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
     private AzureDevOpsPublishConfiguration? _publishConfiguration;
     private AzureDevOpsRunIdCoordinator? _runIdCoordinator;
     private AzureDevOpsCoordinatedRun? _coordinatedRun;
+    private string? _resultMapPath;
 
     public AzureDevOpsTestRunOrchestratorLifetime(
         ICommandLineOptions commandLineOptions,
@@ -155,6 +156,15 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
             // Published before any test host is launched so that every orchestrated process inherits it.
             _environment.SetEnvironmentVariable(AzureDevOpsConstants.TestRunIdEnvironmentVariableName, AzureDevOpsConstants.FormatInheritedTestRunId(publishConfiguration.BuildId, _coordinatedRun.RunId));
 
+            // Attempts publish into one run but run in separate processes with separate results
+            // directories, so the mapping from test to result id needs a location they all agree on and
+            // that only they can see. Naming it after this process keeps two orchestrations of the same
+            // build apart, so neither merges the other's results into a rerun.
+            _resultMapPath = Path.Combine(
+                publishConfiguration.ResultsDirectory,
+                $"azdo-results.{publishConfiguration.BuildId.ToString(CultureInfo.InvariantCulture)}.{_environment.ProcessId.ToString(CultureInfo.InvariantCulture)}.json");
+            _environment.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, AzureDevOpsConstants.FormatResultMapPath(publishConfiguration.BuildId, _resultMapPath));
+
             // Only the process that created the run announces it; the others share the same id and would
             // just repeat the same line.
             if (_coordinatedRun.IsOwner)
@@ -184,9 +194,11 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
         AzureDevOpsCoordinatedRun? coordinatedRun = _coordinatedRun;
         AzureDevOpsRunIdCoordinator? coordinator = _runIdCoordinator;
         AzureDevOpsPublishConfiguration? publishConfiguration = _publishConfiguration;
+        string? resultMapPath = _resultMapPath;
         _coordinatedRun = null;
         _runIdCoordinator = null;
         _publishConfiguration = null;
+        _resultMapPath = null;
 
         if (coordinatedRun is null || coordinator is null || publishConfiguration is null)
         {
@@ -196,6 +208,15 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
         // Stop handing the run id to any process started later: the run is about to be closed, and a
         // straggler publishing into a completed run would be rejected by Azure DevOps.
         TrySetEnvironmentVariable(AzureDevOpsConstants.TestRunIdEnvironmentVariableName, null);
+        TrySetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, null);
+
+        // The map only has meaning for the run being closed, and it lives in the results directory, which
+        // is published as a build artifact. Removing it keeps an internal coordination file out of the
+        // artifacts without affecting anything already in Azure DevOps.
+        if (resultMapPath is not null)
+        {
+            TryDeleteFile(resultMapPath);
+        }
 
         // Azure DevOps uses "Aborted" for cancellation and session-level infrastructure failures.
         // Individual failing tests must still complete the run, so only exit codes that are not a test
@@ -224,6 +245,28 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
             await WarnAsync(
                 $"{AzureDevOpsResources.AzureDevOpsLivePublishingCompleteRunFailed} {ex.Message} {AzureDevOpsResources.AzureDevOpsLivePublishingRunLeftInProgress}",
                 CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Deletes a coordination file, swallowing any failure.
+    /// </summary>
+    /// <remarks>
+    /// Called from teardown, where a leftover file is only untidy: nothing reads it once the handoff
+    /// variable is withdrawn, and it is scoped to a build id and process id that never recur.
+    /// </remarks>
+    private void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (_fileSystem.ExistFile(path))
+            {
+                _fileSystem.DeleteFile(path);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {path}: {ex.Message}");
         }
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestRunOrchestratorLifetime.cs
@@ -253,7 +253,7 @@ internal sealed class AzureDevOpsTestRunOrchestratorLifetime : ITestHostOrchestr
     /// </summary>
     /// <remarks>
     /// Called from teardown, where a leftover file is only untidy: nothing reads it once the handoff
-    /// variable is withdrawn, and it is scoped to a build id and process id that never recur.
+    /// variable is withdrawn, and every later orchestration receives a different random map path.
     /// </remarks>
     private void TryDeleteFile(string path)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/IAzureDevOpsTestResultsClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/IAzureDevOpsTestResultsClient.cs
@@ -17,6 +17,15 @@ internal interface IAzureDevOpsTestResultsClient
     Task<IReadOnlyList<int>?> PublishTestResultsAsync(AzureDevOpsPublishConfiguration configuration, int runId, IReadOnlyList<AzureDevOpsTestCaseResult> results, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Updates results that were already published to the run, identified by
+    /// <see cref="AzureDevOpsTestCaseResult.Id"/>. Used to turn a previously published result into a rerun
+    /// carrying every attempt as a sub-result, instead of appending a second result for the same test.
+    /// Throws on transport/HTTP failures, which the caller may retry: unlike a create, replaying an update
+    /// is idempotent.
+    /// </summary>
+    Task UpdateTestResultsAsync(AzureDevOpsPublishConfiguration configuration, int runId, IReadOnlyList<AzureDevOpsTestCaseResult> results, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Uploads an attachment to a specific test case result within a test run.
     /// </summary>
     Task UploadTestResultAttachmentAsync(AzureDevOpsPublishConfiguration configuration, int runId, int testCaseResultId, AzureDevOpsTestResultAttachment attachment, CancellationToken cancellationToken);

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -66,8 +66,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.init -> void
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.AzureDevOpsPublishedResult(string! Storage, string! Name, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Deconstruct(out string! Storage, out string! Name, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.AzureDevOpsPublishedResult(string! Storage, string! Name, string! Title, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Deconstruct(out string! Storage, out string! Name, out string! Title, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? other) -> bool
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.get -> int
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.init -> void
@@ -75,6 +75,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.g
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.get -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordCreated(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result, int resultId) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.Forget(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published) -> void
@@ -84,8 +86,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.init -> void
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.AzureDevOpsResultMapEntry(string? Storage, string? Name, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Deconstruct(out string? Storage, out string? Name, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.AzureDevOpsResultMapEntry(string? Storage, string? Name, string? Title, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Deconstruct(out string? Storage, out string? Name, out string? Title, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? other) -> bool
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.get -> int
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.init -> void
@@ -93,6 +95,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.ge
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.get -> string?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.AzureDevOpsResultMapFile(int BuildId, int RunId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -77,6 +77,7 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storag
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordCreated(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result, int resultId) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.Forget(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.SaveAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.TryGet(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -77,6 +77,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storag
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.TotalDurationInMs.get -> long?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.TotalDurationInMs.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordCreated(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result, int resultId) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.Forget(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published) -> void
@@ -97,6 +99,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.get -> string?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.TotalDurationInMs.get -> long?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.TotalDurationInMs.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.AzureDevOpsResultMapFile(int BuildId, int RunId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
@@ -162,5 +166,6 @@ static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.o
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts, long? totalDurationInMs) -> void
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextTotalDuration(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> long?

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -66,6 +66,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.CompletedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.CompletedDate.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.AzureDevOpsPublishedResult(string! Storage, string! Name, string! Title, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Deconstruct(out string! Storage, out string! Name, out string! Title, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? other) -> bool
@@ -75,6 +77,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.g
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.StartedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.StartedDate.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Title.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.TotalDurationInMs.get -> long?
@@ -88,6 +92,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.CompletedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.CompletedDate.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.AzureDevOpsResultMapEntry(string? Storage, string? Name, string? Title, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Deconstruct(out string? Storage, out string? Name, out string? Title, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? other) -> bool
@@ -97,6 +103,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.ge
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.get -> string?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.StartedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.StartedDate.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.get -> string?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Title.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.TotalDurationInMs.get -> long?
@@ -166,6 +174,6 @@ static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.o
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts, long? totalDurationInMs) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts, long? totalDurationInMs, System.DateTimeOffset? startedDate, System.DateTimeOffset? completedDate) -> void
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextTotalDuration(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> long?

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -59,3 +59,100 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsPublisherOp
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.FormatInheritedTestRunId(int buildId, int runId) -> string!
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.TryGetInheritedTestRunId(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, int buildId) -> int?
 static Microsoft.Testing.Extensions.StackTraceSourceLocationResolver.TryMakeWorkspaceRelative(string? filePath, string? repoRoot, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem) -> string?
+const Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.ResultMapPathEnvironmentVariableName = "TESTINGPLATFORM_AZUREDEVOPS_RESULTMAP" -> string!
+const Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult = 1000 -> int
+const Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsLivePublishingConstants.RerunResultGroupType = "rerun" -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Attempts.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.AzureDevOpsPublishedResult(string! Storage, string! Name, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Deconstruct(out string! Storage, out string! Name, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? other) -> bool
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.get -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.get -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordCreated(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result, int resultId) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.SaveAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.TryGet(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Attempts.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.AzureDevOpsResultMapEntry(string? Storage, string? Name, int Id, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Deconstruct(out string? Storage, out string? Name, out int Id, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>? Attempts) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? other) -> bool
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.AzureDevOpsResultMapFile(int BuildId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.BuildId.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.BuildId.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Deconstruct(out int BuildId, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? other) -> bool
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Results.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Results.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.Id.get -> int?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.Id.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.ResultGroupType.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.ResultGroupType.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.SubResults.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.SubResults.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultAttachment.WithFileName(string! fileName) -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultAttachment!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsClient.UpdateTestResultsAsync(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishConfiguration! configuration, int runId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult!>! results, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.AzureDevOpsTestSubResult(int SequenceId, string! DisplayName, string! Outcome, long? DurationInMs, string? ErrorMessage, string? StackTrace, System.DateTimeOffset? StartedDate, System.DateTimeOffset? CompletedDate) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.CompletedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.CompletedDate.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.Deconstruct(out int SequenceId, out string! DisplayName, out string! Outcome, out long? DurationInMs, out string? ErrorMessage, out string? StackTrace, out System.DateTimeOffset? StartedDate, out System.DateTimeOffset? CompletedDate) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.DisplayName.get -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.DisplayName.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.DurationInMs.get -> long?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.DurationInMs.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? other) -> bool
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.ErrorMessage.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.ErrorMessage.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.Outcome.get -> string!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.Outcome.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.SequenceId.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.SequenceId.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.StackTrace.get -> string?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.StackTrace.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.StartedDate.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.StartedDate.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.IAzureDevOpsTestResultsClient.UpdateTestResultsAsync(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishConfiguration! configuration, int runId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult!>! results, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Equals(object? obj) -> bool
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.GetHashCode() -> int
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.ToString() -> string!
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Equals(object? obj) -> bool
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.GetHashCode() -> int
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.ToString() -> string!
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Equals(object? obj) -> bool
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.GetHashCode() -> int
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.ToString() -> string!
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.Equals(object? obj) -> bool
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.GetHashCode() -> int
+override Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.ToString() -> string!
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.FormatResultMapPath(int buildId, string! path) -> string!
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.TryGetInheritedResultMapPath(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, int buildId) -> string?
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.OpenAsync(Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Logging.ILogger! logger, string! filePath, int buildId) -> System.Threading.Tasks.Task<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore!>!
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts) -> void
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -94,13 +94,15 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.<Clone>$() -> Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile!
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.AzureDevOpsResultMapFile(int BuildId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.AzureDevOpsResultMapFile(int BuildId, int RunId, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.BuildId.get -> int
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.BuildId.init -> void
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Deconstruct(out int BuildId, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Deconstruct(out int BuildId, out int RunId, out System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>? Results) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? other) -> bool
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Results.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry!>?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.Results.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.RunId.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.RunId.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.Id.get -> int?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.Id.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.ResultGroupType.get -> string?
@@ -147,7 +149,8 @@ static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.Forma
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsConstants.TryGetInheritedResultMapPath(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, int buildId) -> string?
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? right) -> bool
-static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.OpenAsync(Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Logging.ILogger! logger, string! filePath, int buildId) -> System.Threading.Tasks.Task<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore!>!
+static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.OpenAsync(Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Logging.ILogger! logger, string! filePath, int buildId, int runId) -> System.Threading.Tasks.Task<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore!>!
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.TryInvalidatePersistedMap() -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -162,6 +162,9 @@
   <data name="AzureDevOpsLivePublishingFailedToDeleteCoordinationFile" xml:space="preserve">
     <value>Azure DevOps live publishing failed to delete coordination file</value>
   </data>
+  <data name="AzureDevOpsLivePublishingFailedToReadCoordinationFile" xml:space="preserve">
+    <value>Azure DevOps live publishing failed to read coordination file</value>
+  </data>
   <data name="AzureDevOpsLivePublishingFailedToWriteCoordinationFile" xml:space="preserve">
     <value>Azure DevOps live publishing failed to write coordination file</value>
   </data>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -201,6 +201,9 @@
   <data name="AzureDevOpsLivePublishingResultIdParseFailedWarning" xml:space="preserve">
     <value>Azure DevOps live publishing accepted a batch of test results but could not parse the assigned result IDs; result-level attachments for this batch will be skipped.</value>
   </data>
+  <data name="AzureDevOpsLivePublishingResultMapHandoffFailed" xml:space="preserve">
+    <value>Azure DevOps live publishing failed to update the result map handoff.</value>
+  </data>
   <data name="AzureDevOpsLivePublishingResultsDropped" xml:space="preserve">
     <value>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</value>
     <comment>{0} is the number of test results that could not be published.</comment>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Živé publikování Azure DevOps přijalo dávku výsledků testu, ale nepovedlo se parsovat ID přiřazených výsledků. Přílohy na úrovni výsledků pro tuto dávku se přeskočí.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Živé publikování v Azure DevOps nemohlo publikovat výsledky testů ({0}); v testovacím běhu Azure DevOps budou chybět.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Živému publikování Azure DevOps se nepodařilo odstranit koordinační soubor</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Die Azure DevOps Liveveröffentlichung konnte die Koordinierungsdatei nicht löschen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps Liveveröffentlichung hat einen Batch von Testergebnissen akzeptiert, die zugewiesenen Ergebnis-IDs konnten jedoch nicht analysiert werden. Anlagen auf Ergebnisebene für diesen Batch werden übersprungen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps Liveveröffentlichung konnte(n) {0} Testergebnissen nicht veröffentlicht werden. sie fehlen im Azure DevOps Testlauf.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La publicación en directo de Azure DevOps no pudo eliminar el archivo de coordinación</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -117,6 +117,11 @@
         <target state="translated">La publicación en tiempo real de Azure DevOps aceptó un lote de resultados de pruebas, pero no pudo analizar los identificadores de resultado asignados; se omitirán los datos adjuntos de nivel de resultado para este lote.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">La publicación en vivo de Azure DevOps no pudo publicar {0} resultado(s) de prueba; faltarán en la serie de pruebas de Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">La publication en direct Azure DevOps a accepté un lot de résultats de test, mais n’a pas pu analyser les ID de résultat attribués. Les pièces jointes au niveau du résultat pour ce lot sont ignorées.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">La publication en direct Azure DevOps n’a pas pu charger {0} résultat(s) de test. Elles seront absentes de l’exécution de test Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Nous n’avons pas pu effectuer la publication en direct d’Azure DevOps pour supprimer le fichier de coordination</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -117,6 +117,11 @@
         <target state="translated">La pubblicazione live di Azure DevOps ha accettato un batch di risultati dei test ma non è riuscita ad analizzare gli ID dei risultati assegnati; gli allegati a livello di risultato per questo batch verranno ignorati.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">La pubblicazione live di Azure DevOps non è riuscita a pubblicare {0} risultato/i dei test; non saranno presenti nell'esecuzione dei test di Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -62,6 +62,11 @@
         <target state="translated">La pubblicazione live di Azure DevOps non è riuscita a eliminare il file di coordinamento</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps のライブ公開はテスト結果のバッチを受け入れましたが、割り当てられた結果 ID を解析できませんでした。このバッチの結果レベルの添付ファイルはスキップされます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps ライブ パブリッシングでは {0} 件のテスト結果を発行できませんでした。これらは Azure DevOps のテスト実行に含まれません。</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps ライブ公開で調整ファイルを削除できませんでした</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps 라이브 게시에서 조정 파일을 삭제하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps 라이브 게시에서 테스트 결과 일괄 처리를 수락했지만 할당된 결과 ID를 구문 분석할 수 없습니다. 이 일괄 처리의 결과 수준 첨부 파일은 건너뜁니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps 라이브 게시에서 {0} 테스트 결과를 게시할 수 없습니다. 해당 결과는 Azure DevOps 테스트 실행에서 누락됩니다.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Publikowanie na żywo w Azure DevOps zaakceptowało partię wyników testów, ale nie mogło przeanalizować przypisanych identyfikatorów wyników; załączniki na poziomie wyniku dla tej partii zostaną pominięte.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Publikowanie na żywo w usłudze Azure DevOps nie może opublikować {0} wyników testu. Nie będzie ich w przebiegu testu usługi Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Publikowanie na żywo w usłudze Azure DevOps nie może usunąć pliku koordynacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="translated">A publicação ao vivo do Azure DevOps falhou ao excluir o arquivo de coordenação</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -117,6 +117,11 @@
         <target state="translated">A publicação ao vivo do Azure DevOps aceitou um lote de resultados de teste, mas não pôde analisar as IDs de resultado atribuídos; os anexos no nível do resultado deste lote serão ignorados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">A publicação ao vivo do Azure DevOps não pôde publicar {0} resultados de teste; eles estarão ausentes da execução de teste do Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps: не удалось удалить файл координирования при публикации в реальном времени</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Служба прямой публикации Azure DevOps приняла пакет результатов тестирования, но не смогла обработать присвоенные идентификаторы результатов; вложения на уровне результатов для этого пакета будут пропущены.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Динамической публикации Azure DevOps не удалось опубликовать результаты тестов ({0}); они будут отсутствовать в тестовом запуске Azure DevOps.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps canlı yayımlama koordinasyon dosyasını silemedi</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps canlı yayımlama bir grup test sonucunu kabul etti ancak atanan sonuç kimliklerini ayrıştıramadı. Bu grup için sonuç düzeyi ekler atlanacak.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps canlı yayımlama {0} test sonucunu yayımlayamadı; bu ekler Azure DevOps test çalıştırmasında eksik olacak.</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps 实时发布未能删除协调文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps 实时发布已接受一批测试结果，但无法分析分配的结果 ID；将跳过此批次的结果级附件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps 实时发布无法发布 {0} 个测试结果；它们将在 Azure DevOps 测试运行中缺失。</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="translated">Azure DevOps 即時發佈無法刪除協調檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingFailedToReadCoordinationFile">
+        <source>Azure DevOps live publishing failed to read coordination file</source>
+        <target state="new">Azure DevOps live publishing failed to read coordination file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingFailedToWriteCoordinationFile">
         <source>Azure DevOps live publishing failed to write coordination file</source>
         <target state="new">Azure DevOps live publishing failed to write coordination file</target>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -117,6 +117,11 @@
         <target state="translated">Azure DevOps 即時發佈已接受一批測試結果，但無法剖析指派的結果 ID；將略過此批次的結果層級附件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingResultMapHandoffFailed">
+        <source>Azure DevOps live publishing failed to update the result map handoff.</source>
+        <target state="new">Azure DevOps live publishing failed to update the result map handoff.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingResultsDropped">
         <source>Azure DevOps live publishing could not publish {0} test result(s); they will be missing from the Azure DevOps test run.</source>
         <target state="translated">Azure DevOps 即時發佈無法發佈 {0} 個測試結果; 這些測試結果將不會出現在 Azure DevOps 測試執行中。</target>

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IFileSystem.cs
@@ -13,6 +13,8 @@ internal interface IFileSystem
 
     void MoveFile(string sourceFileName, string destFileName, bool overwrite = false);
 
+    void ReplaceFile(string sourceFileName, string destFileName);
+
     IFileStream NewFileStream(string path, FileMode mode);
 
     IFileStream NewFileStream(string path, FileMode mode, FileAccess access);

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/SystemFileSystem.cs
@@ -26,6 +26,18 @@ internal sealed class SystemFileSystem : IFileSystem
     }
 #endif
 
+    public void ReplaceFile(string sourceFileName, string destFileName)
+    {
+        if (File.Exists(destFileName))
+        {
+            File.Replace(sourceFileName, destFileName, destinationBackupFileName: null);
+        }
+        else
+        {
+            File.Move(sourceFileName, destFileName);
+        }
+    }
+
     public IFileStream NewFileStream(string path, FileMode mode) => new SystemFileStream(path, mode);
 
     public IFileStream NewFileStream(string path, FileMode mode, FileAccess access) => new SystemFileStream(path, mode, access);

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 #nullable enable
 Microsoft.Testing.Platform.Helpers.IConsole.Write(System.Text.StringBuilder! value) -> void
+Microsoft.Testing.Platform.Helpers.IFileSystem.ReplaceFile(string! sourceFileName, string! destFileName) -> void
 Microsoft.Testing.Platform.Helpers.SystemConsole.Write(System.Text.StringBuilder! value) -> void
+Microsoft.Testing.Platform.Helpers.SystemFileSystem.ReplaceFile(string! sourceFileName, string! destFileName) -> void
 Microsoft.Testing.Platform.Messages.AsyncConsumerDataProcessor.AsyncConsumerDataProcessor(Microsoft.Testing.Platform.Extensions.IDataConsumer! dataConsumer, Microsoft.Testing.Platform.Helpers.ITask! task, System.Threading.CancellationToken cancellationToken, System.TimeSpan canceledShutdownTimeout) -> void
 Microsoft.Testing.Platform.Messages.AsyncConsumerDataProcessor.IsConsumerRunning.get -> bool
 Microsoft.Testing.Platform.Messages.BlockingConsumerDataProcessor.BlockingConsumerDataProcessor(Microsoft.Testing.Platform.Extensions.IDataConsumer! dataConsumer, System.Threading.CancellationToken cancellationToken, System.TimeSpan canceledShutdownTimeout) -> void

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2934,6 +2934,53 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task FailedDuplicateCreate_DoesNotReleaseEarlierSuccessfulClaim()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "SharedUid",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 461,
+            displayName: "Duplicate title");
+
+        AzureDevOpsTestResultsPublisherOptions options = new(1, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        int createAttempts = 0;
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            createAttempts++;
+            if (createAttempts == 1)
+            {
+                return Task.FromException<IReadOnlyList<int>?>(new HttpRequestException("transient duplicate create failure"));
+            }
+
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([462]);
+        };
+        await StartPublisherAsync(publisher);
+
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "Duplicate title")),
+            CancellationToken.None);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "Duplicate title")),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, client.UpdateTestResultsCalls, "The persisted parent may be updated only once in this attempt.");
+        Assert.HasCount(1, created);
+        Assert.AreEqual("SharedUid", created[0].AutomatedTestName);
+    }
+
+    [TestMethod]
     public async Task FailedPatchInMixedBatch_DoesNotResaveStaleHistory()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -1973,7 +1973,8 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestCaseResult parent = client.UpdateTestResultsCalls.Single().Results.Single();
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, parent.Outcome);
         Assert.AreEqual("second", parent.ErrorMessage, "The parent reports the attempt that decided the outcome.");
-        IReadOnlyList<AzureDevOpsTestSubResult> subResults = parent.SubResults!;
+        Assert.IsNotNull(parent.SubResults);
+        IReadOnlyList<AzureDevOpsTestSubResult> subResults = parent.SubResults;
         Assert.HasCount(2, subResults);
         Assert.AreEqual(1, subResults[0].SequenceId);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, subResults[0].Outcome);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2073,6 +2073,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         AzureDevOpsTestCaseResult parent = secondClient.UpdateTestResultsCalls.Single().Results.Single();
         Assert.AreEqual(31_000, parent.DurationInMs);
+        Assert.AreEqual(RetryTestStartTime, parent.StartedDate);
+        Assert.AreEqual(RetryTestStartTime + TimeSpan.FromSeconds(31), parent.CompletedDate);
         Assert.AreEqual(30_000, parent.SubResults![0].DurationInMs);
         Assert.AreEqual(1_000, parent.SubResults[1].DurationInMs);
     }
@@ -2300,6 +2302,46 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.HasCount(1, created);
         Assert.IsEmpty(client.UpdateTestResultsCalls);
+    }
+
+    [TestMethod]
+    public async Task ResultMapWithoutInheritedRun_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string staleMapPath = Path.Combine(directory.Path, "stale-map.json");
+        const string StaleMap = """{"buildId":123,"runId":999,"results":[]}""";
+        File.WriteAllText(staleMapPath, StaleMap);
+
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        environment
+            .Setup(x => x.GetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName))
+            .Returns(AzureDevOpsConstants.FormatResultMapPath(123, staleMapPath));
+
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient client,
+            out _,
+            out _,
+            environment);
+        client.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(501);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([502]);
+        };
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls);
+        Assert.AreEqual(StaleMap, File.ReadAllText(staleMapPath), "A self-owned run must not open or rewrite an inherited map path.");
     }
 
     [TestMethod]
@@ -2613,7 +2655,7 @@ public sealed class AzureDevOpsLivePublishingTests
         IReadOnlyList<AzureDevOpsTestSubResult> attempts = AzureDevOpsResultIdStore.BuildNextAttempts(
             published,
             first with { ErrorMessage = "second" });
-        updated.RecordAttempts(published, attempts, totalDurationInMs: 2);
+        updated.RecordAttempts(published, attempts, totalDurationInMs: 2, startedDate: null, completedDate: null);
         await updated.SaveAsync(CancellationToken.None);
 
         Assert.IsFalse(File.Exists(mapPath), "A stale map would let the next attempt erase accepted server history.");
@@ -3337,7 +3379,7 @@ public sealed class AzureDevOpsLivePublishingTests
 
     private sealed class FakeAzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClient
     {
-        public Func<AzureDevOpsPublishConfiguration, CancellationToken, Task<int>> CreateTestRunAsyncFunc { get; set; } = (_, _) => Task.FromResult(0);
+        public Func<AzureDevOpsPublishConfiguration, CancellationToken, Task<int>> CreateTestRunAsyncFunc { get; set; } = (_, _) => Task.FromResult(1);
 
         public Func<AzureDevOpsPublishConfiguration, int, IReadOnlyList<AzureDevOpsTestCaseResult>, CancellationToken, Task<IReadOnlyList<int>?>> PublishTestResultsAsyncFunc { get; set; } =
             (_, _, results, _) =>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2093,7 +2093,7 @@ public sealed class AzureDevOpsLivePublishingTests
             Mock.Of<IDataProducer>(),
             CreateMessage(CreateNode(
                 "SharedUid",
-                new FailedTestNodeStateProperty(new InvalidOperationException("row one")),
+                new PassedTestNodeStateProperty(),
                 RetryTestStartTime,
                 displayName: "MyTest(1)")),
             CancellationToken.None);
@@ -2333,7 +2333,7 @@ public sealed class AzureDevOpsLivePublishingTests
         // A batch size of one forces a publish per result, so a per-batch save would rewrite the whole map
         // for every test — quadratic in the size of the suite, and paid even by runs that never retry.
         AzureDevOpsTestResultsPublisherOptions options = new(1, TimeSpan.FromSeconds(5), 40, TimeSpan.FromMilliseconds(250));
-        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         int nextResultId = 100;
         client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
         {
@@ -2380,27 +2380,6 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.IsFalse(File.Exists(mapPath), "An empty map only leaves a coordination file in the results directory for nobody to read.");
-    }
-
-    [TestMethod]
-    public async Task WhenAllResultsPass_NoMapFileIsLeftBehind()
-    {
-        using TestDirectory directory = CreateTestDirectory();
-        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
-        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
-        await lifetime.BeforeRunAsync(CancellationToken.None);
-
-        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
-        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out _, out _, out _, environment);
-
-        await StartPublisherAsync(publisher);
-        await publisher.ConsumeAsync(
-            Mock.Of<IDataProducer>(),
-            CreateMessage(CreateNode("PassingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
-            CancellationToken.None);
-        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
-
-        Assert.IsFalse(File.Exists(mapPath), "Passing tests are not eligible for retry and must not grow the shared map.");
     }
 
     [TestMethod]
@@ -2453,7 +2432,7 @@ public sealed class AzureDevOpsLivePublishingTests
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
         File.WriteAllText(
             mapPath,
-            """{"buildId":123,"runId":4242,"results":[{"storage":"MyTests","name":"MyTest","title":"MyTest","id":81,"attempts":null}]}""");
+            """{"buildId":123,"runId":4242,"results":[null,{"storage":"MyTests","name":"MyTest","title":"MyTest","id":81,"attempts":null}]}""");
 
         AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         List<AzureDevOpsTestCaseResult> created = [];
@@ -2609,7 +2588,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await lifetime.BeforeRunAsync(CancellationToken.None);
 
         AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
-        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([101, 102]);
         client.UploadTestResultAttachmentAsyncFunc = (_, _, _, _, _) => Task.FromException(new OperationCanceledException());
         await StartPublisherAsync(publisher);
@@ -2647,7 +2626,7 @@ public sealed class AzureDevOpsLivePublishingTests
             resultId: 201);
 
         AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
-        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         List<AzureDevOpsTestCaseResult> created = [];
         client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2127,6 +2127,54 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task FoldedDataDrivenRows_SharingUidAndTitleFallBackToCreates()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient firstClient, out _, out _, environment);
+        firstClient.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([411, 412]);
+        await StartPublisherAsync(firstAttempt);
+        for (int i = 0; i < 2; i++)
+        {
+            await firstAttempt.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode(
+                    "SharedUid",
+                    new FailedTestNodeStateProperty(new InvalidOperationException($"row {i}")),
+                    RetryTestStartTime,
+                    displayName: "Duplicate title")),
+                CancellationToken.None);
+        }
+
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient secondClient, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        secondClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([413, 414]);
+        };
+        await StartPublisherAsync(secondAttempt);
+        for (int i = 0; i < 2; i++)
+        {
+            await secondAttempt.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "Duplicate title")),
+                CancellationToken.None);
+        }
+
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(2, created);
+        Assert.IsEmpty(secondClient.UpdateTestResultsCalls, "Ambiguous rows must never be PATCHed to a guessed parent.");
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2483,6 +2483,51 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task FailedPatchInMixedBatch_DoesNotResaveStaleHistory()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "ExistingTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 211);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<string> createdTests = [];
+        int nextResultId = 212;
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            createdTests.AddRange(results.Select(result => result.AutomatedTestName));
+            int[] ids = [.. Enumerable.Range(nextResultId, results.Count)];
+            nextResultId += results.Count;
+            return Task.FromResult<IReadOnlyList<int>?>(ids);
+        };
+        client.UpdateTestResultsAsyncFunc = (_, _, _, _) => Task.FromException(new HttpRequestException("ambiguous failure"));
+        await StartPublisherAsync(publisher);
+
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("NewTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("ExistingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.Contains("NewTest", createdTests);
+        Assert.Contains("ExistingTest", createdTests, "The ambiguous PATCH must retry as a safe create.");
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        Assert.DoesNotContain("\"id\":211", File.ReadAllText(mapPath), "The pre-PATCH result id must not be resurrected.");
+    }
+
+    [TestMethod]
     public void CappedAttemptHistory_ContinuesIncreasingSequenceIds()
     {
         var attempts = new AzureDevOpsTestSubResult[AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult];

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -1973,7 +1973,14 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestCaseResult parent = client.UpdateTestResultsCalls.Single().Results.Single();
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, parent.Outcome);
         Assert.AreEqual("second", parent.ErrorMessage, "The parent reports the attempt that decided the outcome.");
-        Assert.HasCount(2, parent.SubResults!);
+        IReadOnlyList<AzureDevOpsTestSubResult> subResults = parent.SubResults!;
+        Assert.HasCount(2, subResults);
+        Assert.AreEqual(1, subResults[0].SequenceId);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, subResults[0].Outcome);
+        Assert.AreEqual("first", subResults[0].ErrorMessage);
+        Assert.AreEqual(2, subResults[1].SequenceId);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, subResults[1].Outcome);
+        Assert.AreEqual("second", subResults[1].ErrorMessage);
     }
 
     [TestMethod]
@@ -2011,6 +2018,8 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.HasCount(1, client.UploadTestResultAttachmentCalls);
         Assert.AreEqual(25, client.UploadTestResultAttachmentCalls[0].TestCaseResultId);
         Assert.AreEqual("stdout.attempt-2.log", client.UploadTestResultAttachmentCalls[0].Attachment.FileName);
+        Assert.HasCount(1, client.UpdateTestResultsCalls);
+        Assert.AreEqual(2, client.UpdateTestResultsCalls[0].Results.Single().SubResults![1].SequenceId);
     }
 
     [TestMethod]
@@ -2150,6 +2159,7 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.HasCount(1, created);
         Assert.AreEqual("OtherTests", created[0].AutomatedTestStorage);
+        Assert.AreEqual("MyTest", created[0].AutomatedTestName);
         Assert.IsEmpty(client.UpdateTestResultsCalls, "A different assembly is a different test, not another attempt.");
     }
 
@@ -2265,7 +2275,9 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
 
         await lifetime.BeforeRunAsync(CancellationToken.None);
-        Assert.IsNotNull(AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123));
+        string? inheritedMapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123);
+        Assert.IsNotNull(inheritedMapPath);
+        Assert.Contains(directory.Path, inheritedMapPath);
 
         // A value inherited from an earlier build on a reused agent must not redirect this build's updates.
         Assert.IsNull(AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 999));
@@ -2348,7 +2360,9 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.IsTrue(File.Exists(mapPath), "The next attempt still needs the map once the session ends.");
-        Assert.Contains("MyTest4", File.ReadAllText(mapPath));
+        string map = File.ReadAllText(mapPath);
+        Assert.Contains("MyTest0", map);
+        Assert.Contains("MyTest4", map);
     }
 
     [TestMethod]
@@ -2422,6 +2436,8 @@ public sealed class AzureDevOpsLivePublishingTests
         await nextAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.HasCount(1, created);
+        Assert.IsNull(created[0].Id);
+        Assert.IsNull(created[0].SubResults);
         Assert.IsEmpty(client.UpdateTestResultsCalls, "Result ids from another run must never be PATCHed.");
     }
 
@@ -2455,6 +2471,8 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.HasCount(1, created);
+        Assert.IsNull(created[0].Id);
+        Assert.IsNull(created[0].SubResults);
         Assert.IsEmpty(client.UpdateTestResultsCalls, "An incomplete history must fall back to a safe create.");
     }
 
@@ -2608,6 +2626,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
         string map = File.ReadAllText(mapPath);
+        Assert.Contains("\"id\":101", map);
+        Assert.Contains("\"id\":102", map);
         Assert.Contains("FirstTest", map);
         Assert.Contains("SecondTest", map);
     }
@@ -2628,7 +2648,12 @@ public sealed class AzureDevOpsLivePublishingTests
 
         AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
         AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
-        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([202]);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([202]);
+        };
         client.UploadTestResultAttachmentAsyncFunc = (_, _, _, _, _) => Task.FromException(new OperationCanceledException());
         await StartPublisherAsync(publisher);
 
@@ -2644,6 +2669,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.HasCount(1, client.UpdateTestResultsCalls, "The update must reach Azure DevOps before creation attachments are uploaded.");
         Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
+        Assert.HasCount(1, created);
+        Assert.AreEqual("NewTest", created[0].AutomatedTestName);
     }
 
     [TestMethod]
@@ -2686,6 +2713,9 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.Contains("NewTest", createdTests);
         Assert.Contains("ExistingTest", createdTests, "The ambiguous PATCH must retry as a safe create.");
+        Assert.HasCount(2, createdTests);
+        Assert.AreEqual("NewTest", createdTests.Single(name => name == "NewTest"));
+        Assert.AreEqual("ExistingTest", createdTests.Single(name => name == "ExistingTest"));
 
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
         Assert.DoesNotContain("\"id\":211", File.ReadAllText(mapPath), "The pre-PATCH result id must not be resurrected.");

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2280,16 +2280,20 @@ public sealed class AzureDevOpsLivePublishingTests
               {"storage":"tests","name":"First","title":"First","id":431,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
               {"storage":"tests","name":"First","title":"First","id":432,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
               {"storage":"tests","name":"First","title":"First","id":433,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]}
+              {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"Malformed","title":"Malformed","id":434,"attempts":null},
+              {"storage":"tests","name":"Third","title":"Third","id":434,"attempts":[{"sequenceId":1,"displayName":"Third","outcome":"Failed","durationInMs":1}]}
             ]}
             """);
 
         AzureDevOpsResultIdStore store = await AzureDevOpsResultIdStore.OpenAsync(new SystemFileSystem(), new CollectingLogger(), mapPath, buildId: 123, runId: 42);
         AzureDevOpsTestCaseResult first = new("First", "tests", "First", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
         AzureDevOpsTestCaseResult second = new("Second", "tests", "Second", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        AzureDevOpsTestCaseResult third = new("Third", "tests", "Third", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
 
         Assert.IsNull(store.TryGet(first));
         Assert.IsNull(store.TryGet(second));
+        Assert.IsNull(store.TryGet(third));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -31,6 +31,9 @@ public sealed class AzureDevOpsLivePublishingTests
 {
     private const string TruncationMarker = "\n...[truncated]";
 
+    /// <summary>Fixed start time for the retry tests, whose assertions never depend on the clock.</summary>
+    private static readonly DateTimeOffset RetryTestStartTime = new(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
     private readonly List<string> _directoriesToDelete = [];
 
     [TestCleanup]
@@ -1881,6 +1884,461 @@ public sealed class AzureDevOpsLivePublishingTests
 
     #endregion
 
+    #region Retry attempts as sub-results of one result (https://github.com/microsoft/testfx/issues/10400)
+
+    [TestMethod]
+    public async Task RetryAttempt_UpdatesTheResultTheEarlierAttemptCreatedInsteadOfAddingAnother()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+
+        // The orchestrator publishes where the map lives; without it the attempts cannot find each other.
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out FakeAzureDevOpsTestResultsClient _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        // Attempt 1: the test fails, and is created as a new result.
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient firstClient, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        firstClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([777]);
+        };
+
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), RetryTestStartTime)),
+            CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, created[0].Outcome);
+        Assert.IsNull(created[0].Id, "A test seen for the first time is created, not updated.");
+
+        // Attempt 2: the same test passes. It must land on the result attempt 1 created.
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient secondClient, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> createdBySecondAttempt = [];
+        secondClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            createdBySecondAttempt.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([888]);
+        };
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.IsEmpty(createdBySecondAttempt, "The retry attempt must not add a second result for the same test.");
+        Assert.HasCount(1, secondClient.UpdateTestResultsCalls);
+
+        AzureDevOpsTestCaseResult parent = secondClient.UpdateTestResultsCalls[0].Results.Single();
+        Assert.AreEqual(777, parent.Id, "The update has to address the result the first attempt created.");
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.RerunResultGroupType, parent.ResultGroupType);
+
+        // Latest attempt wins: the test ultimately passed, which is what the pipeline's exit code says too.
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, parent.Outcome);
+
+        // The failure is not erased, it becomes the first attempt — that is what makes the flakiness visible.
+        Assert.IsNotNull(parent.SubResults);
+        Assert.HasCount(2, parent.SubResults);
+        Assert.AreEqual(1, parent.SubResults[0].SequenceId);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, parent.SubResults[0].Outcome);
+        Assert.AreEqual("boom", parent.SubResults[0].ErrorMessage);
+        Assert.AreEqual(2, parent.SubResults[1].SequenceId);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, parent.SubResults[1].Outcome);
+    }
+
+    [TestMethod]
+    public async Task RetryAttempt_ThatFailsAgain_KeepsTheParentFailedAndRecordsBothAttempts()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("first")), resultId: 21);
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("second")), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestCaseResult parent = client.UpdateTestResultsCalls.Single().Results.Single();
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, parent.Outcome);
+        Assert.AreEqual("second", parent.ErrorMessage, "The parent reports the attempt that decided the outcome.");
+        Assert.HasCount(2, parent.SubResults!);
+    }
+
+    [TestMethod]
+    public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new PassedTestNodeStateProperty(), resultId: 31);
+
+        // Same test uid, different assembly. TestNode.Uid is only unique within a test application, so
+        // keying on it alone would make the second assembly's test masquerade as a rerun of the first's.
+        Mock<ITestApplicationModuleInfo> otherAssembly = new();
+        otherAssembly.Setup(x => x.TryGetAssemblyName()).Returns("OtherTests");
+        otherAssembly.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns(Path.Combine("artifacts", "OtherTests.dll"));
+
+        AzureDevOpsTestResultsPublisher otherPublisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment, otherAssembly);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([32]);
+        };
+
+        await StartPublisherAsync(otherPublisher);
+        await otherPublisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await otherPublisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.AreEqual("OtherTests", created[0].AutomatedTestStorage);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "A different assembly is a different test, not another attempt.");
+    }
+
+    [TestMethod]
+    public async Task WithoutAnOrchestrator_ResultsAreAlwaysCreated()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+
+        // No orchestrator ran, so no map was published and there is nothing to merge into: this is the
+        // ordinary single-process run, whose behaviour must be exactly what it was before reruns existed.
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 41);
+
+        AzureDevOpsTestResultsPublisher secondPublisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([42]);
+        };
+
+        await StartPublisherAsync(secondPublisher);
+        await secondPublisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondPublisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls);
+    }
+
+    [TestMethod]
+    public async Task WhenTheCreateResponseHasNoIds_TheNextAttemptCreatesItsOwnResultRatherThanLosingIt()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        // Azure DevOps accepted the results but the response could not be parsed, so there is no id to
+        // address later. Publishing a second result is worse than a rerun, but far better than dropping it.
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient firstClient, out _, out _, environment);
+        firstClient.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>(null);
+
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), RetryTestStartTime)),
+            CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient secondClient, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        secondClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([52]);
+        };
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.IsEmpty(secondClient.UpdateTestResultsCalls);
+    }
+
+    [TestMethod]
+    public async Task WhenTheMapIsUnreadable_TheAttemptStillPublishesItsResult()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 61);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        Assert.IsTrue(File.Exists(mapPath), "The first attempt was supposed to leave the map behind for the next one.");
+        File.WriteAllText(mapPath, "{ this is not json");
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([62]);
+        };
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        // Degraded to a separate result rather than to silence.
+        Assert.HasCount(1, created);
+    }
+
+    [TestMethod]
+    public async Task ResultMapPathHandoff_IsScopedToTheBuildAndWithdrawnWhenTheRunCloses()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        Assert.IsNotNull(AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123));
+
+        // A value inherited from an earlier build on a reused agent must not redirect this build's updates.
+        Assert.IsNull(AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 999));
+
+        await lifetime.AfterRunAsync(0, CancellationToken.None);
+        Assert.IsNull(
+            AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123),
+            "A process started after the run closed must not try to update results in it.");
+    }
+
+    [TestMethod]
+    public async Task WhenAnUpdateFails_TheAttemptHistoryDoesNotAdvance()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 71);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        string mapAfterFirstAttempt = File.ReadAllText(mapPath);
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        client.UpdateTestResultsAsyncFunc = (_, _, _, _) => Task.FromException(new HttpRequestException("transient"));
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, client.UpdateTestResultsCalls);
+        Assert.HasCount(2, client.UpdateTestResultsCalls[0].Results.Single().SubResults!);
+
+        // Azure DevOps never accepted that update, so the map must still describe only the attempt that
+        // did land. Advancing it here would make a retry of the update list the same execution twice.
+        Assert.AreEqual(
+            mapAfterFirstAttempt,
+            File.ReadAllText(mapPath),
+            "A rejected update must leave the recorded attempt history untouched.");
+    }
+
+    [TestMethod]
+    public async Task TheMapIsWrittenOncePerSessionRatherThanOncePerBatch()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+
+        // A batch size of one forces a publish per result, so a per-batch save would rewrite the whole map
+        // for every test — quadratic in the size of the suite, and paid even by runs that never retry.
+        AzureDevOpsTestResultsPublisherOptions options = new(1, TimeSpan.FromSeconds(5), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        int nextResultId = 100;
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            int[] ids = new int[results.Count];
+            for (int i = 0; i < results.Count; i++)
+            {
+                ids[i] = nextResultId++;
+            }
+
+            return Task.FromResult<IReadOnlyList<int>?>(ids);
+        };
+
+        await StartPublisherAsync(publisher);
+        for (int i = 0; i < 5; i++)
+        {
+            await publisher.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode($"MyTest{i}", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+                CancellationToken.None);
+
+            Assert.IsFalse(File.Exists(mapPath), "The map is only needed by the next attempt, so it must not be rewritten as results are published.");
+        }
+
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.IsTrue(File.Exists(mapPath), "The next attempt still needs the map once the session ends.");
+        Assert.Contains("MyTest4", File.ReadAllText(mapPath));
+    }
+
+    [TestMethod]
+    public async Task WhenNothingWasPublished_NoMapFileIsLeftBehind()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out _, out _, out _, environment);
+        await StartPublisherAsync(publisher);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.IsFalse(File.Exists(mapPath), "An empty map only leaves a coordination file in the results directory for nobody to read.");
+    }
+
+    /// <summary>
+    /// Runs one publisher to completion for a single test, so a following attempt has something to merge into.
+    /// </summary>
+    private async Task PublishSingleResultAsync(string resultsDirectory, Mock<IEnvironment> environment, string uid, IProperty state, int resultId)
+    {
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(resultsDirectory, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([resultId]);
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(CreateNode(uid, state, RetryTestStartTime)), CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+    }
+
+    // The rerun shape is a contract with Azure DevOps rather than with our own code, so assert on the
+    // bytes actually sent: the verb, the results URI, and the camelCase resultGroupType the service
+    // expects (it rejects the PascalCase spelling used by the client SDK's enum).
+    [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_UpdateTestResults_PatchesTheResultsUriWithARerunPayload()
+    {
+        FakeTask task = new();
+        FakeClock clock = new() { UtcNow = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) };
+        string? capturedBody = null;
+        HttpMethod? capturedMethod = null;
+        Uri? capturedUri = null;
+        QueueHttpMessageHandler handler = new(
+            async (request, cancellationToken) =>
+            {
+                capturedMethod = request.Method;
+                capturedUri = request.RequestUri;
+                capturedBody = await ReadRequestBodyAsync(request, cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"count\":1,\"value\":[]}"),
+                };
+            });
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, task, clock);
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 123, "run", "tests.dll", "results");
+
+        AzureDevOpsTestCaseResult parent = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 5, null, null, null, null)
+        {
+            Id = 777,
+            ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
+            SubResults =
+            [
+                new AzureDevOpsTestSubResult(1, "MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 3, "boom", "at Foo()", null, null),
+                new AzureDevOpsTestSubResult(2, "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 5, null, null, null, null),
+            ],
+        };
+
+        await client.UpdateTestResultsAsync(configuration, runId: 42, [parent], CancellationToken.None);
+
+        Assert.AreEqual("PATCH", capturedMethod!.Method);
+        Assert.AreEqual("https://dev.azure.com/org/project/_apis/test/runs/42/results?api-version=7.1", capturedUri!.ToString());
+        Assert.IsNotNull(capturedBody);
+
+        using var document = JsonDocument.Parse(capturedBody!);
+        JsonElement result = document.RootElement[0];
+        Assert.AreEqual(777, result.GetProperty("id").GetInt32());
+        Assert.AreEqual("rerun", result.GetProperty("resultGroupType").GetString());
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, result.GetProperty("outcome").GetString());
+
+        JsonElement subResults = result.GetProperty("subResults");
+        Assert.AreEqual(2, subResults.GetArrayLength());
+        Assert.AreEqual(1, subResults[0].GetProperty("sequenceId").GetInt32());
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, subResults[0].GetProperty("outcome").GetString());
+        Assert.AreEqual("boom", subResults[0].GetProperty("errorMessage").GetString());
+        Assert.AreEqual(2, subResults[1].GetProperty("sequenceId").GetInt32());
+    }
+
+    // A result being created must not carry any of the rerun fields: sending an explicit null id would
+    // make Azure DevOps treat the create as an update of result 0.
+    [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_PublishTestResults_OmitsRerunFieldsForANewResult()
+    {
+        FakeTask task = new();
+        FakeClock clock = new() { UtcNow = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero) };
+        string? capturedBody = null;
+        QueueHttpMessageHandler handler = new(
+            async (request, cancellationToken) =>
+            {
+                capturedBody = await ReadRequestBodyAsync(request, cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"count\":1,\"value\":[{\"id\":5,\"automatedTestName\":\"MyTest\"}]}"),
+                };
+            });
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, task, clock);
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 123, "run", "tests.dll", "results");
+
+        AzureDevOpsTestCaseResult result = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 5, null, null, null, null);
+        IReadOnlyList<int>? ids = await client.PublishTestResultsAsync(configuration, runId: 42, [result], CancellationToken.None);
+
+        Assert.IsNotNull(ids);
+        Assert.AreEqual(5, ids![0]);
+
+        using var document = JsonDocument.Parse(capturedBody!);
+        JsonElement created = document.RootElement[0];
+        Assert.IsFalse(created.TryGetProperty("id", out _));
+        Assert.IsFalse(created.TryGetProperty("resultGroupType", out _));
+        Assert.IsFalse(created.TryGetProperty("subResults", out _));
+    }
+
+    #endregion
+
     private static AzureDevOpsTestRunOrchestratorLifetime CreateOrchestratorLifetime(
         string resultsDirectory,
         out FakeAzureDevOpsTestResultsClient client,
@@ -1936,6 +2394,13 @@ public sealed class AzureDevOpsLivePublishingTests
         environment.Setup(x => x.GetEnvironmentVariable(AzureDevOpsConstants.TestRunIdEnvironmentVariableName)).Returns(() => runId);
         environment.Setup(x => x.SetEnvironmentVariable(AzureDevOpsConstants.TestRunIdEnvironmentVariableName, It.IsAny<string>()))
             .Callback<string, string>((_, value) => runId = value);
+
+        // The result map path is handed down the same way, so the attempts of one orchestration can find
+        // the results the earlier ones created.
+        string? resultMapPath = null;
+        environment.Setup(x => x.GetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName)).Returns(() => resultMapPath);
+        environment.Setup(x => x.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, It.IsAny<string>()))
+            .Callback<string, string>((_, value) => resultMapPath = value);
         return environment;
     }
 
@@ -2024,9 +2489,14 @@ public sealed class AzureDevOpsLivePublishingTests
 
         environment ??= CreateEnvironmentMock(processId: GetAliveProcessId());
 
-        testApplicationModuleInfo ??= new Mock<ITestApplicationModuleInfo>();
-        testApplicationModuleInfo.Setup(x => x.TryGetAssemblyName()).Returns("MyTests");
-        testApplicationModuleInfo.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns(Path.Combine("testfx-worktrees", "azdo-live", "artifacts", "MyTests.dll"));
+        // Only fill in defaults for a mock we created: a caller that supplies one is describing a
+        // different test application on purpose, and overwriting it would silently undo that.
+        if (testApplicationModuleInfo is null)
+        {
+            testApplicationModuleInfo = new Mock<ITestApplicationModuleInfo>();
+            testApplicationModuleInfo.Setup(x => x.TryGetAssemblyName()).Returns("MyTests");
+            testApplicationModuleInfo.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns(Path.Combine("testfx-worktrees", "azdo-live", "artifacts", "MyTests.dll"));
+        }
 
         if (processExitCode is null)
         {
@@ -2200,6 +2670,10 @@ public sealed class AzureDevOpsLivePublishingTests
                 return Task.FromResult<IReadOnlyList<int>?>(ids);
             };
 
+        public Func<AzureDevOpsPublishConfiguration, int, IReadOnlyList<AzureDevOpsTestCaseResult>, CancellationToken, Task> UpdateTestResultsAsyncFunc { get; set; } = (_, _, _, _) => Task.CompletedTask;
+
+        public List<(int RunId, IReadOnlyList<AzureDevOpsTestCaseResult> Results)> UpdateTestResultsCalls { get; } = [];
+
         public Func<AzureDevOpsPublishConfiguration, int, int, AzureDevOpsTestResultAttachment, CancellationToken, Task> UploadTestResultAttachmentAsyncFunc { get; set; } = (_, _, _, _, _) => Task.CompletedTask;
 
         public Func<AzureDevOpsPublishConfiguration, int, AzureDevOpsTestResultAttachment, CancellationToken, Task> UploadTestRunAttachmentAsyncFunc { get; set; } = (_, _, _, _) => Task.CompletedTask;
@@ -2222,6 +2696,12 @@ public sealed class AzureDevOpsLivePublishingTests
 
         public Task<IReadOnlyList<int>?> PublishTestResultsAsync(AzureDevOpsPublishConfiguration configuration, int runId, IReadOnlyList<AzureDevOpsTestCaseResult> results, CancellationToken cancellationToken)
             => PublishTestResultsAsyncFunc(configuration, runId, results, cancellationToken);
+
+        public Task UpdateTestResultsAsync(AzureDevOpsPublishConfiguration configuration, int runId, IReadOnlyList<AzureDevOpsTestCaseResult> results, CancellationToken cancellationToken)
+        {
+            UpdateTestResultsCalls.Add((runId, results));
+            return UpdateTestResultsAsyncFunc(configuration, runId, results, cancellationToken);
+        }
 
         public Task UpdateTestRunStateAsync(AzureDevOpsPublishConfiguration configuration, int runId, string state, CancellationToken cancellationToken)
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2398,7 +2398,7 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
-    public async Task WhenAnUpdateFails_TheAttemptHistoryDoesNotAdvance()
+    public async Task WhenAnUpdateFails_ForcedFlushRetriesAsCreate()
     {
         using TestDirectory directory = CreateTestDirectory();
         Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
@@ -2411,6 +2411,12 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.IsTrue(File.Exists(mapPath));
 
         AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([72]);
+        };
         client.UpdateTestResultsAsyncFunc = (_, _, _, _) => Task.FromException(new HttpRequestException("transient"));
 
         await StartPublisherAsync(secondAttempt);
@@ -2422,11 +2428,13 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.HasCount(1, client.UpdateTestResultsCalls);
         Assert.HasCount(2, client.UpdateTestResultsCalls[0].Results.Single().SubResults!);
+        Assert.HasCount(1, created);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, created[0].Outcome);
 
         // The map is invalidated before PATCH so a crash after an accepted update can never expose stale
-        // history. A rejected update therefore leaves no map; the next attempt safely creates a separate
-        // result rather than risking an incomplete replacement.
-        Assert.IsFalse(File.Exists(mapPath));
+        // history. The forced session-end flush immediately retries the forgotten attempt as a safe create.
+        Assert.IsTrue(File.Exists(mapPath));
+        Assert.DoesNotContain("\"id\":71", File.ReadAllText(mapPath));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2021,7 +2021,7 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
         await lifetime.BeforeRunAsync(CancellationToken.None);
 
-        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new PassedTestNodeStateProperty(), resultId: 31);
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 31);
 
         // Same test uid, different assembly. TestNode.Uid is only unique within a test application, so
         // keying on it alone would make the second assembly's test masquerade as a rerun of the first's.
@@ -2149,6 +2149,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         // Degraded to a separate result rather than to silence.
         Assert.HasCount(1, created);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, created[0].Outcome);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "An unreadable map must not merge into stale history.");
     }
 
     [TestMethod]
@@ -2233,7 +2235,7 @@ public sealed class AzureDevOpsLivePublishingTests
         {
             await publisher.ConsumeAsync(
                 Mock.Of<IDataProducer>(),
-                CreateMessage(CreateNode($"MyTest{i}", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+                CreateMessage(CreateNode($"MyTest{i}", new FailedTestNodeStateProperty(new InvalidOperationException($"failure {i}")), RetryTestStartTime)),
                 CancellationToken.None);
 
             Assert.IsFalse(File.Exists(mapPath), "The map is only needed by the next attempt, so it must not be rewritten as results are published.");
@@ -2260,6 +2262,27 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.IsFalse(File.Exists(mapPath), "An empty map only leaves a coordination file in the results directory for nobody to read.");
+    }
+
+    [TestMethod]
+    public async Task WhenAllResultsPass_NoMapFileIsLeftBehind()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out _, out _, out _, environment);
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("PassingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.IsFalse(File.Exists(mapPath), "Passing tests are not eligible for retry and must not grow the shared map.");
     }
 
     [TestMethod]
@@ -2549,7 +2572,7 @@ public sealed class AzureDevOpsLivePublishingTests
 
         await publisher.ConsumeAsync(
             Mock.Of<IDataProducer>(),
-            CreateMessage(CreateNode("NewTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CreateMessage(CreateNode("NewTest", new FailedTestNodeStateProperty(new InvalidOperationException("new")), RetryTestStartTime)),
             CancellationToken.None);
         await publisher.ConsumeAsync(
             Mock.Of<IDataProducer>(),

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2014,6 +2014,110 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task RetryAttempt_ParentDurationIncludesAllAttempts()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        TimingProperty firstTiming = new(new TimingInfo(
+            RetryTestStartTime,
+            RetryTestStartTime + TimeSpan.FromSeconds(30),
+            TimeSpan.FromSeconds(30)));
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient firstClient,
+            out _,
+            out _,
+            environment);
+        firstClient.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([26]);
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode(
+                "MyTest",
+                new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+                RetryTestStartTime,
+                firstTiming)),
+            CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        TimingProperty secondTiming = new(new TimingInfo(
+            RetryTestStartTime + TimeSpan.FromSeconds(30),
+            RetryTestStartTime + TimeSpan.FromSeconds(31),
+            TimeSpan.FromSeconds(1)));
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient secondClient,
+            out _,
+            out _,
+            environment);
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime, secondTiming)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestCaseResult parent = secondClient.UpdateTestResultsCalls.Single().Results.Single();
+        Assert.AreEqual(31_000, parent.DurationInMs);
+        Assert.AreEqual(30_000, parent.SubResults![0].DurationInMs);
+        Assert.AreEqual(1_000, parent.SubResults[1].DurationInMs);
+    }
+
+    [TestMethod]
+    public async Task FoldedDataDrivenRows_SharingUidUpdateTheirOwnResults()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient firstClient, out _, out _, environment);
+        firstClient.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([401, 402]);
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode(
+                "SharedUid",
+                new FailedTestNodeStateProperty(new InvalidOperationException("row one")),
+                RetryTestStartTime,
+                displayName: "MyTest(1)")),
+            CancellationToken.None);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode(
+                "SharedUid",
+                new FailedTestNodeStateProperty(new InvalidOperationException("row two")),
+                RetryTestStartTime,
+                displayName: "MyTest(2)")),
+            CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient secondClient, out _, out _, environment);
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "MyTest(1)")),
+            CancellationToken.None);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "MyTest(2)")),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, secondClient.UpdateTestResultsCalls);
+        IReadOnlyList<AzureDevOpsTestCaseResult> updated = secondClient.UpdateTestResultsCalls[0].Results;
+        Assert.HasCount(2, updated);
+        Assert.AreEqual(401, updated.Single(result => result.TestCaseTitle == "MyTest(1)").Id);
+        Assert.AreEqual(402, updated.Single(result => result.TestCaseTitle == "MyTest(2)").Id);
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -2333,7 +2437,7 @@ public sealed class AzureDevOpsLivePublishingTests
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
         File.WriteAllText(
             mapPath,
-            """{"buildId":123,"runId":4242,"results":[{"storage":"MyTests","name":"MyTest","id":81,"attempts":null}]}""");
+            """{"buildId":123,"runId":4242,"results":[{"storage":"MyTests","name":"MyTest","title":"MyTest","id":81,"attempts":null}]}""");
 
         AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         List<AzureDevOpsTestCaseResult> created = [];
@@ -2604,7 +2708,7 @@ public sealed class AzureDevOpsLivePublishingTests
                 null);
         }
 
-        AzureDevOpsPublishedResult published = new("tests", "MyTest", 123, attempts);
+        AzureDevOpsPublishedResult published = new("tests", "MyTest", "MyTest", 123, attempts);
         AzureDevOpsTestCaseResult nextResult = new(
             "MyTest",
             "tests",
@@ -2928,13 +3032,13 @@ public sealed class AzureDevOpsLivePublishingTests
     private static TestNodeUpdateMessage CreateMessage(TestNode node)
         => new(new SessionUid(Guid.NewGuid().ToString()), node);
 
-    private static TestNode CreateNode(string uid, IProperty state, DateTimeOffset startTime, TimingProperty? timing = null)
+    private static TestNode CreateNode(string uid, IProperty state, DateTimeOffset startTime, TimingProperty? timing = null, string? displayName = null)
     {
         PropertyBag properties = timing is null ? new PropertyBag(state) : new PropertyBag(state, timing);
         return new TestNode
         {
             Uid = new TestNodeUid(uid),
-            DisplayName = uid,
+            DisplayName = displayName ?? uid,
             Properties = properties,
         };
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2319,7 +2319,9 @@ public sealed class AzureDevOpsLivePublishingTests
               {"storage":"tests","name":"First","title":"First","id":433,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
               {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]},
               {"storage":"tests","name":"Malformed","title":"Malformed","id":434,"attempts":null},
-              {"storage":"tests","name":"Third","title":"Third","id":434,"attempts":[{"sequenceId":1,"displayName":"Third","outcome":"Failed","durationInMs":1}]}
+              {"storage":"tests","name":"Third","title":"Third","id":434,"attempts":[{"sequenceId":1,"displayName":"Third","outcome":"Failed","durationInMs":1}]},
+              {"storage":null,"name":"MalformedKey","title":"MalformedKey","id":435,"attempts":[{"sequenceId":1,"displayName":"MalformedKey","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"Fourth","title":"Fourth","id":435,"attempts":[{"sequenceId":1,"displayName":"Fourth","outcome":"Failed","durationInMs":1}]}
             ]}
             """);
 
@@ -2327,10 +2329,12 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestCaseResult first = new("First", "tests", "First", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
         AzureDevOpsTestCaseResult second = new("Second", "tests", "Second", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
         AzureDevOpsTestCaseResult third = new("Third", "tests", "Third", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        AzureDevOpsTestCaseResult fourth = new("Fourth", "tests", "Fourth", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
 
         Assert.IsNull(store.TryGet(first));
         Assert.IsNull(store.TryGet(second));
         Assert.IsNull(store.TryGet(third));
+        Assert.IsNull(store.TryGet(fourth));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2144,7 +2144,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 71);
 
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
-        string mapAfterFirstAttempt = File.ReadAllText(mapPath);
+        Assert.IsTrue(File.Exists(mapPath));
 
         AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         client.UpdateTestResultsAsyncFunc = (_, _, _, _) => Task.FromException(new HttpRequestException("transient"));
@@ -2159,12 +2159,10 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.HasCount(1, client.UpdateTestResultsCalls);
         Assert.HasCount(2, client.UpdateTestResultsCalls[0].Results.Single().SubResults!);
 
-        // Azure DevOps never accepted that update, so the map must still describe only the attempt that
-        // did land. Advancing it here would make a retry of the update list the same execution twice.
-        Assert.AreEqual(
-            mapAfterFirstAttempt,
-            File.ReadAllText(mapPath),
-            "A rejected update must leave the recorded attempt history untouched.");
+        // The map is invalidated before PATCH so a crash after an accepted update can never expose stale
+        // history. A rejected update therefore leaves no map; the next attempt safely creates a separate
+        // result rather than risking an incomplete replacement.
+        Assert.IsFalse(File.Exists(mapPath));
     }
 
     [TestMethod]
@@ -2225,6 +2223,196 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.IsFalse(File.Exists(mapPath), "An empty map only leaves a coordination file in the results directory for nobody to read.");
+    }
+
+    [TestMethod]
+    public async Task MapFromAnotherRunInTheSameBuild_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out FakeAzureDevOpsTestResultsClient lifetimeClient, out _, environment);
+        lifetimeClient.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(4242);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(directory.Path, environment, "MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), resultId: 81);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        string map = File.ReadAllText(mapPath);
+        string foreignRunMap = map.Replace("\"runId\":4242", "\"runId\":9999");
+        Assert.AreNotEqual(map, foreignRunMap, "The test expected the map to carry the run id.");
+        File.WriteAllText(mapPath, foreignRunMap);
+
+        AzureDevOpsTestResultsPublisher nextAttempt = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([82]);
+        };
+
+        await StartPublisherAsync(nextAttempt);
+        await nextAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await nextAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "Result ids from another run must never be PATCHed.");
+    }
+
+    [TestMethod]
+    public async Task OrchestrationsWithTheSameProcessId_UseDifferentMapPaths()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId(processId: 4321);
+
+        AzureDevOpsTestRunOrchestratorLifetime first = CreateOrchestratorLifetime(directory.Path, out FakeAzureDevOpsTestResultsClient firstClient, out _, environment);
+        firstClient.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(1001);
+        await first.BeforeRunAsync(CancellationToken.None);
+        string firstPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        await first.AfterRunAsync(0, CancellationToken.None);
+
+        AzureDevOpsTestRunOrchestratorLifetime second = CreateOrchestratorLifetime(directory.Path, out FakeAzureDevOpsTestResultsClient secondClient, out _, environment);
+        secondClient.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(1002);
+        await second.BeforeRunAsync(CancellationToken.None);
+        string secondPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        await second.AfterRunAsync(0, CancellationToken.None);
+
+        Assert.AreNotEqual(firstPath, secondPath, "A recycled process id must not revive a crashed orchestration's map.");
+    }
+
+    [TestMethod]
+    public async Task FailedMapSave_RemovesTheStaleMap()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        CollectingLogger logger = new();
+        SystemFileSystem fileSystem = new();
+
+        AzureDevOpsResultIdStore initial = await AzureDevOpsResultIdStore.OpenAsync(fileSystem, logger, mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult first = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 1, "first", null, null, null);
+        initial.RecordCreated(first, resultId: 91);
+        await initial.SaveAsync(CancellationToken.None);
+        Assert.IsTrue(File.Exists(mapPath));
+
+        UnwritableFileSystem failingFileSystem = new() { FailMoves = true };
+        AzureDevOpsResultIdStore updated = await AzureDevOpsResultIdStore.OpenAsync(failingFileSystem, logger, mapPath, buildId: 123, runId: 42);
+        AzureDevOpsPublishedResult published = updated.TryGet(first)!;
+        IReadOnlyList<AzureDevOpsTestSubResult> attempts = AzureDevOpsResultIdStore.BuildNextAttempts(
+            published,
+            first with { ErrorMessage = "second" });
+        updated.RecordAttempts(published, attempts);
+        await updated.SaveAsync(CancellationToken.None);
+
+        Assert.IsFalse(File.Exists(mapPath), "A stale map would let the next attempt erase accepted server history.");
+    }
+
+    [TestMethod]
+    public async Task CreateOnlySaveFailure_PreservesStillValidExistingEntries()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        CollectingLogger logger = new();
+        SystemFileSystem fileSystem = new();
+
+        AzureDevOpsResultIdStore initial = await AzureDevOpsResultIdStore.OpenAsync(fileSystem, logger, mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult existing = new("ExistingTest", "tests", "ExistingTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 1, "first", null, null, null);
+        initial.RecordCreated(existing, resultId: 95);
+        await initial.SaveAsync(CancellationToken.None);
+
+        UnwritableFileSystem failingFileSystem = new() { FailMoves = true };
+        AzureDevOpsResultIdStore updated = await AzureDevOpsResultIdStore.OpenAsync(failingFileSystem, logger, mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult newlyCreated = new("NewTest", "tests", "NewTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        updated.RecordCreated(newlyCreated, resultId: 96);
+        await updated.SaveAsync(CancellationToken.None);
+
+        Assert.IsTrue(File.Exists(mapPath), "A create-only failure does not make the already persisted entries stale.");
+        string survivingMap = File.ReadAllText(mapPath);
+        Assert.Contains("ExistingTest", survivingMap);
+        Assert.DoesNotContain("NewTest", survivingMap);
+    }
+
+    [TestMethod]
+    public async Task WhenTheExistingMapCannotBeInvalidated_RetryFallsBackToCreate()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        UnwritableFileSystem fileSystem = new();
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient firstClient,
+            out _,
+            out _,
+            environment,
+            fileSystem: fileSystem);
+        firstClient.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([97]);
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("boom")), RetryTestStartTime)),
+            CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        fileSystem.FailDeletes = true;
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient secondClient,
+            out _,
+            out _,
+            environment,
+            fileSystem: fileSystem);
+        List<AzureDevOpsTestCaseResult> created = [];
+        secondClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([98]);
+        };
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created, "The retry should degrade to a separate result when stale history cannot be invalidated.");
+        Assert.IsEmpty(secondClient.UpdateTestResultsCalls);
+    }
+
+    [TestMethod]
+    public async Task AttachmentCancellationAfterCreate_StillRecordsTheWholeAcceptedBatch()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([101, 102]);
+        client.UploadTestResultAttachmentAsyncFunc = (_, _, _, _, _) => Task.FromException(new OperationCanceledException());
+        await StartPublisherAsync(publisher);
+
+        TestNode first = CreateNode("FirstTest", new FailedTestNodeStateProperty(new InvalidOperationException("first")), RetryTestStartTime);
+        first.Properties.Add(new StandardOutputProperty("first output"));
+        TestNode second = CreateNode("SecondTest", new FailedTestNodeStateProperty(new InvalidOperationException("second")), RetryTestStartTime);
+        second.Properties.Add(new StandardOutputProperty("second output"));
+
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(first), CancellationToken.None);
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(second), CancellationToken.None));
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        string map = File.ReadAllText(mapPath);
+        Assert.Contains("FirstTest", map);
+        Assert.Contains("SecondTest", map);
     }
 
     /// <summary>
@@ -2477,7 +2665,8 @@ public sealed class AzureDevOpsLivePublishingTests
         Mock<ITestApplicationModuleInfo>? testApplicationModuleInfo = null,
         ITask? task = null,
         Mock<ITestApplicationProcessExitCode>? processExitCode = null,
-        CollectingOutputDevice? outputDevice = null)
+        CollectingOutputDevice? outputDevice = null,
+        IFileSystem? fileSystem = null)
     {
         Mock<ICommandLineOptions> commandLineOptions = new();
         commandLineOptions.Setup(x => x.IsOptionSet(AzureDevOpsCommandLineOptions.PublishAzureDevOpsTestResultsOptionName)).Returns(true);
@@ -2513,7 +2702,7 @@ public sealed class AzureDevOpsLivePublishingTests
             commandLineOptions.Object,
             configuration.Object,
             environment.Object,
-            new SystemFileSystem(),
+            fileSystem ?? new SystemFileSystem(),
             outputDevice ?? new CollectingOutputDevice(),
             testApplicationModuleInfo.Object,
             processExitCode.Object,
@@ -2547,6 +2736,10 @@ public sealed class AzureDevOpsLivePublishingTests
 
         public bool FailRunIdFileWrites { get; set; }
 
+        public bool FailMoves { get; set; }
+
+        public bool FailDeletes { get; set; }
+
         public IFileStream NewFileStream(string path, FileMode mode, FileAccess access, FileShare share)
             => FailRunIdFileWrites && Path.GetFileName(path).EndsWith(".json", StringComparison.Ordinal) && !Path.GetFileName(path).Contains("participant")
                 ? throw new IOException($"The process cannot access the file '{path}' because it is being used by another process.")
@@ -2556,7 +2749,15 @@ public sealed class AzureDevOpsLivePublishingTests
 
         public string CreateDirectory(string path) => _inner.CreateDirectory(path);
 
-        public void DeleteFile(string path) => _inner.DeleteFile(path);
+        public void DeleteFile(string path)
+        {
+            if (FailDeletes)
+            {
+                throw new IOException($"The process cannot delete the file '{path}'.");
+            }
+
+            _inner.DeleteFile(path);
+        }
 
         public bool ExistDirectory(string? path) => _inner.ExistDirectory(path);
 
@@ -2564,7 +2765,15 @@ public sealed class AzureDevOpsLivePublishingTests
 
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => _inner.GetFiles(path, searchPattern, searchOption);
 
-        public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false) => _inner.MoveFile(sourceFileName, destFileName, overwrite);
+        public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false)
+        {
+            if (FailMoves)
+            {
+                throw new IOException($"The process cannot move the file '{sourceFileName}' to '{destFileName}'.");
+            }
+
+            _inner.MoveFile(sourceFileName, destFileName, overwrite);
+        }
 
         public IFileStream NewFileStream(string path, FileMode mode) => _inner.NewFileStream(path, mode);
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2175,6 +2175,67 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task NewlyDuplicatedFoldedRow_FallsBackToCreates()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "SharedUid",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 421,
+            displayName: "Duplicate title");
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([422, 423]);
+        };
+        await StartPublisherAsync(secondAttempt);
+        for (int i = 0; i < 2; i++)
+        {
+            await secondAttempt.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "Duplicate title")),
+                CancellationToken.None);
+        }
+
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(2, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "Repeated matches to one parent must never produce duplicate PATCH ids.");
+    }
+
+    [TestMethod]
+    public async Task MapEntriesSharingResultId_AreIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        File.WriteAllText(
+            mapPath,
+            """
+            {"buildId":123,"runId":42,"results":[
+              {"storage":"tests","name":"First","title":"First","id":431,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"Second","title":"Second","id":431,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]}
+            ]}
+            """);
+
+        AzureDevOpsResultIdStore store = await AzureDevOpsResultIdStore.OpenAsync(new SystemFileSystem(), new CollectingLogger(), mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult first = new("First", "tests", "First", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        AzureDevOpsTestCaseResult second = new("Second", "tests", "Second", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+
+        Assert.IsNull(store.TryGet(first));
+        Assert.IsNull(store.TryGet(second));
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -2791,13 +2852,22 @@ public sealed class AzureDevOpsLivePublishingTests
     /// <summary>
     /// Runs one publisher to completion for a single test, so a following attempt has something to merge into.
     /// </summary>
-    private async Task PublishSingleResultAsync(string resultsDirectory, Mock<IEnvironment> environment, string uid, IProperty state, int resultId)
+    private async Task PublishSingleResultAsync(
+        string resultsDirectory,
+        Mock<IEnvironment> environment,
+        string uid,
+        IProperty state,
+        int resultId,
+        string? displayName = null)
     {
         AzureDevOpsTestResultsPublisher publisher = CreatePublisher(resultsDirectory, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
         client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([resultId]);
 
         await StartPublisherAsync(publisher);
-        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(CreateNode(uid, state, RetryTestStartTime)), CancellationToken.None);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode(uid, state, RetryTestStartTime, displayName: displayName)),
+            CancellationToken.None);
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2841,8 +2841,15 @@ public sealed class AzureDevOpsLivePublishingTests
             environment,
             fileSystem: fileSystem);
         List<AzureDevOpsTestCaseResult> created = [];
+        int createAttempts = 0;
         secondClient.PublishTestResultsAsyncFunc = (_, _, results, _) =>
         {
+            createAttempts++;
+            if (createAttempts == 1)
+            {
+                return Task.FromException<IReadOnlyList<int>?>(new HttpRequestException("transient safe-create failure"));
+            }
+
             created.AddRange(results);
             return Task.FromResult<IReadOnlyList<int>?>([98]);
         };

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2262,6 +2262,39 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task MapEntryWithoutAttemptHistory_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out FakeAzureDevOpsTestResultsClient lifetimeClient, out _, environment);
+        lifetimeClient.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(4242);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        File.WriteAllText(
+            mapPath,
+            """{"buildId":123,"runId":4242,"results":[{"storage":"MyTests","name":"MyTest","id":81,"attempts":null}]}""");
+
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, AzureDevOpsTestResultsPublisherOptions.Default, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([82]);
+        };
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("MyTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "An incomplete history must fall back to a safe create.");
+    }
+
+    [TestMethod]
     public async Task OrchestrationsWithTheSameProcessId_UseDifferentMapPaths()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2613,7 +2613,7 @@ public sealed class AzureDevOpsLivePublishingTests
         IReadOnlyList<AzureDevOpsTestSubResult> attempts = AzureDevOpsResultIdStore.BuildNextAttempts(
             published,
             first with { ErrorMessage = "second" });
-        updated.RecordAttempts(published, attempts);
+        updated.RecordAttempts(published, attempts, totalDurationInMs: 2);
         await updated.SaveAsync(CancellationToken.None);
 
         Assert.IsFalse(File.Exists(mapPath), "A stale map would let the next attempt erase accepted server history.");
@@ -2834,7 +2834,10 @@ public sealed class AzureDevOpsLivePublishingTests
                 null);
         }
 
-        AzureDevOpsPublishedResult published = new("tests", "MyTest", "MyTest", 123, attempts);
+        AzureDevOpsPublishedResult published = new("tests", "MyTest", "MyTest", 123, attempts)
+        {
+            TotalDurationInMs = 1000,
+        };
         AzureDevOpsTestCaseResult nextResult = new(
             "MyTest",
             "tests",
@@ -2847,14 +2850,20 @@ public sealed class AzureDevOpsLivePublishingTests
             null);
 
         IReadOnlyList<AzureDevOpsTestSubResult> next = AzureDevOpsResultIdStore.BuildNextAttempts(published, nextResult);
+        long? nextTotalDuration = AzureDevOpsResultIdStore.BuildNextTotalDuration(published, nextResult);
         IReadOnlyList<AzureDevOpsTestSubResult> afterNext = AzureDevOpsResultIdStore.BuildNextAttempts(
             published with { Attempts = next },
+            nextResult);
+        long? afterNextTotalDuration = AzureDevOpsResultIdStore.BuildNextTotalDuration(
+            published with { Attempts = next, TotalDurationInMs = nextTotalDuration },
             nextResult);
 
         Assert.HasCount(AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult, next);
         Assert.AreEqual(2, next[0].SequenceId);
         Assert.AreEqual(1001, next[^1].SequenceId);
         Assert.AreEqual(1002, afterNext[^1].SequenceId);
+        Assert.AreEqual(1001, nextTotalDuration);
+        Assert.AreEqual(1002, afterNextTotalDuration);
     }
 
     /// <summary>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2269,6 +2269,43 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task NewlyCreatedDuplicateInLaterBatch_FallsBackToCreate()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(1, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        List<AzureDevOpsTestCaseResult> created = [];
+        int nextId = 471;
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([nextId++]);
+        };
+        await StartPublisherAsync(publisher);
+
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode(
+                "SharedUid",
+                new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+                RetryTestStartTime,
+                displayName: "Duplicate title")),
+            CancellationToken.None);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("SharedUid", new PassedTestNodeStateProperty(), RetryTestStartTime, displayName: "Duplicate title")),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(2, created);
+        Assert.IsEmpty(client.UpdateTestResultsCalls, "A parent created in this attempt must never be reused by another row.");
+    }
+
+    [TestMethod]
     public async Task MapEntriesSharingResultId_AreIgnored()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2047,6 +2047,35 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task FirstAttempt_AttachmentNameIncludesAttemptOne()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient client,
+            out _,
+            out _,
+            environment);
+        TestNode node = CreateNode(
+            "MyTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            RetryTestStartTime);
+        node.Properties.Add(new StandardOutputProperty("first output"));
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(node), CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, client.UploadTestResultAttachmentCalls);
+        Assert.AreEqual("stdout.attempt-1.log", client.UploadTestResultAttachmentCalls[0].Attachment.FileName);
+    }
+
+    [TestMethod]
     public async Task RetryAttempt_ParentDurationIncludesAllAttempts()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -2249,7 +2278,9 @@ public sealed class AzureDevOpsLivePublishingTests
             """
             {"buildId":123,"runId":42,"results":[
               {"storage":"tests","name":"First","title":"First","id":431,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"Second","title":"Second","id":431,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]}
+              {"storage":"tests","name":"First","title":"First","id":432,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"First","title":"First","id":433,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]}
             ]}
             """);
 
@@ -2620,6 +2651,7 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.IsNull(created[0].Id);
         Assert.IsNull(created[0].SubResults);
         Assert.IsEmpty(client.UpdateTestResultsCalls, "Result ids from another run must never be PATCHed.");
+        Assert.AreEqual(foreignRunMap, File.ReadAllText(mapPath), "A foreign map path must remain read-only.");
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -1977,6 +1977,43 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task RetryAttempt_AttachmentNameIncludesAttemptAndPreservesExtension()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "MyTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 25);
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient client,
+            out _,
+            out _,
+            environment);
+        TestNode node = CreateNode(
+            "MyTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("second")),
+            RetryTestStartTime);
+        node.Properties.Add(new StandardOutputProperty("retry output"));
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(node), CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, client.UploadTestResultAttachmentCalls);
+        Assert.AreEqual(25, client.UploadTestResultAttachmentCalls[0].TestCaseResultId);
+        Assert.AreEqual("stdout.attempt-2.log", client.UploadTestResultAttachmentCalls[0].Attachment.FileName);
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2415,6 +2415,46 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.Contains("SecondTest", map);
     }
 
+    [TestMethod]
+    public void CappedAttemptHistory_ContinuesIncreasingSequenceIds()
+    {
+        var attempts = new AzureDevOpsTestSubResult[AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult];
+        for (int i = 0; i < attempts.Length; i++)
+        {
+            attempts[i] = new AzureDevOpsTestSubResult(
+                i + 1,
+                "MyTest",
+                AzureDevOpsLivePublishingConstants.FailedTestOutcome,
+                1,
+                null,
+                null,
+                null,
+                null);
+        }
+
+        AzureDevOpsPublishedResult published = new("tests", "MyTest", 123, attempts);
+        AzureDevOpsTestCaseResult nextResult = new(
+            "MyTest",
+            "tests",
+            "MyTest",
+            AzureDevOpsLivePublishingConstants.PassedTestOutcome,
+            1,
+            null,
+            null,
+            null,
+            null);
+
+        IReadOnlyList<AzureDevOpsTestSubResult> next = AzureDevOpsResultIdStore.BuildNextAttempts(published, nextResult);
+        IReadOnlyList<AzureDevOpsTestSubResult> afterNext = AzureDevOpsResultIdStore.BuildNextAttempts(
+            published with { Attempts = next },
+            nextResult);
+
+        Assert.HasCount(AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult, next);
+        Assert.AreEqual(2, next[0].SequenceId);
+        Assert.AreEqual(1001, next[^1].SequenceId);
+        Assert.AreEqual(1002, afterNext[^1].SequenceId);
+    }
+
     /// <summary>
     /// Runs one publisher to completion for a single test, so a following attempt has something to merge into.
     /// </summary>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2449,6 +2449,40 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task AttachmentCancellationInMixedBatch_DoesNotSkipUpdates()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "ExistingTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 201);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([202]);
+        client.UploadTestResultAttachmentAsyncFunc = (_, _, _, _, _) => Task.FromException(new OperationCanceledException());
+        await StartPublisherAsync(publisher);
+
+        TestNode newTest = CreateNode("NewTest", new FailedTestNodeStateProperty(new InvalidOperationException("new")), RetryTestStartTime);
+        newTest.Properties.Add(new StandardOutputProperty("new output"));
+
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(newTest), CancellationToken.None);
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => publisher.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode("ExistingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+                CancellationToken.None));
+
+        Assert.HasCount(1, client.UpdateTestResultsCalls, "The update must reach Azure DevOps before creation attachments are uploaded.");
+        Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
+    }
+
+    [TestMethod]
     public void CappedAttemptHistory_ContinuesIncreasingSequenceIds()
     {
         var attempts = new AzureDevOpsTestSubResult[AzureDevOpsLivePublishingConstants.MaxSubResultsPerResult];
@@ -2848,6 +2882,16 @@ public sealed class AzureDevOpsLivePublishingTests
             _inner.MoveFile(sourceFileName, destFileName, overwrite);
         }
 
+        public void ReplaceFile(string sourceFileName, string destFileName)
+        {
+            if (FailMoves)
+            {
+                throw new IOException($"The process cannot replace the file '{destFileName}'.");
+            }
+
+            _inner.ReplaceFile(sourceFileName, destFileName);
+        }
+
         public IFileStream NewFileStream(string path, FileMode mode) => _inner.NewFileStream(path, mode);
 
         public IFileStream NewFileStream(string path, FileMode mode, FileAccess access) => _inner.NewFileStream(path, mode, access);
@@ -2888,6 +2932,8 @@ public sealed class AzureDevOpsLivePublishingTests
         public string[] GetFiles(string path, string searchPattern, SearchOption searchOption) => _inner.GetFiles(path, searchPattern, searchOption);
 
         public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false) => _inner.MoveFile(sourceFileName, destFileName, overwrite);
+
+        public void ReplaceFile(string sourceFileName, string destFileName) => _inner.ReplaceFile(sourceFileName, destFileName);
 
         public IFileStream NewFileStream(string path, FileMode mode) => _inner.NewFileStream(path, mode);
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -3195,6 +3195,8 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.AreEqual(777, result.GetProperty("id").GetInt32());
         Assert.AreEqual("rerun", result.GetProperty("resultGroupType").GetString());
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, result.GetProperty("outcome").GetString());
+        Assert.AreEqual(JsonValueKind.Null, result.GetProperty("errorMessage").ValueKind);
+        Assert.AreEqual(JsonValueKind.Null, result.GetProperty("stackTrace").ValueKind);
 
         JsonElement subResults = result.GetProperty("subResults");
         Assert.AreEqual(2, subResults.GetArrayLength());
@@ -3239,6 +3241,8 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.IsFalse(created.TryGetProperty("id", out _));
         Assert.IsFalse(created.TryGetProperty("resultGroupType", out _));
         Assert.IsFalse(created.TryGetProperty("subResults", out _));
+        Assert.IsFalse(created.TryGetProperty("errorMessage", out _));
+        Assert.IsFalse(created.TryGetProperty("stackTrace", out _));
     }
 
     #endregion

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -1578,6 +1578,29 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task OrchestratorLifetime_ResultMapHandoffFailure_UsesSpecificDiagnostic()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        environment.Setup(x => x.SetEnvironmentVariable(AzureDevOpsConstants.ResultMapPathEnvironmentVariableName, It.IsAny<string>()))
+            .Throws(new SecurityException("result map handoff is locked down"));
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(
+            directory.Path,
+            out FakeAzureDevOpsTestResultsClient client,
+            out CollectingLogger logger,
+            environment);
+        client.CreateTestRunAsyncFunc = (_, _) => Task.FromResult(4249);
+
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await lifetime.AfterRunAsync(0, CancellationToken.None);
+
+        Assert.HasCount(1, client.UpdateTestRunStateCalls);
+        Assert.Contains(
+            AzureDevOpsResources.AzureDevOpsLivePublishingResultMapHandoffFailed,
+            string.Join(Environment.NewLine, logger.Logs));
+    }
+
+    [TestMethod]
     public async Task OrchestratorLifetime_PeerOrchestratorsSharingAResultsDirectory_PublishIntoASingleRun()
     {
         // A multi-project 'dotnet test' runs one orchestrator process per test project, all sharing the
@@ -2239,6 +2262,25 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task MapEntryWithTerminalSequenceId_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        File.WriteAllText(
+            mapPath,
+            """
+            {"buildId":123,"runId":42,"results":[
+              {"storage":"tests","name":"MyTest","title":"MyTest","id":441,"attempts":[{"sequenceId":2147483647,"displayName":"MyTest","outcome":"Failed","durationInMs":1}]}
+            ]}
+            """);
+
+        AzureDevOpsResultIdStore store = await AzureDevOpsResultIdStore.OpenAsync(new SystemFileSystem(), new CollectingLogger(), mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult result = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+
+        Assert.IsNull(store.TryGet(result));
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -2810,6 +2852,53 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
         Assert.HasCount(1, created);
         Assert.AreEqual("NewTest", created[0].AutomatedTestName);
+    }
+
+    [TestMethod]
+    public async Task FailedCreationPost_DoesNotConsumeUnattemptedUpdateClaim()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "ExistingTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 451);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        int createAttempts = 0;
+        List<AzureDevOpsTestCaseResult> created = [];
+        client.PublishTestResultsAsyncFunc = (_, _, results, _) =>
+        {
+            createAttempts++;
+            if (createAttempts == 1)
+            {
+                return Task.FromException<IReadOnlyList<int>?>(new HttpRequestException("transient create failure"));
+            }
+
+            created.AddRange(results);
+            return Task.FromResult<IReadOnlyList<int>?>([452]);
+        };
+        await StartPublisherAsync(publisher);
+
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("NewTest", new FailedTestNodeStateProperty(new InvalidOperationException("new")), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(CreateNode("ExistingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+            CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, created);
+        Assert.AreEqual("NewTest", created[0].AutomatedTestName);
+        Assert.HasCount(1, client.UpdateTestResultsCalls, "The untouched parent claim must be available on the forced retry.");
+        Assert.AreEqual(451, client.UpdateTestResultsCalls[0].Results.Single().Id);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxResultStreamingStoreTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxResultStreamingStoreTests.cs
@@ -221,6 +221,8 @@ public sealed class TrxResultStreamingStoreTests
 
         public void MoveFile(string sourceFileName, string destFileName, bool overwrite = false) => throw new NotSupportedException();
 
+        public void ReplaceFile(string sourceFileName, string destFileName) => throw new NotSupportedException();
+
         public string ReadAllText(string path) => File.ReadAllText(path);
 
         public Task<string> ReadAllTextAsync(string path) => Task.FromResult(File.ReadAllText(path));


### PR DESCRIPTION
## Summary

- publish the first execution of a test as a normal Azure DevOps result and persist its assigned result id
- publish later retry attempts by PATCHing that result with `resultGroupType: "rerun"` and accumulated `subResults`
- use the latest attempt as the parent outcome while retaining earlier failures as sub-results
- coordinate result ids across retry-host processes with a run-scoped, atomically written map
- fall back to separate result creation whenever ids or safe persisted state are unavailable, so results are never dropped
- keep retry attachments on the parent result with attempt-qualified names

## Coordination and compatibility

The retry orchestrator gives each attempt a separate results directory, so it publishes a shared map path through a new build-scoped environment-variable handoff. This is intentionally separate from the existing run-id handoff so older processes continue to parse and honor the one-run-per-build contract from #10375.

The map is scoped by a random orchestration id and validates both build id and run id. Before PATCHing an existing result, the persisted map is invalidated; if that cannot be done safely, publishing degrades to a separate POST rather than risking stale history replacing an accepted attempt.

## Validation

- full Debug solution build
- `Microsoft.Testing.Extensions.UnitTests`: 928 passed, 0 failed, 6 skipped
- `Microsoft.Testing.Platform.UnitTests`: 2024 passed, 0 failed
- four independent code-review rounds; all actionable findings addressed

Closes #10400