### PR TITLE
Add Windows app model acceptance coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -773,6 +773,30 @@ stages:
               ArtifactName: TestResults_Windows_$(_BuildConfig)
             condition: failed()
 
+      # Real UWP and packaged WinUI activation require more than a Windows image label. Keep this as a
+      # separate blocking job: its strict preflight verifies the VS/UWP SDKs and interactive machine state
+      # before packing and running the application-model acceptance tests. If this image stops satisfying
+      # those requirements, move the job to a purpose-built pool rather than weakening or skipping tests.
+      - job: WindowsAppModel
+        displayName: Windows application-model acceptance
+        dependsOn: DetectChanges
+        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        timeoutInMinutes: 120
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open
+        variables:
+          - template: /eng/pipelines/variables/test-env-vars.yml
+          - name: _BuildConfig
+            value: Debug
+        steps:
+        - checkout: self
+          clean: true
+
+        - template: /eng/pipelines/steps/install-windows-prereqs.yml
+
+        - template: /eng/pipelines/steps/test-windows-app-model.yml
+
       - job: Linux
         dependsOn: DetectChanges
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -384,7 +384,8 @@ stages:
       artifacts:
         publish:
           artifacts: true
-          logs: true
+          logs:
+            name: 'Logs_Build_$(Agent.JobName)_$(_BuildConfig)'
           manifests: true
       enableTelemetry: true
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -782,7 +782,7 @@ stages:
       - job: WindowsAppModel
         displayName: Windows application-model acceptance
         dependsOn: DetectChanges
-        condition: and(succeeded(), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))
+        condition: and(succeeded(), or(ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'), ne(dependencies.DetectChanges.outputs['detect.hasSamplesChanges'], 'false')))
         timeoutInMinutes: 120
         pool:
           name: NetCore-Public

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -383,7 +383,8 @@ stages:
       testResultsFormat: 'vstest'
       artifacts:
         publish:
-          artifacts: true
+          artifacts:
+            name: 'Artifacts_$(Agent.JobName)_$(_BuildConfig)'
           logs:
             name: 'Logs_Build_$(Agent.JobName)_$(_BuildConfig)'
           manifests: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -791,6 +791,8 @@ stages:
           - template: /eng/pipelines/variables/test-env-vars.yml
           - name: _BuildConfig
             value: Debug
+          - name: Microsoft_Testing_TestInfrastructure_TempDirectory_Cleanup
+            value: 0
         steps:
         - checkout: self
           clean: true

--- a/eng/pipelines/steps/test-windows-app-model.yml
+++ b/eng/pipelines/steps/test-windows-app-model.yml
@@ -23,7 +23,7 @@ steps:
 - script: dotnet build test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-incremental -bl:artifacts\log\$(_BuildConfig)\PackagedWinUI.binlog
   displayName: 'Build packaged WinUI acceptance tests'
 
-- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true -p:ArtifactsTestResultsDir=$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\WindowsApplicationModelPackageContracts
   displayName: 'Test packed Windows application-model contracts'
 
 - script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true

--- a/eng/pipelines/steps/test-windows-app-model.yml
+++ b/eng/pipelines/steps/test-windows-app-model.yml
@@ -1,0 +1,72 @@
+# Strict build, test, diagnostics, and cleanup steps for the real Windows application-model acceptance tests.
+# The consuming job must use an interactive, elevated Windows agent and define _BuildConfig=Debug.
+steps:
+- task: PowerShell@2
+  displayName: 'Preflight Windows application-model agent'
+  inputs:
+    targetType: filePath
+    filePath: ./eng/pipelines/test-windows-app-model-preflight.ps1
+    arguments: -Mode Preflight -RemoveStaleTestPackages
+    failOnStderr: true
+    showWarnings: true
+
+- pwsh: |
+    New-Item "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)" -ItemType Directory -Force | Out-Null
+    New-Item "$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)" -ItemType Directory -Force | Out-Null
+    & .\build.cmd -pack
+    exit $LASTEXITCODE
+  displayName: 'Pack app-model acceptance dependencies'
+
+- script: dotnet build test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-incremental -bl:artifacts\log\$(_BuildConfig)\MSTestWindowsApplicationModel.binlog
+  displayName: 'Build UWP and package-contract acceptance tests'
+
+- script: dotnet build test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-incremental -bl:artifacts\log\$(_BuildConfig)\PackagedWinUI.binlog
+  displayName: 'Build packaged WinUI acceptance tests'
+
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true
+  displayName: 'Test packed Windows application-model contracts'
+
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+  displayName: 'Test real Modern and classic UWP applications'
+  env:
+    TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1
+
+- script: dotnet test test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+  displayName: 'Test real full-trust packaged WinUI application'
+  env:
+    TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1
+
+# This check intentionally runs after a test failure. A successful cleanup check cannot change the
+# existing failed job result, while a leaked registration adds an actionable cleanup failure.
+- task: PowerShell@2
+  displayName: 'Verify app-model package cleanup'
+  condition: always()
+  inputs:
+    targetType: filePath
+    filePath: ./eng/pipelines/test-windows-app-model-preflight.ps1
+    arguments: -Mode LeakCheck
+    failOnStderr: true
+    showWarnings: true
+
+- task: CopyFiles@2
+  displayName: 'Collect app-model diagnostics'
+  condition: always()
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)'
+    Contents: |
+      artifacts/log/$(_BuildConfig)/**
+      artifacts/TestResults/$(_BuildConfig)/**
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/*.binlog
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/*.trx
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/*.build.appxrecipe
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/AppxManifest.xml
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/resolved-mstest-assets.txt
+      artifacts/tmp/$(_BuildConfig)/testsuite/**/*.log
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/windows-app-model'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish app-model diagnostics'
+  condition: always()
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/windows-app-model'
+    ArtifactName: Windows_App_Model_Diagnostics_Attempt$(System.JobAttempt)

--- a/eng/pipelines/steps/test-windows-app-model.yml
+++ b/eng/pipelines/steps/test-windows-app-model.yml
@@ -48,6 +48,10 @@ steps:
     failOnStderr: true
     showWarnings: true
 
+- pwsh: New-Item '$(Build.ArtifactStagingDirectory)/windows-app-model' -ItemType Directory -Force | Out-Null
+  displayName: 'Ensure app-model diagnostics directory exists'
+  condition: always()
+
 - task: CopyFiles@2
   displayName: 'Collect app-model diagnostics'
   condition: always()

--- a/eng/pipelines/steps/test-windows-debug-coverage.yml
+++ b/eng/pipelines/steps/test-windows-debug-coverage.yml
@@ -11,7 +11,7 @@ steps:
 # buffering it until failure, preserving live progress during long-running test sessions.
 - script: |
     echo ##vso[task.setvariable variable=TestStepRan]true
-    dotnet test -c $(_BuildConfig) --no-build --filter "TestCategory!=WindowsApplicationModel" -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+    dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))

--- a/eng/pipelines/steps/test-windows-debug-coverage.yml
+++ b/eng/pipelines/steps/test-windows-debug-coverage.yml
@@ -11,7 +11,7 @@ steps:
 # buffering it until failure, preserving live progress during long-running test sessions.
 - script: |
     echo ##vso[task.setvariable variable=TestStepRan]true
-    dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+    dotnet test -c $(_BuildConfig) --no-build --filter "TestCategory!=WindowsApplicationModel" -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Debug'))

--- a/eng/pipelines/test-windows-app-model-preflight.ps1
+++ b/eng/pipelines/test-windows-app-model-preflight.ps1
@@ -267,41 +267,34 @@ else {
     Write-Host "  Selected Modern UWP SDK: $modernSdkVersion"
 }
 
