### PR TITLE
Avoid rebuilding cached outputs during pack

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -283,6 +283,7 @@ stages:
             -prepareMachine `
             /p:ContinuousIntegrationBuild=true `
             /p:FastAcceptanceTest=true `
+            /p:NoBuild=true `
             /p:MSBuildCachePackageEnabled=true `
             /p:MSBuildCacheEnabled=false
           exit $LASTEXITCODE
@@ -597,6 +598,7 @@ stages:
               "-prepareMachine",
               "/p:ContinuousIntegrationBuild=true",
               "/p:FastAcceptanceTest=true",
+              "/p:NoBuild=true",
               "/p:MSBuildCachePackageEnabled=true",
               "/p:MSBuildCacheEnabled=false"
             )


### PR DESCRIPTION
## Summary

- pass `NoBuild=true` to both cached-output SignPack invocations
- make NuGet Pack consume binaries already materialized by MSBuildCache
- preserve package creation and signing/repack validation

## Motivation

Binlogs from pipeline run 20260807.13 showed 210/210 Debug cache hits and 209/210 Release cache hits, followed by a second compilation of 103 projects. NuGet added `Build` to `GenerateNuspecDependsOn` because `NoBuild` was unset. Direct packing and dry-run signing were comparatively small costs.

## Validation

- verified both cached-output SignPack paths receive `NoBuild=true`
- verified the YAML diff contains only the two intended arguments
- `git diff --check`