### PR TITLE
Document Microsoft.Testing.Platform exit codes

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -130,6 +130,30 @@ A public enum in the `Microsoft.VisualStudio.TestTools.UnitTesting` namespace th
 
 An MSTest attribute (`[DynamicData]`) for data-driven tests where test data is sourced from a static property, method, or field rather than inline `[DataRow]` values. The data source name is passed as a constructor argument; `DynamicDataSourceType` controls how the source is located (`Property`, `Method`, `Field`, or `AutoDetect`). Unlike `[DataRow]`, a single `[DynamicData]` source can be shared across multiple test methods and can produce any number of test cases at runtime. See `docs/RFCs/006-DynamicData-Attribute.md` for the original design.
 
+## E
+
+### Exit Codes
+
+Microsoft.Testing.Platform (MTP) uses the following process exit codes. A CI pipeline or script can use [`--ignore-exit-code`](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-troubleshooting#ignore-specific-exit-codes) to convert selected non-success exit codes to `0`; only ignore a code when the corresponding condition is acceptable for that workflow.
+
+| Code | Name | Meaning and suggested action |
+| ---: | --- | --- |
+| 0 | `Success` | The test run succeeded. |
+| 1 | `GenericFailure` | The test run failed for a reason not represented by a more specific code. Review the preceding error output and diagnostic logs. |
+| 2 | `AtLeastOneTestFailed` | At least one test failed. Review the reported test failures. |
+| 3 | `TestSessionAborted` | The test session was aborted, for example by cancellation. Determine what stopped the run and retry if appropriate. |
+| 4 | `InvalidPlatformSetup` | The test platform setup is invalid. Review the reported configuration or extension validation error. |
+| 5 | `InvalidCommandLine` | The command-line arguments are invalid. Correct the arguments using the `--help` output. |
+| 6 | _Reserved_ | This retired value must not be reused. |
+| 7 | `TestHostProcessExitedNonGracefully` | The test host process exited without completing its shutdown protocol. Review crash output and diagnostic logs. |
+| 8 | `ZeroTests` | No tests counted as executed under the active [zero-tests policy](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options#platform-options). This includes an all-skipped run when the policy is `strict`. Check discovery, filters, skip conditions, and the configured policy. |
+| 9 | `MinimumExpectedTestsPolicyViolation` | Fewer tests ran than required by `--minimum-expected-tests`. Check discovery, filters, and the configured minimum. |
+| 10 | `TestAdapterTestSessionFailure` | The test adapter reported a test-session failure. Review the adapter's error and diagnostic logs. |
+| 11 | `DependentProcessExited` | A process monitored through `--exit-on-process-exit` exited. Review that process and its lifetime relative to the test run. |
+| 12 | `IncompatibleProtocolVersion` | The communicating test-platform processes negotiated incompatible protocol versions. Use compatible platform components. |
+| 13 | `TestExecutionStoppedForMaxFailedTests` | Test execution stopped after reaching the `--maximum-failed-tests` limit. Review the failures or adjust the limit. |
+| 14 | `CoverageThresholdFailed` | One or more [code-coverage thresholds](#testcoveragethresholdmessage) were not met. Review the reported coverage results or threshold configuration. |
+
 ## F
 
 ### FQN (Fully Qualified Name)
@@ -475,7 +499,7 @@ A public sealed class in `Microsoft.Testing.Platform.Extensions.Messages` (exten
 
 ### TestCoverageThresholdMessage
 
-A public sealed class in `Microsoft.Testing.Platform.Extensions.Messages` (extends `DataWithSessionUid`) published by a coverage collector to report the result of a coverage threshold evaluation. Carries the same metric identification as [TestCoverageMessage](#testcoveragemessage) plus: `Aggregation` ([CoverageAggregation](#coverageaggregation)), `AggregatedOver` (optional [CoverageScopeLevel](#coveragescopelevel)), `ActualPercentage`, `RequiredPercentage`, `HasCoverableData`, `TreatNoDataAsFailure`, and `Passed` (derived: a threshold with no coverable data passes unless `TreatNoDataAsFailure` is set). When any threshold message has `Passed == false`, `ITestCoverageResult.HasThresholdFailure` returns `true`; an otherwise-successful run then exits with `ExitCode.CoverageThresholdFailed` (14), while an existing non-success exit code retains precedence. Introduced in [PR #9896](https://github.com/microsoft/testfx/pull/9896). See also [TestCoverageMessage](#testcoveragemessage), [ITestCoverageResult](#itestcoverageresult).
+A public sealed class in `Microsoft.Testing.Platform.Extensions.Messages` (extends `DataWithSessionUid`) published by a coverage collector to report the result of a coverage threshold evaluation. Carries the same metric identification as [TestCoverageMessage](#testcoveragemessage) plus: `Aggregation` ([CoverageAggregation](#coverageaggregation)), `AggregatedOver` (optional [CoverageScopeLevel](#coveragescopelevel)), `ActualPercentage`, `RequiredPercentage`, `HasCoverableData`, `TreatNoDataAsFailure`, and `Passed` (derived: a threshold with no coverable data passes unless `TreatNoDataAsFailure` is set). When any threshold message has `Passed == false`, `ITestCoverageResult.HasThresholdFailure` returns `true`; an otherwise-successful run then exits with [`CoverageThresholdFailed`](#exit-codes), while an existing non-success exit code retains precedence. Introduced in [PR #9896](https://github.com/microsoft/testfx/pull/9896). See also [TestCoverageMessage](#testcoveragemessage), [ITestCoverageResult](#itestcoverageresult).
 
 ### TestFilterContext
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -145,7 +145,7 @@ Microsoft.Testing.Platform (MTP) uses the following process exit codes. A CI pip
 | 4 | `InvalidPlatformSetup` | The test platform setup is invalid. Review the reported configuration or extension validation error. |
 | 5 | `InvalidCommandLine` | The command-line arguments are invalid. Correct the arguments using the `--help` output. |
 | 6 | _Reserved_ | This retired value must not be reused. |
-| 7 | `TestHostProcessExitedNonGracefully` | The test host process exited without completing its shutdown protocol. Review crash output and diagnostic logs. |
+| 7 | `TestHostProcessExitedNonGracefully` | The test host process exited without completing its shutdown protocol, or its IPC-reported exit code differed from its OS exit code. Review crash output and diagnostic logs. |
 | 8 | `ZeroTests` | No tests counted as executed under the active [zero-tests policy](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options#platform-options). This includes an all-skipped run when the policy is `strict`. Check discovery, filters, skip conditions, and the configured policy. |
 | 9 | `MinimumExpectedTestsPolicyViolation` | Fewer tests ran than required by `--minimum-expected-tests`. Check discovery, filters, and the configured minimum. |
 | 10 | `TestAdapterTestSessionFailure` | The test adapter reported a test-session failure. Review the adapter's error and diagnostic logs. |

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
@@ -8,23 +8,80 @@ namespace Microsoft.Testing.Platform.Helpers;
 /// <summary>
 /// We use positive exit codes for failure because POSIX/BASH exit codes are unsigned 8-bit integers.
 /// On POSIX systems the standard exit code is 0 for success and any number from 1 to 255 for anything else.
+/// See the <see href="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes">exit-code reference</see> for user-facing guidance.
 /// </summary>
 [Embedded]
 internal enum ExitCode
 {
+    /// <summary>
+    /// The test run succeeded.
+    /// </summary>
     Success = 0,
+
+    /// <summary>
+    /// The test run failed for a reason not represented by a more specific exit code.
+    /// </summary>
     GenericFailure = 1,
+
+    /// <summary>
+    /// At least one test failed.
+    /// </summary>
     AtLeastOneTestFailed = 2,
+
+    /// <summary>
+    /// The test session was aborted.
+    /// </summary>
     TestSessionAborted = 3,
+
+    /// <summary>
+    /// The test platform setup or extension configuration is invalid.
+    /// </summary>
     InvalidPlatformSetup = 4,
+
+    /// <summary>
+    /// The command-line arguments are invalid.
+    /// </summary>
     InvalidCommandLine = 5,
-    // FeatureNotImplemented = 6,
+
+    // Value 6 is reserved for the retired FeatureNotImplemented code and must not be reused.
+
+    /// <summary>
+    /// The test host process exited without completing its shutdown protocol.
+    /// </summary>
     TestHostProcessExitedNonGracefully = 7,
+
+    /// <summary>
+    /// No tests counted as executed under the active zero-tests policy.
+    /// </summary>
     ZeroTests = 8,
+
+    /// <summary>
+    /// Fewer tests ran than required by the minimum-expected-tests policy.
+    /// </summary>
     MinimumExpectedTestsPolicyViolation = 9,
+
+    /// <summary>
+    /// The test adapter reported a test-session failure.
+    /// </summary>
     TestAdapterTestSessionFailure = 10,
+
+    /// <summary>
+    /// A process monitored by the dependent-process listener exited.
+    /// </summary>
     DependentProcessExited = 11,
+
+    /// <summary>
+    /// The communicating test-platform processes use incompatible protocol versions.
+    /// </summary>
     IncompatibleProtocolVersion = 12,
+
+    /// <summary>
+    /// Test execution stopped after reaching the maximum-failed-tests limit.
+    /// </summary>
     TestExecutionStoppedForMaxFailedTests = 13,
+
+    /// <summary>
+    /// One or more code-coverage thresholds were not met.
+    /// </summary>
     CoverageThresholdFailed = 14,
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/ExitCodes.cs
@@ -46,7 +46,7 @@ internal enum ExitCode
     // Value 6 is reserved for the retired FeatureNotImplemented code and must not be reused.
 
     /// <summary>
-    /// The test host process exited without completing its shutdown protocol.
+    /// The test host process exited without completing its shutdown protocol, or its IPC-reported exit code differed from its OS exit code.
     /// </summary>
     TestHostProcessExitedNonGracefully = 7,
 

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -728,9 +728,10 @@ Read more about Microsoft Testing Platform telemetry: https://aka.ms/testingplat
     <comment>{0} is the directory path, {1} is the underlying error message, {2} is the environment variable name. Do not translate the environment variable name.</comment>
   </data>
   <data name="PlatformCommandLineIgnoreExitCodeOptionDescription" xml:space="preserve">
-    <value>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</value>
-    <comment>{Locked="--ignore-exit-code 8;9"}</comment>
+    <value>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</value>
+    <comment>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</comment>
   </data>
   <data name="PlatformCommandLineExitOnProcessExitOptionDescription" xml:space="preserve">
     <value>Exit the test process if dependent process exits. PID must be provided.</value>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -719,11 +719,12 @@ Volitelně přijímá hodnotu „text“ (výchozí výstup čitelný pro člov�
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Neohlašujte neúspěšnou ukončovací hodnotu pro konkrétní ukončovací kódy
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Neohlašujte neúspěšnou ukončovací hodnotu pro konkrétní ukončovací kódy
 (např. „--ignore-exit-code 8;9“ ignoruje ukončovací kód 8 a 9 a v takovém případě vrátí hodnotu 0.)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -719,11 +719,12 @@ Akzeptiert optional „text“ (die standardmäsige lesbare Ausgabe) oder „jso
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Nicht erfolgreichen Beendigungswert für bestimmte Exitcodes nicht melden
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Nicht erfolgreichen Beendigungswert für bestimmte Exitcodes nicht melden
 (Beispiel: "--ignore-exit-code 8;9' ignoriert Exitcode 8 und 9 und gibt in diesem Fall 0 zurück)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -719,11 +719,12 @@ Opcionalmente, acepta "text" (la salida legible por el usuario predeterminada) o
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">No notificar el valor de salida no correcto para códigos de salida específicos
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">No notificar el valor de salida no correcto para códigos de salida específicos
 (por ejemplo, '--ignore-exit-code 8;9' omitir código de salida 8 y 9 y devolverá 0 en este caso)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -719,11 +719,12 @@ Accepte éventuellement « text » (sortie lisible par l’humain par défaut)
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Ne signalez pas de valeur de sortie non réussie pour des codes de sortie spécifiques
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Ne signalez pas de valeur de sortie non réussie pour des codes de sortie spécifiques
 (par exemple, « --ignore-exit-code 8;9 » ignorent les codes de sortie 8 et 9 et retournent 0 dans ce cas)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -719,11 +719,12 @@ Facoltativamente accetta ''text'' (output leggibile predefinito) o ''json'' per 
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Non segnalare un valore di uscita non riuscito per codici di uscita specifici
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Non segnalare un valore di uscita non riuscito per codici di uscita specifici
 (ad esempio '--ignore-exit-code 8;9' ignora il codice di uscita 8 e 9 e restituirà 0 in questo caso)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -720,11 +720,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">特定の終了コードの成功しなかった終了値を報告しない
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">特定の終了コードの成功しなかった終了値を報告しない
 (例: '--ignore-exit-code 8;9' は終了コード 8 および 9 を無視し、これらの場合は 0 を返します)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -719,11 +719,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">특정 종료 코드에 대해 실패한 종료 값을 보고하지 마세요.
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">특정 종료 코드에 대해 실패한 종료 값을 보고하지 마세요.
 (예: '--ignore-exit-code 8;9'는 종료 코드 8 및 9를 무시하고 이 경우 0을 반환합니다.)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -719,11 +719,12 @@ Opcjonalnie akceptuje „text” (domyślne dane wyjściowe czytelne dla człowi
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Nie zgłaszaj wartości zakończenia zakończonego niepowodzeniem dla określonych kodów zakończenia
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Nie zgłaszaj wartości zakończenia zakończonego niepowodzeniem dla określonych kodów zakończenia
 (np. „--ignore-exit-code 8;9” ignoruje kod zakończenia 8 i 9 i zwróci wartość 0 w tym przypadku)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -719,11 +719,12 @@ Opcionalmente, aceita 'text' (a saída legível por humanos padrão) ou 'json' p
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Não relatar valor de saída não bem-sucedido para códigos de saída específicos
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Não relatar valor de saída não bem-sucedido para códigos de saída específicos
 (por exemplo, '--ignore-exit-code 8;9' ignora o código de saída 8 e 9 e retornará 0 nesses casos)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -719,11 +719,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Не сообщать о неуспешном значении выхода для определенных кодов выхода
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Не сообщать о неуспешном значении выхода для определенных кодов выхода
 (например, "--ignore-exit-code 8;9" игнорирует коды выхода 8 и 9 и в этих случаях возвращает 0)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -719,11 +719,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">Belirli çıkış kodları için başarılı olmayan çıkış değerini raporlamayın
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">Belirli çıkış kodları için başarılı olmayan çıkış değerini raporlamayın
 (ör. '--ignore-exit-code 8;9' çıkış kodu 8 ve 9'u yoksayar ve bu durumda 0 döndürür)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -719,11 +719,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">请勿报告特定退出代码的非成功退出值
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">请勿报告特定退出代码的非成功退出值
 (例如 "--ignore-exit-code 8;9" 忽略退出代码 8 和 9，在这种情况下将返回 0)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -719,11 +719,12 @@ Optionally accepts 'text' (the default human-readable output) or 'json' to print
         <note />
       </trans-unit>
       <trans-unit id="PlatformCommandLineIgnoreExitCodeOptionDescription">
-        <source>Do not report non successful exit value for specific exit codes
-(e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)</source>
-        <target state="translated">不要報告特定結束代碼的未成功結束
+        <source>Do not report a non-successful exit value for the specified exit codes.
+For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.</source>
+        <target state="needs-review-translation">不要報告特定結束代碼的未成功結束
 (例如 '--ignore-exit-code 8;9' 忽略離開代碼 8 和 9，在這些情況下會返回 0)</target>
-        <note>{Locked="--ignore-exit-code 8;9"}</note>
+        <note>{Locked="'--ignore-exit-code 8;9'"} {Locked="https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes"}</note>
       </trans-unit>
       <trans-unit id="PlatformCommandLineInfoOptionDescription">
         <source>Display .NET test application information.</source>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -57,8 +57,9 @@ Options:
     --help
         Show the command line help.
     --ignore-exit-code
-        Do not report non successful exit value for specific exit codes
-        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+        Do not report a non-successful exit value for the specified exit codes.
+        For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+        For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.
     --info
         Display .NET test application information.
     --list-tests

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoAllExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -51,8 +51,9 @@ Options:
     --help
         Show the command line help.
     --ignore-exit-code
-        Do not report non successful exit value for specific exit codes
-        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+        Do not report a non-successful exit value for the specified exit codes.
+        For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+        For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.
     --info
         Display .NET test application information.
     --list-tests
@@ -348,8 +349,9 @@ Built-in command line providers:
       --ignore-exit-code
         Arity: 1
         Hidden: False
-        Description: Do not report non successful exit value for specific exit codes
-        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+        Description: Do not report a non-successful exit value for the specified exit codes.
+        For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+        For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.
       --info
         Arity: 0
         Hidden: False

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HelpInfoTests.cs
@@ -51,8 +51,9 @@ Options:
     --help
         Show the command line help.
     --ignore-exit-code
-        Do not report non successful exit value for specific exit codes
-        (e.g. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case)
+        Do not report a non-successful exit value for the specified exit codes.
+        For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases.
+        For the full list, see https://github.com/microsoft/testfx/blob/main/docs/glossary.md#exit-codes.
     --info
         Display .NET test application information.
     --list-tests
@@ -242,8 +243,9 @@ Built-in command line providers:
       --ignore-exit-code
         Arity: 1
         Hidden: False
-        Description: Do not report non successful exit value for specific exit codes
-        \(e\.g\. '--ignore-exit-code 8;9' ignore exit code 8 and 9 and will return 0 in these case\)
+        Description: Do not report a non-successful exit value for the specified exit codes\.
+        For example, '--ignore-exit-code 8;9' ignores exit codes 8 and 9 and returns 0 in those cases\.
+        For the full list, see https://github\.com/microsoft/testfx/blob/main/docs/glossary\.md#exit-codes\.
       --info
         Arity: 0
         Hidden: False


### PR DESCRIPTION
## Summary

- document every Microsoft.Testing.Platform process exit code and the retired value 6 in the glossary
- add enum member documentation and make `--ignore-exit-code` help point to the authoritative reference
- regenerate localized resources and update MTP/MSTest help and info expectations

Fixes #10437

## Testing

- `./build.cmd -pack -bl`
- 36 targeted MTP and MSTest help/info acceptance cases