-$developerModeSettings = @(
-    @{
-        Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
-        Name = 'AllowDevelopmentWithoutDevLicense'
-    },
-    @{
-        Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
-        Name = 'AllowAllTrustedApps'
-    },
-    @{
-        Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Appx'
-        Name = 'AllowDevelopmentWithoutDevLicense'
-    },
-    @{
-        Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Appx'
-        Name = 'AllowAllTrustedApps'
-    }
-)
-$packageRegistrationEnabled = $false
-foreach ($setting in $developerModeSettings) {
-    $effectiveValue = Get-RegistryValueDisplay -Path $setting.Path -Name $setting.Name
-    Write-Host "  Package registration setting '$($setting.Path)\$($setting.Name)': $effectiveValue"
-    if ($effectiveValue -eq '1') {
-        $packageRegistrationEnabled = $true
-    }
-}
+$appModelUnlockPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+$developerPolicyPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Appx'
+$localDeveloperMode = Get-RegistryValueDisplay -Path $appModelUnlockPath -Name 'AllowDevelopmentWithoutDevLicense'
+$policyDeveloperMode = Get-RegistryValueDisplay -Path $developerPolicyPath -Name 'AllowDevelopmentWithoutDevLicense'
+$localTrustedApps = Get-RegistryValueDisplay -Path $appModelUnlockPath -Name 'AllowAllTrustedApps'
+$policyTrustedApps = Get-RegistryValueDisplay -Path $developerPolicyPath -Name 'AllowAllTrustedApps'
+Write-Host "  Developer Mode local setting: $localDeveloperMode"
+Write-Host "  Developer Mode policy setting: $policyDeveloperMode"
+Write-Host "  Trusted-app sideload local setting (diagnostic only): $localTrustedApps"
+Write-Host "  Trusted-app sideload policy setting (diagnostic only): $policyTrustedApps"
+
+$developerPolicyConfigured = $policyDeveloperMode -notin @('<key missing>', '<value missing>')
+$effectiveDeveloperMode = if ($developerPolicyConfigured) { $policyDeveloperMode } else { $localDeveloperMode }
+$packageRegistrationEnabled = $effectiveDeveloperMode -eq '1'
 if (-not $packageRegistrationEnabled) {
-    if (-not $isAdministrator) {
+    if ($developerPolicyConfigured) {
         Add-PreflightFailure (
-            'Developer Mode or trusted-app sideloading is not enabled, and the agent is not elevated. Enable ' +
-            'AllowDevelopmentWithoutDevLicense or AllowAllTrustedApps before running the application-model tests.'
+            "Developer Mode policy '$developerPolicyPath\AllowDevelopmentWithoutDevLicense' overrides the local setting " +
+            "with '$policyDeveloperMode'. It must be DWORD 1 for unsigned loose package registration."
+        )
+    }
+    elseif (-not $isAdministrator) {
+        Add-PreflightFailure (
+            'Developer Mode is not enabled, and the agent is not elevated. Enable AllowDevelopmentWithoutDevLicense ' +
+            'before running the application-model tests.'
         )
     }
     else {
-        $appModelUnlockPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
         try {
             New-Item -Path $appModelUnlockPath -Force | Out-Null
             New-ItemProperty `
@@ -320,7 +313,7 @@ if (-not $packageRegistrationEnabled) {
     }
 }
 if (-not $packageRegistrationEnabled) {
-    Add-PreflightFailure 'Developer Mode or trusted-app sideloading is required for loose package registration.'
+    Add-PreflightFailure 'Developer Mode is required for unsigned loose package registration.'
 }
 
 $uacPolicyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'

--- a/eng/pipelines/test-windows-app-model-preflight.ps1
+++ b/eng/pipelines/test-windows-app-model-preflight.ps1
@@ -1,0 +1,376 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#Requires -Version 5.1
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost',
+    '',
+    Justification = 'The script emits Azure Pipelines logging commands and an explicit preflight report to the pipeline host.'
+)]
+[CmdletBinding()]
+param(
+    [ValidateSet('Preflight', 'LeakCheck')]
+    [string] $Mode = 'Preflight',
+
+    [switch] $RemoveStaleTestPackages
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+# These prefixes are reserved by the three real application-model acceptance assets. Never broaden
+# package discovery or cleanup beyond this list: package registration is per-user machine state.
+$reservedPackageIdentityPrefixes = @(
+    'MSTestClassicUwp',
+    'MSTestModernUwp',
+    'MTPWinUI'
+)
+
+function Get-ReservedTestPackage {
+    $packages = @(Get-AppxPackage -ErrorAction Stop)
+    return @(
+        $packages | Where-Object {
+            $packageName = $_.Name
+            $reservedPackageIdentityPrefixes.Where(
+                { $packageName.StartsWith($_, [StringComparison]::Ordinal) },
+                'First'
+            ).Count -ne 0
+        }
+    )
+}
+
+function Format-PackageRegistration {
+    param([object[]] $Packages)
+
+    return ($Packages | ForEach-Object {
+            "$($_.Name) [$($_.PackageFullName)] at '$($_.InstallLocation)'"
+        }) -join [Environment]::NewLine
+}
+
+function Get-RegistryValueDisplay {
+    param(
+        [string] $Path,
+        [string] $Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return '<key missing>'
+    }
+
+    $property = Get-ItemProperty -LiteralPath $Path -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $property) {
+        return '<value missing>'
+    }
+
+    return [string] $property.$Name
+}
+
+if ($env:OS -ne 'Windows_NT') {
+    throw "Windows application-model acceptance requires Windows. Current OS marker: '$($env:OS)'."
+}
+
+if (-not (Get-Command Get-AppxPackage -ErrorAction SilentlyContinue)) {
+    throw 'Get-AppxPackage is unavailable. Run this preflight in 64-bit Windows PowerShell on a Windows image with AppX deployment support.'
+}
+
+$reservedPackages = @(Get-ReservedTestPackage)
+if ($Mode -eq 'LeakCheck') {
+    if ($reservedPackages.Count -ne 0) {
+        throw (
+            "Windows application-model acceptance leaked registrations with reserved test prefixes " +
+            "'$($reservedPackageIdentityPrefixes -join "', '")'. Remove only these registrations and investigate the test cleanup failure:" +
+            "$([Environment]::NewLine)$(Format-PackageRegistration -Packages $reservedPackages)"
+        )
+    }
+
+    Write-Host "No package registration remains for reserved test prefixes: $($reservedPackageIdentityPrefixes -join ', ')."
+    return
+}
+
+$failures = [Collections.Generic.List[string]]::new()
+function Add-PreflightFailure {
+    param([string] $Message)
+    $failures.Add($Message)
+    Write-Host "##vso[task.logissue type=error]$Message"
+}
+
+$os = Get-CimInstance -ClassName Win32_OperatingSystem
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [Security.Principal.WindowsPrincipal]::new($identity)
+$isAdministrator = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+$currentProcess = Get-Process -Id $PID
+
+Write-Host "Windows application-model preflight environment:"
+Write-Host "  OS: $($os.Caption) $($os.Version) (build $($os.BuildNumber))"
+Write-Host "  User: $($identity.Name)"
+Write-Host "  Elevated: $isAdministrator"
+Write-Host "  Process/session: $PID / $($currentProcess.SessionId)"
+Write-Host "  SESSIONNAME: $(if ($env:SESSIONNAME) { $env:SESSIONNAME } else { '<missing>' })"
+Write-Host "  UserInteractive: $([Environment]::UserInteractive)"
+
+$programFilesX86 = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFilesX86)
+$vswherePath = Join-Path $programFilesX86 'Microsoft Visual Studio\Installer\vswhere.exe'
+$visualStudio = $null
+if (-not (Test-Path -LiteralPath $vswherePath -PathType Leaf)) {
+    Add-PreflightFailure "vswhere.exe was not found at '$vswherePath'. Install Visual Studio Installer and a full Visual Studio instance."
+}
+else {
+    $vswhereArguments = @(
+        '-latest'
+        '-prerelease'
+        '-products'
+        '*'
+        '-requires'
+        'Microsoft.Component.MSBuild'
+        'Microsoft.VisualStudio.Workload.Universal'
+        'Microsoft.VisualStudio.ComponentGroup.UWP.Support'
+        '-format'
+        'json'
+        '-utf8'
+    )
+    $vswhereOutput = @(& $vswherePath @vswhereArguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        Add-PreflightFailure (
+            "vswhere.exe failed with exit code $LASTEXITCODE while requiring desktop MSBuild, " +
+            "Microsoft.VisualStudio.Workload.Universal, and Microsoft.VisualStudio.ComponentGroup.UWP.Support. Output: $($vswhereOutput -join ' ')"
+        )
+    }
+    else {
+        try {
+            $instances = @($vswhereOutput -join [Environment]::NewLine | ConvertFrom-Json)
+            if ($instances.Count -ne 1) {
+                Add-PreflightFailure (
+                    "vswhere.exe found $($instances.Count) matching Visual Studio instances. Install a prerelease-capable " +
+                    'Visual Studio 2026 instance with desktop MSBuild and the complete UWP support component group.'
+                )
+            }
+            else {
+                $visualStudio = $instances[0]
+            }
+        }
+        catch {
+            Add-PreflightFailure (
+                "vswhere.exe returned invalid JSON while locating the UWP-capable Visual Studio instance: $($_.Exception.Message). " +
+                "Raw output: $($vswhereOutput -join ' ')"
+            )
+        }
+    }
+}
+
+if ($null -ne $visualStudio) {
+    $installationPath = [string] $visualStudio.installationPath
+    $installationVersion = [Version] ([string] $visualStudio.installationVersion)
+    $msbuildPath = Join-Path $installationPath 'MSBuild\Current\Bin\MSBuild.exe'
+    $vstestCandidates = @(
+        (Join-Path $installationPath 'Common7\IDE\Extensions\TestPlatform\vstest.console.exe'),
+        (Join-Path $installationPath 'Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe')
+    )
+    $vstestConsolePath = $vstestCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+    $testPlatformDirectory = Join-Path $installationPath 'Common7\IDE\Extensions\TestPlatform'
+    $uwpRuntimeProviderFiles = @(
+        (Join-Path $testPlatformDirectory 'Extensions\Microsoft.VisualStudio.UwpTestHostRuntimeProvider.dll'),
+        (Join-Path $testPlatformDirectory 'Microsoft.VisualStudio.UwpTestHostRuntimeProvider.Deployment.dll')
+    )
+
+    Write-Host "  Visual Studio: $($visualStudio.displayName) $installationVersion at '$installationPath'"
+    Write-Host "  Desktop MSBuild: '$msbuildPath'"
+    Write-Host "  VSTest console: '$(if ($vstestConsolePath) { $vstestConsolePath } else { '<missing>' })'"
+    Write-Host "  UWP runtime provider: $($uwpRuntimeProviderFiles -join '; ')"
+
+    if ($installationVersion.Major -lt 18) {
+        Add-PreflightFailure (
+            "Modern UWP acceptance requires Visual Studio 2026 (18.x or newer), but vswhere selected " +
+            "'$($visualStudio.displayName)' version '$installationVersion' at '$installationPath'. Use the purpose-built VS 2026 Windows agent."
+        )
+    }
+
+    if (-not (Test-Path -LiteralPath $msbuildPath -PathType Leaf)) {
+        Add-PreflightFailure "Desktop MSBuild.exe is missing at '$msbuildPath'. Repair Microsoft.Component.MSBuild in '$installationPath'."
+    }
+
+    if (-not $vstestConsolePath) {
+        Add-PreflightFailure (
+            "vstest.console.exe is missing from the selected Visual Studio instance. Checked: $($vstestCandidates -join '; '). " +
+            'Install the Visual Studio Test Platform and UWP testing tools.'
+        )
+    }
+
+    $missingRuntimeProviderFiles = @($uwpRuntimeProviderFiles | Where-Object { -not (Test-Path -LiteralPath $_ -PathType Leaf) })
+    if ($missingRuntimeProviderFiles.Count -ne 0) {
+        Add-PreflightFailure (
+            "The VSTest UWP runtime provider required for real .build.appxrecipe execution is incomplete. " +
+            "Install or repair the UWP testing tools. Missing: $($missingRuntimeProviderFiles -join '; ')"
+        )
+    }
+
+    $testPlatformUniversalManifest = Join-Path $programFilesX86 (
+        "Microsoft SDKs\Windows Kits\10\ExtensionSDKs\TestPlatform.Universal\$($installationVersion.Major).0\SDKManifest.xml"
+    )
+    Write-Host "  TestPlatform.Universal SDK: '$testPlatformUniversalManifest'"
+    if (-not (Test-Path -LiteralPath $testPlatformUniversalManifest -PathType Leaf)) {
+        Add-PreflightFailure (
+            "The TestPlatform.Universal $($installationVersion.Major).0 extension SDK required by classic UWP is missing at " +
+            "'$testPlatformUniversalManifest'. Repair the selected Visual Studio UWP testing tools."
+        )
+    }
+}
+
+$windowsKitsRoot = Join-Path $programFilesX86 'Windows Kits\10'
+$classicSdkVersion = [Version] '10.0.16299.0'
+$classicSdkFiles = @(
+    (Join-Path $windowsKitsRoot "bin\$classicSdkVersion\x64\makeappx.exe"),
+    (Join-Path $windowsKitsRoot "bin\$classicSdkVersion\x64\makepri.exe"),
+    (Join-Path $windowsKitsRoot "Platforms\UAP\$classicSdkVersion\Platform.xml"),
+    (Join-Path $windowsKitsRoot "UnionMetadata\$classicSdkVersion\Windows.winmd")
+)
+$missingClassicSdkFiles = @($classicSdkFiles | Where-Object { -not (Test-Path -LiteralPath $_ -PathType Leaf) })
+Write-Host "  Classic UWP SDK: $classicSdkVersion at '$windowsKitsRoot'"
+if ($missingClassicSdkFiles.Count -ne 0) {
+    Add-PreflightFailure (
+        "Classic UWP acceptance requires Windows SDK $classicSdkVersion with UWP managed and x64 packaging tools. " +
+        "Run eng/install-windows-sdk.ps1 or install the SDK through Visual Studio. Missing: $($missingClassicSdkFiles -join '; ')"
+    )
+}
+
+$minimumModernSdkVersion = [Version] '10.0.26100.0'
+$sdkBinRoot = Join-Path $windowsKitsRoot 'bin'
+$installedSdkVersions = @()
+if (Test-Path -LiteralPath $sdkBinRoot -PathType Container) {
+    $installedSdkVersions = @(
+        Get-ChildItem -LiteralPath $sdkBinRoot -Directory | ForEach-Object {
+            $parsedVersion = $null
+            if ([Version]::TryParse($_.Name, [ref] $parsedVersion)) {
+                $parsedVersion
+            }
+        } | Sort-Object -Descending
+    )
+}
+
+$modernSdkVersion = $installedSdkVersions | Where-Object {
+    $_ -ge $minimumModernSdkVersion -and
+    (Test-Path -LiteralPath (Join-Path $sdkBinRoot "$_\x64\makeappx.exe") -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $sdkBinRoot "$_\x64\makepri.exe") -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $windowsKitsRoot "Platforms\UAP\$_\Platform.xml") -PathType Leaf) -and
+    (Test-Path -LiteralPath (Join-Path $windowsKitsRoot "UnionMetadata\$_\Windows.winmd") -PathType Leaf)
+} | Select-Object -First 1
+Write-Host "  Installed Windows SDK bin versions: $(if ($installedSdkVersions.Count) { $installedSdkVersions -join ', ' } else { '<none>' })"
+if (-not $modernSdkVersion) {
+    Add-PreflightFailure (
+        "Modern UWP acceptance requires a complete Windows SDK $minimumModernSdkVersion or newer beneath '$windowsKitsRoot'. " +
+        'A capable SDK must include x64 makeappx.exe/makepri.exe, the UAP platform metadata, and UnionMetadata\Windows.winmd. ' +
+        "Installed bin versions: $(if ($installedSdkVersions.Count) { $installedSdkVersions -join ', ' } else { '<none>' })."
+    )
+}
+else {
+    Write-Host "  Selected Modern UWP SDK: $modernSdkVersion"
+}
+
+$developerModeSettings = @(
+    @{
+        Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+        Name = 'AllowDevelopmentWithoutDevLicense'
+    },
+    @{
+        Path = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+        Name = 'AllowAllTrustedApps'
+    },
+    @{
+        Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Appx'
+        Name = 'AllowDevelopmentWithoutDevLicense'
+    },
+    @{
+        Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Appx'
+        Name = 'AllowAllTrustedApps'
+    }
+)
+$packageRegistrationEnabled = $false
+foreach ($setting in $developerModeSettings) {
+    $effectiveValue = Get-RegistryValueDisplay -Path $setting.Path -Name $setting.Name
+    Write-Host "  Package registration setting '$($setting.Path)\$($setting.Name)': $effectiveValue"
+    if ($effectiveValue -eq '1') {
+        $packageRegistrationEnabled = $true
+    }
+}
+if (-not $packageRegistrationEnabled) {
+    Add-PreflightFailure (
+        'Developer Mode or trusted-app sideloading is not enabled. Enable AllowDevelopmentWithoutDevLicense or ' +
+        'AllowAllTrustedApps through Windows Developer settings or machine policy. The preflight does not mutate machine policy.'
+    )
+}
+
+$uacPolicyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+$enableLua = Get-RegistryValueDisplay -Path $uacPolicyPath -Name 'EnableLUA'
+Write-Host "  UAC EnableLUA: $enableLua"
+if ($enableLua -ne '1') {
+    Add-PreflightFailure "UAC must be enabled for packaged application activation. '$uacPolicyPath\EnableLUA' is '$enableLua'; set it to DWORD 1 and reboot the agent."
+}
+
+if (-not [Environment]::UserInteractive) {
+    Add-PreflightFailure 'The agent process is not in an interactive user context ([Environment]::UserInteractive is false). Use an auto-logon, interactive purpose-built Windows agent.'
+}
+if ($currentProcess.SessionId -le 0) {
+    Add-PreflightFailure "The agent runs in session $($currentProcess.SessionId). AUMID activation requires a logged-on user session greater than zero."
+}
+if ([string]::IsNullOrWhiteSpace($env:SESSIONNAME) -or $env:SESSIONNAME -eq 'Services') {
+    Add-PreflightFailure (
+        "SESSIONNAME is '$(if ($env:SESSIONNAME) { $env:SESSIONNAME } else { '<missing>' })'. " +
+        'AUMID activation requires a Console/RDP interactive user desktop, not the Services session.'
+    )
+}
+if (-not (Test-Path -LiteralPath 'HKCU:\Software')) {
+    Add-PreflightFailure "The current user's registry hive is not loaded. Per-user package registration and AUMID activation require an HKCU profile."
+}
+
+$sameSessionExplorer = @(Get-Process -Name explorer -ErrorAction SilentlyContinue | Where-Object SessionId -eq $currentProcess.SessionId)
+if ($sameSessionExplorer.Count -eq 0) {
+    Add-PreflightFailure "No explorer.exe shell is running in agent session $($currentProcess.SessionId). Use a purpose-built auto-logon agent with an interactive desktop."
+}
+
+try {
+    Add-Type -AssemblyName System.Windows.Forms
+    $virtualScreen = [Windows.Forms.SystemInformation]::VirtualScreen
+    Write-Host "  Interactive desktop bounds: $($virtualScreen.Width)x$($virtualScreen.Height)"
+    if ($virtualScreen.Width -lt 1024 -or $virtualScreen.Height -lt 768) {
+        Add-PreflightFailure "The interactive desktop is $($virtualScreen.Width)x$($virtualScreen.Height); Windows app activation requires a usable desktop of at least 1024x768."
+    }
+}
+catch {
+    Add-PreflightFailure "Failed to query the interactive desktop bounds: $($_.Exception.Message). Use an agent with a loaded interactive desktop."
+}
+
+if ($RemoveStaleTestPackages) {
+    foreach ($package in $reservedPackages) {
+        Write-Host "Removing stale reserved test registration '$($package.PackageFullName)'."
+        try {
+            Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop
+        }
+        catch {
+            Add-PreflightFailure "Failed to remove stale reserved test registration '$($package.PackageFullName)': $($_.Exception.Message)"
+        }
+    }
+
+    $remainingPackages = @(Get-ReservedTestPackage)
+    if ($remainingPackages.Count -ne 0) {
+        Add-PreflightFailure (
+            "Reserved test registrations remain after scoped cleanup:$([Environment]::NewLine)" +
+            (Format-PackageRegistration -Packages $remainingPackages)
+        )
+    }
+}
+elseif ($reservedPackages.Count -ne 0) {
+    Add-PreflightFailure (
+        "Stale package registrations already use reserved application-model test prefixes. " +
+        "Run this script with -RemoveStaleTestPackages before testing:$([Environment]::NewLine)" +
+        (Format-PackageRegistration -Packages $reservedPackages)
+    )
+}
+
+if ($failures.Count -ne 0) {
+    throw (
+        "Windows application-model preflight failed with $($failures.Count) prerequisite error(s):$([Environment]::NewLine)- " +
+        ($failures -join "$([Environment]::NewLine)- ")
+    )
+}
+
+Write-Host 'Windows application-model preflight passed. The agent is explicitly capable of running the real UWP and packaged WinUI acceptance tests.'

--- a/eng/pipelines/test-windows-app-model-preflight.ps1
+++ b/eng/pipelines/test-windows-app-model-preflight.ps1
@@ -293,10 +293,33 @@ foreach ($setting in $developerModeSettings) {
     }
 }
 if (-not $packageRegistrationEnabled) {
-    Add-PreflightFailure (
-        'Developer Mode or trusted-app sideloading is not enabled. Enable AllowDevelopmentWithoutDevLicense or ' +
-        'AllowAllTrustedApps through Windows Developer settings or machine policy. The preflight does not mutate machine policy.'
-    )
+    if (-not $isAdministrator) {
+        Add-PreflightFailure (
+            'Developer Mode or trusted-app sideloading is not enabled, and the agent is not elevated. Enable ' +
+            'AllowDevelopmentWithoutDevLicense or AllowAllTrustedApps before running the application-model tests.'
+        )
+    }
+    else {
+        $appModelUnlockPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+        try {
+            New-Item -Path $appModelUnlockPath -Force | Out-Null
+            New-ItemProperty `
+                -Path $appModelUnlockPath `
+                -Name 'AllowDevelopmentWithoutDevLicense' `
+                -PropertyType DWord `
+                -Value 1 `
+                -Force | Out-Null
+            $packageRegistrationEnabled =
+                (Get-RegistryValueDisplay -Path $appModelUnlockPath -Name 'AllowDevelopmentWithoutDevLicense') -eq '1'
+            Write-Host "  Enabled Developer Mode for this elevated, ephemeral test agent: $packageRegistrationEnabled"
+        }
+        catch {
+            Add-PreflightFailure "Failed to enable Developer Mode for the test agent: $($_.Exception.Message)"
+        }
+    }
+}
+if (-not $packageRegistrationEnabled) {
+    Add-PreflightFailure 'Developer Mode or trusted-app sideloading is required for loose package registration.'
 }
 
 $uacPolicyPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
@@ -312,11 +335,13 @@ if (-not [Environment]::UserInteractive) {
 if ($currentProcess.SessionId -le 0) {
     Add-PreflightFailure "The agent runs in session $($currentProcess.SessionId). AUMID activation requires a logged-on user session greater than zero."
 }
-if ([string]::IsNullOrWhiteSpace($env:SESSIONNAME) -or $env:SESSIONNAME -eq 'Services') {
+if ($env:SESSIONNAME -eq 'Services') {
     Add-PreflightFailure (
-        "SESSIONNAME is '$(if ($env:SESSIONNAME) { $env:SESSIONNAME } else { '<missing>' })'. " +
-        'AUMID activation requires a Console/RDP interactive user desktop, not the Services session.'
+        "SESSIONNAME is 'Services'. AUMID activation requires a Console/RDP interactive user desktop, not the Services session."
     )
+}
+elseif ([string]::IsNullOrWhiteSpace($env:SESSIONNAME)) {
+    Write-Host '  SESSIONNAME is unavailable; UserInteractive, SessionId, Explorer, HKCU, and desktop bounds remain authoritative.'
 }
 if (-not (Test-Path -LiteralPath 'HKCU:\Software')) {
     Add-PreflightFailure "The current user's registry hive is not loaded. Per-user package registration and AUMID activation require an HKCU profile."

--- a/eng/pipelines/test-windows-app-model-preflight.ps1
+++ b/eng/pipelines/test-windows-app-model-preflight.ps1
@@ -222,6 +222,7 @@ $classicSdkFiles = @(
     (Join-Path $windowsKitsRoot "bin\$classicSdkVersion\x64\makeappx.exe"),
     (Join-Path $windowsKitsRoot "bin\$classicSdkVersion\x64\makepri.exe"),
     (Join-Path $windowsKitsRoot "Platforms\UAP\$classicSdkVersion\Platform.xml"),
+    (Join-Path $windowsKitsRoot "References\$classicSdkVersion\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd"),
     (Join-Path $windowsKitsRoot "UnionMetadata\$classicSdkVersion\Windows.winmd")
 )
 $missingClassicSdkFiles = @($classicSdkFiles | Where-Object { -not (Test-Path -LiteralPath $_ -PathType Leaf) })

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ClassicUwpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ClassicUwpTests.cs
@@ -1,0 +1,343 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Exercises the locally packed MSTest packages from a real classic UWP application.
+/// </summary>
+[TestClass]
+[TestCategory("WindowsApplicationModel")]
+[MemberCondition(
+    typeof(AcceptanceTestBase),
+    nameof(AcceptanceTestBase.IsWindowsApplicationModelTestEnvironment),
+    IgnoreMessage = "Requires the dedicated preflight-gated Windows application-model test environment.")]
+[DoNotParallelize]
+public sealed class ClassicUwpTests : AcceptanceTestBase
+{
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows, IgnoreMessage = "Classic UWP execution is supported only on Windows.")]
+    public async Task ClassicUwp_ConsumesUapAssets_AndRunsPlainAndUiTestsThroughVSTest()
+    {
+        string uniqueSuffix = Guid.NewGuid().ToString("N");
+        string assetName = $"ClassicUwp{uniqueSuffix[..12]}";
+        string packageIdentityName = $"MSTestClassicUwp{uniqueSuffix}";
+        string sourceCode = ClassicUwpSourceCode
+            .PatchCodeWithReplace("$AssetName$", assetName)
+            .PatchCodeWithReplace("$PackageIdentityName$", packageIdentityName)
+            .PatchCodeWithReplace("$MSBuildSdkExtrasVersion$", MSBuildSdkExtrasVersion)
+            .PatchCodeWithReplace("$MicrosoftNETCoreUniversalWindowsPlatformVersion$", MicrosoftNETCoreUniversalWindowsPlatformVersion)
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
+        try
+        {
+            WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
+            await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
+
+            VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateClassicUwpVisualStudioToolsAsync(TestContext.CancellationToken);
+            UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
+                tools,
+                testAsset,
+                $"{assetName}.csproj",
+                TestContext.CancellationToken);
+
+            string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
+            WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
+                resolvedAssetsReport,
+                WindowsApplicationModelAssetKind.ClassicUwp);
+            AssertClassicUwpPackageLayout(build, packageIdentityName);
+
+            string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
+            UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
+                tools,
+                build.RecipePath,
+                resultsDirectory,
+                TestContext.CancellationToken);
+
+            Assert.AreEqual(
+                0,
+                run.ExitCode,
+                $"VSTest failed to execute the real classic UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
+                $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
+                $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
+            Assert.DoesNotContain(
+                "No test is available",
+                run.StandardOutput,
+                $"VSTest reported no discovered tests for '{build.RecipePath}'.");
+            Assert.DoesNotContain(
+                "Total tests: 0",
+                run.StandardOutput,
+                $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
+
+            AssertClassicUwpTrx(run.TrxPath, build);
+        }
+        finally
+        {
+            await WindowsApplicationModelTestTools.RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
+        }
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+
+    private static async Task EnsureGeneratedCSharpFilesHaveUtf8BomAsync(
+        string targetAssetPath,
+        CancellationToken cancellationToken)
+    {
+        byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
+        foreach (string path in Directory.GetFiles(targetAssetPath, "*.cs", SearchOption.AllDirectories))
+        {
+            string content = await File.ReadAllTextAsync(path, cancellationToken);
+            await File.WriteAllTextAsync(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true), cancellationToken);
+            byte[] actualPreamble = new byte[utf8Preamble.Length];
+            await using FileStream stream = File.OpenRead(path);
+            int bytesRead = await stream.ReadAsync(actualPreamble, cancellationToken);
+            Assert.AreEqual(utf8Preamble.Length, bytesRead, $"Generated C# file '{path}' is shorter than the UTF-8 BOM.");
+            CollectionAssert.AreEqual(utf8Preamble, actualPreamble, $"Generated C# file '{path}' is not UTF-8 with BOM.");
+        }
+    }
+
+    private static void AssertClassicUwpPackageLayout(UwpBuildResult build, string expectedPackageIdentityName)
+    {
+        Assert.IsTrue(
+            Directory.Exists(build.PackageLayoutPath),
+            $"The classic UWP package layout '{build.PackageLayoutPath}' does not exist. Binlog: '{build.BinlogPath}'.");
+
+        string manifestPath = Path.Combine(build.PackageLayoutPath, "AppxManifest.xml");
+        Assert.IsTrue(
+            File.Exists(manifestPath),
+            $"The classic UWP package layout does not contain the tooling-generated manifest '{manifestPath}'. " +
+            $"Recipe: '{build.RecipePath}'. Binlog: '{build.BinlogPath}'.");
+
+        XNamespace foundation = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
+        var manifest = XDocument.Load(manifestPath);
+        XElement identity = manifest.Root?.Element(foundation + "Identity")
+            ?? throw new AssertFailedException($"The tooling-generated package manifest '{manifestPath}' has no Identity element.");
+        Assert.AreEqual(
+            expectedPackageIdentityName,
+            (string?)identity.Attribute("Name"),
+            $"Unexpected package identity in the tooling-generated manifest '{manifestPath}'.");
+    }
+
+    private static void AssertClassicUwpTrx(string trxPath, UwpBuildResult build)
+    {
+        Assert.IsTrue(
+            File.Exists(trxPath),
+            $"VSTest did not create the expected TRX '{trxPath}' for recipe '{build.RecipePath}'. Binlog: '{build.BinlogPath}'.");
+
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        var trx = XDocument.Load(trxPath);
+        XElement[] results = [.. trx.Descendants(ns + "UnitTestResult")];
+        Assert.HasCount(2, results, $"Expected exactly the plain and UI classic UWP tests in '{trxPath}'.");
+
+        string[] actualTestNames = results
+            .Select(result => (string?)result.Attribute("testName"))
+            .Where(name => name is not null)
+            .Cast<string>()
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        string[] expectedTestNames =
+        [
+            "PlainTestMethod_RunsInClassicUwpPackage",
+            "UITestMethod_RunsOnCoreWindowDispatcher",
+        ];
+        CollectionAssert.AreEqual(expectedTestNames, actualTestNames, $"Unexpected test results were written to '{trxPath}'.");
+        Assert.IsTrue(
+            results.All(result => (string?)result.Attribute("outcome") == "Passed"),
+            $"Every classic UWP result must pass. TRX: '{trxPath}'.");
+
+        XElement counters = trx.Descendants(ns + "Counters").Single();
+        AssertCounter(counters, "total", 2, trxPath);
+        AssertCounter(counters, "executed", 2, trxPath);
+        AssertCounter(counters, "passed", 2, trxPath);
+        AssertCounter(counters, "failed", 0, trxPath);
+        AssertCounter(counters, "error", 0, trxPath);
+        AssertCounter(counters, "inconclusive", 0, trxPath);
+        AssertCounter(counters, "notExecuted", 0, trxPath);
+    }
+
+    private static void AssertCounter(XElement counters, string name, int expected, string trxPath)
+        => Assert.AreEqual(
+            expected.ToString(CultureInfo.InvariantCulture),
+            (string?)counters.Attribute(name),
+            $"Unexpected '{name}' counter in '{trxPath}'.");
+
+    private const string ClassicUwpSourceCode = """
+#file $AssetName$.csproj
+<Project Sdk="MSBuild.Sdk.Extras/$MSBuildSdkExtrasVersion$">
+  <PropertyGroup>
+    <TargetFramework>uap10.0.16299</TargetFramework>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+    <OutputType>AppContainerExe</OutputType>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="TestContainer" />
+    <SDKReference Include="TestPlatform.Universal, Version=$(VisualStudioVersion)" />
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Update="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <AppxManifest Include="Package.appxmanifest" />
+    <Content Include="Assets\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="$MicrosoftNETCoreUniversalWindowsPlatformVersion$" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" GeneratePathProperty="true">
+      <NoWarn>NU1903</NoWarn>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" GeneratePathProperty="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="$(PkgNewtonsoft_Json)\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll"
+             Link="Newtonsoft.Json.dll" />
+    <Content Include="$(PkgMSTest_TestFramework)\lib\uap10.0\MSTest.TestFramework.dll"
+             Link="MSTest.TestFramework.dll" />
+    <Content Include="$(PkgMSTest_TestFramework)\lib\uap10.0\MSTest.TestFramework.Extensions.dll"
+             Link="MSTest.TestFramework.Extensions.dll" />
+  </ItemGroup>
+
+  <Target Name="WriteResolvedMSTestAssets" AfterTargets="ResolveReferences">
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="TargetFramework=$(TargetFramework);TargetPlatformVersion=$(TargetPlatformVersion);MSBuildRuntimeType=$(MSBuildRuntimeType)"
+      Overwrite="true" />
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="@(ReferencePath->'%(FullPath)')"
+      Overwrite="false" />
+  </Target>
+</Project>
+
+#file App.xaml
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="$AssetName$.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:$AssetName$" />
+
+#file App.xaml.cs
+using System;
+using Microsoft.VisualStudio.TestPlatform.TestExecutor;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace $AssetName$
+{
+    sealed partial class App : Application
+    {
+        public App() => InitializeComponent();
+
+        protected override void OnLaunched(LaunchActivatedEventArgs args)
+        {
+            Frame rootFrame = Window.Current.Content as Frame;
+            if (rootFrame == null)
+            {
+                rootFrame = new Frame();
+                rootFrame.NavigationFailed += OnNavigationFailed;
+                Window.Current.Content = rootFrame;
+            }
+
+            UnitTestClient.CreateDefaultUI();
+            Window.Current.Activate();
+            UnitTestClient.Run(args.Arguments);
+        }
+
+        private static void OnNavigationFailed(object sender, NavigationFailedEventArgs args)
+        {
+            throw new InvalidOperationException("Failed to load page '" + args.SourcePageType.FullName + "'.");
+        }
+    }
+}
+
+#file Package.appxmanifest
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+  <Identity Name="$PackageIdentityName$" Publisher="CN=MSTest" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="8c009b7d-f28c-4f09-8e97-0669b8aac67d" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>$AssetName$</DisplayName>
+    <PublisherDisplayName>MSTest</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.16299.0" MaxVersionTested="10.0.16299.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="vstest.executionengine.universal.App" Executable="$targetnametoken$.exe" EntryPoint="$AssetName$.App">
+      <uap:VisualElements
+        DisplayName="$AssetName$"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"
+        Description="MSTest classic UWP acceptance asset"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClientServer" />
+    <Capability Name="privateNetworkClientServer" />
+  </Capabilities>
+</Package>
+
+#file UnitTests.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.ApplicationModel;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Controls;
+
+namespace $AssetName$
+{
+    [TestClass]
+    public sealed class ClassicUwpPackageTests
+    {
+        [TestMethod]
+        public void PlainTestMethod_RunsInClassicUwpPackage()
+        {
+            Assert.AreEqual("$PackageIdentityName$", Package.Current.Id.Name);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(Package.Current.Id.FamilyName));
+        }
+
+        [UITestMethod]
+        public void UITestMethod_RunsOnCoreWindowDispatcher()
+        {
+            CoreWindow coreWindow = CoreWindow.GetForCurrentThread();
+            Assert.IsNotNull(coreWindow);
+            Assert.IsTrue(coreWindow.Dispatcher.HasThreadAccess);
+
+            var grid = new Grid();
+            Assert.IsNotNull(grid.Dispatcher);
+            Assert.IsTrue(grid.Dispatcher.HasThreadAccess);
+        }
+    }
+}
+""";
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ClassicUwpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ClassicUwpTests.cs
@@ -31,53 +31,52 @@ public sealed class ClassicUwpTests : AcceptanceTestBase
             .PatchCodeWithReplace("$MicrosoftNETCoreUniversalWindowsPlatformVersion$", MicrosoftNETCoreUniversalWindowsPlatformVersion)
             .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion);
 
-        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
-        try
-        {
-            WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
-            await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
+        TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
+        await WindowsApplicationModelTestTools.ExecuteWithPackageCleanupAsync(
+            testAsset,
+            packageIdentityName,
+            async () =>
+            {
+                WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
+                await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
 
-            VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateClassicUwpVisualStudioToolsAsync(TestContext.CancellationToken);
-            UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
-                tools,
-                testAsset,
-                $"{assetName}.csproj",
-                TestContext.CancellationToken);
+                VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateClassicUwpVisualStudioToolsAsync(TestContext.CancellationToken);
+                UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
+                    tools,
+                    testAsset,
+                    $"{assetName}.csproj",
+                    TestContext.CancellationToken);
 
-            string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
-            WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
-                resolvedAssetsReport,
-                WindowsApplicationModelAssetKind.ClassicUwp);
-            AssertClassicUwpPackageLayout(build, packageIdentityName);
+                string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
+                WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
+                    resolvedAssetsReport,
+                    WindowsApplicationModelAssetKind.ClassicUwp);
+                AssertClassicUwpPackageLayout(build, packageIdentityName);
 
