### PR TITLE
Fix process metric collection after exit

### DIFF
--- a/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
@@ -94,7 +94,7 @@ internal class DotnetTestProcess : IStep<BuildArtifact, Files>
             // Drain stdout/stderr asynchronously to prevent buffer deadlocks.
             Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
             Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndGetTotalProcessorTimeAsync(process);
+            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndSampleTotalProcessorTimeAsync(process);
             TimeSpan elapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
             await Task.WhenAll(stdoutTask, stderrTask);
 

--- a/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/DotnetTestProcess.cs
@@ -24,9 +24,8 @@ namespace MSTest.Performance.Runner.Steps;
 /// <para>
 /// <b>Measurement note:</b> <see cref="Process.TotalProcessorTime"/> reflects only the
 /// <c>dotnet test</c> parent process; the spawned test-host child's CPU time is not included.
-/// <see cref="Process.ExitTime"/> minus <see cref="Process.StartTime"/> (wall-clock) is the
-/// primary metric and represents the end-to-end time a user observes when running
-/// <c>dotnet test</c>.
+/// Wall-clock time is the primary metric and represents the end-to-end time a user observes
+/// when running <c>dotnet test</c>.
 /// </para>
 /// </remarks>
 internal class DotnetTestProcess : IStep<BuildArtifact, Files>
@@ -90,11 +89,13 @@ internal class DotnetTestProcess : IStep<BuildArtifact, Files>
         List<object> results = [];
         for (int i = 0; i < _numberOfRun; i++)
         {
+            long startTimestamp = Stopwatch.GetTimestamp();
             using Process process = Process.Start(psi)!;
             // Drain stdout/stderr asynchronously to prevent buffer deadlocks.
             Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
             Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
+            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndGetTotalProcessorTimeAsync(process);
+            TimeSpan elapsedTime = Stopwatch.GetElapsedTime(startTimestamp);
             await Task.WhenAll(stdoutTask, stderrTask);
 
             // Fail fast on a non-zero exit code: `dotnet test` has many infrastructure failure
@@ -110,8 +111,8 @@ internal class DotnetTestProcess : IStep<BuildArtifact, Files>
 
             var result = new
             {
-                ElapsedTime = process.ExitTime - process.StartTime,
-                process.TotalProcessorTime,
+                ElapsedTime = elapsedTime,
+                TotalProcessorTime = totalProcessorTime,
                 Environment.ProcessorCount,
                 GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
             };

--- a/test/Performance/MSTest.Performance.Runner/Steps/PlainProcess.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/PlainProcess.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
 using System.IO.Compression;
 using System.Text.Json;
 
@@ -41,12 +42,13 @@ internal class PlainProcess : IStep<BuildArtifact, Files>
         List<object> results = [];
         for (int i = 0; i < _numberOfRun; i++)
         {
+            long startTimestamp = Stopwatch.GetTimestamp();
             using Process process = Process.Start(processStartInfo)!;
-            await process.WaitForExitAsync();
+            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndGetTotalProcessorTimeAsync(process);
             var result = new
             {
-                ElapsedTime = process.ExitTime - process.StartTime,
-                process.TotalProcessorTime,
+                ElapsedTime = Stopwatch.GetElapsedTime(startTimestamp),
+                TotalProcessorTime = totalProcessorTime,
                 Environment.ProcessorCount,
                 GC.GetGCMemoryInfo().TotalAvailableMemoryBytes,
             };
@@ -65,5 +67,43 @@ internal class PlainProcess : IStep<BuildArtifact, Files>
         ZipFile.CreateFromDirectory(payload.TestAsset.TargetAssetPath, sample, _compressionLevel, includeBaseDirectory: true);
 
         return new Files([sample]);
+    }
+}
+
+internal static class ProcessMeasurement
+{
+    private static readonly TimeSpan SamplingInterval = TimeSpan.FromMilliseconds(10);
+
+    public static async Task<TimeSpan> WaitForExitAndGetTotalProcessorTimeAsync(Process process)
+    {
+        Task waitForExitTask = process.WaitForExitAsync();
+        if (OperatingSystem.IsWindows())
+        {
+            await waitForExitTask;
+            return process.TotalProcessorTime;
+        }
+
+        // Unix removes process metrics when a child is reaped, so retain the latest live sample.
+        TimeSpan totalProcessorTime = TimeSpan.Zero;
+        while (!waitForExitTask.IsCompleted)
+        {
+            try
+            {
+                totalProcessorTime = process.TotalProcessorTime;
+            }
+            catch (InvalidOperationException) when (process.HasExited)
+            {
+                break;
+            }
+            catch (Win32Exception) when (process.HasExited)
+            {
+                break;
+            }
+
+            await Task.WhenAny(waitForExitTask, Task.Delay(SamplingInterval));
+        }
+
+        await waitForExitTask;
+        return totalProcessorTime;
     }
 }

