### PR TITLE
Add automatic CTRF artifact post-processing

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Extensions.CtrfReport.Resources;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+
+namespace Microsoft.Testing.Extensions.CtrfReport;
+
+internal sealed class CtrfArtifactPostProcessor : IArtifactPostProcessor
+{
+    private const string MergedReportDirectoryName = "merged";
+
+    private static readonly string[] SupportedArtifactKinds = [CtrfReportGenerator.CtrfArtifactKind];
+    private static readonly string[] NoSupportedExtensions = [];
+
+    public string Uid => "Microsoft.Testing.Extensions.CtrfReport.PostProcessor";
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => ExtensionResources.CtrfArtifactPostProcessorDisplayName;
+
+    public string Description => ExtensionResources.CtrfArtifactPostProcessorDescription;
+
+    // CTRF has no marker that lets this merger label an incomplete input set as a partial run.
+    public bool SupportsTruncatedRuns => false;
+
+    public IReadOnlyList<string> SupportedKinds => SupportedArtifactKinds;
+
+    // JSON is shared by many report formats, so accepting untagged .json artifacts would be unsafe.
+    public IReadOnlyList<string> SupportedFileExtensionsFallback => NoSupportedExtensions;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public async Task<ProcessedArtifact?> ProcessAsync(
+        IReadOnlyList<InputArtifact> inputs,
+        string outputDirectory,
+        ArtifactPostProcessingContext context,
+        CancellationToken cancellationToken)
+    {
+        if (inputs.Count < 2)
+        {
+            return null;
+        }
+
+        InputArtifact[] orderedInputs =
+        [
+            .. inputs
+                .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
+                .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
+        ];
+        string[] inputPaths = [.. orderedInputs.Select(input => input.Path)];
+        Guid artifactId = CreateArtifactId(orderedInputs);
+        string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
+        Directory.CreateDirectory(mergedDirectory);
+        if (IsReparsePoint(mergedDirectory))
+        {
+            return null;
+        }
+
+        string outputPath = Path.Combine(mergedDirectory, $"merged-{artifactId:N}.ctrf.json");
+        await CtrfReportMerger.MergeAllToFileAsync(inputPaths, outputPath, cancellationToken).ConfigureAwait(false);
+
+        return new ProcessedArtifact(
+            outputPath,
+            CtrfReportGenerator.CtrfArtifactKind,
+            ExtensionResources.CtrfMergedArtifactDisplayName,
+            string.Format(CultureInfo.CurrentCulture, ExtensionResources.CtrfMergedArtifactDescription, inputs.Count));
+    }
+
+    private static Guid CreateArtifactId(IReadOnlyList<InputArtifact> inputs)
+    {
+        const ulong fnvPrime = 1099511628211UL;
+        ulong hashLow = 14695981039346656037UL;
+        ulong hashHigh = 0x9E3779B97F4A7C15UL;
+
+        foreach (InputArtifact input in inputs)
+        {
+            string value = $"{Path.GetFullPath(input.Path)}\0{input.ExecutionId}";
+            foreach (char c in value)
+            {
+                hashLow = (hashLow ^ c) * fnvPrime;
+                hashHigh = (hashHigh ^ c) * fnvPrime;
+            }
+
+            hashLow = (hashLow ^ (ulong)value.Length) * fnvPrime;
+            hashHigh = (hashHigh ^ ((ulong)value.Length + 1UL)) * fnvPrime;
+        }
+
+        byte[] bytes = new byte[16];
+        for (int i = 0; i < 8; i++)
+        {
+            bytes[i] = (byte)(hashLow >> (i * 8));
+            bytes[i + 8] = (byte)(hashHigh >> (i * 8));
+        }
+
+        return new Guid(bytes);
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
@@ -49,7 +49,11 @@ internal sealed class CtrfArtifactPostProcessor : IArtifactPostProcessor
                 .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
         ];
         string[] inputPaths = [.. orderedInputs.Select(input => input.Path)];
-        Guid artifactId = CreateArtifactId(orderedInputs);
+        string[] identityInputs =
+        [
+            .. orderedInputs.Select(input => $"{Path.GetFullPath(input.Path)}\0{input.ExecutionId}"),
+        ];
+        Guid artifactId = CtrfReportMerger.CreateDeterministicId(identityInputs);
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
         Directory.CreateDirectory(mergedDirectory);
         if (IsReparsePoint(mergedDirectory))
@@ -65,35 +69,6 @@ internal sealed class CtrfArtifactPostProcessor : IArtifactPostProcessor
             CtrfReportGenerator.CtrfArtifactKind,
             ExtensionResources.CtrfMergedArtifactDisplayName,
             string.Format(CultureInfo.CurrentCulture, ExtensionResources.CtrfMergedArtifactDescription, inputs.Count));