-            string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
-            UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
-                tools,
-                build.RecipePath,
-                resultsDirectory,
-                TestContext.CancellationToken);
+                string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
+                UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
+                    tools,
+                    build.RecipePath,
+                    resultsDirectory,
+                    TestContext.CancellationToken);
 
-            Assert.AreEqual(
-                0,
-                run.ExitCode,
-                $"VSTest failed to execute the real classic UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
-                $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
-                $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
-            Assert.DoesNotContain(
-                "No test is available",
-                run.StandardOutput,
-                $"VSTest reported no discovered tests for '{build.RecipePath}'.");
-            Assert.DoesNotContain(
-                "Total tests: 0",
-                run.StandardOutput,
-                $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
+                Assert.AreEqual(
+                    0,
+                    run.ExitCode,
+                    $"VSTest failed to execute the real classic UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
+                    $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
+                    $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
+                Assert.DoesNotContain(
+                    "No test is available",
+                    run.StandardOutput,
+                    $"VSTest reported no discovered tests for '{build.RecipePath}'.");
+                Assert.DoesNotContain(
+                    "Total tests: 0",
+                    run.StandardOutput,
+                    $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
 
-            AssertClassicUwpTrx(run.TrxPath, build);
-        }
-        finally
-        {
-            await WindowsApplicationModelTestTools.RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
-        }
+                AssertClassicUwpTrx(run.TrxPath, build);
+            });
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ModernUwpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ModernUwpTests.cs
@@ -30,55 +30,54 @@ public sealed class ModernUwpTests : AcceptanceTestBase
             .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
             .PatchCodeWithReplace("$TestPlatformVersion$", MicrosoftNETTestSdkVersion);
 
-        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
-        try
-        {
-            WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
-            await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
+        TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
+        await WindowsApplicationModelTestTools.ExecuteWithPackageCleanupAsync(
+            testAsset,
+            packageIdentityName,
+            async () =>
+            {
+                WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
+                await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
 
-            VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateModernUwpVisualStudioToolsAsync(TestContext.CancellationToken);
-            UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
-                tools,
-                testAsset,
-                $"{assetName}.csproj",
-                TestContext.CancellationToken);
+                VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateModernUwpVisualStudioToolsAsync(TestContext.CancellationToken);
+                UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
+                    tools,
+                    testAsset,
+                    $"{assetName}.csproj",
+                    TestContext.CancellationToken);
 
-            string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
-            WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
-                resolvedAssetsReport,
-                WindowsApplicationModelAssetKind.ModernUwp);
-            Assert.IsTrue(
-                Directory.Exists(build.PackageLayoutPath),
-                $"The Modern UWP package layout '{build.PackageLayoutPath}' does not exist. Binlog: '{build.BinlogPath}'.");
+                string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
+                WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
+                    resolvedAssetsReport,
+                    WindowsApplicationModelAssetKind.ModernUwp);
+                Assert.IsTrue(
+                    Directory.Exists(build.PackageLayoutPath),
+                    $"The Modern UWP package layout '{build.PackageLayoutPath}' does not exist. Binlog: '{build.BinlogPath}'.");
 
