### PR TITLE
Enforce warnings as errors for all acceptance assets

### DIFF
--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/AcceptanceSourceGen.cs
@@ -98,9 +98,7 @@ public static class AcceptanceSourceGen
         string sourceGenModeArg = metadataMode == MetadataMode.AotSourceGeneration
             ? " -p:MSTestSourceGenMode=ReflectionFree"
             : " -p:MSTestSourceGenMode=Rooting";
-        string warningsAsErrorsArg = metadataMode == MetadataMode.AotSourceGeneration
-            ? " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true"
-            : string.Empty;
+        const string warningsAsErrorsArg = " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true";
 
         // - CustomBeforeMicrosoftCommonProps injects the source-generator PackageReference early
         //   enough for restore to see it, without clobbering any Directory.Build.props.
@@ -110,9 +108,8 @@ public static class AcceptanceSourceGen
         //   escape the quote on Windows and corrupt the argument. MSBuild accepts forward slashes on
         //   all platforms.
         // - The version property feeds the resolved package version into the injected props.
-        // - ReflectionFree warnings are errors so AOTSG diagnostics for unsupported shapes cannot
-        //   silently drop tests from the generated registry. MSBuild warnings remain errors as well,
-        //   preserving the warning-clean build guarantee documented in the injected props.
+        // - Compiler and MSBuild warnings are errors for every source-generation mode so diagnostics
+        //   cannot silently drop tests from the generated registry.
         return $"-p:CustomBeforeMicrosoftCommonProps=\"{propsPath}\" "
             + $"-p:BaseOutputPath=\"bin/{outputSubFolder}/\" "
             + $"-p:BaseIntermediateOutputPath=\"obj/{outputSubFolder}/\" "

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -62,7 +62,11 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     {
         (string assetId, string assetName, string assetCode) = GetAssetsToGenerate();
         TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetId, assetCode, _tempDirectory);
-        DotnetMuxerResult result = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -c Release", callerMemberName: assetName, cancellationToken: cancellationToken);
+        DotnetMuxerResult result = await DotnetCli.RunAsync(
+            $"build {testAsset.TargetAssetPath} -c Release -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true",
+            warnAsError: false,
+            callerMemberName: assetName,
+            cancellationToken: cancellationToken);
         testAsset.DotnetResult = result;
         _testAssets.TryAdd(assetId, testAsset);
 
@@ -80,9 +84,9 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
                 DotnetMuxerResult sourceGenResult = await DotnetCli.RunAsync(
                     $"build {testAsset.TargetAssetPath} -c Release {sourceGenArgs}",
                     failIfReturnValueIsNotZero: false,
-                    // ReflectionFree carries its own warning promotion in sourceGenArgs. Disable the
-                    // shared default here so acceptance runs verify that mode-specific contract.
-                    warnAsError: mode != MetadataMode.AotSourceGeneration,
+                    // Every source-generation mode carries warning promotion in sourceGenArgs. Disable
+                    // the shared default here so acceptance runs verify that explicit contract.
+                    warnAsError: false,
                     callerMemberName: $"{assetName}_{AcceptanceSourceGen.GetOutputSubFolder(mode)}",
                     cancellationToken: cancellationToken);
 


### PR DESCRIPTION
## Summary

- explicitly pass `MSBuildTreatWarningsAsErrors=true` and `TreatWarningsAsErrors=true` to normal generated acceptance asset builds
- enforce the same explicit properties for both Rooting and ReflectionFree source-generation variants
- disable the shared implicit `DotnetCli` injection at these call sites so acceptance runs verify the explicit contract

## Validation

- `.\build.cmd -c Release -pack -bl` - passed with 0 warnings and 0 errors
- MSTest acceptance suite - 960 passed, 4 skipped; 4 NativeAOT failures caused by unavailable `vswhere.exe`
- Microsoft.Testing.Platform acceptance suite - 781 passed, 13 skipped; 2 identical NativeAOT tooling failures and one unrelated, reproducible net462 TRX artifact failure
- representative Reflection, Rooting, and ReflectionFree asset binlogs confirmed both properties on the MSBuild command line and no repository warning diagnostics

A focused code-review pass found no issues.