### PR TITLE
Add MSTEST0077 fixture branch coverage

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -572,6 +572,64 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenAssemblyInitializeWritesConstantPath_NoDiagnostic()
+    {
+        // [AssemblyInitialize] is serialized before any tests run, so its mutation cannot race a concurrent test.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [AssemblyInitialize]
+                public static void AssemblySetup(TestContext context)
+                {
+                    File.WriteAllText("setup.txt", "data");
+                }
+
+                [TestMethod]
+                public void MyTestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
+    public async Task WhenGlobalTestInitializeWritesConstantPath_Diagnostic()
+    {
+        // [GlobalTestInitialize] runs around every test and can race concurrent tests.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [GlobalTestInitialize]
+                public static void GlobalSetup(TestContext context)
+                {
+                    {|#0:File.WriteAllText("setup.txt", "data")|};
+                }
+
+                [TestMethod]
+                public void MyTestMethod() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(SharedFileSystemPathInTestAnalyzer.Rule)
+                .WithLocation(0)
+                .WithArguments("setup.txt"));
+    }
+
+    [TestMethod]
     public async Task WhenTestMethodDeletesFileWithConstantPath_Diagnostic()
     {
         // File.Delete removes the entry named by its single 'path' argument, so a constant path is a mutation


### PR DESCRIPTION
## Summary

- cover the serialized `[AssemblyInitialize]` branch where MSTEST0077 stays silent
- cover the concurrent `[GlobalTestInitialize]` branch where MSTEST0077 reports the shared-path mutation

## Validation

- built `MSTest.Analyzers.UnitTests` with a binary log
- passed all 60 `SharedFileSystemPathInTestAnalyzerTests` before and after two independent review rounds

Closes #10493