-    }
-
-    private static Guid CreateArtifactId(IReadOnlyList<InputArtifact> inputs)
-    {
-        const ulong fnvPrime = 1099511628211UL;
-        ulong hashLow = 14695981039346656037UL;
-        ulong hashHigh = 0x9E3779B97F4A7C15UL;
-
-        foreach (InputArtifact input in inputs)
-        {
-            string value = $"{Path.GetFullPath(input.Path)}\0{input.ExecutionId}";
-            foreach (char c in value)
-            {
-                hashLow = (hashLow ^ c) * fnvPrime;
-                hashHigh = (hashHigh ^ c) * fnvPrime;
-            }
-
-            hashLow = (hashLow ^ (ulong)value.Length) * fnvPrime;
-            hashHigh = (hashHigh ^ ((ulong)value.Length + 1UL)) * fnvPrime;
-        }
-
-        byte[] bytes = new byte[16];
-        for (int i = 0; i < 8; i++)
-        {
-            bytes[i] = (byte)(hashLow >> (i * 8));
-            bytes[i + 8] = (byte)(hashHigh >> (i * 8));
-        }
-
-        return new Guid(bytes);
     }
 
     private static bool IsReparsePoint(string path)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -18,9 +18,18 @@ public static class CtrfReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddCtrfReportProvider(this ITestApplicationBuilder builder)
-        => ReportProviderRegistration.AddReportProvider(
+    {
+        if (builder is not IArtifactPostProcessingApplicationBuilder artifactPostProcessingBuilder)
+        {
+            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
+        }
+
+        ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
             () => new CtrfReportGeneratorCommandLine(),
             serviceProvider => new CtrfReportGenerator(serviceProvider));
+
+        artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new CtrfArtifactPostProcessor());
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Testing.Extensions.CtrfReport;
 
 internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenerator, CapturedTestResult>
 {
+    internal const string CtrfArtifactKind = "microsoft.testing.ctrf";
+
     public CtrfReportGenerator(IServiceProvider serviceProvider)
         : base(serviceProvider, CtrfReportGeneratorCommandLine.CtrfReportOptionName)
     {
@@ -24,7 +26,7 @@ internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenera
 
     protected override string ArtifactDisplayName => ExtensionResources.CtrfReportArtifactDisplayName;
 
-    protected override string? ArtifactKind => "microsoft.testing.ctrf";
+    protected override string? ArtifactKind => CtrfArtifactKind;
 
     protected override string ArtifactDescription => ExtensionResources.CtrfReportArtifactDescription;
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.FileMerge.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.FileMerge.cs
@@ -69,7 +69,7 @@ internal static partial class CtrfReportMerger
 #endif
         }
 
-        string merged = Merge(reports, mode, requireAllReports);
+        string merged = Merge(reports, mode, requireAllReports, nameof(inputPaths));
 
         string? outputDirectory = Path.GetDirectoryName(outputPath);
         if (!RoslynString.IsNullOrEmpty(outputDirectory))

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.FileMerge.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.FileMerge.cs
@@ -17,10 +17,24 @@ internal static partial class CtrfReportMerger
         CancellationToken cancellationToken)
         => MergeToFileAsync(inputPaths, outputPath, CtrfMergeMode.Concatenate, cancellationToken);
 
