### PR TITLE
Align slowest test output formatting

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Microsoft.Testing.Platform.UnitTests.csproj
@@ -43,6 +43,7 @@
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Helpers\TimeSpanParser.cs" Link="Helpers\TimeSpanParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\TargetFrameworkParser.cs" Link="Helpers\TargetFrameworkParser.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />
+    <Compile Include="$(RepoRoot)test\Utilities\Microsoft.Testing.TestInfrastructure\SlowestTestsConsumer.cs" Link="TestInfrastructure\SlowestTestsConsumer.cs" />
     <!-- The terminal reporter types are [Embedded] (hidden cross-assembly) so they can be shared as source.
          Link the source here so the unit tests compile their own copy instead of relying on IVT. -->
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\OutputDevice\Terminal\*.cs" Link="OutputDevice\Terminal\%(Filename)%(Extension)" />

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestInfrastructure/SlowestTestsConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestInfrastructure/SlowestTestsConsumerTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.Testing.TestInfrastructure;
+
+namespace Microsoft.Testing.Platform.UnitTests.TestInfrastructure;
+
+[TestClass]
+public sealed class SlowestTestsConsumerTests
+{
+    [TestMethod]
+    public async Task OnTestSessionFinishingAsync_WritesIndentedDurationFirstEntries()
+    {
+        List<string> lines = [];
+        var consumer = new SlowestTestsConsumer(lines.Add);
+
+        await consumer.ConsumeAsync(null!, CreatePassedTestNodeUpdate("FasterTest", TimeSpan.FromSeconds(1.25)), CancellationToken.None);
+        await consumer.ConsumeAsync(null!, CreatePassedTestNodeUpdate("SlowerTest", TimeSpan.FromSeconds(12)), CancellationToken.None);
+        await consumer.OnTestSessionFinishingAsync(null!);
+
+        Assert.HasCount(3, lines);
+        Assert.AreEqual("Slowest 10 tests:", lines[0]);
+        Assert.AreEqual($"  {12d:F5}s SlowerTest", lines[1]);
+        Assert.AreEqual($"  {1.25d:F5}s FasterTest", lines[2]);
+    }
+
+    private static TestNodeUpdateMessage CreatePassedTestNodeUpdate(string displayName, TimeSpan duration)
+    {
+        DateTimeOffset startTime = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        return new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = displayName,
+                DisplayName = displayName,
+                Properties = new PropertyBag(
+                    PassedTestNodeStateProperty.CachedInstance,
+                    new TimingProperty(new(startTime, startTime + duration, duration))),
+            });
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestInfrastructure/SlowestTestsConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/TestInfrastructure/SlowestTestsConsumerTests.cs
@@ -26,6 +26,25 @@ public sealed class SlowestTestsConsumerTests
         Assert.AreEqual($"  {1.25d:F5}s FasterTest", lines[2]);
     }
 
+    [TestMethod]
+    public async Task OnTestSessionFinishingAsync_WritesOnlyTenSlowestEntries()
+    {
+        List<string> lines = [];
+        var consumer = new SlowestTestsConsumer(lines.Add);
+
+        for (int i = 0; i < 11; i++)
+        {
+            await consumer.ConsumeAsync(null!, CreatePassedTestNodeUpdate($"Test{i}", TimeSpan.FromSeconds(i + 1)), CancellationToken.None);
+        }
+
+        await consumer.OnTestSessionFinishingAsync(null!);
+
+        Assert.HasCount(11, lines);
+        Assert.AreEqual($"  {11d:F5}s Test10", lines[1]);
+        Assert.AreEqual($"  {2d:F5}s Test1", lines[10]);
+        Assert.DoesNotContain(static line => line.EndsWith(" Test0", StringComparison.Ordinal), lines);
+    }
+
     private static TestNodeUpdateMessage CreatePassedTestNodeUpdate(string displayName, TimeSpan duration)
     {
         DateTimeOffset startTime = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/SlowestTestsConsumer.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/SlowestTestsConsumer.cs
@@ -40,10 +40,10 @@ public sealed class SlowestTestsConsumer : IDataConsumer, ITestSessionLifetimeHa
 
     public Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
     {
-        Console.WriteLine("Slowest 10 tests");
+        Console.WriteLine("Slowest 10 tests:");
         foreach ((_, string displayName, double milliseconds) in _testPerf.OrderByDescending(x => x.Milliseconds).Take(10))
         {
-            Console.WriteLine($"{displayName} {TimeSpan.FromMilliseconds(milliseconds).TotalSeconds:F5}s");
+            Console.WriteLine($"  {TimeSpan.FromMilliseconds(milliseconds).TotalSeconds:F5}s {displayName}");
         }
 
         return Task.CompletedTask;

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/SlowestTestsConsumer.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/SlowestTestsConsumer.cs
@@ -11,6 +11,15 @@ namespace Microsoft.Testing.TestInfrastructure;
 public sealed class SlowestTestsConsumer : IDataConsumer, ITestSessionLifetimeHandler
 {
     private readonly List<(string TestId, string DisplayName, double Milliseconds)> _testPerf = [];
+    private readonly Action<string> _writeLine;
+
+    public SlowestTestsConsumer()
+        : this(Console.WriteLine)
+    {
+    }
+
+    internal SlowestTestsConsumer(Action<string> writeLine)
+        => _writeLine = writeLine;
 
     public Type[] DataTypesConsumed => [typeof(TestNodeUpdateMessage)];
 
@@ -40,10 +49,10 @@ public sealed class SlowestTestsConsumer : IDataConsumer, ITestSessionLifetimeHa
 
     public Task OnTestSessionFinishingAsync(ITestSessionContext testSessionContext)
     {
-        Console.WriteLine("Slowest 10 tests:");
+        _writeLine("Slowest 10 tests:");
         foreach ((_, string displayName, double milliseconds) in _testPerf.OrderByDescending(x => x.Milliseconds).Take(10))
         {
-            Console.WriteLine($"  {TimeSpan.FromMilliseconds(milliseconds).TotalSeconds:F5}s {displayName}");
+            _writeLine($"  {TimeSpan.FromMilliseconds(milliseconds).TotalSeconds:F5}s {displayName}");
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
## Summary
- indent slow-test entries beneath their section heading
- place each duration before the test display name
- add a colon to the slow-test section heading
- add focused coverage for the exact output format

## Before
```text
Slowest 10 tests
NativeAotTests_HonorsGeneratedInheritedTypeAndMethodMetadata ("net10.0") 76.25811s
NativeAotTests_WillRunWithExitCodeZero ("net10.0") 75.64710s
```

## After
```text
Slowest 10 tests:
  76.25811s NativeAotTests_HonorsGeneratedInheritedTypeAndMethodMetadata ("net10.0")
  75.64710s NativeAotTests_WillRunWithExitCodeZero ("net10.0")
```

## Validation
- `.\build.cmd -projects test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj -bl`
- `.\.dotnet\dotnet.exe run --project test\UnitTests\Microsoft.Testing.Platform.UnitTests -f net8.0 --no-build -c Debug -- --filter-uid Microsoft.Testing.Platform.UnitTests.TestInfrastructure.SlowestTestsConsumerTests.OnTestSessionFinishingAsync_WritesIndentedDurationFirstEntries`