### PR TITLE
Avoid restoring cached outputs before pack

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -283,6 +283,7 @@ stages:
             -prepareMachine `
             /p:ContinuousIntegrationBuild=true `
             /p:FastAcceptanceTest=true `
+            /p:NoBuild=true `
             /p:MSBuildCachePackageEnabled=true `
             /p:MSBuildCacheEnabled=false
           exit $LASTEXITCODE
@@ -597,6 +598,7 @@ stages:
               "-prepareMachine",
               "/p:ContinuousIntegrationBuild=true",
               "/p:FastAcceptanceTest=true",
+              "/p:NoBuild=true",
               "/p:MSBuildCachePackageEnabled=true",
               "/p:MSBuildCacheEnabled=false"
             )

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,7 +277,6 @@ stages:
             -disablePipelineSetResult `
             -configuration $(_BuildConfig) `
             -binaryLogName "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog" `
-            -restore `
             -sign `
             -pack `
             -prepareMachine `
@@ -592,7 +591,6 @@ stages:
               "-disablePipelineSetResult",
               "-configuration", "$(_BuildConfig)",
               "-binaryLogName", "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog",
-              "-restore",
               "-sign",
               "-pack",
               "-prepareMachine",


### PR DESCRIPTION
## Summary

- remove `-restore` from the two cache-success SignPack invocations
- retain `/restore` on both preceding MSBuildCache graph builds and preserve all fallback and ordinary restore behavior

## Rationale

This PR depends on #10509, which adds `NoBuild=true` so Pack consumes the binaries already materialized by MSBuildCache.

Pipeline run `20260807.13` showed that workload installation took about 1m45s and that the outer Arcade restore repeated after the cache pass. The graph invocation already runs `/restore` and initializes the repo-local toolset, so restoring again before signing and packing is redundant.