### PR TITLE
Add JUnit artifact post-processing

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,17 @@
 #nullable enable
+const Microsoft.Testing.Extensions.JUnitReport.JUnitReportGenerator.JUnitArtifactKind = "microsoft.testing.junit" -> string!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.Description.get -> string!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.DisplayName.get -> string!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.JUnitArtifactPostProcessor() -> void
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.ProcessAsync(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, string! outputDirectory, Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ArtifactPostProcessingContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ProcessedArtifact?>!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.SupportsTruncatedRuns.get -> bool
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.SupportedFileExtensionsFallback.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.SupportedKinds.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.Uid.get -> string!
+Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.Version.get -> string!
+static Microsoft.Testing.Extensions.JUnitReport.JUnitArtifactPostProcessor.CreateMergeId(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs) -> string!
 virtual Microsoft.Testing.Extensions.ReportGeneratorBase<TGenerator, TCapturedTestResult>.ArtifactKind.get -> string?
 Microsoft.Testing.Extensions.JUnitReport.JUnitReportMerger
 static Microsoft.Testing.Extensions.JUnitReport.JUnitReportMerger.Merge(System.Collections.Generic.IReadOnlyList<System.Xml.Linq.XDocument!>! inputReports, string! reportName) -> System.Xml.Linq.XDocument!

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -44,12 +44,7 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
 
         InputArtifact[] orderedInputs =
         [
-            .. inputs
-                .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-                .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
-                .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
-                .ThenBy(input => input.Architecture, StringComparer.Ordinal)
-                .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
+            .. OrderInputs(inputs),
         ];
 
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
@@ -59,7 +54,7 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
             return null;
         }
 
-        string mergeId = CreateMergeId(orderedInputs);
+        string mergeId = CreateMergeIdFromOrderedInputs(orderedInputs);
         string outputPath = Path.Combine(mergedDirectory, $"merged-{mergeId}.xml");
         await JUnitReportMerger.MergeToFileAsync(
             [.. orderedInputs.Select(input => input.Path)],
@@ -75,14 +70,12 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
     }
 
     internal static string CreateMergeId(IReadOnlyList<InputArtifact> inputs)
+        => CreateMergeIdFromOrderedInputs(OrderInputs(inputs));
+
+    private static string CreateMergeIdFromOrderedInputs(IEnumerable<InputArtifact> orderedInputs)
     {
         var identity = new StringBuilder();
-        foreach (InputArtifact input in inputs
-            .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
-            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
-            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
-            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal))
+        foreach (InputArtifact input in orderedInputs)
         {
             AppendIdentityPart(identity, Path.GetFullPath(input.Path));
             AppendIdentityPart(identity, input.ProducingTestModule);
@@ -101,6 +94,13 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
 
         return result.ToString();
     }
+
+    private static IOrderedEnumerable<InputArtifact> OrderInputs(IEnumerable<InputArtifact> inputs)
+        => inputs.OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
+            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
+            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
+            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
+            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
 
     private static void AppendIdentityPart(StringBuilder builder, string? value)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -22,7 +22,7 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
 
     public string Description => ExtensionResources.JUnitArtifactPostProcessorDescription;
 
