### PR TITLE
Add nameof edge-case coverage for MSTEST0073

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/PreferConstantForResourceLockAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/PreferConstantForResourceLockAnalyzerTests.cs
@@ -99,6 +99,26 @@ public sealed class PreferConstantForResourceLockAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenResourceKeyIsNameofExpression_NoDiagnostic()
+    {
+        string code = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [ResourceLock(nameof(MyTestClass))]
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     public async Task WhenResourceKeyIsLiteralConcatenation_Diagnostic()
     {
         string code = """


### PR DESCRIPTION
## Summary

- Add coverage that `ResourceLock(nameof(MyTestClass))` does not trigger MSTEST0073.
- Exercise the analyzer's handling of compile-time string expressions without string-literal tokens.

## Tests

- Targeted `MSTest.Analyzers.UnitTests` Debug build
- `PreferConstantForResourceLockAnalyzerTests`: 11 passed

Closes #10439