### PR TITLE
Enforce warnings as errors for reflection-free acceptance builds

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
@@ -98,6 +98,9 @@ public static class AcceptanceSourceGen
         string sourceGenModeArg = metadataMode == MetadataMode.AotSourceGeneration
             ? " -p:MSTestSourceGenMode=ReflectionFree"
             : " -p:MSTestSourceGenMode=Rooting";
+        string warningsAsErrorsArg = metadataMode == MetadataMode.AotSourceGeneration
+            ? " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true"
+            : string.Empty;
 
         // - CustomBeforeMicrosoftCommonProps injects the source-generator PackageReference early
         //   enough for restore to see it, without clobbering any Directory.Build.props.
@@ -107,11 +110,15 @@ public static class AcceptanceSourceGen
         //   escape the quote on Windows and corrupt the argument. MSBuild accepts forward slashes on
         //   all platforms.
         // - The version property feeds the resolved package version into the injected props.
+        // - ReflectionFree warnings are errors so AOTSG diagnostics for unsupported shapes cannot
+        //   silently drop tests from the generated registry. MSBuild warnings remain errors as well,
+        //   preserving the warning-clean build guarantee documented in the injected props.
         return $"-p:CustomBeforeMicrosoftCommonProps=\"{propsPath}\" "
             + $"-p:BaseOutputPath=\"bin/{outputSubFolder}/\" "
             + $"-p:BaseIntermediateOutputPath=\"obj/{outputSubFolder}/\" "
             + $"-p:{versionProperty}={version}"
-            + sourceGenModeArg;
+            + sourceGenModeArg
+            + warningsAsErrorsArg;
     }
 
     private static string BuildPropsContent(string packageId, string versionProperty) =>

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -80,6 +80,9 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
                 DotnetMuxerResult sourceGenResult = await DotnetCli.RunAsync(
                     $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
                     failIfReturnValueIsNotZero: false,
+                    // ReflectionFree carries its own warning promotion in sourceGenArgs. Disable the
+                    // shared default here so acceptance runs verify that mode-specific contract.
+                    warnAsError: mode != MetadataMode.AotSourceGeneration,
                     callerMemberName: $"{assetName}_{AcceptanceSourceGen.GetOutputSubFolder(mode)}",
                     cancellationToken: cancellationToken);
 


### PR DESCRIPTION
## Summary
- promote compiler and MSBuild warnings to errors in `ReflectionFree` acceptance builds
- make the reflection-free mode own this contract instead of relying on the shared CLI default
- exercise the mode-specific warning settings in regular acceptance asset builds

## Validation
- built `Microsoft.Testing.TestInfrastructure.csproj` with 0 warnings and 0 errors
- ran `build.cmd -c Release -pack` with 0 warnings and 0 errors
- ran `MSTest.Acceptance.IntegrationTests.InconclusiveTests`: 24 passed, including all 8 `AotSourceGeneration` cases