### PR TITLE
Update version prefixes to 4.3.4 and 2.3.4

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup Label="Version settings">
     <!-- MSTest version -->
-    <VersionPrefix>4.3.3</VersionPrefix>
+    <VersionPrefix>4.3.4</VersionPrefix>
     <!-- Testing Platform version -->
-    <TestingPlatformVersionPrefix>2.3.3</TestingPlatformVersionPrefix>
+    <TestingPlatformVersionPrefix>2.3.4</TestingPlatformVersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">


### PR DESCRIPTION
## Summary

- update the MSTest version prefix from 4.3.3 to 4.3.4
- update the Microsoft.Testing.Platform version prefix from 2.3.3 to 2.3.4

This prepares the `rel/4.3` branch for the next servicing release.
