### PR TITLE
Fix pipeline matrix job titles

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ stages:
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   jobs:
   - job: Windows
-    displayName: Windows $(_BuildConfig)
+    displayName: Windows
     timeoutInMinutes: 90
     pool:
       name: NetCore-Public


### PR DESCRIPTION
## Summary

- remove the runtime matrix variable from the Windows job display name
- let Azure DevOps append the `Release` and `Debug` matrix leg names
- fix titles rendering as `Windows $(_BuildConfig) Release` / `Debug`

Related build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1540570&view=logs&j=d89d42a5-6233-54f2-c754-4640cafeacb4