-    internal static async Task MergeToFileAsync(
+    internal static Task MergeAllToFileAsync(
+        IReadOnlyList<string> inputPaths,
+        string outputPath,
+        CancellationToken cancellationToken)
+        => MergeToFileAsync(inputPaths, outputPath, CtrfMergeMode.Concatenate, requireAllReports: true, cancellationToken);
+
+    internal static Task MergeToFileAsync(
         IReadOnlyList<string> inputPaths,
         string outputPath,
         CtrfMergeMode mode,
+        CancellationToken cancellationToken)
+        => MergeToFileAsync(inputPaths, outputPath, mode, requireAllReports: false, cancellationToken);
+
+    private static async Task MergeToFileAsync(
+        IReadOnlyList<string> inputPaths,
+        string outputPath,
+        CtrfMergeMode mode,
+        bool requireAllReports,
         CancellationToken cancellationToken)
     {
         if (inputPaths is null)
@@ -55,7 +69,7 @@ internal static partial class CtrfReportMerger
 #endif
         }
 
-        string merged = Merge(reports, mode);
+        string merged = Merge(reports, mode, requireAllReports);
 
         string? outputDirectory = Path.GetDirectoryName(outputPath);
         if (!RoslynString.IsNullOrEmpty(outputDirectory))

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.JsonHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.JsonHelpers.cs
@@ -126,19 +126,28 @@ internal static partial class CtrfReportMerger
     /// collision-resistant enough to identify a merged report, not secret.
     /// </summary>
     private static string CreateDeterministicReportId(IReadOnlyList<string> acceptedReports, CtrfMergeMode mode)
+        => CreateDeterministicId(acceptedReports, (ulong)mode).ToString("D");
+
+    internal static Guid CreateDeterministicId(IReadOnlyList<string> values)
+        => CreateDeterministicId(values, discriminator: null);
+
+    private static Guid CreateDeterministicId(IReadOnlyList<string> values, ulong? discriminator)
     {
         const ulong fnvPrime = 1099511628211UL;
         ulong hashLow = 14695981039346656037UL;
         ulong hashHigh = 0x9E3779B97F4A7C15UL;
 
-        // Fold in the merge mode: the same inputs concatenated and collapsed are two materially different
-        // documents, and CTRF 5.3 wants a distinct reportId for each rather than one id naming both.
-        hashLow = (hashLow ^ (ulong)mode) * fnvPrime;
-        hashHigh = (hashHigh ^ ((ulong)mode + 1UL)) * fnvPrime;
-
-        foreach (string report in acceptedReports)
+        if (discriminator is { } value)
         {
-            foreach (char c in report)
+            // The report merge mode is a discriminator: the same inputs concatenated and collapsed are two
+            // materially different documents, and CTRF 5.3 wants a distinct reportId for each.
+            hashLow = (hashLow ^ value) * fnvPrime;
+            hashHigh = (hashHigh ^ (value + 1UL)) * fnvPrime;
+        }
+
+        foreach (string input in values)
+        {
+            foreach (char c in input)
             {
                 hashLow = (hashLow ^ c) * fnvPrime;
                 hashHigh = (hashHigh ^ c) * fnvPrime;
@@ -146,14 +155,14 @@ internal static partial class CtrfReportMerger
 
             // Fold in each input's length so different chunk boundaries (e.g. ["ab","c"] vs ["a","bc"])
             // never collide.
-            hashLow = (hashLow ^ (ulong)report.Length) * fnvPrime;
-            hashHigh = (hashHigh ^ ((ulong)report.Length + 1UL)) * fnvPrime;
+            hashLow = (hashLow ^ (ulong)input.Length) * fnvPrime;
+            hashHigh = (hashHigh ^ ((ulong)input.Length + 1UL)) * fnvPrime;
         }
 
         byte[] bytes = new byte[16];
         BitConverter.GetBytes(hashLow).CopyTo(bytes, 0);
         BitConverter.GetBytes(hashHigh).CopyTo(bytes, 8);
-        return new Guid(bytes).ToString("D");
+        return new Guid(bytes);
     }
 
     private static long Min(long? current, long candidate)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.JsonHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.JsonHelpers.cs
@@ -160,8 +160,14 @@ internal static partial class CtrfReportMerger
         }
 
         byte[] bytes = new byte[16];
-        BitConverter.GetBytes(hashLow).CopyTo(bytes, 0);
-        BitConverter.GetBytes(hashHigh).CopyTo(bytes, 8);
+        for (int i = 0; i < 8; i++)
+        {
+            // Serialize explicitly in little-endian order so identical inputs produce the same identifier on
+            // every architecture. Guid(byte[]) has a stable interpretation once the byte sequence is fixed.
+            bytes[i] = (byte)(hashLow >> (i * 8));
+            bytes[i + 8] = (byte)(hashHigh >> (i * 8));
+        }
+
         return new Guid(bytes);
     }
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -52,6 +52,13 @@ internal static partial class CtrfReportMerger
         => Merge(inputReports, mode, requireAllReports: false);
 
     private static string Merge(IReadOnlyList<string> inputReports, CtrfMergeMode mode, bool requireAllReports)
+        => Merge(inputReports, mode, requireAllReports, nameof(inputReports));
+
+    private static string Merge(
+        IReadOnlyList<string> inputReports,
+        CtrfMergeMode mode,
+        bool requireAllReports,
+        string invalidInputParameterName)
     {
         if (inputReports is null)
         {
@@ -121,7 +128,7 @@ internal static partial class CtrfReportMerger
                 && (root["results"]?["tests"] is not JsonArray strictTests
                     || strictTests.Any(test => test is not JsonObject)))
             {
-                throw new ArgumentException("Every input must be a valid CTRF report.", nameof(inputReports));
+                throw new ArgumentException("Every input must be a valid CTRF report.", invalidInputParameterName);
             }
 
             first ??= root;
@@ -194,7 +201,7 @@ internal static partial class CtrfReportMerger
 
         if (requireAllReports && reportCount != inputReports.Count)
         {
-            throw new ArgumentException("Every input must be a valid CTRF report.", nameof(inputReports));
+            throw new ArgumentException("Every input must be a valid CTRF report.", invalidInputParameterName);
         }
 
         if (first is null)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -49,6 +49,9 @@ internal static partial class CtrfReportMerger
         => Merge(inputReports, CtrfMergeMode.Concatenate);
 
     internal static string Merge(IReadOnlyList<string> inputReports, CtrfMergeMode mode)
+        => Merge(inputReports, mode, requireAllReports: false);
+
+    private static string Merge(IReadOnlyList<string> inputReports, CtrfMergeMode mode, bool requireAllReports)
     {
         if (inputReports is null)
         {
@@ -176,6 +179,11 @@ internal static partial class CtrfReportMerger
                     latestStop = Max(latestStop, stop);
                 }
             }
+        }
+
+        if (requireAllReports && reportCount != inputReports.Count)
+        {
+            throw new ArgumentException("Every input must be a valid CTRF report.", nameof(inputReports));
         }
 
         if (first is null)

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -113,6 +113,17 @@ internal static partial class CtrfReportMerger
                 continue;
             }
 