-            string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
-            UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
-                tools,
-                build.RecipePath,
-                resultsDirectory,
-                TestContext.CancellationToken);
+                string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
+                UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
+                    tools,
+                    build.RecipePath,
+                    resultsDirectory,
+                    TestContext.CancellationToken);
 
-            Assert.AreEqual(
-                0,
-                run.ExitCode,
-                $"VSTest failed to execute the real Modern UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
-                $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
-                $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
-            Assert.DoesNotContain(
-                "No test is available",
-                run.StandardOutput,
-                $"VSTest reported no discovered tests for '{build.RecipePath}'.");
-            Assert.DoesNotContain(
-                "Total tests: 0",
-                run.StandardOutput,
-                $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
+                Assert.AreEqual(
+                    0,
+                    run.ExitCode,
+                    $"VSTest failed to execute the real Modern UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
+                    $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
+                    $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
+                Assert.DoesNotContain(
+                    "No test is available",
+                    run.StandardOutput,
+                    $"VSTest reported no discovered tests for '{build.RecipePath}'.");
+                Assert.DoesNotContain(
+                    "Total tests: 0",
+                    run.StandardOutput,
+                    $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
 
-            AssertModernUwpTrx(run.TrxPath, build);
-        }
-        finally
-        {
-            await WindowsApplicationModelTestTools.RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
-        }
+                AssertModernUwpTrx(run.TrxPath, build);
+            });
     }
 
     public TestContext TestContext { get; set; } = default!;

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ModernUwpTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ModernUwpTests.cs
@@ -1,0 +1,348 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Exercises the locally packed MSTest packages from a real Modern UWP application.
+/// </summary>
+[TestClass]
+[TestCategory("WindowsApplicationModel")]
+[MemberCondition(
+    typeof(AcceptanceTestBase),
+    nameof(AcceptanceTestBase.IsWindowsApplicationModelTestEnvironment),
+    IgnoreMessage = "Requires the dedicated preflight-gated Windows application-model test environment.")]
+[DoNotParallelize]
+public sealed class ModernUwpTests : AcceptanceTestBase
+{
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows, IgnoreMessage = "Modern UWP execution is supported only on Windows.")]
+    public async Task ModernUwp_ConsumesUwpAssets_AndRunsPlainAndUiTestsThroughVSTest()
+    {
+        string uniqueSuffix = Guid.NewGuid().ToString("N");
+        string assetName = $"ModernUwp{uniqueSuffix[..12]}";
+        string packageIdentityName = $"MSTestModernUwp{uniqueSuffix}";
+        string sourceCode = ModernUwpSourceCode
+            .PatchCodeWithReplace("$AssetName$", assetName)
+            .PatchCodeWithReplace("$PackageIdentityName$", packageIdentityName)
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+            .PatchCodeWithReplace("$TestPlatformVersion$", MicrosoftNETTestSdkVersion);
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(assetName, sourceCode);
+        try
+        {
+            WindowsApplicationModelTestTools.CopySampleAssets(testAsset.TargetAssetPath);
+            await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
+
+            VisualStudioTestTools tools = await WindowsApplicationModelTestTools.LocateModernUwpVisualStudioToolsAsync(TestContext.CancellationToken);
+            UwpBuildResult build = await WindowsApplicationModelTestTools.BuildUwpAssetAsync(
+                tools,
+                testAsset,
+                $"{assetName}.csproj",
+                TestContext.CancellationToken);
+
+            string resolvedAssetsReport = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
+            WindowsApplicationModelTestTools.AssertResolvedMSTestAssets(
+                resolvedAssetsReport,
+                WindowsApplicationModelAssetKind.ModernUwp);
+            Assert.IsTrue(
+                Directory.Exists(build.PackageLayoutPath),
+                $"The Modern UWP package layout '{build.PackageLayoutPath}' does not exist. Binlog: '{build.BinlogPath}'.");
+
+            string resultsDirectory = Path.Combine(testAsset.TargetAssetPath, "TestResults");
+            UwpRunResult run = await WindowsApplicationModelTestTools.RunUwpRecipeAsync(
+                tools,
+                build.RecipePath,
+                resultsDirectory,
+                TestContext.CancellationToken);
+
+            Assert.AreEqual(
+                0,
+                run.ExitCode,
+                $"VSTest failed to execute the real Modern UWP recipe '{build.RecipePath}'. TRX: '{run.TrxPath}'. " +
+                $"Binlog: '{build.BinlogPath}'.{Environment.NewLine}Standard output:{Environment.NewLine}{run.StandardOutput}" +
+                $"{Environment.NewLine}Standard error:{Environment.NewLine}{run.ErrorOutput}");
+            Assert.DoesNotContain(
+                "No test is available",
+                run.StandardOutput,
+                $"VSTest reported no discovered tests for '{build.RecipePath}'.");
+            Assert.DoesNotContain(
+                "Total tests: 0",
+                run.StandardOutput,
+                $"VSTest reported zero discovered tests for '{build.RecipePath}'.");
+
+            AssertModernUwpTrx(run.TrxPath, build);
+        }
+        finally
+        {
+            await WindowsApplicationModelTestTools.RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
+        }
+    }
+
+    public TestContext TestContext { get; set; } = default!;
+
+    private static async Task EnsureGeneratedCSharpFilesHaveUtf8BomAsync(
+        string targetAssetPath,
+        CancellationToken cancellationToken)
+    {
+        byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
+        foreach (string path in Directory.GetFiles(targetAssetPath, "*.cs", SearchOption.AllDirectories))
+        {
+            string content = await File.ReadAllTextAsync(path, cancellationToken);
+            await File.WriteAllTextAsync(path, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true), cancellationToken);
+            byte[] actualPreamble = new byte[utf8Preamble.Length];
+            await using FileStream stream = File.OpenRead(path);
+            int bytesRead = await stream.ReadAsync(actualPreamble, cancellationToken);
+            Assert.AreEqual(utf8Preamble.Length, bytesRead, $"Generated C# file '{path}' is shorter than the UTF-8 BOM.");
+            CollectionAssert.AreEqual(utf8Preamble, actualPreamble, $"Generated C# file '{path}' is not UTF-8 with BOM.");
+        }
+    }
+
+    private static void AssertModernUwpTrx(string trxPath, UwpBuildResult build)
+    {
+        Assert.IsTrue(
+            File.Exists(trxPath),
+            $"VSTest did not create the expected TRX '{trxPath}' for recipe '{build.RecipePath}'. Binlog: '{build.BinlogPath}'.");
+
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        var trx = XDocument.Load(trxPath);
+        XElement[] results = [.. trx.Descendants(ns + "UnitTestResult")];
+        Assert.HasCount(2, results, $"Expected exactly the plain and UI Modern UWP tests in '{trxPath}'.");
+
+        string[] actualTestNames = results
+            .Select(result => (string?)result.Attribute("testName"))
+            .Where(name => name is not null)
+            .Cast<string>()
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        string[] expectedTestNames =
+        [
+            "PlainTestMethod_RunsInPackagedUwp",
+            "UITestMethod_RunsOnCoreWindowDispatcher",
+        ];
+        CollectionAssert.AreEqual(expectedTestNames, actualTestNames, $"Unexpected test results were written to '{trxPath}'.");
+        Assert.IsTrue(
+            results.All(result => (string?)result.Attribute("outcome") == "Passed"),
+            $"Every Modern UWP result must pass. TRX: '{trxPath}'.");
+
+        XElement counters = trx.Descendants(ns + "Counters").Single();
+        AssertCounter(counters, "total", 2, trxPath);
+        AssertCounter(counters, "executed", 2, trxPath);
+        AssertCounter(counters, "passed", 2, trxPath);
+        AssertCounter(counters, "failed", 0, trxPath);
+        AssertCounter(counters, "error", 0, trxPath);
+        AssertCounter(counters, "inconclusive", 0, trxPath);
+        AssertCounter(counters, "notExecuted", 0, trxPath);
+    }
+
+    private static void AssertCounter(XElement counters, string name, int expected, string trxPath)
+        => Assert.AreEqual(
+            expected.ToString(CultureInfo.InvariantCulture),
+            (string?)counters.Attribute(name),
+            $"Unexpected '{name}' counter in '{trxPath}'.");
+
+    private const string ModernUwpSourceCode = """
+#file $AssetName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <Platforms>x64</Platforms>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <PublishAot>true</PublishAot>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <UseUwp>true</UseUwp>
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+    <EnableMsixTooling>true</EnableMsixTooling>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="TestContainer" />
+    <SDKReference Include="TestPlatform.Universal, Version=$(VisualStudioVersion)" />
+    <RuntimeHostConfigurationOption Include="MSTest.EnableParentProcessQuery"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$TestPlatformVersion$" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="$TestPlatformVersion$" ExcludeAssets="build" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+
+  <Target Name="UseNuGetTestPlatformRuntime" BeforeTargets="SDKRedistOutputGroup">
+    <ItemGroup>
+      <ResolvedRedistFiles Remove="$(MSBuildProgramFiles32)\Microsoft SDKs\Windows Kits\10\ExtensionSDKs\TestPlatform.Universal\$(VisualStudioVersion)\Redist\**\*" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="WriteResolvedMSTestAssets" AfterTargets="ResolveReferences">
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="UseUwpTools=$(UseUwpTools)"
+      Overwrite="true" />
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="@(ReferencePath->'%(FullPath)')"
+      Overwrite="false" />
+  </Target>
+</Project>
+
+#file Properties/PublishProfiles/win-x64.pubxml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+</Project>
+
+#file App.xaml
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="$AssetName$.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:$AssetName$" />
+
+#file App.xaml.cs
+using System;
+using Microsoft.VisualStudio.TestPlatform.TestExecutor;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
+
+namespace $AssetName$;
+
+public sealed partial class App : Application
+{
+    public App() => InitializeComponent();
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        var rootFrame = Window.Current.Content as Frame;
+        if (rootFrame is null)
+        {
+            rootFrame = new Frame();
+            rootFrame.NavigationFailed += OnNavigationFailed;
+            Window.Current.Content = rootFrame;
+        }
+
+        UnitTestClient.CreateDefaultUI();
+        Window.Current.Activate();
+        UnitTestClient.Run(args.Arguments);
+    }
+
+    private static void OnNavigationFailed(object sender, NavigationFailedEventArgs args)
+        => throw new InvalidOperationException($"Failed to load page '{args.SourcePageType.FullName}'.");
+}
+
+#file MainPage.xaml
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="$AssetName$.MainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:$AssetName$"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+  <Grid>
+    <TextBlock Text="MSTest Modern UWP acceptance asset" />
+  </Grid>
+</Page>
+
+#file MainPage.xaml.cs
+using Windows.UI.Xaml.Controls;
+
+namespace $AssetName$;
+
+public sealed partial class MainPage : Page
+{
+    public MainPage() => InitializeComponent();
+}
+
+#file Package.appxmanifest
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  IgnorableNamespaces="uap mp">
+  <Identity Name="$PackageIdentityName$" Publisher="CN=MSTest" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="75f918cb-650b-479f-98d2-7f9f05b9a5a1" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>$AssetName$</DisplayName>
+    <PublisherDisplayName>MSTest</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="vstest.executionengine.universal.App" Executable="$targetnametoken$.exe" EntryPoint="$AssetName$.App">
+      <uap:VisualElements
+        DisplayName="$AssetName$"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"
+        Description="MSTest Modern UWP acceptance asset"
+        BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <Capability Name="internetClientServer" />
+    <Capability Name="privateNetworkClientServer" />
+  </Capabilities>
+</Package>
+
+#file UnitTests.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.ApplicationModel;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Controls;
+
+namespace $AssetName$;
+
+[TestClass]
+public sealed class ModernUwpPackageTests
+{
+    [TestMethod]
+    public void PlainTestMethod_RunsInPackagedUwp()
+    {
+        Assert.AreEqual("$PackageIdentityName$", Package.Current.Id.Name);
+        Assert.IsFalse(string.IsNullOrWhiteSpace(Package.Current.Id.FamilyName));
+    }
+
+    [UITestMethod]
+    public void UITestMethod_RunsOnCoreWindowDispatcher()
+    {
+        CoreWindow coreWindow = CoreWindow.GetForCurrentThread();
+        Assert.IsNotNull(coreWindow);
+        Assert.IsTrue(coreWindow.Dispatcher.HasThreadAccess);
+
+        var grid = new Grid();
+        Assert.IsNotNull(grid.Dispatcher);
+        Assert.IsTrue(grid.Dispatcher.HasThreadAccess);
+    }
+}
+""";
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
@@ -11,6 +11,7 @@ namespace MSTest.Acceptance.IntegrationTests;
 /// Verifies the physical Windows application-model assets in the configuration-matched MSTest packages.
 /// </summary>
 [TestClass]
+[OSCondition(OperatingSystems.Windows, IgnoreMessage = "Windows application-model package assets are produced only by Windows packs.")]
 public sealed class WindowsApplicationModelPackageTests
 {
     private static readonly string[] RequiredTestAdapterEntries =

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
@@ -83,13 +83,6 @@ public sealed class WindowsApplicationModelPackageTests
             GetExactCurrentPackagePath("MSTest.TestFramework"),
             RequiredTestFrameworkEntries);
 