-    public bool SupportsTruncatedRuns => true;
+    public bool SupportsTruncatedRuns => false;
 
     public IReadOnlyList<string> SupportedKinds => SupportedArtifactKinds;
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+using Microsoft.Testing.Extensions.JUnitReport.Resources;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+
+namespace Microsoft.Testing.Extensions.JUnitReport;
+
+internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
+{
+    private const string MergedReportDirectoryName = "merged";
+
+    private static readonly string[] SupportedArtifactKinds = [JUnitReportGenerator.JUnitArtifactKind];
+
+    public string Uid => "Microsoft.Testing.Extensions.JUnitReport.PostProcessor";
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => ExtensionResources.JUnitArtifactPostProcessorDisplayName;
+
+    public string Description => ExtensionResources.JUnitArtifactPostProcessorDescription;
+
+    public bool SupportsTruncatedRuns => true;
+
+    public IReadOnlyList<string> SupportedKinds => SupportedArtifactKinds;
+
+    // JUnit uses the generic .xml extension, so extension-only matching would claim unrelated XML artifacts.
+    public IReadOnlyList<string> SupportedFileExtensionsFallback => [];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public async Task<ProcessedArtifact?> ProcessAsync(
+        IReadOnlyList<InputArtifact> inputs,
+        string outputDirectory,
+        ArtifactPostProcessingContext context,
+        CancellationToken cancellationToken)
+    {
+        if (inputs.Count < 2)
+        {
+            return null;
+        }
+
+        InputArtifact[] orderedInputs =
+        [
+            .. inputs
+                .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
+                .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
+                .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
+                .ThenBy(input => input.Architecture, StringComparer.Ordinal)
+                .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
+        ];
+
+        string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
+        Directory.CreateDirectory(mergedDirectory);
+        if (IsReparsePoint(mergedDirectory))
+        {
+            return null;
+        }
+
+        string mergeId = CreateMergeId(orderedInputs);
+        string outputPath = Path.Combine(mergedDirectory, $"merged-{mergeId}.xml");
+        await JUnitReportMerger.MergeToFileAsync(
+            [.. orderedInputs.Select(input => input.Path)],
+            outputPath,
+            ExtensionResources.JUnitMergedReportName,
+            cancellationToken).ConfigureAwait(false);
+
+        return new ProcessedArtifact(
+            outputPath,
+            JUnitReportGenerator.JUnitArtifactKind,
+            ExtensionResources.JUnitMergedArtifactDisplayName,
+            string.Format(CultureInfo.CurrentCulture, ExtensionResources.JUnitMergedArtifactDescription, inputs.Count));
+    }
+
+    internal static string CreateMergeId(IReadOnlyList<InputArtifact> inputs)
+    {
+        var identity = new StringBuilder();
+        foreach (InputArtifact input in inputs
+            .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
+            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
+            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
+            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
+            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal))
+        {
+            AppendIdentityPart(identity, Path.GetFullPath(input.Path));
+            AppendIdentityPart(identity, input.ProducingTestModule);
+            AppendIdentityPart(identity, input.TargetFramework);
+            AppendIdentityPart(identity, input.Architecture);
+            AppendIdentityPart(identity, input.ExecutionId);
+        }
+
+        using var sha256 = SHA256.Create();
+        byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(identity.ToString()));
+        var result = new StringBuilder(32);
+        for (int i = 0; i < 16; i++)
+        {
+            result.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return result.ToString();
+    }
+
+    private static void AppendIdentityPart(StringBuilder builder, string? value)
+    {
+        if (value is null)
+        {
+            builder.Append("-1:");
+            return;
+        }
+
+        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(value);
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -48,7 +48,15 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
         ];
 
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
-        Directory.CreateDirectory(mergedDirectory);
+        try
+        {
+            Directory.CreateDirectory(mergedDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
         if (IsReparsePoint(mergedDirectory))
         {
             return null;

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -21,7 +21,7 @@ public static class JUnitReportExtensions
     {
         if (builder is not IArtifactPostProcessingApplicationBuilder artifactPostProcessingBuilder)
         {
-            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
+            throw new InvalidOperationException(ExtensionResources.JUnitReportRequiresArtifactPostProcessing);
         }
 
         ReportProviderRegistration.AddReportProvider(

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -18,9 +18,18 @@ public static class JUnitReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddJUnitReportProvider(this ITestApplicationBuilder builder)
-        => ReportProviderRegistration.AddReportProvider(
+    {
+        if (builder is not IArtifactPostProcessingApplicationBuilder artifactPostProcessingBuilder)
+        {
+            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
+        }
+
+        ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
             () => new JUnitReportGeneratorCommandLine(),
             serviceProvider => new JUnitReportGenerator(serviceProvider));
+
+        artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new JUnitArtifactPostProcessor());
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Testing.Extensions.JUnitReport;
 
 internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGenerator, CapturedTestResult>
 {
+    internal const string JUnitArtifactKind = "microsoft.testing.junit";
+
     // Parent chain for ALL TestNodeUpdateMessages (including Discovered / InProgress).
     // Keyed by the TestNodeUid value after truncation to TestResultCaptureHelper.MaxIdentityFieldLength
     // so it matches the capped RawUid / ParentRawUid keys used everywhere else in capture
@@ -33,7 +35,7 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
 
     protected override string ArtifactDisplayName => ExtensionResources.JUnitReportArtifactDisplayName;
 
-    protected override string? ArtifactKind => "microsoft.testing.junit";
+    protected override string? ArtifactKind => JUnitArtifactKind;
 
     protected override string ArtifactDescription => ExtensionResources.JUnitReportArtifactDescription;
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
@@ -118,6 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidTestApplicationBuilderType" xml:space="preserve">
+    <value>Invalid test application builder type. Expected 'TestApplicationBuilder'.</value>
+    <comment>Do not localize {Locked="TestApplicationBuilder"}.</comment>
+  </data>
+  <data name="JUnitReportRequiresArtifactPostProcessing" xml:space="preserve">
     <value>JUnit report generation requires a test application builder that supports artifact post-processing.</value>
     <comment>Do not localize format name {Locked="JUnit"}.</comment>
   </data>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/ExtensionResources.resx
@@ -118,8 +118,28 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidTestApplicationBuilderType" xml:space="preserve">
-    <value>Invalid test application builder type. Expected 'TestApplicationBuilder'.</value>
-    <comment>Do not localize {Locked="TestApplicationBuilder"}.</comment>
+    <value>JUnit report generation requires a test application builder that supports artifact post-processing.</value>
+    <comment>Do not localize format name {Locked="JUnit"}.</comment>
+  </data>
+  <data name="JUnitArtifactPostProcessorDescription" xml:space="preserve">
+    <value>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</value>
+    <comment>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</comment>
+  </data>
+  <data name="JUnitArtifactPostProcessorDisplayName" xml:space="preserve">
+    <value>JUnit XML report merger</value>
+    <comment>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</comment>
+  </data>
+  <data name="JUnitMergedArtifactDescription" xml:space="preserve">
+    <value>{0} JUnit XML report files merged</value>
+    <comment>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</comment>
+  </data>
+  <data name="JUnitMergedArtifactDisplayName" xml:space="preserve">
+    <value>JUnit XML report (merged)</value>
+    <comment>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</comment>
+  </data>
+  <data name="JUnitMergedReportName" xml:space="preserve">
+    <value>Merged JUnit XML report</value>
+    <comment>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</comment>
   </data>
   <data name="JUnitReportArtifactDescription" xml:space="preserve">
     <value>JUnit XML report file</value>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Neplatný typ tvůrce testovací aplikace Očekával se typ TestApplicationBuilder.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Příklad: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Povolit generování sestavy JUnit XML</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Neplatný typ tvůrce testovací aplikace Očekával se typ TestApplicationBuilder.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Neplatný typ tvůrce testovací aplikace Očekával se typ TestApplicationBuilder.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Neplatný typ tvůrce testovací aplikace Očekával se typ TestApplicationBuilder.</target>
+        <target state="translated">Neplatný typ tvůrce testovací aplikace Očekával se typ TestApplicationBuilder.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Ungültiger Testanwendungs-Generatortyp. „TestApplicationBuilder“ wurde erwartet.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Ungültiger Testanwendungs-Generatortyp. „TestApplicationBuilder“ wurde erwartet.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Ungültiger Testanwendungs-Generatortyp. „TestApplicationBuilder“ wurde erwartet.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Beispiel: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Generieren eines JUnit-XML-Berichts aktivieren</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.de.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Ungültiger Testanwendungs-Generatortyp. „TestApplicationBuilder“ wurde erwartet.</target>
+        <target state="translated">Ungültiger Testanwendungs-Generatortyp. „TestApplicationBuilder“ wurde erwartet.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Tipo de generador de aplicaciones de prueba no válido. Se esperaba "TestApplicationBuilder".</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Tipo de generador de aplicaciones de prueba no válido. Se esperaba "TestApplicationBuilder".</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Tipo de generador de aplicaciones de prueba no válido. Se esperaba "TestApplicationBuilder".</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Ejemplo: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Habilitación de la generación de un informe XML de JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.es.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Tipo de generador de aplicaciones de prueba no válido. Se esperaba "TestApplicationBuilder".</target>
+        <target state="translated">Tipo de generador de aplicaciones de prueba no válido. Se esperaba "TestApplicationBuilder".</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Type de générateur d’applications de test non valide. « TestApplicationBuilder » attendu.</target>
+        <target state="translated">Type de générateur d’applications de test non valide. « TestApplicationBuilder » attendu.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Type de générateur d’applications de test non valide. « TestApplicationBuilder » attendu.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Exemple : MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Activer la génération d’un rapport XML JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Type de générateur d’applications de test non valide. « TestApplicationBuilder » attendu.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Type de générateur d’applications de test non valide. « TestApplicationBuilder » attendu.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Tipo di generatore di applicazioni di test non valido. Valore previsto "TestApplicationBuilder".</target>
+        <target state="translated">Tipo di generatore di applicazioni di test non valido. Valore previsto "TestApplicationBuilder".</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Tipo di generatore di applicazioni di test non valido. Valore previsto "TestApplicationBuilder".</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Tipo di generatore di applicazioni di test non valido. Valore previsto "TestApplicationBuilder".</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.it.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Tipo di generatore di applicazioni di test non valido. Valore previsto "TestApplicationBuilder".</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Esempio: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Abilitare la generazione di un report XML JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">テスト アプリケーション ビルダーの種類が無効です。'TestApplicationBuilder' が必要です。</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">JUnit XML レポートの生成を有効にする</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">テスト アプリケーション ビルダーの種類が無効です。'TestApplicationBuilder' が必要です。</target>
+        <target state="translated">テスト アプリケーション ビルダーの種類が無効です。'TestApplicationBuilder' が必要です。</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">テスト アプリケーション ビルダーの種類が無効です。'TestApplicationBuilder' が必要です。</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">テスト アプリケーション ビルダーの種類が無効です。'TestApplicationBuilder' が必要です。</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">잘못된 테스트 애플리케이션 빌더 형식입니다. 'TestApplicationBuilder'가 필요합니다.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">JUnit XML 보고서 생성 사용</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">잘못된 테스트 애플리케이션 빌더 형식입니다. 'TestApplicationBuilder'가 필요합니다.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">잘못된 테스트 애플리케이션 빌더 형식입니다. 'TestApplicationBuilder'가 필요합니다.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">잘못된 테스트 애플리케이션 빌더 형식입니다. 'TestApplicationBuilder'가 필요합니다.</target>
+        <target state="translated">잘못된 테스트 애플리케이션 빌더 형식입니다. 'TestApplicationBuilder'가 필요합니다.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Nieprawidłowy typ konstruktora aplikacji testowej. Oczekiwano „TestApplicationBuilder”.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Nieprawidłowy typ konstruktora aplikacji testowej. Oczekiwano „TestApplicationBuilder”.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Nieprawidłowy typ konstruktora aplikacji testowej. Oczekiwano „TestApplicationBuilder”.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Przykład: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Włącz generowanie raportu XML JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Nieprawidłowy typ konstruktora aplikacji testowej. Oczekiwano „TestApplicationBuilder”.</target>
+        <target state="translated">Nieprawidłowy typ konstruktora aplikacji testowej. Oczekiwano „TestApplicationBuilder”.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Tipo de construtor de aplicativo de teste inválido. Esperava-se "TestApplicationBuilder".</target>
+        <target state="translated">Tipo de construtor de aplicativo de teste inválido. Esperava-se "TestApplicationBuilder".</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Tipo de construtor de aplicativo de teste inválido. Esperava-se "TestApplicationBuilder".</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Exemplo: MyReport_{tfm}.xml</target>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Habilitar a geração de um relatório XML JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Tipo de construtor de aplicativo de teste inválido. Esperava-se "TestApplicationBuilder".</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Tipo de construtor de aplicativo de teste inválido. Esperava-se "TestApplicationBuilder".</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Недопустимый тип построителя тестового приложения. Ожидается тип "TestApplicationBuilder".</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Недопустимый тип построителя тестового приложения. Ожидается тип "TestApplicationBuilder".</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Недопустимый тип построителя тестового приложения. Ожидается тип "TestApplicationBuilder".</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">Включение создания XML-отчета JUnit</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Недопустимый тип построителя тестового приложения. Ожидается тип "TestApplicationBuilder".</target>
+        <target state="translated">Недопустимый тип построителя тестового приложения. Ожидается тип "TestApplicationBuilder".</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">Geçersiz test uygulaması oluşturucu türü. Beklenen: 'TestApplicationBuilder'.</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">JUnit XML raporu oluşturmayı etkinleştir</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">Geçersiz test uygulaması oluşturucu türü. Beklenen: 'TestApplicationBuilder'.</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">Geçersiz test uygulaması oluşturucu türü. Beklenen: 'TestApplicationBuilder'.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">Geçersiz test uygulaması oluşturucu türü. Beklenen: 'TestApplicationBuilder'.</target>
+        <target state="translated">Geçersiz test uygulaması oluşturucu türü. Beklenen: 'TestApplicationBuilder'.</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">测试应用程序生成器类型无效。应为 "TestApplicationBuilder"。</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">测试应用程序生成器类型无效。应为 "TestApplicationBuilder"。</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">测试应用程序生成器类型无效。应为 "TestApplicationBuilder"。</target>
+        <target state="translated">测试应用程序生成器类型无效。应为 "TestApplicationBuilder"。</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">测试应用程序生成器类型无效。应为 "TestApplicationBuilder"。</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">启用 JUnit XML 报表生成</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -3,9 +3,34 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="translated">無效的測試應用程式建立器類型。必須是 'TestApplicationBuilder'。</target>
-        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="needs-review-translation">無效的測試應用程式建立器類型。必須是 'TestApplicationBuilder'。</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDescription">
+        <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
+        <target state="new">Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"} or assembly name {Locked="Microsoft.Testing.Extensions.JUnitReport"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitArtifactPostProcessorDisplayName">
+        <source>JUnit XML report merger</source>
+        <target state="new">JUnit XML report merger</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDescription">
+        <source>{0} JUnit XML report files merged</source>
+        <target state="new">{0} JUnit XML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedArtifactDisplayName">
+        <source>JUnit XML report (merged)</source>
+        <target state="new">JUnit XML report (merged)</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitMergedReportName">
+        <source>Merged JUnit XML report</source>
+        <target state="new">Merged JUnit XML report</target>
+        <note>Do not localize format names {Locked="JUnit"}{Locked="XML"}.</note>
       </trans-unit>
       <trans-unit id="JUnitReportArtifactDescription">
         <source>JUnit XML report file</source>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -3,9 +3,9 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
-        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
         <target state="needs-review-translation">無效的測試應用程式建立器類型。必須是 'TestApplicationBuilder'。</target>
-        <note>Do not localize format name {Locked="JUnit"}.</note>
+        <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">
         <source>Merges JUnit XML reports produced by Microsoft.Testing.Extensions.JUnitReport</source>
@@ -95,6 +95,11 @@ Example: MyReport_{tfm}.xml</source>
         <source>Enable generating a JUnit XML report</source>
         <target state="translated">啟用產生 JUnit XML 報告</target>
         <note>Do not localize option name {Locked="--report-junit"} or format names {Locked="JUnit"}{Locked="XML"}.</note>
+      </trans-unit>
+      <trans-unit id="JUnitReportRequiresArtifactPostProcessing">
+        <source>JUnit report generation requires a test application builder that supports artifact post-processing.</source>
+        <target state="new">JUnit report generation requires a test application builder that supports artifact post-processing.</target>
+        <note>Do not localize format name {Locked="JUnit"}.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>Invalid test application builder type. Expected 'TestApplicationBuilder'.</source>
-        <target state="needs-review-translation">無效的測試應用程式建立器類型。必須是 'TestApplicationBuilder'。</target>
+        <target state="translated">無效的測試應用程式建立器類型。必須是 'TestApplicationBuilder'。</target>
         <note>Do not localize {Locked="TestApplicationBuilder"}.</note>
       </trans-unit>
       <trans-unit id="JUnitArtifactPostProcessorDescription">

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
@@ -47,6 +47,31 @@ public sealed class JUnitArtifactPostProcessorTests
     }
 
     [TestMethod]
+    public void AddJUnitReportProvider_RequiresArtifactPostProcessingBuilder()
+    {
+        ITestApplicationBuilder builder = new Mock<ITestApplicationBuilder>().Object;
+
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => builder.AddJUnitReportProvider());
+
+        Assert.AreEqual(
+            "JUnit report generation requires a test application builder that supports artifact post-processing.",
+            exception.Message);
+    }
+
+    [TestMethod]
+    public void AddJUnitReportProvider_RequiresTestApplicationBuilder()
+    {
+        Mock<ITestApplicationBuilder> builder = new();
+        builder.As<IArtifactPostProcessingApplicationBuilder>();
+
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => builder.Object.AddJUnitReportProvider());
+
+        Assert.AreEqual("Invalid test application builder type. Expected 'TestApplicationBuilder'.", exception.Message);
+    }
+
+    [TestMethod]
     public async Task ProcessAsync_WithFewerThanTwoInputs_ReturnsNull()
     {
         JUnitArtifactPostProcessor processor = new();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport;
+using Microsoft.Testing.Extensions.JUnitReport.Resources;
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
@@ -55,7 +56,7 @@ public sealed class JUnitArtifactPostProcessorTests
             () => builder.AddJUnitReportProvider());
 
         Assert.AreEqual(
-            "JUnit report generation requires a test application builder that supports artifact post-processing.",
+            ExtensionResources.JUnitReportRequiresArtifactPostProcessing,
             exception.Message);
     }
 
@@ -68,7 +69,7 @@ public sealed class JUnitArtifactPostProcessorTests
         InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(
             () => builder.Object.AddJUnitReportProvider());
 
-        Assert.AreEqual("Invalid test application builder type. Expected 'TestApplicationBuilder'.", exception.Message);
+        Assert.AreEqual(ExtensionResources.InvalidTestApplicationBuilderType, exception.Message);
     }
 
     [TestMethod]
@@ -106,8 +107,10 @@ public sealed class JUnitArtifactPostProcessorTests
 
             Assert.IsNotNull(output);
             Assert.AreEqual(JUnitReportGenerator.JUnitArtifactKind, output.Kind);
-            Assert.AreEqual("JUnit XML report (merged)", output.DisplayName);
-            Assert.AreEqual("2 JUnit XML report files merged", output.Description);
+            Assert.AreEqual(ExtensionResources.JUnitMergedArtifactDisplayName, output.DisplayName);
+            Assert.AreEqual(
+                string.Format(CultureInfo.CurrentCulture, ExtensionResources.JUnitMergedArtifactDescription, 2),
+                output.Description);
             Assert.MatchesRegex(new Regex("^merged-[0-9a-f]{32}\\.xml$", RegexOptions.CultureInvariant), Path.GetFileName(output.Path));
             Assert.AreEqual("merged", Path.GetFileName(Path.GetDirectoryName(output.Path)));
             Assert.AreEqual("5", XDocument.Load(output.Path).Root!.Attribute("tests")!.Value);
@@ -171,6 +174,34 @@ public sealed class JUnitArtifactPostProcessorTests
             JUnitArtifactPostProcessor.CreateMergeId([second]));
     }
 
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedPathIsAFile_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        Directory.CreateDirectory(resultsDirectory);
+        File.WriteAllText(Path.Combine(resultsDirectory, "merged"), string.Empty);
+        try
+        {
+            string firstPath = Path.Combine(resultsDirectory, "first.xml");
+            string secondPath = Path.Combine(resultsDirectory, "second.xml");
+            WriteReport(firstPath, "first", tests: 1);
+            WriteReport(secondPath, "second", tests: 1);
+
+            ProcessedArtifact? output = await new JUnitArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath)],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
 #if NETCOREAPP
     [TestMethod]
     public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