+            // The permissive manual merger drops non-object test entries and tolerates a missing tests array.
+            // Artifact post-processing cannot do that because its output must represent every supplied input,
+            // so strict mode rejects precisely the shapes the merger could not carry through. Test objects
+            // themselves remain pass-through data under the validity contract documented above.
+            if (requireAllReports
+                && (root["results"]?["tests"] is not JsonArray strictTests
+                    || strictTests.Any(test => test is not JsonObject)))
+            {
+                throw new ArgumentException("Every input must be a valid CTRF report.", nameof(inputReports));
+            }
+
             first ??= root;
             reportCount++;
             acceptedReports.Add(reportJson);

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,9 +1,22 @@
 #nullable enable
+const Microsoft.Testing.Extensions.CtrfReport.CtrfReportGenerator.CtrfArtifactKind = "microsoft.testing.ctrf" -> string!
 virtual Microsoft.Testing.Extensions.ReportGeneratorBase<TGenerator, TCapturedTestResult>.ArtifactKind.get -> string?
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.CtrfArtifactPostProcessor() -> void
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.Description.get -> string!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.DisplayName.get -> string!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.ProcessAsync(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, string! outputDirectory, Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ArtifactPostProcessingContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ProcessedArtifact?>!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.SupportsTruncatedRuns.get -> bool
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.SupportedFileExtensionsFallback.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.SupportedKinds.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.Uid.get -> string!
+Microsoft.Testing.Extensions.CtrfReport.CtrfArtifactPostProcessor.Version.get -> string!
 Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.CollapseRetryAttempts = 1 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.Concatenate = 0 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger
+static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.MergeAllToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports) -> string!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports, Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode mode) -> string!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode mode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -16,6 +16,7 @@ Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.CollapseRetryAttempts = 1 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode.Concatenate = 0 -> Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode
 Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger
+static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.CreateDeterministicId(System.Collections.Generic.IReadOnlyList<string!>! values) -> System.Guid
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.MergeAllToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports) -> string!
 static Microsoft.Testing.Extensions.CtrfReport.CtrfReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports, Microsoft.Testing.Extensions.CtrfReport.CtrfMergeMode mode) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/ExtensionResources.resx