-    [TestMethod]
-    public void PackedWindowsApplicationModelAssets_AreFromCurrentPack()
-    {
-        _ = GetExactCurrentPackagePath("MSTest.TestAdapter");
-        _ = GetExactCurrentPackagePath("MSTest.TestFramework");
-    }
-
     private static string GetExactCurrentPackagePath(string packageId)
     {
         string expectedVersion = AcceptanceTestBase.MSTestVersion;

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelPackageTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Compression;
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Verifies the physical Windows application-model assets in the configuration-matched MSTest packages.
+/// </summary>
+[TestClass]
+public sealed class WindowsApplicationModelPackageTests
+{
+    private static readonly string[] RequiredTestAdapterEntries =
+    [
+        // Classic UWP.
+        "build/uap10.0/MSTest.TestAdapter.props",
+        "build/uap10.0/MSTest.TestAdapter.targets",
+        "buildTransitive/uap10.0/MSTest.TestAdapter.dll",
+        "buildTransitive/uap10.0/MSTestAdapter.PlatformServices.dll",
+        "buildTransitive/uap10.0/MSTest.TestAdapter.props",
+        "buildTransitive/uap10.0/MSTest.TestAdapter.targets",
+        "buildTransitive/uap10.0/Parallelize.targets",
+
+        // Modern UWP and its normal net9.0 selection targets.
+        "build/net9.0/MSTest.TestAdapter.props",
+        "build/net9.0/MSTest.TestAdapter.targets",
+        "buildTransitive/net9.0/MSTest.TestAdapter.props",
+        "buildTransitive/net9.0/MSTest.TestAdapter.targets",
+        "buildTransitive/net9.0/Parallelize.targets",
+        "buildTransitive/net9.0/uwp/MSTest.TestAdapter.dll",
+        "buildTransitive/net9.0/uwp/MSTestAdapter.PlatformServices.dll",
+
+        // WinUI and its normal net8.0 selection targets.
+        "build/net8.0/MSTest.TestAdapter.props",
+        "build/net8.0/MSTest.TestAdapter.targets",
+        "buildTransitive/net8.0/MSTest.TestAdapter.props",
+        "buildTransitive/net8.0/MSTest.TestAdapter.targets",
+        "buildTransitive/net8.0/Parallelize.targets",
+        "buildTransitive/net8.0/winui/MSTest.TestAdapter.dll",
+        "buildTransitive/net8.0/winui/MSTestAdapter.PlatformServices.dll",
+    ];
+
+    private static readonly string[] RequiredTestFrameworkEntries =
+    [
+        // Classic UWP.
+        "lib/uap10.0/MSTest.TestFramework.dll",
+        "lib/uap10.0/MSTest.TestFramework.xml",
+        "lib/uap10.0/MSTest.TestFramework.Extensions.dll",
+        "lib/uap10.0/MSTest.TestFramework.Extensions.xml",
+        "build/uap10.0/MSTest.TestFramework.targets",
+        "buildTransitive/uap10.0/MSTest.TestFramework.targets",
+
+        // Modern UWP and its normal net9.0 framework assets.
+        "lib/net9.0/MSTest.TestFramework.dll",
+        "lib/net9.0/MSTest.TestFramework.xml",
+        "build/net9.0/MSTest.TestFramework.targets",
+        "buildTransitive/net9.0/MSTest.TestFramework.targets",
+        "buildTransitive/net9.0/uwp/MSTest.TestFramework.Extensions.dll",
+        "buildTransitive/net9.0/uwp/MSTest.TestFramework.Extensions.xml",
+
+        // WinUI and its normal net8.0 framework assets.
+        "lib/net8.0/MSTest.TestFramework.dll",
+        "lib/net8.0/MSTest.TestFramework.xml",
+        "build/net8.0/MSTest.TestFramework.targets",
+        "buildTransitive/net8.0/MSTest.TestFramework.targets",
+        "buildTransitive/net8.0/winui/MSTest.TestFramework.Extensions.dll",
+        "buildTransitive/net8.0/winui/MSTest.TestFramework.Extensions.xml",
+    ];
+
+    [TestMethod]
+    public void PackedMSTestTestAdapter_ContainsRequiredWindowsApplicationModelAssets()
+        => AssertPackageContainsAllEntries(
+            GetExactCurrentPackagePath("MSTest.TestAdapter"),
+            RequiredTestAdapterEntries);
+
+    [TestMethod]
+    public void PackedMSTestTestFramework_ContainsRequiredWindowsApplicationModelAssets()
+        => AssertPackageContainsAllEntries(
+            GetExactCurrentPackagePath("MSTest.TestFramework"),
+            RequiredTestFrameworkEntries);
+
+    [TestMethod]
+    public void PackedWindowsApplicationModelAssets_AreFromCurrentPack()
+    {
+        _ = GetExactCurrentPackagePath("MSTest.TestAdapter");
+        _ = GetExactCurrentPackagePath("MSTest.TestFramework");
+    }
+
+    private static string GetExactCurrentPackagePath(string packageId)
+    {
+        string expectedVersion = AcceptanceTestBase.MSTestVersion;
+        string[] matches = Directory.Exists(Constants.ArtifactsPackagesShipping)
+            ? Directory.GetFiles(Constants.ArtifactsPackagesShipping, $"{packageId}.*.nupkg", SearchOption.TopDirectoryOnly)
+            : [];
+        string expectedPath = Path.Combine(
+            Constants.ArtifactsPackagesShipping,
+            $"{packageId}.{expectedVersion}.nupkg");
+
+        Assert.HasCount(
+            1,
+            matches,
+            $"Expected exactly one configuration-matched '{packageId}' package in '{Constants.ArtifactsPackagesShipping}', but found {matches.Length}:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, matches.Select(Path.GetFileName))}" +
+            $"{Environment.NewLine}Run '.\\build.cmd -pack' for {Constants.BuildConfiguration}; stale packages must not be selected by timestamp.");
+        Assert.AreEqual(
+            expectedPath,
+            matches[0],
+            ignoreCase: true,
+            $"The only '{packageId}' package does not match the exact locally packed MSTest version '{expectedVersion}'.");
+        Assert.IsTrue(File.Exists(expectedPath), $"The expected current packed package '{expectedPath}' does not exist.");
+        return expectedPath;
+    }
+
+    private static void AssertPackageContainsAllEntries(string packagePath, IEnumerable<string> expectedEntries)
+    {
+        using ZipArchive archive = ZipFile.OpenRead(packagePath);
+        var actualEntries = archive.Entries
+            .Select(entry => entry.FullName.Replace('\\', '/'))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        string[] missing = expectedEntries.Where(path => !actualEntries.Contains(path)).ToArray();
+
+        Assert.IsEmpty(
+            missing,
+            $"Package '{packagePath}' is missing required Windows application-model assets:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, missing));
+    }
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
@@ -260,7 +260,59 @@ internal static class WindowsApplicationModelTestTools
         }
     }
 
-    public static async Task RemoveAndVerifyPackageRegistrationAsync(string packageIdentityName)
+    public static async Task ExecuteWithPackageCleanupAsync(
+        TestAsset testAsset,
+        string packageIdentityName,
+        Func<Task> testAction)
+    {
+        Exception? testFailure = null;
+        Exception? cleanupFailure = null;
+
+        try
+        {
+            await testAction();
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
+        }
+
+        try
+        {
+            await RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
+        }
+        catch (Exception ex)
+        {
+            cleanupFailure = ex;
+        }
+
+        if (cleanupFailure is null)
+        {
+            testAsset.Dispose();
+        }
+
+        if (testFailure is not null && cleanupFailure is not null)
+        {
+            throw new AggregateException(
+                $"The UWP acceptance test failed and cleanup also failed for identity '{packageIdentityName}'. The package layout was retained.",
+                testFailure,
+                cleanupFailure);
+        }
+
+        if (cleanupFailure is not null)
+        {
+            throw new AggregateException(
+                $"Cleanup failed for UWP identity '{packageIdentityName}'. The package layout was retained.",
+                cleanupFailure);
+        }
+
+        if (testFailure is not null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(testFailure).Throw();
+        }
+    }
+
+    private static async Task RemoveAndVerifyPackageRegistrationAsync(string packageIdentityName)
     {
         string escapedIdentity = packageIdentityName.Replace("'", "''", StringComparison.Ordinal);
         string script =

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
@@ -372,7 +372,7 @@ internal static class WindowsApplicationModelTestTools
             .Cast<Version>()
             .OrderDescending()
             .ToArray();
-        Version selectedSdkVersion = installedSdkVersions.FirstOrDefault(version =>
+        _ = installedSdkVersions.FirstOrDefault(version =>
             version >= MinimumModernUwpWindowsSdkVersion
             && GetMissingModernUwpSdkFiles(windowsKitsRoot, sdkBinRoot, version).Length == 0)
             ?? throw new InvalidOperationException(

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
@@ -1,0 +1,390 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+internal enum WindowsApplicationModelAssetKind
+{
+    ClassicUwp,
+    ModernUwp,
+    WinUI,
+}
+
+internal sealed record VisualStudioTestTools(string InstallationPath, string MSBuildPath, string VSTestConsolePath);
+
+internal sealed record UwpBuildResult(
+    string ProjectPath,
+    string BinlogPath,
+    string RecipePath,
+    string PackageLayoutPath,
+    string StandardOutput,
+    string ErrorOutput);
+
+internal sealed record UwpRunResult(
+    int ExitCode,
+    string StandardOutput,
+    string ErrorOutput,
+    string TrxPath);
+
+/// <summary>
+/// Test-only infrastructure for building and executing real Windows application-model assets.
+/// </summary>
+internal static class WindowsApplicationModelTestTools
+{
+    private static readonly Version ClassicUwpWindowsSdkVersion = new(10, 0, 16299, 0);
+    private static readonly Version MinimumModernUwpWindowsSdkVersion = new(10, 0, 26100, 0);
+
+    public static async Task<VisualStudioTestTools> LocateVisualStudioToolsAsync(CancellationToken cancellationToken)
+    {
+        string installationPath = await AcceptanceTestBase.FindVisualStudioWithUwpToolsAsync(cancellationToken);
+        string msbuildPath = Path.Combine(installationPath, "MSBuild", "Current", "Bin", "MSBuild.exe");
+        if (!File.Exists(msbuildPath))
+        {
+            throw new FileNotFoundException(
+                $"Visual Studio at '{installationPath}' satisfies the UWP workload query, but desktop MSBuild.exe was not found at '{msbuildPath}'. " +
+                "Repair Microsoft.Component.MSBuild in that installation.",
+                msbuildPath);
+        }
+
+        string[] vstestCandidates =
+        [
+            Path.Combine(installationPath, "Common7", "IDE", "Extensions", "TestPlatform", "vstest.console.exe"),
+            Path.Combine(installationPath, "Common7", "IDE", "CommonExtensions", "Microsoft", "TestWindow", "vstest.console.exe"),
+        ];
+        string vstestConsolePath = vstestCandidates.FirstOrDefault(File.Exists)
+            ?? throw new FileNotFoundException(
+                $"Visual Studio at '{installationPath}' has MSBuild and the UWP workload, but vstest.console.exe was not found. " +
+                $"Install the Visual Studio Test Platform/UWP test tools. Checked:{Environment.NewLine}{string.Join(Environment.NewLine, vstestCandidates)}");
+
+        string testPlatformDirectory = Path.Combine(installationPath, "Common7", "IDE", "Extensions", "TestPlatform");
+        string[] uwpRuntimeProviderFiles =
+        [
+            Path.Combine(testPlatformDirectory, "Extensions", "Microsoft.VisualStudio.UwpTestHostRuntimeProvider.dll"),
+            Path.Combine(testPlatformDirectory, "Microsoft.VisualStudio.UwpTestHostRuntimeProvider.Deployment.dll"),
+        ];
+        string[] missingRuntimeProviderFiles = uwpRuntimeProviderFiles.Where(path => !File.Exists(path)).ToArray();
+        return missingRuntimeProviderFiles.Length == 0
+            ? new(installationPath, msbuildPath, vstestConsolePath)
+            : throw new FileNotFoundException(
+                $"Visual Studio 2026 at '{installationPath}' does not contain the VSTest UWP runtime provider required to execute " +
+                $".build.appxrecipe files. Install or repair the UWP testing tools. Missing:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, missingRuntimeProviderFiles));
+    }
+
+    public static async Task<VisualStudioTestTools> LocateModernUwpVisualStudioToolsAsync(CancellationToken cancellationToken)
+    {
+        VisualStudioTestTools tools = await LocateVisualStudioToolsAsync(cancellationToken);
+        var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(tools.MSBuildPath);
+        if (msbuildVersionInfo.FileMajorPart < 18)
+        {
+            throw new InvalidOperationException(
+                $"Modern UWP requires Visual Studio 2026 (version 18 or newer), but the UWP-capable installation at " +
+                $"'{tools.InstallationPath}' contains MSBuild version '{msbuildVersionInfo.FileVersion}'. Install Visual Studio 2026 " +
+                "with the Universal Windows Platform development workload and retry.");
+        }
+
+        AssertModernUwpWindowsSdkInstalled();
+        return tools;
+    }
+
+    public static async Task<VisualStudioTestTools> LocateClassicUwpVisualStudioToolsAsync(CancellationToken cancellationToken)
+    {
+        VisualStudioTestTools tools = await LocateVisualStudioToolsAsync(cancellationToken);
+        AssertClassicUwpWindowsSdkInstalled(tools);
+        return tools;
+    }
+
+    public static async Task<UwpBuildResult> BuildUwpAssetAsync(
+        VisualStudioTestTools tools,
+        TestAsset testAsset,
+        string projectFileName,
+        CancellationToken cancellationToken)
+    {
+        string projectPath = Path.Combine(testAsset.TargetAssetPath, projectFileName);
+        Assert.IsTrue(File.Exists(projectPath), $"The generated UWP project '{projectPath}' does not exist.");
+
+        string[] staleRecipes = Directory.GetFiles(testAsset.TargetAssetPath, "*.build.appxrecipe", SearchOption.AllDirectories);
+        Assert.IsEmpty(
+            staleRecipes,
+            $"The unique UWP test asset '{testAsset.TargetAssetPath}' contained stale .build.appxrecipe files before its build:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, staleRecipes)}");
+
+        string binlogPath = Path.Combine(testAsset.TargetAssetPath, $"{Path.GetFileNameWithoutExtension(projectFileName)}.binlog");
+        BoundedCommandLineResult result = await AcceptanceTestBase.RunWindowsApplicationModelCommandAsync(
+            $"\"{tools.MSBuildPath}\" \"{projectPath}\" /restore /t:Build /p:Configuration=Release /p:Platform=x64 /warnaserror /bl:\"{binlogPath}\"",
+            testAsset.TargetAssetPath,
+            cancellationToken);
+        Assert.AreEqual(
+            0,
+            result.ExitCode,
+            $"Building the real UWP asset failed. Project: '{projectPath}'. Binlog: '{binlogPath}'.{Environment.NewLine}" +
+            $"Standard output:{Environment.NewLine}{result.StandardOutput}{Environment.NewLine}" +
+            $"Standard error:{Environment.NewLine}{result.ErrorOutput}");
+
+        string[] recipes = Directory.GetFiles(testAsset.TargetAssetPath, "*.build.appxrecipe", SearchOption.AllDirectories);
+        Assert.HasCount(
+            1,
+            recipes,
+            $"Expected exactly one tooling-generated .build.appxrecipe beneath '{testAsset.TargetAssetPath}', but found {recipes.Length}:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, recipes)}{Environment.NewLine}Binlog: '{binlogPath}'.");
+
+        string recipePath = recipes[0];
+        string[] generatedManifests = Directory.GetFiles(testAsset.TargetAssetPath, "AppxManifest.xml", SearchOption.AllDirectories)
+            .Where(path => !path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Contains("obj", StringComparer.OrdinalIgnoreCase))
+            .ToArray();
+        Assert.IsNotEmpty(
+            generatedManifests,
+            $"The UWP build produced recipe '{recipePath}' but no tooling-generated AppxManifest.xml package layout. Binlog: '{binlogPath}'.");
+
+        string recipeDirectory = Path.GetDirectoryName(recipePath)!;
+        string generatedManifest = generatedManifests
+            .OrderByDescending(path => GetCommonPathPrefixLength(recipeDirectory, path))
+            .First();
+        string packageLayoutPath = Path.GetDirectoryName(generatedManifest)!;
+
+        return new(projectPath, binlogPath, recipePath, packageLayoutPath, result.StandardOutput, result.ErrorOutput);
+    }
+
+    public static async Task<UwpRunResult> RunUwpRecipeAsync(
+        VisualStudioTestTools tools,
+        string recipePath,
+        string resultsDirectory,
+        CancellationToken cancellationToken)
+    {
+        Assert.IsTrue(File.Exists(recipePath), $"The UWP recipe '{recipePath}' does not exist.");
+        Directory.CreateDirectory(resultsDirectory);
+        string trxFileName = $"uwp-{Guid.NewGuid():N}.trx";
+        string trxPath = Path.Combine(resultsDirectory, trxFileName);
+
+        BoundedCommandLineResult result = await AcceptanceTestBase.RunWindowsApplicationModelCommandAsync(
+            $"\"{tools.VSTestConsolePath}\" \"{recipePath}\" /Logger:\"trx;LogFileName={trxFileName}\" /ResultsDirectory:\"{resultsDirectory}\" /Platform:x64 /Framework:FrameworkUap10",
+            Path.GetDirectoryName(recipePath),
+            cancellationToken);
+
+        return new(result.ExitCode, result.StandardOutput, result.ErrorOutput, trxPath);
+    }
+
+    public static void AssertResolvedMSTestAssets(string reportPath, WindowsApplicationModelAssetKind assetKind)
+    {
+        Assert.IsTrue(File.Exists(reportPath), $"The resolved MSTest asset report '{reportPath}' does not exist.");
+        string report = File.ReadAllText(reportPath).Replace('\\', '/');
+
+        (string[] Required, string[] Rejected) assetPaths = assetKind switch
+        {
+            WindowsApplicationModelAssetKind.ClassicUwp =>
+            (
+                [
+                    "/buildTransitive/uap10.0/MSTest.TestAdapter.dll",
+                    "/buildTransitive/uap10.0/MSTestAdapter.PlatformServices.dll",
+                    "/lib/uap10.0/MSTest.TestFramework.dll",
+                    "/lib/uap10.0/MSTest.TestFramework.Extensions.dll",
+                ],
+                [
+                    "/lib/netstandard2.0/MSTest.TestFramework.dll",
+                    "/lib/netstandard2.0/MSTest.TestFramework.Extensions.dll",
+                ]),
+            WindowsApplicationModelAssetKind.ModernUwp =>
+            (
+                [
+                    "/lib/net9.0/MSTest.TestFramework.dll",
+                    "/buildTransitive/net9.0/uwp/MSTest.TestAdapter.dll",
+                    "/buildTransitive/net9.0/uwp/MSTestAdapter.PlatformServices.dll",
+                    "/buildTransitive/net9.0/uwp/MSTest.TestFramework.Extensions.dll",
+                ],
+                [
+                    "/buildTransitive/net9.0/MSTest.TestAdapter.dll",
+                    "/buildTransitive/net9.0/MSTestAdapter.PlatformServices.dll",
+                    "/buildTransitive/net9.0/MSTest.TestFramework.Extensions.dll",
+                ]),
+            WindowsApplicationModelAssetKind.WinUI =>
+            (
+                [
+                    "/buildTransitive/net8.0/winui/MSTest.TestAdapter.dll",
+                    "/buildTransitive/net8.0/winui/MSTestAdapter.PlatformServices.dll",
+                    "/buildTransitive/net8.0/winui/MSTest.TestFramework.Extensions.dll",
+                ],
+                [
+                    "/buildTransitive/net8.0/MSTest.TestAdapter.dll",
+                    "/buildTransitive/net8.0/MSTestAdapter.PlatformServices.dll",
+                    "/buildTransitive/net8.0/MSTest.TestFramework.Extensions.dll",
+                ]),
+            _ => throw new ArgumentOutOfRangeException(nameof(assetKind), assetKind, "Unknown Windows application model."),
+        };
+
+        string[] required = assetPaths.Required;
+        string[] rejected = assetPaths.Rejected;
+        if (assetKind == WindowsApplicationModelAssetKind.ModernUwp)
+        {
+            Assert.Contains(
+                "UseUwpTools=true",
+                report,
+                $"The resolved MSTest report '{reportPath}' does not prove that the Modern UWP SDK enabled UseUwpTools.");
+        }
+        else if (assetKind == WindowsApplicationModelAssetKind.ClassicUwp)
+        {
+            Assert.Contains(
+                "TargetFramework=uap10.0.16299",
+                report,
+                $"The resolved MSTest report '{reportPath}' does not prove the classic UWP consumer targeted uap10.0.16299.");
+            Assert.Contains(
+                "MSBuildRuntimeType=Full",
+                report,
+                $"The resolved MSTest report '{reportPath}' does not prove the classic UWP consumer used desktop MSBuild.");
+        }
+
+        string[] missing = required.Where(path => !report.Contains(path, StringComparison.OrdinalIgnoreCase)).ToArray();
+        string[] unexpectedlyResolved = rejected.Where(path => report.Contains(path, StringComparison.OrdinalIgnoreCase)).ToArray();
+        Assert.IsEmpty(
+            missing,
+            $"The resolved MSTest report '{reportPath}' is missing the following {assetKind} assets:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, missing));
+        Assert.IsEmpty(
+            unexpectedlyResolved,
+            $"The resolved MSTest report '{reportPath}' selected ordinary assets instead of specialized {assetKind} assets:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, unexpectedlyResolved)}");
+    }
+
+    public static void CopySampleAssets(string targetAssetPath)
+    {
+        string sourceAssets = Path.Combine(Constants.Root, "samples", "public", "BlankUwpNet9App", "Assets");
+        Assert.IsTrue(Directory.Exists(sourceAssets), $"Canonical UWP sample assets were not found at '{sourceAssets}'.");
+
+        string destinationAssets = Path.Combine(targetAssetPath, "Assets");
+        Directory.CreateDirectory(destinationAssets);
+        foreach (string sourceFile in Directory.GetFiles(sourceAssets, "*", SearchOption.TopDirectoryOnly))
+        {
+            File.Copy(sourceFile, Path.Combine(destinationAssets, Path.GetFileName(sourceFile)), overwrite: true);
+        }
+    }
+
+    public static async Task RemoveAndVerifyPackageRegistrationAsync(string packageIdentityName)
+    {
+        string escapedIdentity = packageIdentityName.Replace("'", "''", StringComparison.Ordinal);
+        string script =
+            $"$packages = @(Get-AppxPackage -Name '{escapedIdentity}' -ErrorAction Stop | " +
+            $"Where-Object {{ $_.Name -ceq '{escapedIdentity}' }}); " +
+            "foreach ($package in $packages) { Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop }; " +
+            $"$remaining = @(Get-AppxPackage -Name '{escapedIdentity}' -ErrorAction Stop | " +
+            $"Where-Object {{ $_.Name -ceq '{escapedIdentity}' }}); " +
+            "if ($remaining.Count -ne 0) { throw \"Package registration still exists after cleanup: $($remaining.PackageFullName -join ', ')\" }; " +
+            "Write-Output 'WINDOWS_APP_MODEL_REGISTRATION_ABSENT'";
+        string encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        BoundedCommandLineResult result = await AcceptanceTestBase.RunWindowsApplicationModelCommandAsync(
+            $"powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedCommand}",
+            workingDirectory: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.AreEqual(
+            0,
+            result.ExitCode,
+            $"Failed to remove or verify removal of UWP identity '{packageIdentityName}'." +
+            $"{Environment.NewLine}Standard output:{Environment.NewLine}{result.StandardOutput}" +
+            $"{Environment.NewLine}Standard error:{Environment.NewLine}{result.ErrorOutput}");
+        Assert.Contains(
+            "WINDOWS_APP_MODEL_REGISTRATION_ABSENT",
+            result.StandardOutput,
+            $"Cleanup did not verify that UWP identity '{packageIdentityName}' is absent.");
+    }
+
+    private static int GetCommonPathPrefixLength(string first, string second)
+    {
+        int length = Math.Min(first.Length, second.Length);
+        int index = 0;
+        while (index < length && char.ToUpperInvariant(first[index]) == char.ToUpperInvariant(second[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    private static void AssertClassicUwpWindowsSdkInstalled(VisualStudioTestTools tools)
+    {
+        string windowsKitsRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Windows Kits",
+            "10");
+        string sdkVersion = ClassicUwpWindowsSdkVersion.ToString();
+        string[] requiredSdkFiles =
+        [
+            Path.Combine(windowsKitsRoot, "bin", sdkVersion, "x64", "makeappx.exe"),
+            Path.Combine(windowsKitsRoot, "Platforms", "UAP", sdkVersion, "Platform.xml"),
+            Path.Combine(
+                windowsKitsRoot,
+                "References",
+                sdkVersion,
+                "Windows.Foundation.FoundationContract",
+                "3.0.0.0",
+                "Windows.Foundation.FoundationContract.winmd"),
+            Path.Combine(windowsKitsRoot, "UnionMetadata", sdkVersion, "Windows.winmd"),
+        ];
+        string[] missingSdkFiles = requiredSdkFiles.Where(path => !File.Exists(path)).ToArray();
+        if (missingSdkFiles.Length != 0)
+        {
+            throw new FileNotFoundException(
+                $"Classic UWP requires Windows SDK {ClassicUwpWindowsSdkVersion} and its x64 packaging tools. " +
+                $"Install that SDK through the Visual Studio installer. Missing:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, missingSdkFiles));
+        }
+
+        var msbuildVersionInfo = FileVersionInfo.GetVersionInfo(tools.MSBuildPath);
+        string testPlatformUniversalVersion = $"{msbuildVersionInfo.FileMajorPart}.0";
+        string testPlatformUniversalManifest = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft SDKs",
+            "Windows Kits",
+            "10",
+            "ExtensionSDKs",
+            "TestPlatform.Universal",
+            testPlatformUniversalVersion,
+            "SDKManifest.xml");
+        if (!File.Exists(testPlatformUniversalManifest))
+        {
+            throw new FileNotFoundException(
+                $"Classic UWP execution requires the TestPlatform.Universal {testPlatformUniversalVersion} extension SDK matching " +
+                $"desktop MSBuild '{tools.MSBuildPath}', but its manifest was not found at '{testPlatformUniversalManifest}'. " +
+                "Install or repair the Visual Studio UWP testing tools.",
+                testPlatformUniversalManifest);
+        }
+    }
+
+    private static void AssertModernUwpWindowsSdkInstalled()
+    {
+        string windowsKitsRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Windows Kits",
+            "10");
+        string sdkBinRoot = Path.Combine(windowsKitsRoot, "bin");
+        if (!Directory.Exists(sdkBinRoot))
+        {
+            throw new DirectoryNotFoundException(
+                $"Modern UWP requires Windows SDK {MinimumModernUwpWindowsSdkVersion} or newer, but the Windows SDK bin directory " +
+                $"'{sdkBinRoot}' does not exist. Install that SDK through the Visual Studio 2026 installer.");
+        }
+
+        Version[] installedSdkVersions = Directory.GetDirectories(sdkBinRoot)
+            .Select(Path.GetFileName)
+            .Select(name => Version.TryParse(name, out Version? version) ? version : null)
+            .Where(version => version is not null)
+            .Cast<Version>()
+            .OrderDescending()
+            .ToArray();
+        Version selectedSdkVersion = installedSdkVersions.FirstOrDefault(version => version >= MinimumModernUwpWindowsSdkVersion)
+            ?? throw new InvalidOperationException(
+                $"Modern UWP requires Windows SDK {MinimumModernUwpWindowsSdkVersion} or newer beneath '{sdkBinRoot}', but found: " +
+                $"{(installedSdkVersions.Length == 0 ? "<none>" : string.Join(", ", installedSdkVersions))}. " +
+                "Install a current Windows 11 SDK through the Visual Studio 2026 installer.");
+
+        string makeAppxPath = Path.Combine(sdkBinRoot, selectedSdkVersion.ToString(), "x64", "makeappx.exe");
+        if (!File.Exists(makeAppxPath))
+        {
+            throw new FileNotFoundException(
+                $"Windows SDK {selectedSdkVersion} was found, but its x64 MSIX packaging tool is missing at '{makeAppxPath}'. " +
+                "Repair the Windows SDK and its UWP managed tools component.",
+                makeAppxPath);
+        }
+    }
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/WindowsApplicationModelTestTools.cs
@@ -372,19 +372,25 @@ internal static class WindowsApplicationModelTestTools
             .Cast<Version>()
             .OrderDescending()
             .ToArray();
-        Version selectedSdkVersion = installedSdkVersions.FirstOrDefault(version => version >= MinimumModernUwpWindowsSdkVersion)
+        Version selectedSdkVersion = installedSdkVersions.FirstOrDefault(version =>
+            version >= MinimumModernUwpWindowsSdkVersion
+            && GetMissingModernUwpSdkFiles(windowsKitsRoot, sdkBinRoot, version).Length == 0)
             ?? throw new InvalidOperationException(
-                $"Modern UWP requires Windows SDK {MinimumModernUwpWindowsSdkVersion} or newer beneath '{sdkBinRoot}', but found: " +
+                $"Modern UWP requires a complete Windows SDK {MinimumModernUwpWindowsSdkVersion} or newer beneath '{sdkBinRoot}', but found: " +
                 $"{(installedSdkVersions.Length == 0 ? "<none>" : string.Join(", ", installedSdkVersions))}. " +
                 "Install a current Windows 11 SDK through the Visual Studio 2026 installer.");
+    }
 
-        string makeAppxPath = Path.Combine(sdkBinRoot, selectedSdkVersion.ToString(), "x64", "makeappx.exe");
-        if (!File.Exists(makeAppxPath))
-        {
-            throw new FileNotFoundException(
-                $"Windows SDK {selectedSdkVersion} was found, but its x64 MSIX packaging tool is missing at '{makeAppxPath}'. " +
-                "Repair the Windows SDK and its UWP managed tools component.",
-                makeAppxPath);
-        }
+    private static string[] GetMissingModernUwpSdkFiles(string windowsKitsRoot, string sdkBinRoot, Version sdkVersion)
+    {
+        string version = sdkVersion.ToString();
+        string[] requiredFiles =
+        [
+            Path.Combine(sdkBinRoot, version, "x64", "makeappx.exe"),
+            Path.Combine(sdkBinRoot, version, "x64", "makepri.exe"),
+            Path.Combine(windowsKitsRoot, "Platforms", "UAP", version, "Platform.xml"),
+            Path.Combine(windowsKitsRoot, "UnionMetadata", version, "Windows.winmd"),
+        ];
+        return requiredFiles.Where(path => !File.Exists(path)).ToArray();
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -238,8 +238,8 @@ public abstract class AcceptanceTestBase
             "vswhere.exe");
         return await RunAndGetSingleLineStandardOutputAsync(
             vswherePath,
-            "-latest -prerelease -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.Universal -property installationPath",
-            "a prerelease-capable Visual Studio installation with Microsoft.Component.MSBuild and Microsoft.VisualStudio.Workload.Universal",
+            "-latest -prerelease -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.Universal Microsoft.VisualStudio.ComponentGroup.UWP.Support -property installationPath",
+            "a prerelease-capable Visual Studio installation with Microsoft.Component.MSBuild, Microsoft.VisualStudio.Workload.Universal, and Microsoft.VisualStudio.ComponentGroup.UWP.Support",
             cancellationToken);
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceTestBase.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+
 using Combinatorial.MSTest;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+internal sealed record BoundedCommandLineResult(int ExitCode, string StandardOutput, string ErrorOutput);
 
 public abstract class AcceptanceTestBase
 {
@@ -13,6 +17,14 @@ public abstract class AcceptanceTestBase
     {
         var cpmPropFileDoc = XDocument.Load(Path.Combine(RootFinder.Find(), "Directory.Packages.props"));
         MicrosoftNETTestSdkVersion = cpmPropFileDoc.Descendants("MicrosoftNETTestSdkVersion").Single().Value;
+        MicrosoftNETCoreUniversalWindowsPlatformVersion = cpmPropFileDoc.Descendants("MicrosoftNETCoreUniversalWindowsPlatformVersion").Single().Value;
+
+        using var globalJson = JsonDocument.Parse(File.ReadAllText(Path.Combine(RootFinder.Find(), "global.json")));
+        MSBuildSdkExtrasVersion = globalJson.RootElement
+            .GetProperty("msbuild-sdks")
+            .GetProperty("MSBuild.Sdk.Extras")
+            .GetString()
+            ?? throw new InvalidOperationException("The repository global.json does not define a non-empty MSBuild.Sdk.Extras version.");
 
         MSTestVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "MSTest.TestFramework.");
         MicrosoftTestingPlatformVersion = ExtractVersionFromPackage(Constants.ArtifactsPackagesShipping, "Microsoft.Testing.Platform.");
@@ -66,6 +78,24 @@ public abstract class AcceptanceTestBase
     public static string MSTestSourceGenerationVersion { get; private set; }
 
     public static string MicrosoftNETTestSdkVersion { get; private set; }
+
+    public static string MicrosoftNETCoreUniversalWindowsPlatformVersion { get; private set; }
+
+    public static string MSBuildSdkExtrasVersion { get; private set; }
+
+    // Keep this known-working Windows App SDK/BuildTools pair together. Generated WinUI assets use
+    // these shared values rather than adding independent package-version literals.
+    public const string WindowsAppSdkPackageVersion = "1.8.251106002";
+
+    public const string WindowsSdkBuildToolsPackageVersion = "10.0.26100.7175";
+
+    public static TimeSpan WindowsApplicationModelExecutionTimeout { get; } = TimeSpan.FromMinutes(5);
+
+    public static bool IsWindowsApplicationModelTestEnvironment
+        => string.Equals(
+            Environment.GetEnvironmentVariable("TESTFX_RUN_WINDOWS_APP_MODEL_TESTS"),
+            "1",
+            StringComparison.Ordinal);
 
     public static string MicrosoftTestingPlatformVersion { get; private set; }
 
@@ -191,14 +221,78 @@ public abstract class AcceptanceTestBase
     private protected static async Task<string> FindMsbuildWithVsWhereAsync(CancellationToken cancellationToken)
     {
         string vswherePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "Installer", "vswhere.exe");
-        string path = await RunAndGetSingleLineStandardOutputAsync(vswherePath, "-find MSBuild\\**\\Bin\\MSBuild.exe", cancellationToken);
+        string path = await RunAndGetSingleLineStandardOutputAsync(
+            vswherePath,
+            "-latest -prerelease -products * -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe",
+            "Visual Studio with Microsoft.Component.MSBuild",
+            cancellationToken);
         return path;
     }
 
-    private static async Task<string> RunAndGetSingleLineStandardOutputAsync(string vswherePath, string arg, CancellationToken cancellationToken)
+    internal static async Task<string> FindVisualStudioWithUwpToolsAsync(CancellationToken cancellationToken)
     {
-        var commandLine = new TestInfrastructure.CommandLine();
-        await commandLine.RunAsync($"\"{vswherePath}\" -latest -prerelease -requires Microsoft.Component.MSBuild {arg}", cancellationToken: cancellationToken);
+        string vswherePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft Visual Studio",
+            "Installer",
+            "vswhere.exe");
+        return await RunAndGetSingleLineStandardOutputAsync(
+            vswherePath,
+            "-latest -prerelease -products * -requires Microsoft.Component.MSBuild Microsoft.VisualStudio.Workload.Universal -property installationPath",
+            "a prerelease-capable Visual Studio installation with Microsoft.Component.MSBuild and Microsoft.VisualStudio.Workload.Universal",
+            cancellationToken);
+    }
+
+    internal static async Task<BoundedCommandLineResult> RunWindowsApplicationModelCommandAsync(
+        string command,
+        string? workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(WindowsApplicationModelExecutionTimeout);
+        using var commandLine = new TestInfrastructure.CommandLine();
+
+        try
+        {
+            int exitCode = await commandLine.RunAsyncAndReturnExitCodeAsync(
+                command,
+                workingDirectory: workingDirectory,
+                cancellationToken: timeout.Token);
+            return new(exitCode, commandLine.StandardOutput, commandLine.ErrorOutput);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"Command did not exit within {WindowsApplicationModelExecutionTimeout}: {command}{Environment.NewLine}" +
+                $"Standard output:{Environment.NewLine}{commandLine.StandardOutput}{Environment.NewLine}" +
+                $"Standard error:{Environment.NewLine}{commandLine.ErrorOutput}");
+        }
+    }
+
+    private static async Task<string> RunAndGetSingleLineStandardOutputAsync(
+        string vswherePath,
+        string arguments,
+        string requiredCapability,
+        CancellationToken cancellationToken)
+    {
+        if (!File.Exists(vswherePath))
+        {
+            throw new FileNotFoundException(
+                $"Visual Studio discovery requires vswhere.exe at '{vswherePath}'. Install Visual Studio Installer and {requiredCapability}.",
+                vswherePath);
+        }
+
+        using var commandLine = new TestInfrastructure.CommandLine();
+        int exitCode = await commandLine.RunAsyncAndReturnExitCodeAsync(
+            $"\"{vswherePath}\" {arguments}",
+            cancellationToken: cancellationToken);
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"vswhere.exe failed while locating {requiredCapability} (exit code {exitCode}).{Environment.NewLine}" +
+                $"Standard output:{Environment.NewLine}{commandLine.StandardOutput}{Environment.NewLine}" +
+                $"Standard error:{Environment.NewLine}{commandLine.ErrorOutput}");
+        }
 
         string? path = null;
         using (var stringReader = new StringReader(commandLine.StandardOutput))
@@ -208,14 +302,20 @@ public abstract class AcceptanceTestBase
             {
                 if (path != null)
                 {
-                    throw new Exception("vswhere returned more than 1 line");
+                    throw new InvalidOperationException(
+                        $"vswhere.exe returned more than one path while locating {requiredCapability}:{Environment.NewLine}{commandLine.StandardOutput}");
                 }
 
-                path = line;
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    path = line.Trim();
+                }
             }
         }
 
-        return path!;
+        return path
+            ?? throw new InvalidOperationException(
+                $"vswhere.exe did not find {requiredCapability}. Install the required Visual Studio workload/components and retry.");
     }
 }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedWinUITests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/PackagedWinUITests.cs
@@ -1,0 +1,720 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Exercises the real full-trust packaged WinUI launch path contributed by
+/// Microsoft.Testing.Extensions.PackagedApp.
+/// </summary>
+[TestClass]
+[TestCategory("WindowsApplicationModel")]
+[MemberCondition(
+    typeof(AcceptanceTestBase),
+    nameof(AcceptanceTestBase.IsWindowsApplicationModelTestEnvironment),
+    IgnoreMessage = "Requires the dedicated preflight-gated Windows application-model test environment.")]
+[OSCondition(OperatingSystems.Windows, IgnoreMessage = "Packaged WinUI activation is supported only on Windows.")]
+[DoNotParallelize]
+public sealed class PackagedWinUITests : AcceptanceTestBase<NopAssetFixture>
+{
+    private const string TargetFramework = "net8.0-windows10.0.19041.0";
+    private const string RuntimeIdentifier = "win-x64";
+    private const string Publisher = "CN=MSTestAcceptance";
+    private const string LauncherModeEnvironmentVariable = "TESTINGPLATFORM_PACKAGEDAPP_LAUNCHER";
+
+    [TestMethod]
+    public async Task PackagedFullTrustWinUI_RegistersActivatesConnectsBackRunsUiTestsAndCleansUp()
+    {
+        string uniqueSuffix = Guid.NewGuid().ToString("N");
+        // The Windows App SDK still runs the .NET Framework XamlCompiler.exe. Keep the generated
+        // project, root namespace, and assembly name short enough that its intermediatexaml assembly
+        // stays below MAX_PATH; otherwise MarkupCompilePass2 exits with code 1 and no diagnostic.
+        const string AssetName = "PackagedWinUI";
+        string packageIdentityName = $"MTPWinUI{uniqueSuffix}";
+        string expectedPackageFamilyName = ComputePackageFamilyName(packageIdentityName, Publisher);
+        string phoneProductId = Guid.NewGuid().ToString();
+        TestAsset? testAsset = null;
+        Exception? testFailure = null;
+        Exception? cleanupFailure = null;
+        bool cleanupSucceeded = false;
+
+        try
+        {
+            testAsset = await TestAsset.GenerateAssetAsync(
+                AssetName,
+                SourceCode
+                    .PatchCodeWithReplace("$AssetName$", AssetName)
+                    .PatchCodeWithReplace("$PackageIdentityName$", packageIdentityName)
+                    .PatchCodeWithReplace("$ExpectedPackageFamilyName$", expectedPackageFamilyName)
+                    .PatchCodeWithReplace("$Publisher$", Publisher)
+                    .PatchCodeWithReplace("$PhoneProductId$", phoneProductId)
+                    .PatchCodeWithReplace("$TargetFramework$", TargetFramework)
+                    .PatchCodeWithReplace("$RuntimeIdentifier$", RuntimeIdentifier)
+                    .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+                    .PatchCodeWithReplace("$MicrosoftTestingExtensionsPackagedAppVersion$", MicrosoftTestingExtensionsPackagedAppVersion)
+                    .PatchCodeWithReplace("$WindowsAppSdkVersion$", WindowsAppSdkPackageVersion)
+                    .PatchCodeWithReplace("$WindowsSdkBuildToolsVersion$", WindowsSdkBuildToolsPackageVersion));
+
+            string identityMarkerPath = Path.Combine(testAsset.TargetAssetPath, "activated-package-identity.txt");
+            string executionMarkerPath = Path.Combine(testAsset.TargetAssetPath, "executed-tests.txt");
+            PatchMarkerPaths(testAsset.TargetAssetPath, identityMarkerPath, executionMarkerPath);
+            CopyPackagedWinUISampleAssets(testAsset.TargetAssetPath);
+            await EnsureGeneratedCSharpFilesHaveUtf8BomAsync(testAsset.TargetAssetPath, TestContext.CancellationToken);
+
+            PackagedWinUIBuild build = await BuildAssetAsync(testAsset, AssetName, packageIdentityName);
+            AssertResolvedWinUIAssets(build.ResolvedAssetsReportPath);
+
+            var testHost = TestInfrastructure.TestHost.LocateFrom(build.PackageLayoutPath, AssetName);
+            TestHostResult testHostResult = await ExecuteBoundedAsync(
+                testHost,
+                environmentVariables: new Dictionary<string, string?>
+                {
+                    // Make the environment deterministic: an inherited override must not turn this into the
+                    // forced loose-layout path. The AppxManifest.xml probe has to enable the launcher.
+                    [LauncherModeEnvironmentVariable] = null,
+                });
+
+            testHostResult.AssertExitCodeIs(ExitCode.Success);
+            AssertExecutedTestsMarker(executionMarkerPath);
+
+            AssertActivatedIdentityMarker(
+                identityMarkerPath,
+                packageIdentityName,
+                expectedPackageFamilyName,
+                build.PackageLayoutPath);
+            await AssertPackageIsRegisteredAsync(
+                packageIdentityName,
+                expectedPackageFamilyName,
+                build.PackageLayoutPath);
+        }
+        catch (Exception ex)
+        {
+            testFailure = ex;
+        }
+        finally
+        {
+            try
+            {
+                await RemoveAndVerifyPackageRegistrationAsync(packageIdentityName);
+                cleanupSucceeded = true;
+            }
+            catch (Exception ex)
+            {
+                cleanupFailure = ex;
+            }
+
+            // A registered loose package must never point at a directory that this test has deleted. Keep
+            // the layout for diagnosis when cleanup failed; otherwise disposal is safe even after a test
+            // assertion failed.
+            if (cleanupSucceeded)
+            {
+                testAsset?.Dispose();
+            }
+        }
+
+        if (testFailure is not null && cleanupFailure is not null)
+        {
+            throw new AggregateException(
+                $"The packaged WinUI test failed and cleanup also failed for identity '{packageIdentityName}'. " +
+                "The loose layout was retained.",
+                testFailure,
+                cleanupFailure);
+        }
+
+        if (cleanupFailure is not null)
+        {
+            throw new AggregateException(
+                $"Cleanup failed for packaged WinUI identity '{packageIdentityName}'. The loose layout was retained.",
+                cleanupFailure);
+        }
+
+        if (testFailure is not null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(testFailure).Throw();
+        }
+    }
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private async Task<PackagedWinUIBuild> BuildAssetAsync(
+        TestAsset testAsset,
+        string assetName,
+        string packageIdentityName)
+    {
+        string projectPath = Path.Combine(testAsset.TargetAssetPath, $"{assetName}.csproj");
+        DotnetMuxerResult buildResult = await DotnetCli.RunAsync(
+            $"build \"{projectPath}\" -c Release -p:Platform=x64 -p:RuntimeIdentifier={RuntimeIdentifier} " +
+            "-p:AppxPackageSigningEnabled=false -p:GenerateAppxPackageOnBuild=false",
+            workingDirectory: testAsset.TargetAssetPath,
+            failIfReturnValueIsNotZero: false,
+            // The PRI tooling can report warnings for third-party localized resource assemblies. Those
+            // warnings are unrelated to the app-model behavior under test.
+            warnAsError: false,
+            cancellationToken: TestContext.CancellationToken);
+        Assert.AreEqual(
+            0,
+            buildResult.ExitCode,
+            $"Building the real packaged WinUI asset failed. Project: '{projectPath}'. Binlog: '{buildResult.BinlogPath}'." +
+            $"{Environment.NewLine}{buildResult}");
+
+        string packageLayoutPath = Path.Combine(
+            testAsset.TargetAssetPath,
+            "bin",
+            "x64",
+            "Release",
+            TargetFramework,
+            RuntimeIdentifier);
+        Assert.IsTrue(
+            Directory.Exists(packageLayoutPath),
+            $"The WinUI/MSIX tooling did not create the expected loose package layout '{packageLayoutPath}'. " +
+            $"Binlog: '{buildResult.BinlogPath}'.");
+
+        string sourceManifestPath = Path.Combine(testAsset.TargetAssetPath, "Package.appxmanifest");
+        string generatedManifestPath = Path.Combine(packageLayoutPath, "AppxManifest.xml");
+        Assert.IsTrue(File.Exists(sourceManifestPath), $"The generated asset is missing its source manifest '{sourceManifestPath}'.");
+        Assert.IsTrue(
+            File.Exists(generatedManifestPath),
+            $"The real WinUI/MSIX build did not produce the tooling-generated manifest '{generatedManifestPath}'. " +
+            $"A copied source manifest is not accepted as packaged WinUI coverage. Binlog: '{buildResult.BinlogPath}'.");
+        Assert.AreNotEqual(
+            Path.GetFullPath(sourceManifestPath),
+            Path.GetFullPath(generatedManifestPath),
+            "The package layout must use the AppxManifest.xml generated by MSIX tooling, not the source Package.appxmanifest.");
+
+        AssertFullTrustGeneratedManifest(
+            generatedManifestPath,
+            packageLayoutPath,
+            assetName,
+            packageIdentityName);
+
+        string resolvedAssetsReportPath = Path.Combine(testAsset.TargetAssetPath, "resolved-mstest-assets.txt");
+        return new(packageLayoutPath, generatedManifestPath, resolvedAssetsReportPath, buildResult.BinlogPath!);
+    }
+
+    private static void AssertFullTrustGeneratedManifest(
+        string generatedManifestPath,
+        string packageLayoutPath,
+        string assetName,
+        string packageIdentityName)
+    {
+        var manifest = XDocument.Load(generatedManifestPath);
+        XElement root = manifest.Root
+            ?? throw new AssertFailedException($"The generated manifest '{generatedManifestPath}' has no Package root.");
+        XElement identity = root.Elements().Single(element => element.Name.LocalName == "Identity");
+        Assert.AreEqual(
+            packageIdentityName,
+            (string?)identity.Attribute("Name"),
+            $"Unexpected package identity in generated manifest '{generatedManifestPath}'.");
+        Assert.AreEqual(Publisher, (string?)identity.Attribute("Publisher"), generatedManifestPath);
+        Assert.AreEqual("x64", (string?)identity.Attribute("ProcessorArchitecture"), generatedManifestPath);
+
+        XElement application = root
+            .Descendants()
+            .Single(element => element.Name.LocalName == "Application");
+        string executable = (string?)application.Attribute("Executable")
+            ?? throw new AssertFailedException($"The generated manifest '{generatedManifestPath}' does not declare an executable.");
+        Assert.AreEqual($"{assetName}.exe", executable, ignoreCase: true, generatedManifestPath);
+        Assert.AreEqual(
+            "Windows.FullTrustApplication",
+            (string?)application.Attribute("EntryPoint"),
+            $"The generated manifest '{generatedManifestPath}' must describe a full-trust desktop application.");
+
+        string executablePath = Path.Combine(packageLayoutPath, executable.Replace('\\', Path.DirectorySeparatorChar));
+        Assert.IsTrue(
+            File.Exists(executablePath),
+            $"The generated manifest declares '{executable}', but the matching real executable does not exist at '{executablePath}'.");
+        Assert.IsNotEmpty(
+            root.Descendants().Where(element =>
+                element.Name.LocalName == "Capability"
+                && string.Equals((string?)element.Attribute("Name"), "runFullTrust", StringComparison.Ordinal)).ToArray(),
+            $"The generated manifest '{generatedManifestPath}' does not retain rescap:Capability Name=\"runFullTrust\".");
+    }
+
+    private static void AssertResolvedWinUIAssets(string reportPath)
+    {
+        Assert.IsTrue(File.Exists(reportPath), $"The resolved WinUI asset report '{reportPath}' does not exist.");
+        string report = File.ReadAllText(reportPath).Replace('\\', '/');
+        Assert.Contains("UseWinUI=true", report, reportPath);
+        Assert.Contains($"TargetFramework={TargetFramework}", report, reportPath);
+
+        string[] required =
+        [
+            "/buildTransitive/net8.0/winui/MSTest.TestAdapter.dll",
+            "/buildTransitive/net8.0/winui/MSTestAdapter.PlatformServices.dll",
+            "/buildTransitive/net8.0/winui/MSTest.TestFramework.Extensions.dll",
+            "/lib/net8.0-windows10.0.19041/Microsoft.Testing.Extensions.PackagedApp.dll",
+        ];
+        string[] rejected =
+        [
+            "/buildTransitive/net8.0/MSTest.TestAdapter.dll",
+            "/buildTransitive/net8.0/MSTestAdapter.PlatformServices.dll",
+            "/buildTransitive/net8.0/MSTest.TestFramework.Extensions.dll",
+            "/lib/net8.0/Microsoft.Testing.Extensions.PackagedApp.dll",
+        ];
+
+        string[] missing = required.Where(path => !report.Contains(path, StringComparison.OrdinalIgnoreCase)).ToArray();
+        string[] unexpectedlyResolved = rejected.Where(path => report.Contains(path, StringComparison.OrdinalIgnoreCase)).ToArray();
+        Assert.IsEmpty(
+            missing,
+            $"The packaged WinUI consumer did not resolve all required net8.0/winui and Windows packaged-app assets:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, missing)}{Environment.NewLine}Report: '{reportPath}'.");
+        Assert.IsEmpty(
+            unexpectedlyResolved,
+            $"The packaged WinUI consumer resolved ordinary assets instead of its specialized WinUI/Windows assets:" +
+            $"{Environment.NewLine}{string.Join(Environment.NewLine, unexpectedlyResolved)}{Environment.NewLine}Report: '{reportPath}'.");
+    }
+
+    private async Task<TestHostResult> ExecuteBoundedAsync(
+        TestInfrastructure.TestHost testHost,
+        Dictionary<string, string?> environmentVariables)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        timeout.CancelAfter(WindowsApplicationModelExecutionTimeout);
+        try
+        {
+            return await testHost.ExecuteAsync(
+                environmentVariables: environmentVariables,
+                cancellationToken: timeout.Token);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !TestContext.CancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"The full-trust packaged WinUI test host did not exit within {WindowsApplicationModelExecutionTimeout}. " +
+                "The package may have failed during registration/AUMID activation, WinUI startup, or MTP connect-back.");
+        }
+    }
+
+    private static void AssertActivatedIdentityMarker(
+        string markerPath,
+        string packageIdentityName,
+        string expectedPackageFamilyName,
+        string packageLayoutPath)
+    {
+        Assert.IsTrue(
+            File.Exists(markerPath),
+            $"The activated test did not report its package identity to '{markerPath}'.");
+        string[] marker = File.ReadAllText(markerPath).Trim().Split('|');
+        Assert.HasCount(3, marker, $"Unexpected activated identity marker content in '{markerPath}'.");
+        Assert.AreEqual(packageIdentityName, marker[0], $"Unexpected Package.Current.Id.Name in '{markerPath}'.");
+        Assert.AreEqual(expectedPackageFamilyName, marker[1], $"Unexpected Package.Current.Id.FamilyName in '{markerPath}'.");
+        Assert.AreEqual(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(packageLayoutPath)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(marker[2])),
+            ignoreCase: true,
+            $"The activated app did not run from the tooling-generated loose package layout. Marker: '{markerPath}'.");
+    }
+
+    private static void AssertExecutedTestsMarker(string markerPath)
+    {
+        Assert.IsTrue(
+            File.Exists(markerPath),
+            $"The activated test host did not report its executed tests to '{markerPath}'.");
+        string[] actual = File.ReadAllLines(markerPath)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToArray();
+        string[] expected =
+        [
+            "PlainTestMethod_Runs",
+            "PlainTestMethod_HasExpectedPackageIdentity",
+            "UITestMethod_RunsOnWinUIDispatcher",
+        ];
+        Array.Sort(expected, StringComparer.Ordinal);
+        Array.Sort(actual, StringComparer.Ordinal);
+        Assert.AreSequenceEqual(
+            expected,
+            actual,
+            $"The AUMID-activated test host did not run exactly the expected plain, identity, and UI tests. Marker: '{markerPath}'.");
+    }
+
+    private static async Task AssertPackageIsRegisteredAsync(
+        string packageIdentityName,
+        string expectedPackageFamilyName,
+        string packageLayoutPath)
+    {
+        string escapedIdentity = EscapePowerShellLiteral(packageIdentityName);
+        string script =
+            $"$packages = @(Get-AppxPackage -Name '{escapedIdentity}' -ErrorAction Stop | " +
+            $"Where-Object {{ $_.Name -ceq '{escapedIdentity}' }}); " +
+            "if ($packages.Count -ne 1) { throw \"Expected exactly one matching package registration, found $($packages.Count).\" }; " +
+            "$package = $packages[0]; " +
+            "Write-Output ('PACKAGED_WINUI_REGISTRATION=' + $package.Name + '|' + $package.PackageFamilyName + '|' + $package.InstallLocation)";
+        BoundedCommandLineResult result = await RunPowerShellAsync(script);
+        Assert.AreEqual(
+            0,
+            result.ExitCode,
+            $"Failed to verify the packaged WinUI registration for '{packageIdentityName}'." +
+            $"{Environment.NewLine}Standard output:{Environment.NewLine}{result.StandardOutput}" +
+            $"{Environment.NewLine}Standard error:{Environment.NewLine}{result.ErrorOutput}");
+
+        string registrationLine = result.StandardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Single(line => line.StartsWith("PACKAGED_WINUI_REGISTRATION=", StringComparison.Ordinal));
+        string[] registration = registrationLine["PACKAGED_WINUI_REGISTRATION=".Length..].Split('|');
+        Assert.HasCount(3, registration, registrationLine);
+        Assert.AreEqual(packageIdentityName, registration[0], registrationLine);
+        Assert.AreEqual(expectedPackageFamilyName, registration[1], registrationLine);
+        Assert.AreEqual(
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(packageLayoutPath)),
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(registration[2])),
+            ignoreCase: true,
+            registrationLine);
+    }
+
+    private static async Task RemoveAndVerifyPackageRegistrationAsync(string packageIdentityName)
+    {
+        string escapedIdentity = EscapePowerShellLiteral(packageIdentityName);
+        string script =
+            $"$packages = @(Get-AppxPackage -Name '{escapedIdentity}' -ErrorAction Stop | " +
+            $"Where-Object {{ $_.Name -ceq '{escapedIdentity}' }}); " +
+            "foreach ($package in $packages) { Remove-AppxPackage -Package $package.PackageFullName -ErrorAction Stop }; " +
+            $"$remaining = @(Get-AppxPackage -Name '{escapedIdentity}' -ErrorAction Stop | " +
+            $"Where-Object {{ $_.Name -ceq '{escapedIdentity}' }}); " +
+            "if ($remaining.Count -ne 0) { throw \"Package registration still exists after cleanup: $($remaining.PackageFullName -join ', ')\" }; " +
+            "Write-Output 'PACKAGED_WINUI_REGISTRATION_ABSENT'";
+        BoundedCommandLineResult result = await RunPowerShellAsync(script);
+        Assert.AreEqual(
+            0,
+            result.ExitCode,
+            $"Failed to remove or verify removal of packaged WinUI identity '{packageIdentityName}'." +
+            $"{Environment.NewLine}Standard output:{Environment.NewLine}{result.StandardOutput}" +
+            $"{Environment.NewLine}Standard error:{Environment.NewLine}{result.ErrorOutput}");
+        Assert.Contains(
+            "PACKAGED_WINUI_REGISTRATION_ABSENT",
+            result.StandardOutput,
+            $"Cleanup did not verify that package identity '{packageIdentityName}' is absent.");
+    }
+
+    private static Task<BoundedCommandLineResult> RunPowerShellAsync(string script)
+    {
+        string encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(script));
+        return RunWindowsApplicationModelCommandAsync(
+            $"powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand {encodedCommand}",
+            workingDirectory: null,
+            cancellationToken: CancellationToken.None);
+    }
+
+    private static string EscapePowerShellLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static string ComputePackageFamilyName(string packageIdentityName, string publisher)
+    {
+        const string PublisherHashAlphabet = "0123456789abcdefghjkmnpqrstvwxyz";
+        byte[] hash = SHA256.HashData(Encoding.Unicode.GetBytes(publisher));
+        var publisherId = new StringBuilder(13);
+        int buffer = 0;
+        int bitsInBuffer = 0;
+        for (int index = 0; index < 8; index++)
+        {
+            buffer = (buffer << 8) | hash[index];
+            bitsInBuffer += 8;
+            while (bitsInBuffer >= 5)
+            {
+                bitsInBuffer -= 5;
+                publisherId.Append(PublisherHashAlphabet[(buffer >> bitsInBuffer) & 0x1F]);
+                buffer &= (1 << bitsInBuffer) - 1;
+            }
+        }
+
+        if (bitsInBuffer > 0)
+        {
+            publisherId.Append(PublisherHashAlphabet[(buffer << (5 - bitsInBuffer)) & 0x1F]);
+        }
+
+        return $"{packageIdentityName}_{publisherId}";
+    }
+
+    private static void PatchMarkerPaths(
+        string targetAssetPath,
+        string identityMarkerPath,
+        string executionMarkerPath)
+    {
+        string unitTestsPath = Path.Combine(targetAssetPath, "UnitTests.cs");
+        string unitTests = File.ReadAllText(unitTestsPath)
+            .PatchCodeWithReplace("$IdentityMarkerPath$", identityMarkerPath)
+            .PatchCodeWithReplace("$ExecutionMarkerPath$", executionMarkerPath);
+        File.WriteAllText(unitTestsPath, unitTests, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+    }
+
+    private static void CopyPackagedWinUISampleAssets(string targetAssetPath)
+    {
+        string sourceAssets = Path.Combine(
+            Constants.Root,
+            "samples",
+            "public",
+            "mstest-runner",
+            "MSTestRunnerWinUI",
+            "MSTestRunnerWinUI",
+            "Assets");
+        Assert.IsTrue(
+            Directory.Exists(sourceAssets),
+            $"The canonical packaged MSTestRunnerWinUI assets were not found at '{sourceAssets}'.");
+
+        string destinationAssets = Path.Combine(targetAssetPath, "Assets");
+        Directory.CreateDirectory(destinationAssets);
+        foreach (string sourceFile in Directory.GetFiles(sourceAssets, "*", SearchOption.TopDirectoryOnly))
+        {
+            File.Copy(sourceFile, Path.Combine(destinationAssets, Path.GetFileName(sourceFile)), overwrite: true);
+        }
+    }
+
+    private static async Task EnsureGeneratedCSharpFilesHaveUtf8BomAsync(
+        string targetAssetPath,
+        CancellationToken cancellationToken)
+    {
+        byte[] expectedPreamble = Encoding.UTF8.GetPreamble();
+        foreach (string path in Directory.GetFiles(targetAssetPath, "*.cs", SearchOption.AllDirectories))
+        {
+            string content = await File.ReadAllTextAsync(path, cancellationToken);
+            await File.WriteAllTextAsync(
+                path,
+                content,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: true),
+                cancellationToken);
+
+            byte[] actualPreamble = new byte[expectedPreamble.Length];
+            await using FileStream stream = File.OpenRead(path);
+            int bytesRead = await stream.ReadAsync(actualPreamble, cancellationToken);
+            Assert.AreEqual(expectedPreamble.Length, bytesRead, $"Generated C# file '{path}' is shorter than the UTF-8 BOM.");
+            Assert.AreSequenceEqual(expectedPreamble, actualPreamble, $"Generated C# file '{path}' is not UTF-8 with BOM.");
+        }
+    }
+
+    private sealed record PackagedWinUIBuild(
+        string PackageLayoutPath,
+        string GeneratedManifestPath,
+        string ResolvedAssetsReportPath,
+        string BinlogPath);
+
+    private const string SourceCode = """
+#file $AssetName$.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$TargetFramework$</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>$AssetName$</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>$RuntimeIdentifier$</RuntimeIdentifier>
+    <UseWinUI>true</UseWinUI>
+    <WinUIDSKReferences>false</WinUIDSKReferences>
+    <EnableMsixTooling>true</EnableMsixTooling>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);NETSDK1201;TPEXP</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Page Remove="UnitTestApp.xaml" />
+    <ApplicationDefinition Include="UnitTestApp.xaml" />
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Assets\**\*" />
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="$WindowsSdkBuildToolsVersion$" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="$WindowsAppSdkVersion$" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+    <PackageReference Include="Microsoft.Testing.Extensions.PackagedApp" Version="$MicrosoftTestingExtensionsPackagedAppVersion$" />
+  </ItemGroup>
+
+  <Target Name="WriteResolvedWinUIAssets" AfterTargets="ResolveReferences">
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="UseWinUI=$(UseWinUI);TargetFramework=$(TargetFramework);RuntimeIdentifier=$(RuntimeIdentifier)"
+      Overwrite="true" />
+    <WriteLinesToFile
+      File="$(MSBuildProjectDirectory)\resolved-mstest-assets.txt"
+      Lines="@(ReferencePath->'%(FullPath)')"
+      Overwrite="false" />
+  </Target>
+</Project>
+
+#file app.manifest
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="$AssetName$.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>
+
+#file Package.appxmanifest
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+  <Identity Name="$PackageIdentityName$" Publisher="$Publisher$" Version="1.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="$PhoneProductId$" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
+  <Properties>
+    <DisplayName>$AssetName$</DisplayName>
+    <PublisherDisplayName>MSTest acceptance</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="x-generate" />
+  </Resources>
+  <Applications>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="$targetentrypoint$">
+      <uap:VisualElements
+        DisplayName="$AssetName$"
+        Description="MSTest packaged WinUI acceptance asset"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>
+
+#file UnitTestApp.xaml
+<?xml version="1.0" encoding="utf-8"?>
+<Application
+    x:Class="$AssetName$.UnitTestApp"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:$AssetName$">
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
+</Application>
+
+#file UnitTestApp.xaml.cs
+using System;
+using System.Linq;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+
+namespace $AssetName$;
+
+public partial class UnitTestApp : Application
+{
+    private Window? _window;
+
+    public UnitTestApp() => InitializeComponent();
+
+    protected override async void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new UnitTestAppWindow();
+        _window.Activate();
+        UITestMethodAttribute.DispatcherQueue = _window.DispatcherQueue;
+
+        try
+        {
+            string[] cliArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+            ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(cliArgs);
+            builder.AddSelfRegisteredExtensions(cliArgs);
+            using ITestApplication app = await builder.BuildAsync();
+            Environment.ExitCode = await app.RunAsync();
+        }
+        finally
+        {
+            _window.Close();
+            Exit();
+        }
+    }
+}
+
+#file UnitTestAppWindow.xaml
+<?xml version="1.0" encoding="utf-8"?>
+<Window
+    x:Class="$AssetName$.UnitTestAppWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:$AssetName$"
+    Title="$AssetName$">
+  <Grid />
+</Window>
+
+#file UnitTestAppWindow.xaml.cs
+using Microsoft.UI.Xaml;
+
+namespace $AssetName$;
+
+public sealed partial class UnitTestAppWindow : Window
+{
+    public UnitTestAppWindow() => InitializeComponent();
+}
+
+#file UnitTests.cs
+using System;
+using System.IO;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting.AppContainer;
+using Windows.ApplicationModel;
+
+namespace $AssetName$;
+
+[TestClass]
+public sealed class PackagedWinUITestCases
+{
+    private static readonly object s_executionMarkerLock = new();
+
+    [TestMethod]
+    public void PlainTestMethod_Runs()
+    {
+        RecordExecution(nameof(PlainTestMethod_Runs));
+    }
+
+    [TestMethod]
+    public void PlainTestMethod_HasExpectedPackageIdentity()
+    {
+        Package package = Package.Current;
+        Assert.AreEqual("$PackageIdentityName$", package.Id.Name);
+        Assert.AreEqual("$ExpectedPackageFamilyName$", package.Id.FamilyName);
+        File.WriteAllText(
+            @"$IdentityMarkerPath$",
+            $"{package.Id.Name}|{package.Id.FamilyName}|{AppContext.BaseDirectory}");
+        RecordExecution(nameof(PlainTestMethod_HasExpectedPackageIdentity));
+    }
+
+    [UITestMethod]
+    public void UITestMethod_RunsOnWinUIDispatcher()
+    {
+        var grid = new Grid();
+
+        Assert.IsTrue(grid.DispatcherQueue.HasThreadAccess);
+        RecordExecution(nameof(UITestMethod_RunsOnWinUIDispatcher));
+    }
+
+    private static void RecordExecution(string testName)
+    {
+        lock (s_executionMarkerLock)
+        {
+            File.AppendAllLines(@"$ExecutionMarkerPath$", [testName]);
+        }
+    }
+}
+""";
+}


### PR DESCRIPTION
MSTest ships specialized assets for classic UWP, Modern UWP, and WinUI, but only unpackaged WinUI had real end-to-end acceptance coverage. This adds executable coverage for the missing packaged application models so asset-selection, activation, UI dispatch, and cleanup regressions are caught before release.

- Build and execute real classic UWP and Modern UWP packages through VSTest `.build.appxrecipe` files.
- Register and activate a real full-trust packaged WinUI app through MTP, including controller connect-back and UI-thread execution.
- Verify the packed MSTest NuGets contain and resolve the expected UWP and WinUI assets.
- Remove and verify package registrations after every run, with a pipeline leak check as a final guard.
- Run activation tests only in a dedicated preflight-gated Windows job; ordinary and official test runs skip the environment-specific category.

Validation covered package creation, all three application-model activation paths, package asset contracts, disabled-environment gating, and package-registration cleanup.