### PR TITLE
Add GlobalTestInitialize analyzer branch tests

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/CultureMutationUnderParallelizationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/CultureMutationUnderParallelizationAnalyzerTests.cs
@@ -356,4 +356,37 @@ public sealed class CultureMutationUnderParallelizationAnalyzerTests
 
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
+
+    [TestMethod]
+    public async Task WhenGlobalTestInitializeSetsDefaultThreadCurrentCulture_Diagnostic()
+    {
+        // Unlike assembly initialization, a global fixture runs around every test and can race concurrent tests.
+        string code = """
+            using System.Globalization;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [GlobalTestInitialize]
+                public static void GlobalSetup(TestContext context)
+                {
+                    {|#0:CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(CultureMutationUnderParallelizationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("CultureInfo.DefaultThreadCurrentCulture"));
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/UndeclaredProcessGlobalStateMutationAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/UndeclaredProcessGlobalStateMutationAnalyzerTests.cs
@@ -225,6 +225,41 @@ public sealed class UndeclaredProcessGlobalStateMutationAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestMethodSetsEnvironmentVariableInGlobalTestInitialize_DiagnosticWithoutFix()
+    {
+        // A global fixture can race every test in the assembly, but it has no effective ResourceLock target.
+        // Verify that the diagnostic is reported without offering a code fix.
+        string code = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [GlobalTestInitialize]
+                public static void GlobalSetup(TestContext context)
+                {
+                    {|#0:Environment.SetEnvironmentVariable("MY_VAR", "value")|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic(UndeclaredProcessGlobalStateMutationAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("Environment.SetEnvironmentVariable", "EnvironmentVariables"),
+            code);
+    }
+
+    [TestMethod]
     public async Task WhenTestMethodSetsEnvironmentVariableInClassInitialize_Diagnostic()
     {
         // Contrast with the two tests above: ClassInitialize runs per class, so under MethodLevel parallelization


### PR DESCRIPTION
## Summary

- add MSTEST0074 coverage for a process-global mutation in `GlobalTestInitialize`
- verify MSTEST0074 reports the diagnostic without offering an ineffective resource-lock fix
- add MSTEST0076 coverage for a culture mutation in `GlobalTestInitialize`

## Testing

- targeted Debug build: `.\build.cmd -projects test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj -bl`
- both new net8.0 analyzer tests passed before and after review

Closes #10467