@@ -58,6 +58,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CtrfArtifactPostProcessorDescription" xml:space="preserve">
+    <value>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</value>
+    <comment>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</comment>
+  </data>
+  <data name="CtrfArtifactPostProcessorDisplayName" xml:space="preserve">
+    <value>CTRF report merger</value>
+    <comment>Do not localize format name {Locked="CTRF"}.</comment>
+  </data>
+  <data name="CtrfMergedArtifactDescription" xml:space="preserve">
+    <value>{0} CTRF files merged</value>
+    <comment>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</comment>
+  </data>
+  <data name="CtrfMergedArtifactDisplayName" xml:space="preserve">
+    <value>CTRF report (merged)</value>
+    <comment>Do not localize format name {Locked="CTRF"}.</comment>
+  </data>
   <data name="CtrfReportArtifactDescription" xml:space="preserve">
     <value>CTRF (Common Test Report Format) JSON test report</value>
     <comment>Do not localize {Locked="CTRF"}, {Locked="Common Test Report Format"}, or {Locked="JSON"}.</comment>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Testovací sestava JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.de.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF-JSON-Testbericht (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.es.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Informe de prueba JSON de CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Rapport de test JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.it.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Report di test JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF (Common Test Report Format) JSON テスト レポート</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF(Common Test Report Format) JSON 테스트 보고서</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Raport testowy JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Relatório de teste JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">Тестовый отчет JSON CTRF (Common Test Report Format)</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF (Common Test Report Format) JSON test raporu</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF (Common Test Report Format) JSON 测试报表</target>

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -2,6 +2,26 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="CtrfArtifactPostProcessorDescription">
+        <source>Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</source>
+        <target state="new">Merges CTRF reports produced by Microsoft.Testing.Extensions.CtrfReport</target>
+        <note>Do not localize format name {Locked="CTRF"} or assembly name {Locked="Microsoft.Testing.Extensions.CtrfReport"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfArtifactPostProcessorDisplayName">
+        <source>CTRF report merger</source>
+        <target state="new">CTRF report merger</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDescription">
+        <source>{0} CTRF files merged</source>
+        <target state="new">{0} CTRF files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
+      <trans-unit id="CtrfMergedArtifactDisplayName">
+        <source>CTRF report (merged)</source>
+        <target state="new">CTRF report (merged)</target>
+        <note>Do not localize format name {Locked="CTRF"}.</note>
+      </trans-unit>
       <trans-unit id="CtrfReportArtifactDescription">
         <source>CTRF (Common Test Report Format) JSON test report</source>
         <target state="translated">CTRF (Common Test Report Format) JSON 測試報告</target>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
@@ -55,7 +55,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                 "ArtifactPostProcessor",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.HostType]);
             Assert.AreEqual(
-                "microsoft.testing.trx;test.summary;test.xml",
+                "microsoft.testing.ctrf;microsoft.testing.trx;test.summary;test.xml",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
             Assert.AreEqual(
                 "test.summary",
@@ -72,6 +72,69 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
             Assert.AreSequenceEqual(
                 [Path.GetFullPath(firstPath), Path.GetFullPath(secondPath)],
                 artifacts[0].InputArtifactPaths);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_AdvertisesCtrfCapabilityAndReturnsMergedArtifact()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"artifact-dispatcher-ctrf-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.ctrf.json");
+            string secondPath = Path.Combine(directory, "second.ctrf.json");
+            WriteMinimalCtrfReport(firstPath, "first");
+            WriteMinimalCtrfReport(secondPath, "second");
+            string manifestPath = Path.Combine(directory, "manifest.json");
+            File.WriteAllText(
+                manifestPath,
+                JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    outputDirectory = directory,
+                    inputs = new[]
+                    {
+                        new { path = firstPath, kind = "microsoft.testing.ctrf", executionId = "execution-1" },
+                        new { path = secondPath, kind = "microsoft.testing.ctrf", executionId = "execution-2" },
+                    },
+                }));
+
+            var testHost = TestInfrastructure.TestHost.LocateFrom(
+                AssetFixture.TargetAssetPath,
+                AssetName,
+                TargetFrameworks.NetCurrent);
+            FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+                testHost,
+                extraArguments: $"--manifest \"{manifestPath}\"",
+                supportedProtocolVersions: "1.4.0",
+                toolName: "internal-merge-artifacts",
+                cancellationToken: TestContext.CancellationToken);
+
+            result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+            Assert.IsNotNull(result.ReceivedHandshake);
+            Assert.AreEqual(
+                "microsoft.testing.ctrf;microsoft.testing.trx;test.summary;test.xml",
+                result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
+
+            RawMessage[] artifactFrames = [.. result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.FileArtifactMessages)];
+            Assert.HasCount(1, artifactFrames);
+            IReadOnlyList<FileArtifact> artifacts = DotnetTestPipeProtocol.DecodeFileArtifacts(artifactFrames[0].Body);
+            Assert.HasCount(1, artifacts);
+            Assert.AreEqual("microsoft.testing.ctrf", artifacts[0].Kind);
+            Assert.IsNotNull(artifacts[0].FullPath);
+            Assert.IsTrue(File.Exists(artifacts[0].FullPath!));
+            Assert.IsNotNull(artifacts[0].InputArtifactPaths);
+            Assert.AreSequenceEqual(
+                [Path.GetFullPath(firstPath), Path.GetFullPath(secondPath)],
+                artifacts[0].InputArtifactPaths);
+
+            using var merged = JsonDocument.Parse(File.ReadAllText(artifacts[0].FullPath!));
+            Assert.AreEqual(2, merged.RootElement.GetProperty("results").GetProperty("tests").GetArrayLength());
         }
         finally
         {
@@ -402,6 +465,30 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
             .Save(path);
     }
 
