### PR TITLE
Report artifact post-processing input provenance

### DIFF
--- a/docs/RFCs/018-Artifact-Post-Processing.md
+++ b/docs/RFCs/018-Artifact-Post-Processing.md
@@ -397,9 +397,9 @@ The relaunched host runs a **platform-owned dispatcher `ITool`** (`internal-merg
 4. Routes inputs to eligible processors **by Kind first, then by file-extension fallback** for untagged inputs. An input is never routed to more than one processor.
 5. Calls each matched processor's `ProcessAsync` once with the run context.
 6. Reports each merged `ProcessedArtifact` back over the connected `dotnet-test` pipe as a
-   `FileArtifactMessage`. Its `InputArtifactPaths` field contains the fully qualified paths of every input
-   supplied to that processor invocation, and the SDK removes exactly those job inputs from the summary.
-   The dispatcher surfaces per-processor errors, then exits.
+   `FileArtifactMessage`. Its `InputArtifactPaths` field contains the original manifest path strings for
+   every input supplied to that processor invocation, copied verbatim, and the SDK removes exactly those
+   job inputs from the summary. The dispatcher surfaces per-processor errors, then exits.
 
 A non-null `ProcessedArtifact` represents every input supplied to that processor invocation. A processor
 that cannot produce one artifact representing the complete input set returns `null` or throws. This
@@ -447,10 +447,11 @@ Manifest (orchestrator -> dispatcher):
 
 **Preferred result path: over the pipe.** In the recommended design the dispatcher reports each merged
 artifact back as a `FileArtifactMessage`, so there is no separate result file and no SDK-side result-JSON
-parsing. Each dispatcher output includes the additive `InputArtifactPaths` field (field ID 8). The SDK
-intersects those paths with the job manifest and collapses exactly the matching originals. Older readers
-skip the unknown field; newer readers treat its absence as an old-host response and use a conservative
-fallback. No protocol-version bump or handshake capability is required.
+parsing. Each dispatcher output includes the additive `InputArtifactPaths` field (field ID 8), containing
+the original manifest path strings copied verbatim. The SDK intersects those strings with the job manifest
+and collapses exactly the matching originals. Older readers skip the unknown field; newer readers treat its
+absence as an old-host response and use a conservative fallback. No protocol-version bump or handshake
+capability is required.
 
 **Transitional result path: result JSON.** If the pipe-composition task in §7.6 is deferred, the dispatcher writes a result JSON (path supplied in the manifest) and the SDK performs the swap. This keeps the same typed contract and the same manifest; only the *return channel* changes. Keeping the manifest/result schema `schemaVersion`-versioned means the return channel can switch from files to the pipe without touching `IArtifactPostProcessor`.
 

--- a/docs/RFCs/018-Artifact-Post-Processing.md
+++ b/docs/RFCs/018-Artifact-Post-Processing.md
@@ -376,8 +376,9 @@ foreach (PostProcessingJob job in plan.Jobs)
         manifestPath: job.WriteManifest(),
         onMergedArtifact: merged =>
         {
-            // Re-enters the normal reporter path; collapse the consumed originals.
-            output.RemoveArtifacts(job.InputsFor(merged.Kind));
+            // Re-enters the normal reporter path; collapse only the inputs that
+            // the dispatcher reports as represented by this output.
+            output.RemoveArtifacts(job.Inputs.IntersectByPath(merged.InputArtifactPaths));
             output.ArtifactAdded(outOfProcess: true, path: merged.Path, /* ... */);
         },
         onError: err => output.Warning($"Post-processing of {err.ProcessorUid}: {err.Message}"),
@@ -395,7 +396,16 @@ The relaunched host runs a **platform-owned dispatcher `ITool`** (`internal-merg
 3. Reads the manifest and filters out processors that did not opt into its truncation state.
 4. Routes inputs to eligible processors **by Kind first, then by file-extension fallback** for untagged inputs. An input is never routed to more than one processor.
 5. Calls each matched processor's `ProcessAsync` once with the run context.
-6. Reports each merged `ProcessedArtifact` back over the connected `dotnet-test` pipe as a `FileArtifactMessage`, and surfaces per-processor errors, then exits.
+6. Reports each merged `ProcessedArtifact` back over the connected `dotnet-test` pipe as a
+   `FileArtifactMessage`. Its `InputArtifactPaths` field contains the fully qualified paths of every input
+   supplied to that processor invocation, and the SDK removes exactly those job inputs from the summary.
+   The dispatcher surfaces per-processor errors, then exits.
+
+A non-null `ProcessedArtifact` represents every input supplied to that processor invocation. A processor
+that cannot produce one artifact representing the complete input set returns `null` or throws. This
+all-or-nothing rule makes `InputArtifactPaths` authoritative without changing the processor API. A
+processor that advertises both kinds and legacy extensions can receive the union of producer-kind matches
+and untagged extension-fallback matches, so it must be able to represent that complete union.
 
 The dispatcher tool is marked **internal** (a flag mirroring command-line `IsHidden`) so it is not listed under "Registered tools:" by `--info`. A user would never type `--tool internal-merge-artifacts --manifest ...`; the non-hidden manual value comes entirely from the per-extension user tools in §7.2, which ship regardless of this decision.
 
@@ -435,7 +445,12 @@ Manifest (orchestrator -> dispatcher):
 
 `truncationReason` is an additive schema-1 field because the existing parser ignores unknown fields. An old dispatcher reading a new manifest therefore continues to fail closed at election time: an SDK must elect a host through the new truncated-run capability before it writes this field. A new dispatcher reading an old manifest treats the run as complete.
 
-**Preferred result path: over the pipe.** In the recommended design the dispatcher reports each merged artifact back as a `FileArtifactMessage`, so there is no separate result file and no SDK-side result-JSON parsing. The SDK correlates the incoming merged artifact to the job it dispatched (it knows which inputs it sent) and collapses the originals.
+**Preferred result path: over the pipe.** In the recommended design the dispatcher reports each merged
+artifact back as a `FileArtifactMessage`, so there is no separate result file and no SDK-side result-JSON
+parsing. Each dispatcher output includes the additive `InputArtifactPaths` field (field ID 8). The SDK
+intersects those paths with the job manifest and collapses exactly the matching originals. Older readers
+skip the unknown field; newer readers treat its absence as an old-host response and use a conservative
+fallback. No protocol-version bump or handshake capability is required.
 
 **Transitional result path: result JSON.** If the pipe-composition task in §7.6 is deferred, the dispatcher writes a result JSON (path supplied in the manifest) and the SDK performs the swap. This keeps the same typed contract and the same manifest; only the *return channel* changes. Keeping the manifest/result schema `schemaVersion`-versioned means the return channel can switch from files to the pipe without touching `IArtifactPostProcessor`.
 
@@ -456,6 +471,7 @@ Dispatcher exit codes (final values to be finalized so they don't overlap existi
 | 5 modules, 5 TRX, all tag `microsoft.testing.trx` | 1 relaunch, 1 merged TRX, 5 originals on disk, 1 summary line. |
 | 5 modules, mixed TRX + coverage, one app covers both | 1 relaunch (set-cover), 1 merged TRX + 1 merged coverage. |
 | `.xml` artifacts: 3 JUnit (kind `junit.report`) + 2 NUnit3 (kind `nunit.report`) | Two distinct groups, two merges, no cross-contamination (would have collided under pure extension matching). |
+| Tagged JUnit and untagged NUnit3 `.xml` artifacts route to different processors in one app | Per-output dispatcher provenance collapses each processor's inputs independently; if the fallback processor returns `null`, those legacy inputs remain listed. |
 | Module lacks a processor for `playwright.trace` | Those files listed individually (today's behavior). |
 | Older testfx with no `IArtifactPostProcessor` | No advertisements -> no relaunch -> today's behavior end-to-end. |
 | New SDK + new platform + producer not tagging Kind yet | Orchestrator falls back to file extension; merge still happens. |

--- a/docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md
+++ b/docs/mstest-runner-protocol/004-protocol-dotnet-test-pipe.md
@@ -561,9 +561,13 @@ currently running (rendered by non-IDE consumers as a "currently running tests" 
 
 Reports produced files (per-test artifacts, session artifacts, and standalone `FileArtifact`s). Each
 `FileArtifactMessage`: `FullPath`(1), `DisplayName`(2), `Description`(3), `TestUid`(4),
-`TestDisplayName`(5), `SessionUid`(6), `Kind`(7). `Kind` carries the producer-asserted artifact kind
-used for post-processor routing. Test-scoped artifacts fill `TestUid`/`TestDisplayName`; session and
-standalone artifacts leave them empty.
+`TestDisplayName`(5), `SessionUid`(6), `Kind`(7), `InputArtifactPaths`(8, string list). `Kind` carries
+the producer-asserted artifact kind used for post-processor routing. `InputArtifactPaths` is present
+only on dispatcher-produced artifacts and contains the non-empty set of manifest input paths represented
+by that output. The dispatcher preserves each path string exactly as received; consumers intersect it
+with the paths from that job's manifest rather than independently normalizing it. Its absence means
+provenance is unavailable, including messages from older hosts. Test-scoped artifacts fill
+`TestUid`/`TestDisplayName`; session and standalone artifacts leave them empty.
 
 ### 9.6 `CommandLineOptionMessages` (ID 3)
 
@@ -603,6 +607,13 @@ agent.
 | 1.2.0 | Adds `AzureDevOpsLogMessage` (ID 11). Host forwards ADO logging commands (only on an ADO agent). |
 | 1.3.0 | Adds `DisplayMessage` (ID 12). Host forwards warning/error host diagnostics (always). |
 | 1.4.0 | Adds the reverse **server-control** channel (`WaitForServerControlRequest` ID 13, `ServerControlMessage` ID 14). Version is bumped so negotiated state advances in lockstep, but the feature itself is gated on the `ServerControlPipeName` handshake property, not on the version. **testfx-side / pending SDK support:** the current `dotnet/sdk` advertises only `1.0.0`–`1.3.0` and does not vendor serializers 13/14, so it cannot advertise `ServerControlPipeName` or drive the channel yet. In practice the negotiated version tops out at 1.3.0 until the coordinated SDK change lands (see §12). |
+
+Additive fields on known messages do not require a protocol-version bump:
+
+| MTP package version | Message field |
+| --- | --- |
+| 2.4.0 | `FileArtifactMessage.Kind` (7) |
+| 2.4.0 | `FileArtifactMessage.InputArtifactPaths` (8) |
 
 Compatibility rules / assumptions:
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
+const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPaths = 8 -> ushort
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int

--- a/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.MSBuild/InternalAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
+const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPaths = 8 -> ushort
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 const Microsoft.Testing.Platform.IPC.NamedPipeServer.MaxUnixDomainSocketPathLengthInBytes = 103 -> int

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
+const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPaths = 8 -> ushort
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_PIPE_DIRECTORY = "TESTINGPLATFORM_PIPE_DIRECTORY" -> string!
 Microsoft.Testing.Platform.Helpers.ArgumentGuard

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -3,6 +3,7 @@ Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
 static Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper.IsMultiThreaded.get -> bool
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
 const Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.TrxArtifactKind = "microsoft.testing.trx" -> string!
+const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPaths = 8 -> ushort
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.Merge(System.Collections.Generic.IReadOnlyList<System.Xml.Linq.XDocument!>! inputReports, System.Guid runId, string! runName) -> System.Xml.Linq.XDocument!
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Guid runId, string! runName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/ArtifactPostProcessingDispatcherTool.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/ArtifactPostProcessingDispatcherTool.cs
@@ -72,7 +72,7 @@ internal sealed class ArtifactPostProcessingDispatcherTool(
         await WarnAboutProcessorConflictsAsync(eligibleProcessors, cancellationToken).ConfigureAwait(false);
 
         List<InputArtifact> unmatchedInputs = [.. manifest.Inputs];
-        List<ProcessedArtifact> outputs = [];
+        List<FileArtifactMessage> outputs = [];
         bool failed = false;
         foreach (IArtifactPostProcessor processor in eligibleProcessors)
         {
@@ -91,7 +91,16 @@ internal sealed class ArtifactPostProcessingDispatcherTool(
                     manifest.Context,
                     cancellationToken).ConfigureAwait(false) is { } output)
                 {
-                    outputs.Add(ValidateProcessedArtifact(output, manifest.OutputDirectory, matchingInputs));
+                    ProcessedArtifact validatedOutput = ValidateProcessedArtifact(output, manifest.OutputDirectory, matchingInputs);
+                    outputs.Add(new FileArtifactMessage(
+                        validatedOutput.Path,
+                        validatedOutput.DisplayName,
+                        validatedOutput.Description,
+                        TestUid: null,
+                        TestDisplayName: null,
+                        SessionUid: null,
+                        validatedOutput.Kind,
+                        [.. matchingInputs.Select(input => input.Path)]));
                 }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -109,18 +118,10 @@ internal sealed class ArtifactPostProcessingDispatcherTool(
 
         if (outputs.Count > 0)
         {
-            FileArtifactMessage[] messages = [.. outputs.Select(output => new FileArtifactMessage(
-                output.Path,
-                output.DisplayName,
-                output.Description,
-                TestUid: null,
-                TestDisplayName: null,
-                SessionUid: null,
-                output.Kind))];
             await _protocol.SendMessageAsync(new FileArtifactMessages(
                 _environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_EXECUTIONID),
                 _protocol.InstanceId,
-                messages)).ConfigureAwait(false);
+                [.. outputs])).ConfigureAwait(false);
         }
 
         return failed ? (int)ExitCode.GenericFailure : (int)ExitCode.Success;

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessor.cs
@@ -36,9 +36,16 @@ public interface IArtifactPostProcessor : IExtension
     /// <param name="outputDirectory">The directory under which the processed artifact must be written.</param>
     /// <param name="context">The context describing the test run that produced the artifacts.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>The processed artifact, or <see langword="null"/> when no processing is needed.</returns>
+    /// <returns>
+    /// The processed artifact representing all <paramref name="inputs"/>, or <see langword="null"/> when no
+    /// processing is needed.
+    /// </returns>
     /// <remarks>
     /// Implementations must be deterministic and idempotent because orchestrators may retry transient failures.
+    /// A non-<see langword="null"/> result must represent every supplied input. Implementations that cannot produce
+    /// one artifact representing the complete input set must return <see langword="null"/> or throw.
+    /// When a processor declares both kinds and legacy file extensions, <paramref name="inputs"/> can contain the
+    /// union of producer-kind matches and untagged extension-fallback matches.
     /// </remarks>
     Task<ProcessedArtifact?> ProcessAsync(
         IReadOnlyList<InputArtifact> inputs,

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -126,11 +126,14 @@ Microsoft.Testing.Platform.OutputDevice.ProxyOutputDevice.Dispose() -> void
 *REMOVED*Microsoft.Testing.Platform.Tools.IToolsManager.AddTool(System.Func<System.IServiceProvider!, Microsoft.Testing.Platform.Tools.ITool!>! toolFactory) -> void
 *REMOVED*Microsoft.Testing.Platform.OutputDevice.Terminal.SimpleTerminal.RenderProgress(Microsoft.Testing.Platform.OutputDevice.Terminal.TestProgressState?[]! progress) -> void
 const Microsoft.Testing.Platform.Helpers.EnvironmentVariableConstants.TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER" -> string!
+const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPaths = 8 -> ushort
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Platform.IPC.DotnetTestDataConsumer.CreateFileArtifactMessages(string? executionId, Microsoft.Testing.Platform.Extensions.Messages.FileArtifact! fileArtifact) -> Microsoft.Testing.Platform.IPC.Models.FileArtifactMessages!
 static Microsoft.Testing.Platform.IPC.DotnetTestDataConsumer.CreateFileArtifactMessages(string? executionId, Microsoft.Testing.Platform.Extensions.Messages.SessionFileArtifact! sessionFileArtifact) -> Microsoft.Testing.Platform.IPC.Models.FileArtifactMessages!
-Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Deconstruct(out string? FullPath, out string? DisplayName, out string? Description, out string? TestUid, out string? TestDisplayName, out string? SessionUid, out string? Kind) -> void
-Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid, string? Kind) -> void
+Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Deconstruct(out string? FullPath, out string? DisplayName, out string? Description, out string? TestUid, out string? TestDisplayName, out string? SessionUid, out string? Kind, out string![]? InputArtifactPaths) -> void
+Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid, string? Kind, string![]? InputArtifactPaths = null) -> void
+Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.InputArtifactPaths.get -> string![]?
+Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.InputArtifactPaths.init -> void
 Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Kind.get -> string?
 Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Kind.init -> void
 *REMOVED*Microsoft.Testing.Platform.IPC.Models.FileArtifactMessage.Deconstruct(out string? FullPath, out string? DisplayName, out string? Description, out string? TestUid, out string? TestDisplayName, out string? SessionUid) -> void

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/FileArtifactMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Models/FileArtifactMessages.cs
@@ -3,6 +3,14 @@
 
 namespace Microsoft.Testing.Platform.IPC.Models;
 
-internal sealed record FileArtifactMessage(string? FullPath, string? DisplayName, string? Description, string? TestUid, string? TestDisplayName, string? SessionUid, string? Kind);
+internal sealed record FileArtifactMessage(
+    string? FullPath,
+    string? DisplayName,
+    string? Description,
+    string? TestUid,
+    string? TestDisplayName,
+    string? SessionUid,
+    string? Kind,
+    string[]? InputArtifactPaths = null);
 
 internal sealed record FileArtifactMessages(string? ExecutionId, string? InstanceId, FileArtifactMessage[] FileArtifacts) : IRequest;

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/ObjectFieldIds.cs
@@ -151,6 +151,7 @@ internal static class FileArtifactMessageFieldsId
     public const ushort TestDisplayName = 5;
     public const ushort SessionUid = 6;
     public const ushort Kind = 7;
+    public const ushort InputArtifactPaths = 8;
 }
 
 [Embedded]

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Serializers/FileArtifactMessagesSerializer.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Testing.Platform.IPC.Serializers;
         |---FileArtifactMessageList[0].Kind Id---| (2 bytes)
         |---FileArtifactMessageList[0].Kind Size---| (4 bytes)
         |---FileArtifactMessageList[0].Kind Value---| (n bytes)
+
+        |---FileArtifactMessageList[0].InputArtifactPaths Id---| (2 bytes)
+        |---FileArtifactMessageList[0].InputArtifactPaths Size---| (4 bytes)
+        |---FileArtifactMessageList[0].InputArtifactPaths Value---| (n bytes)
+            |---InputArtifactPaths Length---| (4 bytes)
+            |---InputArtifactPaths[0] Size---| (4 bytes)
+            |---InputArtifactPaths[0] Value---| (n bytes)
     */
 
 internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileArtifactMessages>, INamedPipeSerializer
@@ -89,6 +96,7 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
         for (int i = 0; i < length; i++)
         {
             string? fullPath = null, displayName = null, description = null, testUid = null, testDisplayName = null, sessionUid = null, kind = null;
+            string[]? inputArtifactPaths = null;
 
             ReadFields(stream, (fieldId, fieldSize) =>
             {
@@ -122,15 +130,39 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
                         kind = ReadStringValue(stream, fieldSize);
                         return true;
 
+                    case FileArtifactMessageFieldsId.InputArtifactPaths:
+                        inputArtifactPaths = ReadInputArtifactPathsPayload(stream);
+                        return true;
+
                     default:
                         return false;
                 }
             });
 
-            fileArtifactMessages[i] = new FileArtifactMessage(fullPath, displayName, description, testUid, testDisplayName, sessionUid, kind);
+            fileArtifactMessages[i] = new FileArtifactMessage(
+                fullPath,
+                displayName,
+                description,
+                testUid,
+                testDisplayName,
+                sessionUid,
+                kind,
+                inputArtifactPaths);
         }
 
         return fileArtifactMessages;
