### PR TITLE
Suppress redundant in-progress test updates

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TestNodeStateChangeAggregator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TestNodeStateChangeAggregator.cs
@@ -29,6 +29,34 @@ internal sealed partial class ServerTestHost
             => _stateChanges.Add(stateChangedMessage);
 
         public TestNodeStateChangedEventArgs BuildAggregatedChange()
-            => new(RunId, [.. _stateChanges]);
+        {
+            HashSet<TestNodeUid>? terminalTestNodeUids = null;
+            foreach (TestNodeUpdateMessage stateChange in _stateChanges)
+            {
+                TestNodeStateProperty? state = stateChange.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>();
+                if (IsTerminalState(state))
+                {
+                    (terminalTestNodeUids ??= []).Add(stateChange.TestNode.Uid);
+                }
+            }
+
+            TestNodeUpdateMessage[] changes = terminalTestNodeUids is null
+                ? [.. _stateChanges]
+                : [.. _stateChanges.Where(stateChange =>
+                    stateChange.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>() is not InProgressTestNodeStateProperty
+                    || !terminalTestNodeUids.Contains(stateChange.TestNode.Uid))];
+
+            return new(RunId, changes);
+        }
+
+#pragma warning disable CS0618, MTP0001
+        private static bool IsTerminalState(TestNodeStateProperty? state)
+            => state is PassedTestNodeStateProperty
+                or SkippedTestNodeStateProperty
+                or FailedTestNodeStateProperty
+                or ErrorTestNodeStateProperty
+                or TimeoutTestNodeStateProperty
+                or CancelledTestNodeStateProperty;
+#pragma warning restore CS0618, MTP0001
     }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ServerModeTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ServerModeTests.cs
@@ -37,7 +37,7 @@ public sealed class ServerModeTests : ServerModeTestsBase<ServerModeTests.TestAs
 
         await Task.WhenAll(discoveryListener.WaitCompletion(), runListener.WaitCompletion());
         Assert.ContainsSingle(x => x.Node.NodeType == "action", discoveryCollector.TestNodeUpdates, "Wrong number of discovery");
-        Assert.HasCount(2, runCollector.TestNodeUpdates);
+        Assert.ContainsSingle(x => x.Node.ExecutionState == "passed", runCollector.TestNodeUpdates);
         Assert.IsNotEmpty(logs, "Logs are empty");
         Assert.IsFalse(telemetry.IsEmpty, "telemetry is empty");
         await jsonClient.Exit();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Hosts;