@@ -205,6 +236,45 @@ public sealed class JUnitArtifactPostProcessorTests
 
             Assert.IsNull(output);
             Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsADanglingReparsePoint_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string missingDirectory = Path.Combine(root, "missing");
+        Directory.CreateDirectory(resultsDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), missingDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = Path.Combine(resultsDirectory, "first.xml");
+            string secondPath = Path.Combine(resultsDirectory, "second.xml");
+            WriteReport(firstPath, "first", tests: 1);
+            WriteReport(secondPath, "second", tests: 1);
+
+            ProcessedArtifact? output = await new JUnitArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath)],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsFalse(Directory.Exists(missingDirectory));
         }
         finally
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
@@ -25,7 +25,7 @@ public sealed class JUnitArtifactPostProcessorTests
 
         Assert.AreSequenceEqual(new[] { JUnitReportGenerator.JUnitArtifactKind }, processor.SupportedKinds);
         Assert.IsEmpty(processor.SupportedFileExtensionsFallback);
-        Assert.IsTrue(processor.SupportsTruncatedRuns);
+        Assert.IsFalse(processor.SupportsTruncatedRuns);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitArtifactPostProcessorTests.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.JUnitReport;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+#pragma warning disable TPEXP // Artifact post-processing is experimental.
+
+[TestClass]
+public sealed class JUnitArtifactPostProcessorTests
+{
+    [TestMethod]
+    public void Capabilities_DescribeJUnitArtifacts()
+    {
+        JUnitArtifactPostProcessor processor = new();
+
+        Assert.AreSequenceEqual(new[] { JUnitReportGenerator.JUnitArtifactKind }, processor.SupportedKinds);
+        Assert.IsEmpty(processor.SupportedFileExtensionsFallback);
+        Assert.IsTrue(processor.SupportsTruncatedRuns);
+    }
+
+    [TestMethod]
+    public async Task AddJUnitReportProvider_RegistersArtifactPostProcessor()
+    {
+        var builder = new TestApplicationBuilder(
+            new ApplicationLoggingState(LogLevel.None, new CommandLineParseResult(null, [], [])),
+            DateTimeOffset.UtcNow,
+            new TestApplicationOptions(),
+            new Mock<IUnhandledExceptionsHandler>().Object,
+            []);
+
+        builder.AddJUnitReportProvider();
+        IReadOnlyList<IArtifactPostProcessor> processors =
+            await ((ArtifactPostProcessingManager)builder.ArtifactPostProcessing).BuildAsync(new ServiceProvider());
+
+        Assert.HasCount(1, processors);
+        Assert.IsInstanceOfType<JUnitArtifactPostProcessor>(processors[0]);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithFewerThanTwoInputs_ReturnsNull()
+    {
+        JUnitArtifactPostProcessor processor = new();
+        InputArtifact input = CreateInput("input.xml");
+
+        Assert.IsNull(await processor.ProcessAsync(
+            [input],
+            Path.GetTempPath(),
+            new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+            CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithTwoInputs_WritesMergedReport()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.xml");
+            string secondPath = Path.Combine(directory, "second.xml");
+            WriteReport(firstPath, "first", tests: 2);
+            WriteReport(secondPath, "second", tests: 3);
+
+            ProcessedArtifact? output = await new JUnitArtifactPostProcessor().ProcessAsync(
+                [
+                    CreateInput(firstPath, executionId: "execution-1"),
+                    CreateInput(secondPath, executionId: "execution-2"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            Assert.AreEqual(JUnitReportGenerator.JUnitArtifactKind, output.Kind);
+            Assert.AreEqual("JUnit XML report (merged)", output.DisplayName);
+            Assert.AreEqual("2 JUnit XML report files merged", output.Description);
+            Assert.MatchesRegex(new Regex("^merged-[0-9a-f]{32}\\.xml$", RegexOptions.CultureInvariant), Path.GetFileName(output.Path));
+            Assert.AreEqual("merged", Path.GetFileName(Path.GetDirectoryName(output.Path)));
+            Assert.AreEqual("5", XDocument.Load(output.Path).Root!.Attribute("tests")!.Value);
+            Assert.AreSequenceEqual(
+                new[] { "first.xml", "second.xml" },
+                Directory.GetFiles(directory, "*.xml").Select(Path.GetFileName).OrderBy(name => name, StringComparer.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithReorderedInputs_ProducesIdenticalOutput()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.xml");
+            string secondPath = Path.Combine(directory, "second.xml");
+            WriteReport(firstPath, "first", tests: 2);
+            WriteReport(secondPath, "second", tests: 3);
+            JUnitArtifactPostProcessor processor = new();
+            InputArtifact first = CreateInput(firstPath, executionId: "execution-1");
+            InputArtifact second = CreateInput(secondPath, executionId: "execution-2");
+
+            ProcessedArtifact? output = await processor.ProcessAsync(
+                [first, second],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+            Assert.IsNotNull(output);
+            byte[] firstMerge = File.ReadAllBytes(output.Path);
+
+            ProcessedArtifact? retriedOutput = await processor.ProcessAsync(
+                [second, first],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(retriedOutput);
+            Assert.AreEqual(output.Path, retriedOutput.Path);
+            Assert.AreSequenceEqual(firstMerge, File.ReadAllBytes(retriedOutput.Path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateMergeId_IncludesExecutionProvenance()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "report.xml");
+        InputArtifact first = CreateInput(path, module: "module.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-1");
+        InputArtifact second = CreateInput(path, module: "module.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-2");
+
+        Assert.AreNotEqual(
+            JUnitArtifactPostProcessor.CreateMergeId([first]),
+            JUnitArtifactPostProcessor.CreateMergeId([second]));
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string outsideDirectory = Path.Combine(root, "outside");
+        Directory.CreateDirectory(resultsDirectory);
+        Directory.CreateDirectory(outsideDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), outsideDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = Path.Combine(resultsDirectory, "first.xml");
+            string secondPath = Path.Combine(resultsDirectory, "second.xml");
+            WriteReport(firstPath, "first", tests: 1);
+            WriteReport(secondPath, "second", tests: 1);
+
+            ProcessedArtifact? output = await new JUnitArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath)],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+#endif
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"junit-post-processor-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static InputArtifact CreateInput(
+        string path,
+        string? module = null,
+        string? targetFramework = null,
+        string? architecture = null,
+        string? executionId = null)
+        => new(path, JUnitReportGenerator.JUnitArtifactKind, module, targetFramework, architecture, executionId);
+
+    private static void WriteReport(string path, string suiteName, int tests)
+        => new XDocument(
+            new XElement(
+                "testsuites",
+                new XElement(
+                    "testsuite",
+                    new XAttribute("name", suiteName),
+                    new XAttribute("tests", tests),
+                    new XAttribute("failures", 0),
+                    new XAttribute("errors", 0),
+                    new XAttribute("skipped", 0),
+                    new XAttribute("time", "0.000"))))
+            .Save(path);
+}


### PR DESCRIPTION
## Summary

- register a JUnit artifact post-processor for `dotnet test` orchestration
- merge two or more `microsoft.testing.junit` reports deterministically under the fixed `merged` output directory
- include execution provenance in ordering and output identity, reject pre-existing reparse points, and skip truncated runs
- add localized merged-report metadata and focused processor/registration tests

## Testing

- focused `Microsoft.Testing.Extensions.UnitTests` net8.0 build (0 warnings, 0 errors)
- `JUnitArtifactPostProcessorTests` (7 passed)
- `JUnitReportMergerTests` (12 passed)