+    }
+
+    private static string[] ReadInputArtifactPathsPayload(Stream stream)
+    {
+        int length = ReadInt(stream);
+        string[] inputArtifactPaths = new string[length];
+        for (int i = 0; i < length; i++)
+        {
+            inputArtifactPaths[i] = ReadString(stream);
+        }
+
+        return inputArtifactPaths;
     }
 
     protected override void SerializeCore(FileArtifactMessages objectToSerialize, Stream stream)
@@ -156,7 +188,15 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
             WriteField(s, FileArtifactMessageFieldsId.TestDisplayName, fileArtifactMessage.TestDisplayName);
             WriteField(s, FileArtifactMessageFieldsId.SessionUid, fileArtifactMessage.SessionUid);
             WriteField(s, FileArtifactMessageFieldsId.Kind, fileArtifactMessage.Kind);
+            WriteInputArtifactPathsPayload(s, fileArtifactMessage.InputArtifactPaths);
         });
+
+    private static void WriteInputArtifactPathsPayload(Stream stream, string[]? inputArtifactPaths)
+        => WriteListPayload(
+            stream,
+            FileArtifactMessageFieldsId.InputArtifactPaths,
+            inputArtifactPaths,
+            static (s, inputArtifactPath) => WriteString(s, inputArtifactPath));
 
     private static ushort GetFieldCount(FileArtifactMessage fileArtifactMessage) =>
         (ushort)((fileArtifactMessage.FullPath is null ? 0 : 1) +
@@ -165,5 +205,6 @@ internal sealed class FileArtifactMessagesSerializer : NamedPipeSerializer<FileA
         (fileArtifactMessage.TestUid is null ? 0 : 1) +
         (fileArtifactMessage.TestDisplayName is null ? 0 : 1) +
         (fileArtifactMessage.SessionUid is null ? 0 : 1) +
-        (fileArtifactMessage.Kind is null ? 0 : 1));
+        (fileArtifactMessage.Kind is null ? 0 : 1) +
+        (IsNullOrEmpty(fileArtifactMessage.InputArtifactPaths) ? 0 : 1));
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
@@ -55,7 +55,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                 "ArtifactPostProcessor",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.HostType]);
             Assert.AreEqual(
-                "microsoft.testing.trx;test.summary",
+                "microsoft.testing.trx;test.summary;test.xml",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
             Assert.AreEqual(
                 "test.summary",
@@ -68,6 +68,135 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
             Assert.AreEqual("microsoft.testing.trx", artifacts[0].Kind);
             Assert.IsNotNull(artifacts[0].FullPath);
             Assert.IsTrue(File.Exists(artifacts[0].FullPath));
+            Assert.IsNotNull(artifacts[0].InputArtifactPaths);
+            Assert.AreSequenceEqual(
+                [Path.GetFullPath(firstPath), Path.GetFullPath(secondPath)],
+                artifacts[0].InputArtifactPaths);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_ReportsOnlyInputsRepresentedByEachOutput()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"artifact-dispatcher-provenance-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.xml");
+            string secondPath = Path.Combine(directory, "second.xml");
+            string unrelatedPath = Path.Combine(directory, "unrelated.xml");
+            string firstManifestPath = firstPath.Replace('\\', '/');
+            File.WriteAllText(firstPath, "first");
+            File.WriteAllText(secondPath, "second");
+            File.WriteAllText(unrelatedPath, "unrelated");
+            string manifestPath = Path.Combine(directory, "manifest.json");
+            File.WriteAllText(
+                manifestPath,
+                JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    outputDirectory = directory,
+                    inputs = new[]
+                    {
+                        new { path = firstManifestPath, kind = (string?)"test.xml" },
+                        new { path = secondPath, kind = (string?)"test.xml" },
+                        new { path = unrelatedPath, kind = (string?)null },
+                    },
+                }));
+
+            var testHost = TestInfrastructure.TestHost.LocateFrom(
+                AssetFixture.TargetAssetPath,
+                AssetName,
+                TargetFrameworks.NetCurrent);
+            FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+                testHost,
+                extraArguments: $"--manifest \"{manifestPath}\"",
+                supportedProtocolVersions: "1.4.0",
+                toolName: "internal-merge-artifacts",
+                cancellationToken: TestContext.CancellationToken);
+
+            result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+            RawMessage[] artifactFrames = [.. result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.FileArtifactMessages)];
+            Assert.HasCount(1, artifactFrames);
+            IReadOnlyList<FileArtifact> artifacts = DotnetTestPipeProtocol.DecodeFileArtifacts(artifactFrames[0].Body);
+            Assert.HasCount(1, artifacts);
+            Assert.AreEqual("test.xml.processed", artifacts[0].Kind);
+            Assert.IsNotNull(artifacts[0].InputArtifactPaths);
+            Assert.AreSequenceEqual(
+                [firstManifestPath, secondPath],
+                artifacts[0].InputArtifactPaths);
+            Assert.DoesNotContain(unrelatedPath, artifacts[0].InputArtifactPaths);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_ReportsDisjointInputsForMultipleOutputsAndLegacyReaderSkipsProvenance()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"artifact-dispatcher-multiple-provenance-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string firstTaggedPath = Path.Combine(directory, "first-tagged.xml");
+            string secondTaggedPath = Path.Combine(directory, "second-tagged.xml");
+            string firstLegacyPath = Path.Combine(directory, "first-legacy.xml");
+            string secondLegacyPath = Path.Combine(directory, "second-legacy.xml");
+            File.WriteAllText(firstTaggedPath, "first tagged");
+            File.WriteAllText(secondTaggedPath, "second tagged");
+            File.WriteAllText(firstLegacyPath, "first legacy");
+            File.WriteAllText(secondLegacyPath, "second legacy");
+            string manifestPath = Path.Combine(directory, "manifest.json");
+            File.WriteAllText(
+                manifestPath,
+                JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    outputDirectory = directory,
+                    inputs = new[]
+                    {
+                        new { path = firstTaggedPath, kind = (string?)"test.xml" },
+                        new { path = secondTaggedPath, kind = (string?)"test.xml" },
+                        new { path = firstLegacyPath, kind = (string?)null },
+                        new { path = secondLegacyPath, kind = (string?)null },
+                    },
+                }));
+
+            var testHost = TestInfrastructure.TestHost.LocateFrom(
+                AssetFixture.TargetAssetPath,
+                AssetName,
+                TargetFrameworks.NetCurrent);
+            FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+                testHost,
+                extraArguments: $"--manifest \"{manifestPath}\"",
+                supportedProtocolVersions: "1.4.0",
+                toolName: "internal-merge-artifacts",
+                cancellationToken: TestContext.CancellationToken);
+
+            result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+            RawMessage artifactFrame = Assert.ContainsSingle(
+                result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.FileArtifactMessages));
+
+            IReadOnlyList<FileArtifact> artifacts = DotnetTestPipeProtocol.DecodeFileArtifacts(artifactFrame.Body);
+            Assert.HasCount(2, artifacts);
+            Assert.AreEqual("test.xml.processed", artifacts[0].Kind);
+            Assert.AreSequenceEqual([firstTaggedPath, secondTaggedPath], artifacts[0].InputArtifactPaths);
+            Assert.AreEqual("legacy.xml.processed", artifacts[1].Kind);
+            Assert.AreSequenceEqual([firstLegacyPath, secondLegacyPath], artifacts[1].InputArtifactPaths);
+
+            IReadOnlyList<FileArtifact> legacyReaderArtifacts =
+                DotnetTestPipeProtocol.DecodeFileArtifacts(artifactFrame.Body, readInputArtifactPaths: false);
+            Assert.HasCount(2, legacyReaderArtifacts);
+            Assert.AreEqual("test.xml.processed", legacyReaderArtifacts[0].Kind);
+            Assert.AreEqual("legacy.xml.processed", legacyReaderArtifacts[1].Kind);
+            Assert.IsNull(legacyReaderArtifacts[0].InputArtifactPaths);
+            Assert.IsNull(legacyReaderArtifacts[1].InputArtifactPaths);
         }
         finally
         {
@@ -308,6 +437,10 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                     builder.AddTrxReportProvider();
                     ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing
                         .AddArtifactPostProcessor(_ => new SummaryArtifactPostProcessor());
+                    ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing
+                        .AddArtifactPostProcessor(_ => new XmlArtifactPostProcessor());
+                    ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing
+                        .AddArtifactPostProcessor(_ => new LegacyXmlArtifactPostProcessor());
                     builder.RegisterTestFramework(_ => new TestFrameworkCapabilities(), (_, _) => new DummyTestFramework());
                     using ITestApplication app = await builder.BuildAsync();
                     return await app.RunAsync();
@@ -359,6 +492,63 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                         "test.summary.processed",
                         "Partial summary",
                         null);
