### PR TITLE
Test filter provider accessibility handling

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/TestFilterProviderShouldBeValidAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/TestFilterProviderShouldBeValidAnalyzerTests.cs
@@ -48,6 +48,25 @@ public sealed class TestFilterProviderShouldBeValidAnalyzerTests
         await VerifyCS.VerifyAnalyzerAsync(code);
     }
 
+    // Activator.CreateInstance(Type) can instantiate a non-public type as long as its parameterless
+    // constructor is public, so the type's effective accessibility must not cause a diagnostic.
+    [TestMethod]
+    public async Task WhenFilterTypeIsInternalWithPublicParameterlessConstructor_NoDiagnostic()
+    {
+        string code = Header + """
+            [assembly: TestFilterProvider(typeof(MyFilter))]
+
+            internal sealed class MyFilter : ITestFilter
+            {
+                public MyFilter() { }
+
+                public TestFilterResult Filter(TestFilterContext context) => TestFilterResult.Run;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
     [TestMethod]
     public async Task WhenNoProviderIsRegistered_NoDiagnostic()
     {
@@ -244,6 +263,27 @@ public sealed class TestFilterProviderShouldBeValidAnalyzerTests
             public sealed class MyFilter : ITestFilter
             {
                 private MyFilter() { }
+
+                public TestFilterResult Filter(TestFilterContext context) => TestFilterResult.Run;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic(TestFilterProviderShouldBeValidAnalyzer.NoParameterlessConstructorRule)
+                .WithLocation(0)
+                .WithArguments("MyFilter"));
+    }
+
+    [TestMethod]
+    public async Task WhenFilterTypeIsInternalWithInternalParameterlessConstructor_Diagnostic()
+    {
+        string code = Header + """
+            [assembly: {|#0:TestFilterProvider(typeof(MyFilter))|}]
+
+            internal sealed class MyFilter : ITestFilter
+            {
+                internal MyFilter() { }
 
                 public TestFilterResult Filter(TestFilterContext context) => TestFilterResult.Run;
             }


### PR DESCRIPTION
## Summary

- cover internal test filter providers with public parameterless constructors
- verify internal parameterless constructors still produce MSTEST0081
- align analyzer coverage with the adapter's `Activator.CreateInstance(Type)` behavior

## Testing

- targeted analyzer test class on `net8.0` (30 passed)
- targeted analyzer test class on `net472` (21 passed)
- multi-target analyzer test project build

Closes #10521
