### PR TITLE
Consolidate coordinator exception handlers

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.FileIO.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.FileIO.cs
@@ -64,11 +64,7 @@ internal sealed partial class AzureDevOpsRunIdCoordinator
                 _fileSystem.DeleteFile(path);
             }
         }
-        catch (IOException ex)
-        {
-            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {path}: {ex.Message}");
-        }
-        catch (UnauthorizedAccessException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingFailedToDeleteCoordinationFile} {path}: {ex.Message}");
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.Leases.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.Leases.cs
@@ -96,15 +96,7 @@ internal sealed partial class AzureDevOpsRunIdCoordinator
             // surface this as a transient read error so the caller doesn't race the writer.
             return new LeaseReadResult(LeaseFileStatus.TransientReadError, null);
         }
-        catch (IOException)
-        {
-            return new LeaseReadResult(LeaseFileStatus.TransientReadError, null);
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return new LeaseReadResult(LeaseFileStatus.TransientReadError, null);
-        }
-        catch (JsonException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
         {
             return new LeaseReadResult(LeaseFileStatus.TransientReadError, null);
         }
@@ -124,11 +116,7 @@ internal sealed partial class AzureDevOpsRunIdCoordinator
             await WriteLeaseFileAsync(path, payload, overwrite, cancellationToken).ConfigureAwait(false);
             return true;
         }
-        catch (IOException)
-        {
-            return false;
-        }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
             return false;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.Participants.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsRunIdCoordinator.Participants.cs
@@ -82,11 +82,7 @@ internal sealed partial class AzureDevOpsRunIdCoordinator
             using var process = Process.GetProcessById(processId);
             return !process.HasExited;
         }
-        catch (ArgumentException)
-        {
-            return false;
-        }
-        catch (InvalidOperationException)
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
             return false;
         }


### PR DESCRIPTION
`AzureDevOpsRunIdCoordinator` contains several adjacent catch blocks with identical fallback behavior. Consolidate each set with an exception filter, preserving the exact handled exception types and behavior while removing duplication.

## Testing

- Built `Microsoft.Testing.Extensions.UnitTests` for `net8.0` with no warnings or errors.
- All 118 `AzureDevOpsLivePublishingTests` passed.

Closes #10454