+using Microsoft.Testing.Platform.ServerMode;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class TestNodeStateChangeAggregatorTests
+{
+    [TestMethod]
+    [DynamicData(nameof(TerminalStates))]
+    public void BuildAggregatedChange_InProgressThenTerminalForSameUid_OmitsInProgress(TestNodeStateProperty terminalState)
+    {
+        var runId = Guid.NewGuid();
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(runId);
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage terminal = CreateUpdate("test", terminalState);
+
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(terminal);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.AreEqual(runId, aggregatedChange.RunId);
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(1, aggregatedChange.Changes);
+        Assert.AreSame(terminal, aggregatedChange.Changes[0]);
+    }
+
+    [TestMethod]
+    public void BuildAggregatedChange_TerminalThenInProgressForSameUid_OmitsInProgress()
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage terminal = CreateUpdate("test", PassedTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+
+        aggregator.OnStateChange(terminal);
+        aggregator.OnStateChange(inProgress);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(1, aggregatedChange.Changes);
+        Assert.AreSame(terminal, aggregatedChange.Changes[0]);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(NonTerminalStates))]
+    public void BuildAggregatedChange_NonTerminalStateForSameUid_RetainsInProgress(TestNodeStateProperty nonTerminalState)
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage nonTerminal = CreateUpdate("test", nonTerminalState);
+
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(nonTerminal);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(2, aggregatedChange.Changes);
+        Assert.AreSame(inProgress, aggregatedChange.Changes[0]);
+        Assert.AreSame(nonTerminal, aggregatedChange.Changes[1]);
+    }
+
+    [TestMethod]
+    public void BuildAggregatedChange_NoStateForSameUid_RetainsInProgress()
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage noState = CreateUpdate("test");
+
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(noState);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(2, aggregatedChange.Changes);
+        Assert.AreSame(inProgress, aggregatedChange.Changes[0]);
+        Assert.AreSame(noState, aggregatedChange.Changes[1]);
+    }
+
+    [TestMethod]
+    public void BuildAggregatedChange_TerminalForDifferentUid_RetainsInProgress()
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage inProgress = CreateUpdate("in-progress", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage terminal = CreateUpdate("terminal", PassedTestNodeStateProperty.CachedInstance);
+
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(terminal);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(2, aggregatedChange.Changes);
+        Assert.AreSame(inProgress, aggregatedChange.Changes[0]);
+        Assert.AreSame(terminal, aggregatedChange.Changes[1]);
+    }
+
+    [TestMethod]
+    public void BuildAggregatedChange_WhenSuppressingInProgress_PreservesRetainedOrderAndIdentity()
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage before = CreateUpdate("before");
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage noState = CreateUpdate("test");
+        TestNodeUpdateMessage discovered = CreateUpdate("test", DiscoveredTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage terminal = CreateUpdate("test", PassedTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage after = CreateUpdate("after", InProgressTestNodeStateProperty.CachedInstance);
+
+        aggregator.OnStateChange(before);
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(noState);
+        aggregator.OnStateChange(discovered);
+        aggregator.OnStateChange(terminal);
+        aggregator.OnStateChange(after);
+
+        TestNodeStateChangedEventArgs aggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(aggregatedChange.Changes);
+        Assert.HasCount(5, aggregatedChange.Changes);
+        Assert.AreSame(before, aggregatedChange.Changes[0]);
+        Assert.AreSame(noState, aggregatedChange.Changes[1]);
+        Assert.AreSame(discovered, aggregatedChange.Changes[2]);
+        Assert.AreSame(terminal, aggregatedChange.Changes[3]);
+        Assert.AreSame(after, aggregatedChange.Changes[4]);
+    }
+
+    [TestMethod]
+    public void BuildAggregatedChange_SeparateAggregatorBatches_DoNotInfluenceEachOther()
+    {
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage terminal = CreateUpdate("test", PassedTestNodeStateProperty.CachedInstance);
+        ServerTestHost.TestNodeStateChangeAggregator inProgressBatch = new(Guid.NewGuid());
+        ServerTestHost.TestNodeStateChangeAggregator terminalBatch = new(Guid.NewGuid());
+
+        inProgressBatch.OnStateChange(inProgress);
+        terminalBatch.OnStateChange(terminal);
+
+        TestNodeStateChangedEventArgs firstAggregatedChange = inProgressBatch.BuildAggregatedChange();
+        TestNodeStateChangedEventArgs secondAggregatedChange = terminalBatch.BuildAggregatedChange();
+
+        Assert.IsNotNull(firstAggregatedChange.Changes);
+        Assert.HasCount(1, firstAggregatedChange.Changes);
+        Assert.AreSame(inProgress, firstAggregatedChange.Changes[0]);
+        Assert.IsNotNull(secondAggregatedChange.Changes);
+        Assert.HasCount(1, secondAggregatedChange.Changes);
+        Assert.AreSame(terminal, secondAggregatedChange.Changes[0]);
+    }
+
+    public static IEnumerable<object[]> TerminalStates()
+    {
+        yield return [PassedTestNodeStateProperty.CachedInstance];
+        yield return [SkippedTestNodeStateProperty.CachedInstance];
+        yield return [new FailedTestNodeStateProperty()];
+        yield return [new ErrorTestNodeStateProperty()];
+        yield return [new TimeoutTestNodeStateProperty()];
+#pragma warning disable CS0618, MTP0001
+        yield return [new CancelledTestNodeStateProperty()];
+#pragma warning restore CS0618, MTP0001
+    }
+
+    public static IEnumerable<object[]> NonTerminalStates()
+    {
+        yield return [DiscoveredTestNodeStateProperty.CachedInstance];
+        yield return [new CustomTestNodeStateProperty()];
+    }
+
+    private static TestNodeUpdateMessage CreateUpdate(string uid, TestNodeStateProperty? state = null)
+        => new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = new TestNodeUid(uid),
+                DisplayName = uid,
+                Properties = state is null ? new PropertyBag() : new PropertyBag(state),
+            });
+
+    private sealed class CustomTestNodeStateProperty : TestNodeStateProperty
+    {
+        public CustomTestNodeStateProperty()
+            : base(null)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Suppress redundant in-progress `TestNodeUpdateMessage` entries when the same test UID has a terminal state in the emitted batch. Discovered, custom, and state-less updates remain untouched, retained updates preserve order, and separate batches remain independent.

Adds focused coverage for every known terminal state, custom non-terminal states, both update orders, unrelated UIDs, retained order and identity, and batch isolation.

Closes #5348

## Validation

- `Microsoft.Testing.Platform.UnitTests` targeted build with binary log
- 13 focused aggregator tests
- Full 2,134-test `Microsoft.Testing.Platform.UnitTests` net8 suite