--- a/test/Performance/MSTest.Performance.Runner/Steps/PlainProcess.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/PlainProcess.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
 using System.IO.Compression;
 using System.Text.Json;
 
@@ -44,7 +43,7 @@ internal class PlainProcess : IStep<BuildArtifact, Files>
         {
             long startTimestamp = Stopwatch.GetTimestamp();
             using Process process = Process.Start(processStartInfo)!;
-            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndGetTotalProcessorTimeAsync(process);
+            TimeSpan totalProcessorTime = await ProcessMeasurement.WaitForExitAndSampleTotalProcessorTimeAsync(process);
             var result = new
             {
                 ElapsedTime = Stopwatch.GetElapsedTime(startTimestamp),
@@ -67,43 +66,5 @@ internal class PlainProcess : IStep<BuildArtifact, Files>
         ZipFile.CreateFromDirectory(payload.TestAsset.TargetAssetPath, sample, _compressionLevel, includeBaseDirectory: true);
 
         return new Files([sample]);
-    }
-}
-
-internal static class ProcessMeasurement
-{
-    private static readonly TimeSpan SamplingInterval = TimeSpan.FromMilliseconds(10);
-
-    public static async Task<TimeSpan> WaitForExitAndGetTotalProcessorTimeAsync(Process process)
-    {
-        Task waitForExitTask = process.WaitForExitAsync();
-        if (OperatingSystem.IsWindows())
-        {
-            await waitForExitTask;
-            return process.TotalProcessorTime;
-        }
-
-        // Unix removes process metrics when a child is reaped, so retain the latest live sample.
-        TimeSpan totalProcessorTime = TimeSpan.Zero;
-        while (!waitForExitTask.IsCompleted)
-        {
-            try
-            {
-                totalProcessorTime = process.TotalProcessorTime;
-            }
-            catch (InvalidOperationException) when (process.HasExited)
-            {
-                break;
-            }
-            catch (Win32Exception) when (process.HasExited)
-            {
-                break;
-            }
-
-            await Task.WhenAny(waitForExitTask, Task.Delay(SamplingInterval));
-        }
-
-        await waitForExitTask;
-        return totalProcessorTime;
     }
 }

--- a/test/Performance/MSTest.Performance.Runner/Steps/ProcessMeasurement.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/ProcessMeasurement.cs
@@ -41,9 +41,11 @@ internal static class ProcessMeasurement
         }
         catch (InvalidOperationException) when (process.HasExited)
         {
+            // Retain the last sample because Unix removes process metrics after reaping.
         }
         catch (Win32Exception) when (process.HasExited)
         {
+            // Retain the last sample because Unix removes process metrics after reaping.
         }
     }
 }

--- a/test/Performance/MSTest.Performance.Runner/Steps/ProcessMeasurement.cs
+++ b/test/Performance/MSTest.Performance.Runner/Steps/ProcessMeasurement.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+
+namespace MSTest.Performance.Runner.Steps;
+
+internal static class ProcessMeasurement
+{
+    private static readonly TimeSpan SamplingInterval = TimeSpan.FromMilliseconds(10);
+
+    public static async Task<TimeSpan> WaitForExitAndSampleTotalProcessorTimeAsync(Process process)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            await process.WaitForExitAsync();
+            return process.TotalProcessorTime;
+        }
+
+        // Unix removes process metrics when a child is reaped, so retain the latest live sample.
+        // The final CPU slice between the last sample and exit cannot be observed through Process.
+        TimeSpan totalProcessorTime = TimeSpan.Zero;
+        TryUpdateTotalProcessorTime(process, ref totalProcessorTime);
+
+        Task waitForExitTask = process.WaitForExitAsync();
+        while (!waitForExitTask.IsCompleted)
+        {
+            await Task.WhenAny(waitForExitTask, Task.Delay(SamplingInterval));
+            TryUpdateTotalProcessorTime(process, ref totalProcessorTime);
+        }
+
+        await waitForExitTask;
+        return totalProcessorTime;
+    }
+
+    private static void TryUpdateTotalProcessorTime(Process process, ref TimeSpan totalProcessorTime)
+    {
+        try
+        {
+            totalProcessorTime = process.TotalProcessorTime;
+        }
+        catch (InvalidOperationException) when (process.HasExited)
+        {
+        }
+        catch (Win32Exception) when (process.HasExited)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10519

`Process.StartTime` and `TotalProcessorTime` are unavailable after a child is reaped on Unix. Measure wall-clock duration with `Stopwatch`, sample processor time while Unix children are alive, and retain the exact post-exit processor-time path on Windows.

The same handling is applied to both plain-process and `dotnet test` performance scenarios.

Validation: targeted `MSTest.Performance.Runner` build completed with 0 warnings and 0 errors.