### PR TITLE
Simplify UseAttributeOnTestMethodAnalyzer description field

### DIFF
--- a/src/Analyzers/MSTest.Analyzers/UseAttributeOnTestMethodAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/UseAttributeOnTestMethodAnalyzer.cs
@@ -19,6 +19,13 @@ namespace MSTest.Analyzers;
 public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
 {
     private const string OwnerAttributeShortName = "Owner";
+    private const string PriorityAttributeShortName = "Priority";
+    private const string DescriptionAttributeShortName = "Description";
+    private const string TestPropertyAttributeShortName = "TestProperty";
+    private const string WorkItemAttributeShortName = "WorkItem";
+    private const string ConditionBaseAttributeShortName = "ConditionBaseAttribute";
+
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor OwnerRule = DiagnosticDescriptorHelper.Create(
@@ -27,12 +34,10 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), OwnerAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), OwnerAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private const string PriorityAttributeShortName = "Priority";
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor PriorityRule = DiagnosticDescriptorHelper.Create(
@@ -41,12 +46,10 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), PriorityAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), PriorityAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private const string DescriptionAttributeShortName = "Description";
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor DescriptionRule = DiagnosticDescriptorHelper.Create(
@@ -55,12 +58,10 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), DescriptionAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), DescriptionAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private const string TestPropertyAttributeShortName = "TestProperty";
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor TestPropertyRule = DiagnosticDescriptorHelper.Create(
@@ -69,12 +70,10 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), TestPropertyAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), TestPropertyAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private const string WorkItemAttributeShortName = "WorkItem";
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor WorkItemRule = DiagnosticDescriptorHelper.Create(
@@ -83,12 +82,10 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), WorkItemAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), WorkItemAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
-
-    private const string ConditionBaseAttributeShortName = "ConditionBaseAttribute";
 
     /// <inheritdoc cref="Resources.UseAttributeOnTestMethodAnalyzerTitle" />
     public static readonly DiagnosticDescriptor ConditionBaseRule = DiagnosticDescriptorHelper.Create(
@@ -97,7 +94,7 @@ public sealed class UseAttributeOnTestMethodAnalyzer : DiagnosticAnalyzer
             nameof(Resources.UseAttributeOnTestMethodAnalyzerTitle), Resources.ResourceManager, typeof(Resources), ConditionBaseAttributeShortName),
         messageFormat: new LocalizableResourceString(
             nameof(Resources.UseAttributeOnTestMethodAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources), ConditionBaseAttributeShortName),
-        description: new LocalizableResourceString(nameof(Resources.UseAttributeOnTestMethodAnalyzerDescription), Resources.ResourceManager, typeof(Resources)),
+        description: Description,
         Category.Usage,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);


### PR DESCRIPTION
## Summary

- reuse one localized description across all MSTEST0007 diagnostic descriptors
- group attribute-name constants before non-constant fields
- preserve diagnostic behavior while removing duplicate construction

## Testing

- `build.cmd -projects test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj -test -bl`
- passed on `net472` and `net8.0` with zero warnings and errors

Fixes #10433