+                }
+            }
+
+            public sealed class XmlArtifactPostProcessor : IArtifactPostProcessor
+            {
+                public string Uid => nameof(XmlArtifactPostProcessor);
+                public string Version => "1.0.0";
+                public string DisplayName => nameof(XmlArtifactPostProcessor);
+                public string Description => nameof(XmlArtifactPostProcessor);
+                public bool SupportsTruncatedRuns => false;
+                public IReadOnlyList<string> SupportedKinds => ["test.xml"];
+                public IReadOnlyList<string> SupportedFileExtensionsFallback => [];
+                public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+                public async Task<ProcessedArtifact?> ProcessAsync(
+                    IReadOnlyList<InputArtifact> inputs,
+                    string outputDirectory,
+                    ArtifactPostProcessingContext context,
+                    CancellationToken cancellationToken)
+                {
+                    string outputPath = Path.Combine(outputDirectory, "merged.xml");
+                    await File.WriteAllTextAsync(
+                        outputPath,
+                        string.Join("|", inputs.Select(input => File.ReadAllText(input.Path))),
+                        cancellationToken);
+                    return new ProcessedArtifact(outputPath, "test.xml.processed", "Merged XML", null);
+                }
+            }
+
+            public sealed class LegacyXmlArtifactPostProcessor : IArtifactPostProcessor
+            {
+                public string Uid => nameof(LegacyXmlArtifactPostProcessor);
+                public string Version => "1.0.0";
+                public string DisplayName => nameof(LegacyXmlArtifactPostProcessor);
+                public string Description => nameof(LegacyXmlArtifactPostProcessor);
+                public bool SupportsTruncatedRuns => false;
+                public IReadOnlyList<string> SupportedKinds => [];
+                public IReadOnlyList<string> SupportedFileExtensionsFallback => [".xml"];
+                public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+                public async Task<ProcessedArtifact?> ProcessAsync(
+                    IReadOnlyList<InputArtifact> inputs,
+                    string outputDirectory,
+                    ArtifactPostProcessingContext context,
+                    CancellationToken cancellationToken)
+                {
+                    if (inputs.Count < 2)
+                    {
+                        return null;
+                    }
+
+                    string outputPath = Path.Combine(outputDirectory, "legacy-merged.xml");
+                    await File.WriteAllTextAsync(
+                        outputPath,
+                        string.Join("|", inputs.Select(input => File.ReadAllText(input.Path))),
+                        cancellationToken);
+                    return new ProcessedArtifact(outputPath, "legacy.xml.processed", "Merged legacy XML", null);
                 }
             }
             """;

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeProtocol.cs
@@ -374,12 +374,13 @@ internal static class DotnetTestPipeProtocol
         return (executionId, instanceId, level, text);
     }
 
-    public static IReadOnlyList<FileArtifact> DecodeFileArtifacts(byte[] body)
+    public static IReadOnlyList<FileArtifact> DecodeFileArtifacts(byte[] body, bool readInputArtifactPaths = true)
     {
         const ushort fileArtifactMessageListFieldId = 3;
         const ushort fullPathFieldId = 1;
         const ushort displayNameFieldId = 2;
         const ushort kindFieldId = 7;
+        const ushort inputArtifactPathsFieldId = 8;
 
         List<FileArtifact> artifacts = [];
         using MemoryStream stream = new(body, writable: false);
@@ -400,6 +401,7 @@ internal static class DotnetTestPipeProtocol
                 string? fullPath = null;
                 string? displayName = null;
                 string? kind = null;
+                string[]? inputArtifactPaths = null;
                 ushort messageFieldCount = ReadUShort(stream);
                 for (int messageFieldIndex = 0; messageFieldIndex < messageFieldCount; messageFieldIndex++)
                 {
@@ -416,13 +418,22 @@ internal static class DotnetTestPipeProtocol
                         case kindFieldId:
                             kind = ReadFixedSizeString(stream, messageFieldSize);
                             break;
+                        case inputArtifactPathsFieldId when readInputArtifactPaths:
+                            int inputArtifactPathCount = ReadInt(stream);
+                            inputArtifactPaths = new string[inputArtifactPathCount];
+                            for (int inputArtifactPathIndex = 0; inputArtifactPathIndex < inputArtifactPathCount; inputArtifactPathIndex++)
+                            {
+                                inputArtifactPaths[inputArtifactPathIndex] = ReadLengthPrefixedString(stream);
+                            }
+
+                            break;
                         default:
                             stream.Seek(messageFieldSize, SeekOrigin.Current);
                             break;
                     }
                 }
 
-                artifacts.Add(new FileArtifact(fullPath, displayName, kind));
+                artifacts.Add(new FileArtifact(fullPath, displayName, kind, inputArtifactPaths));
             }
         }
 
@@ -680,7 +691,7 @@ internal static class DotnetTestPipeProtocol
 /// <summary>A raw decoded pipe frame (serializer id + body bytes, no further decoding).</summary>
 internal sealed record RawMessage(int SerializerId, byte[] Body);
 
-internal sealed record FileArtifact(string? FullPath, string? DisplayName, string? Kind);
+internal sealed record FileArtifact(string? FullPath, string? DisplayName, string? Kind, string[]? InputArtifactPaths);
 
 /// <summary>
 /// A fully decoded discovered test message: the complete discovery object the SDK needs to build the

--- a/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolSerializerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests/DotnetTestProtocolSerializerTests.cs
@@ -146,15 +146,16 @@ public sealed class DotnetTestProtocolSerializerTests
     }
 
     [TestMethod]
-    public void FileArtifactMessageFieldIds_Kind_IsStable()
+    public void FileArtifactMessageFieldIds_AreStable()
     {
-        // Kind is an externally shared wire id (the SDK decodes it with its own vendored copy of the same
-        // number), so renumbering it would silently break cross-process decoding without failing the
+        // These are externally shared wire ids (the SDK decodes them with its own vendored copy of the same
+        // numbers), so renumbering them would silently break cross-process decoding without failing the
         // round-trip tests (which use the same constant on both writer and reader). Pin the literal here.
         // The declared value is read via reflection (a runtime read, not a compile-time constant) so that
         // renumbering the constant is actually caught rather than folded away by the compiler.
         Assert.AreEqual((ushort)6, GetConstantValue(nameof(FileArtifactMessageFieldsId.SessionUid)));
         Assert.AreEqual((ushort)7, GetConstantValue(nameof(FileArtifactMessageFieldsId.Kind)));
+        Assert.AreEqual((ushort)8, GetConstantValue(nameof(FileArtifactMessageFieldsId.InputArtifactPaths)));
 
         static ushort GetConstantValue(string fieldName)
             => (ushort)typeof(FileArtifactMessageFieldsId).GetField(fieldName)!.GetRawConstantValue()!;
@@ -243,8 +244,24 @@ public sealed class DotnetTestProtocolSerializerTests
             "executionId",
             "instanceId",
             [
-                new FileArtifactMessage("full/path.txt", "artifact", "desc", "testUid", "testDisplay", "sessionUid", "microsoft.testing.trx"),
-                new FileArtifactMessage("other.txt", "other", null, null, null, null, null),
+                new FileArtifactMessage(
+                    "full/path.txt",
+                    "artifact",
+                    "desc",
+                    "testUid",
+                    "testDisplay",
+                    "sessionUid",
+                    "microsoft.testing.trx",
+                    ["input/first.txt", "input/second.txt"]),
+                new FileArtifactMessage(
+                    "other.txt",
+                    "other",
+                    null,
+                    null,
+                    null,
+                    null,
+                    "microsoft.testing.coverage",
+                    ["input/coverage.txt"]),
             ]);
 
         FileArtifactMessages actual = RoundTrip(new FileArtifactMessagesSerializer(), message);
@@ -254,9 +271,13 @@ public sealed class DotnetTestProtocolSerializerTests
         Assert.AreEqual("full/path.txt", actual.FileArtifacts[0].FullPath);
         Assert.AreEqual("sessionUid", actual.FileArtifacts[0].SessionUid);
         Assert.AreEqual("microsoft.testing.trx", actual.FileArtifacts[0].Kind);
+        Assert.AreSequenceEqual(
+            ["input/first.txt", "input/second.txt"],
+            actual.FileArtifacts[0].InputArtifactPaths);
         Assert.AreEqual("other.txt", actual.FileArtifacts[1].FullPath);
         Assert.IsNull(actual.FileArtifacts[1].Description);
-        Assert.IsNull(actual.FileArtifacts[1].Kind);
+        Assert.AreEqual("microsoft.testing.coverage", actual.FileArtifacts[1].Kind);
+        Assert.AreSequenceEqual(["input/coverage.txt"], actual.FileArtifacts[1].InputArtifactPaths);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolEdgeCaseTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolEdgeCaseTests.cs
@@ -212,6 +212,28 @@ public sealed class ProtocolEdgeCaseTests
         Assert.IsNull(actual.FileArtifacts[1].Kind);
         Assert.AreEqual("session2", actual.FileArtifacts[2].SessionUid);
         Assert.IsNull(actual.FileArtifacts[2].DisplayName);
+        Assert.IsNull(actual.FileArtifacts[2].InputArtifactPaths);
+    }
+
+    [TestMethod]
+    public void FileArtifactMessages_WhenUnknownFieldsPrecedeKnownFields_DeserializesRemainingFields()
+    {
+        byte[] fileArtifact = WriteFields(
+            (ushort.MaxValue, [0xAA, 0xBB]),
+            (FileArtifactMessageFieldsId.FullPath, WriteString("/a/b.trx")),
+            (FileArtifactMessageFieldsId.Kind, WriteString("microsoft.testing.trx")));
+        byte[] payload = WriteFields(
+            (ushort.MaxValue, [0xCC]),
+            (FileArtifactMessagesFieldsId.InstanceId, WriteString("instance")),
+            (FileArtifactMessagesFieldsId.FileArtifactMessageList, WriteList(fileArtifact)));
+
+        FileArtifactMessages actual = DeserializePayload<FileArtifactMessages>(new FileArtifactMessagesSerializer(), payload);
+
+        Assert.AreEqual("instance", actual.InstanceId);
+        Assert.HasCount(1, actual.FileArtifacts);
+        Assert.AreEqual("/a/b.trx", actual.FileArtifacts[0].FullPath);
+        Assert.AreEqual("microsoft.testing.trx", actual.FileArtifacts[0].Kind);
+        Assert.IsNull(actual.FileArtifacts[0].InputArtifactPaths);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/IPC/ProtocolTests.cs
@@ -437,8 +437,24 @@ public sealed class ProtocolTests
             "MyExecId",
             "MyInstId",
             [
-                new FileArtifactMessage("/full/path/artifact1.txt", "artifact1", "description1", "uid-1", "Test 1", "session-1", "microsoft.testing.trx"),
-                new FileArtifactMessage("/full/path/artifact2.coverage", "artifact2", null, null, null, null, null),
+                new FileArtifactMessage(
+                    "/full/path/artifact1.txt",
+                    "artifact1",
+                    "description1",
+                    "uid-1",
+                    "Test 1",
+                    "session-1",
+                    "microsoft.testing.trx",
+                    ["/full/path/input1.trx", "/full/path/input2.trx"]),
+                new FileArtifactMessage(
+                    "/full/path/artifact2.coverage",
+                    "artifact2",
+                    null,
+                    null,
+                    null,
+                    null,
+                    "microsoft.testing.coverage",
+                    ["/full/path/input1.coverage", "/full/path/input2.coverage"]),
             ]);
 
         var stream = new MemoryStream();
@@ -460,6 +476,7 @@ public sealed class ProtocolTests
             Assert.AreEqual(expected.TestDisplayName, actualArtifact.TestDisplayName);
             Assert.AreEqual(expected.SessionUid, actualArtifact.SessionUid);
             Assert.AreEqual(expected.Kind, actualArtifact.Kind);
+            Assert.AreSequenceEqual(expected.InputArtifactPaths, actualArtifact.InputArtifactPaths);
         }
     }
 


### PR DESCRIPTION
## Summary

- add additive `FileArtifactMessage.InputArtifactPaths` field ID 8 to report the exact manifest inputs represented by each processed artifact
- populate provenance per dispatcher output and define non-null `ProcessedArtifact` results as representing every supplied input
- preserve manifest path strings verbatim so the SDK can intersect them with the originating job without cross-process normalization drift
- cover serializer compatibility, old readers skipping field 8, multiple disjoint outputs, and the generic `.xml` collision from dotnet/sdk#55555
- update the dotnet-test pipe protocol and artifact post-processing RFC

## Compatibility

This remains an additive field on serializer ID 7. Older readers skip it, newer readers treat its absence as an old-host response, and no protocol-version bump or handshake capability is required.

A follow-up SDK change is still required to vendor field 8 and remove only provenance paths that intersect the dispatched job's manifest. Relates to dotnet/sdk#55555.

## Testing

- `./build.cmd -pack -bl`
- 129 protocol test executions across `net462`, `net8.0`, and `net9.0`
- 69 shared protocol-contract test executions across `net462`, `net8.0`, and `net9.0`
- 3 focused artifact post-processing acceptance tests on `net11.0`