### PR TITLE
Mark artifact post-processing RFC implemented

### DIFF
--- a/docs/RFCs/018-Artifact-Post-Processing.md
+++ b/docs/RFCs/018-Artifact-Post-Processing.md
@@ -2,7 +2,7 @@
 
 - [ ] Approved in principle
 - [x] Under discussion
-- [ ] Implementation
+- [x] Implementation
 - [ ] Shipped
 
 > **Renumber note.** This design was originally drafted as "RFC 017" in [microsoft/testfx#9187](https://github.com/microsoft/testfx/pull/9187). `017` has since been taken by `017-TestHost-Launcher.md` (merged in [#9349](https://github.com/microsoft/testfx/pull/9349)), so this document is renumbered to **018**.


### PR DESCRIPTION
## Summary

- mark RFC 018's implementation phase complete
- record that the artifact post-processing contract, dispatcher, protocol, provenance, and truncated-run opt-in design have implementations

## Validation

Documentation-only change.

Coordinated with dotnet/sdk#55637.

Closes #10414