### PR TITLE
Accept diagnostic log collision suffix in tests

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DiagnosticTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // Suppress CS0618 for the entire file: we intentionally exercise the deprecated legacy
@@ -14,6 +14,20 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public class DiagnosticTests : AcceptanceTestBase<DiagnosticTests.TestAssetFixture>
 {
     private const string AssetName = "DiagnosticTest";
+
+    [DataRow("")]
+    [DataRow("_1236_1")]
+    [TestMethod]
+    public void BuildDefaultDiagnosticFilePathPattern_MatchesFileLoggerFileName(string collisionSuffix)
+    {
+        const string Tfm = "net10.0";
+        string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+        string diagPath = Path.Combine("artifacts", AggregatedConfiguration.DefaultTestResultFolderName);
+        string filePath = Path.Combine(diagPath, $"{AssetName}_{Tfm}_{arch}_260805150845821{collisionSuffix}.diag");
+        string diagPathPattern = BuildDefaultDiagnosticFilePathPattern(diagPath, AssetName, Tfm);
+
+        Assert.IsTrue(Regex.IsMatch(filePath, $"^{diagPathPattern}$"), $"'{filePath}' did not match '{diagPathPattern}'.");
+    }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -40,7 +40,7 @@ public abstract class AcceptanceTestBase
         string arch = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
         const string FileNamePlaceholder = "__DIAG_FILENAME__";
         string combinedPath = Path.Combine(diagPath, FileNamePlaceholder).Replace(@"\", @"\\");
-        return combinedPath.Replace(FileNamePlaceholder, $@"{assetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}\.diag");
+        return combinedPath.Replace(FileNamePlaceholder, $@"{assetName}_{Regex.Escape(tfm)}_{arch}_\d{{15}}(?:_\d+_\d+)?\.diag");
     }
 
     protected static string GetTestExecutablePath(Microsoft.Testing.TestInfrastructure.TestHost testHost)


### PR DESCRIPTION
Fixes #10462

## Summary
- accept FileLogger's optional `_<process-id>_<counter>` collision suffix in the shared diagnostic filename pattern
- keep accepting the normal timestamp-only diagnostic filename
- add focused regression coverage for both valid forms
- leave product FileLogger behavior unchanged

## Validation
- `.\build.cmd -pack -configuration Debug -verbosity minimal -binaryLog`
- targeted `dotnet test` for `BuildDefaultDiagnosticFilePathPattern_MatchesFileLoggerFileName` with `/bl:artifacts\log\Debug\issue10462-focused-test-pass.binlog` (2 passed)
- independent code-review pass found no significant issues
