### PR TITLE
Avoid stale AzDO retry failure annotations

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
     <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --retry-failed-tests 3</TestRunnerAdditionalArguments>
+    <!-- Retry attempts emit Azure DevOps annotations before the retry orchestrator knows the final outcome.
+         Keep those annotations visible as warnings; the final process exit code and published TRX still fail
+         the step and Tests tab when all retry attempts are exhausted. -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo-severity warning</TestingPlatformCommandLineArguments>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <OutputType>Exe</OutputType>
     <DefineConstants Condition=" '$(FastAcceptanceTest)' == 'true'">$(DefineConstants);SKIP_INTERMEDIATE_TARGET_FRAMEWORKS</DefineConstants>


### PR DESCRIPTION
## Summary

- report retry-enabled acceptance-test Azure DevOps annotations as warnings
- keep transient failures visible without leaving stale failed-test errors after a successful retry
- preserve genuine final failures through the test process exit code and published TRX results

## Root cause

`--report-azdo` emits an irreversible `##vso[task.logissue type=error]` as soon as an attempt fails. The retry orchestrator can later recover the test, but Azure DevOps retains the initial error annotation even though the final retry summary, exit code, and Tests tab are green.

## Validation

- built `Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj` in Release
- confirmed the evaluated command line contains `--report-azdo-severity warning`
- completed three independent code-review passes with no actionable findings