+    private static void WriteMinimalCtrfReport(string path, string name)
+        => File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(new
+            {
+                reportFormat = "CTRF",
+                specVersion = "0.0.0",
+                reportId = Guid.NewGuid().ToString("D"),
+                results = new
+                {
+                    summary = new
+                    {
+                        tests = 1,
+                        passed = 1,
+                        start = 1000,
+                        stop = 2000,
+                    },
+                    tests = new[]
+                    {
+                        new { name, status = "passed" },
+                    },
+                },
+            }));
+
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {
         private const string AssetCode = """
@@ -418,6 +505,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
               </PropertyGroup>
               <ItemGroup>
                 <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+                <PackageReference Include="Microsoft.Testing.Extensions.CtrfReport" Version="$MicrosoftTestingExtensionsCtrfReportVersion$" />
                 <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$MicrosoftTestingPlatformVersion$" />
               </ItemGroup>
             </Project>
@@ -434,6 +522,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                 public static async Task<int> Main(string[] args)
                 {
                     ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+                    builder.AddCtrfReportProvider();
                     builder.AddTrxReportProvider();
                     ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing
                         .AddArtifactPostProcessor(_ => new SummaryArtifactPostProcessor());
@@ -558,6 +647,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
         public override (string ID, string Name, string Code) GetAssetsToGenerate()
             => (AssetName, AssetName, AssetCode
                 .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
-                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsCtrfReportVersion$", MicrosoftTestingExtensionsCtrfReportVersion));
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfArtifactPostProcessorTests.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+using Microsoft.Testing.Extensions.CtrfReport;
+using Microsoft.Testing.Extensions.CtrfReport.Resources;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+#pragma warning disable TPEXP // Artifact post-processing is experimental.
+
+[TestClass]
+public sealed class CtrfArtifactPostProcessorTests
+{
+    [TestMethod]
+    public void Capabilities_DescribeCtrfArtifactsConservatively()
+    {
+        CtrfArtifactPostProcessor processor = new();
+
+        Assert.AreSequenceEqual(new[] { CtrfReportGenerator.CtrfArtifactKind }, processor.SupportedKinds);
+        Assert.IsEmpty(processor.SupportedFileExtensionsFallback);
+        Assert.IsFalse(processor.SupportsTruncatedRuns);
+    }
+
+    [TestMethod]
+    public async Task AddCtrfReportProvider_RegistersArtifactPostProcessor()
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync([]);
+
+        builder.AddCtrfReportProvider();
+        IArtifactPostProcessingManager postProcessing =
+            ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing;
+        var manager = (ArtifactPostProcessingManager)postProcessing;
+        IReadOnlyList<IArtifactPostProcessor> processors = await manager.BuildAsync(new ServiceProvider());
+
+        Assert.HasCount(1, processors);
+        Assert.IsInstanceOfType<CtrfArtifactPostProcessor>(processors[0]);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithFewerThanTwoInputs_ReturnsNull()
+    {
+        CtrfArtifactPostProcessor processor = new();
+        var input = new InputArtifact("input.ctrf.json", CtrfReportGenerator.CtrfArtifactKind, null, null, null, null);
+
+        Assert.IsNull(await processor.ProcessAsync(
+            [input],
+            Path.GetTempPath(),
+            new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+            CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithTwoInputs_WritesMergedReportAndMetadata()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = WriteReport(directory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(directory, "second.ctrf.json", "second");
+            CtrfArtifactPostProcessor processor = new();
+
+            ProcessedArtifact? output = await processor.ProcessAsync(
+                [
+                    CreateInput(firstPath, "execution-1"),
+                    CreateInput(secondPath, "execution-2"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            Assert.AreEqual(CtrfReportGenerator.CtrfArtifactKind, output.Kind);
+            Assert.AreEqual(ExtensionResources.CtrfMergedArtifactDisplayName, output.DisplayName);
+            Assert.AreEqual(
+                string.Format(CultureInfo.CurrentCulture, ExtensionResources.CtrfMergedArtifactDescription, 2),
+                output.Description);
+            Assert.MatchesRegex(
+                new Regex("^merged-[0-9a-f]{32}\\.ctrf\\.json$", RegexOptions.CultureInvariant),
+                Path.GetFileName(output.Path));
+            Assert.AreEqual("merged", Path.GetFileName(Path.GetDirectoryName(output.Path)));
+
+            JsonNode merged = JsonNode.Parse(File.ReadAllText(output.Path))!;
+            Assert.AreEqual("CTRF", (string?)merged["reportFormat"]);
+            Assert.AreEqual(2, merged["results"]!["tests"]!.AsArray().Count);
+            Assert.IsTrue(Guid.TryParse((string?)merged["reportId"], out _));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithInvalidCtrfInput_DoesNotPublishPartialMerge()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string validPath = WriteReport(directory, "valid.ctrf.json", "valid");
+            string invalidPath = Path.Combine(directory, "invalid.ctrf.json");
+            File.WriteAllText(invalidPath, """{"not":"ctrf"}""");
+            CtrfArtifactPostProcessor processor = new();
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(() => processor.ProcessAsync(
+                [CreateInput(validPath, "execution-1"), CreateInput(invalidPath, "execution-2")],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None));
+
+            Assert.IsEmpty(Directory.GetFiles(Path.Combine(directory, "merged")));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithReorderedInputs_ProducesIdenticalOutput()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = WriteReport(directory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(directory, "second.ctrf.json", "second");
+            InputArtifact first = CreateInput(firstPath, "execution-1");
+            InputArtifact second = CreateInput(secondPath, "execution-2");
+            CtrfArtifactPostProcessor processor = new();
+
+            ProcessedArtifact? output = await processor.ProcessAsync(
+                [first, second],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+            Assert.IsNotNull(output);
+            byte[] firstMerge = File.ReadAllBytes(output.Path);
+
+            ProcessedArtifact? retriedOutput = await processor.ProcessAsync(
+                [second, first],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(retriedOutput);
+            Assert.AreEqual(output.Path, retriedOutput.Path);
+            Assert.AreSequenceEqual(firstMerge, File.ReadAllBytes(retriedOutput.Path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithDifferentExecutionProvenance_ProducesDifferentArtifactIdentity()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = WriteReport(directory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(directory, "second.ctrf.json", "second");
+            CtrfArtifactPostProcessor processor = new();
+            ArtifactPostProcessingContext context = new(ArtifactPostProcessingTruncationReason.None);
+
+            ProcessedArtifact? firstOutput = await processor.ProcessAsync(
+                [CreateInput(firstPath, "execution-1"), CreateInput(secondPath, "execution-2")],
+                directory,
+                context,
+                CancellationToken.None);
+            ProcessedArtifact? secondOutput = await processor.ProcessAsync(
+                [CreateInput(firstPath, "execution-3"), CreateInput(secondPath, "execution-2")],
+                directory,
+                context,
+                CancellationToken.None);
+
+            Assert.IsNotNull(firstOutput);
+            Assert.IsNotNull(secondOutput);
+            Assert.AreNotEqual(firstOutput.Path, secondOutput.Path);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string outsideDirectory = Path.Combine(root, "outside");
+        Directory.CreateDirectory(resultsDirectory);
+        Directory.CreateDirectory(outsideDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), outsideDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = WriteReport(resultsDirectory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(resultsDirectory, "second.ctrf.json", "second");
+            CtrfArtifactPostProcessor processor = new();
+
+            ProcessedArtifact? output = await processor.ProcessAsync(
+                [CreateInput(firstPath, "execution-1"), CreateInput(secondPath, "execution-2")],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+#endif
+
+    private static InputArtifact CreateInput(string path, string executionId)
+        => new(path, CtrfReportGenerator.CtrfArtifactKind, null, null, null, executionId);
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"ctrf-post-processor-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static string WriteReport(string directory, string fileName, string testName)
+    {
+        string path = Path.Combine(directory, fileName);
+        var report = new JsonObject
+        {
+            ["reportFormat"] = "CTRF",
+            ["specVersion"] = "0.0.0",
+            ["reportId"] = Guid.NewGuid().ToString("D"),
+            ["results"] = new JsonObject
+            {
+                ["summary"] = new JsonObject
+                {
+                    ["tests"] = 1,
+                    ["passed"] = 1,
+                    ["start"] = 1000,
+                    ["stop"] = 2000,
+                },
+                ["tests"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["name"] = testName,
+                        ["status"] = "passed",
+                    }),
+            },
+        };
+        File.WriteAllText(path, report.ToJsonString());
+        return path;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -348,6 +348,98 @@ public sealed class CtrfReportMergerTests
         }
     }
 
+    [TestMethod]
+    public async Task MergeAllToFileAsync_WithInvalidInput_ThrowsWithoutWritingOutput()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            string valid = Path.Combine(tempDirectory, "valid.json");
+            string invalid = Path.Combine(tempDirectory, "invalid.json");
+            string output = Path.Combine(tempDirectory, "out", "merged.json");
+            File.WriteAllText(valid, BuildReport());
+            File.WriteAllText(invalid, """{"not":"ctrf"}""");
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => CtrfReportMerger.MergeAllToFileAsync([valid, invalid], output, CancellationToken.None));
+
+            Assert.IsFalse(File.Exists(output));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task MergeAllToFileAsync_WithAllInputsInvalid_ThrowsWithoutWritingOutput()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            string first = Path.Combine(tempDirectory, "first.json");
+            string second = Path.Combine(tempDirectory, "second.json");
+            string output = Path.Combine(tempDirectory, "out", "merged.json");
+            File.WriteAllText(first, """{"not":"ctrf"}""");
+            File.WriteAllText(second, "[]");
+
+            ArgumentException exception = await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => CtrfReportMerger.MergeAllToFileAsync([first, second], output, CancellationToken.None));
+
+            Assert.AreEqual("inputReports", exception.ParamName);
+            Assert.Contains("Every input must be a valid CTRF report.", exception.Message);
+            Assert.IsFalse(File.Exists(output));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task MergeAllToFileAsync_WithUnrepresentableTests_ThrowsWithoutWritingOutput()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"ctrf-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            string valid = Path.Combine(tempDirectory, "valid.json");
+            string invalid = Path.Combine(tempDirectory, "invalid.json");
+            File.WriteAllText(valid, BuildReport());
+            string[] invalidReports =
+            [
+                """{"reportFormat":"CTRF","results":{}}""",
+                """{"reportFormat":"CTRF","results":{"tests":["not-a-test"]}}""",
+            ];
+
+            for (int i = 0; i < invalidReports.Length; i++)
+            {
+                string output = Path.Combine(tempDirectory, "out", $"merged-{i}.json");
+                File.WriteAllText(invalid, invalidReports[i]);
+
+                await Assert.ThrowsExactlyAsync<ArgumentException>(
+                    () => CtrfReportMerger.MergeAllToFileAsync([valid, invalid], output, CancellationToken.None));
+
+                Assert.IsFalse(File.Exists(output));
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateDeterministicId_IsStableAndSensitiveToInputValues()
+    {
+        Guid first = CtrfReportMerger.CreateDeterministicId(["a\0execution-1", "b\0execution-2"]);
+
+        Assert.AreEqual(first, CtrfReportMerger.CreateDeterministicId(["a\0execution-1", "b\0execution-2"]));
+        Assert.AreNotEqual(first, CtrfReportMerger.CreateDeterministicId(["a\0execution-3", "b\0execution-2"]));
+    }
+
 #if NETCOREAPP
     [TestMethod]
     public async Task MergeToFileAsync_WhenOutputAliasesInputViaSymlinkedParent_ThrowsAndPreservesInput()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -361,9 +361,11 @@ public sealed class CtrfReportMergerTests
             File.WriteAllText(valid, BuildReport());
             File.WriteAllText(invalid, """{"not":"ctrf"}""");
 
-            await Assert.ThrowsExactlyAsync<ArgumentException>(
+            ArgumentException exception = await Assert.ThrowsExactlyAsync<ArgumentException>(
                 () => CtrfReportMerger.MergeAllToFileAsync([valid, invalid], output, CancellationToken.None));
 
+            Assert.AreEqual("inputReports", exception.ParamName);
+            Assert.Contains("Every input must be a valid CTRF report.", exception.Message);
             Assert.IsFalse(File.Exists(output));
         }
         finally

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -438,6 +438,7 @@ public sealed class CtrfReportMergerTests
     {
         Guid first = CtrfReportMerger.CreateDeterministicId(["a\0execution-1", "b\0execution-2"]);
 
+        Assert.AreEqual(new Guid("a013bf25-9502-a584-31ca-332457e596d2"), first);
         Assert.AreEqual(first, CtrfReportMerger.CreateDeterministicId(["a\0execution-1", "b\0execution-2"]));
         Assert.AreNotEqual(first, CtrfReportMerger.CreateDeterministicId(["a\0execution-3", "b\0execution-2"]));
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -364,7 +364,7 @@ public sealed class CtrfReportMergerTests
             ArgumentException exception = await Assert.ThrowsExactlyAsync<ArgumentException>(
                 () => CtrfReportMerger.MergeAllToFileAsync([valid, invalid], output, CancellationToken.None));
 
-            Assert.AreEqual("inputReports", exception.ParamName);
+            Assert.AreEqual("inputPaths", exception.ParamName);
             Assert.Contains("Every input must be a valid CTRF report.", exception.Message);
             Assert.IsFalse(File.Exists(output));
         }
@@ -390,7 +390,7 @@ public sealed class CtrfReportMergerTests
             ArgumentException exception = await Assert.ThrowsExactlyAsync<ArgumentException>(
                 () => CtrfReportMerger.MergeAllToFileAsync([first, second], output, CancellationToken.None));
 
-            Assert.AreEqual("inputReports", exception.ParamName);
+            Assert.AreEqual("inputPaths", exception.ParamName);
             Assert.Contains("Every input must be a valid CTRF report.", exception.Message);
             Assert.IsFalse(File.Exists(output));
         }


### PR DESCRIPTION
## Summary

- register a built-in CTRF artifact post-processor for `dotnet test` orchestration
- merge two or more CTRF reports deterministically under the orchestrator's fixed `merged` directory, including execution provenance in artifact identity
- reject unsafe reparse-point output directories and strict-mode inputs that cannot be represented without loss
- advertise conservative capabilities: CTRF kind only, no ambiguous `.json` fallback, and no truncated-run support
- add localized merged-artifact metadata and focused registration, capability, determinism, safety, and strict-merge tests

## Testing

- targeted `net8.0` build of `Microsoft.Testing.Extensions.UnitTests` (0 warnings, 0 errors)
- CTRF-focused unit tests: 108 total, 107 passed, 1 filesystem-dependent inconclusive, 0 failed