### PR TITLE
Add HTML report artifact consolidation

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+using Microsoft.Testing.Extensions.HtmlReport.Resources;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+
+namespace Microsoft.Testing.Extensions.HtmlReport;
+
+internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
+{
+    private const string MergedReportDirectoryName = "merged";
+
+    private static readonly string[] SupportedArtifactKinds = [HtmlReportGenerator.HtmlArtifactKind];
+
+    public string Uid => "Microsoft.Testing.Extensions.HtmlReport.PostProcessor";
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => ExtensionResources.HtmlArtifactPostProcessorDisplayName;
+
+    public string Description => ExtensionResources.HtmlArtifactPostProcessorDescription;
+
+    public bool SupportsTruncatedRuns => false;
+
+    public IReadOnlyList<string> SupportedKinds => SupportedArtifactKinds;
+
+    // HTML is a general-purpose format, so extension-only matching would claim unrelated artifacts.
+    public IReadOnlyList<string> SupportedFileExtensionsFallback => [];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public async Task<ProcessedArtifact?> ProcessAsync(
+        IReadOnlyList<InputArtifact> inputs,
+        string outputDirectory,
+        ArtifactPostProcessingContext context,
+        CancellationToken cancellationToken)
+    {
+        if (inputs.Count < 2)
+        {
+            return null;
+        }
+
+        InputArtifact[] orderedInputs =
+        [
+            .. OrderInputs(inputs),
+        ];
+
+        string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
+        try
+        {
+            Directory.CreateDirectory(mergedDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        if (IsReparsePoint(mergedDirectory))
+        {
+            return null;
+        }
+
+        string mergeId = CreateMergeIdFromOrderedInputs(orderedInputs);
+        string outputPath = Path.Combine(mergedDirectory, $"merged-{mergeId}.html");
+        await HtmlReportMerger.MergeToFileAsync(
+            orderedInputs,
+            outputPath,
+            cancellationToken).ConfigureAwait(false);
+
+        return new ProcessedArtifact(
+            outputPath,
+            HtmlReportGenerator.HtmlArtifactKind,
+            ExtensionResources.HtmlMergedArtifactDisplayName,
+            string.Format(CultureInfo.CurrentCulture, ExtensionResources.HtmlMergedArtifactDescription, inputs.Count));
+    }
+
+    internal static string CreateMergeId(IReadOnlyList<InputArtifact> inputs)
+        => CreateMergeIdFromOrderedInputs(OrderInputs(inputs));
+
+    private static string CreateMergeIdFromOrderedInputs(IEnumerable<InputArtifact> orderedInputs)
+    {
+        var identity = new StringBuilder();
+        foreach (InputArtifact input in orderedInputs)
+        {
+            AppendIdentityPart(identity, Path.GetFullPath(input.Path));
+            AppendIdentityPart(identity, input.ProducingTestModule);
+            AppendIdentityPart(identity, input.TargetFramework);
+            AppendIdentityPart(identity, input.Architecture);
+            AppendIdentityPart(identity, input.ExecutionId);
+        }
+
+        using var sha256 = SHA256.Create();
+        byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(identity.ToString()));
+        var result = new StringBuilder(32);
+        for (int i = 0; i < 16; i++)
+        {
+            result.Append(hash[i].ToString("x2", CultureInfo.InvariantCulture));
+        }
+
+        return result.ToString();
+    }
+
+    private static IOrderedEnumerable<InputArtifact> OrderInputs(IEnumerable<InputArtifact> inputs)
+        => inputs.OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
+            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
+            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
+            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
+            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
+
+    private static void AppendIdentityPart(StringBuilder builder, string? value)
+    {
+        if (value is null)
+        {
+            builder.Append("-1:");
+            return;
+        }
+
+        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(value);
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -10,6 +10,8 @@ internal sealed class HtmlReportEngine : ReportEngineBase
 {
     private const string TemplateResourceName = "Microsoft.Testing.Extensions.HtmlReport.Templates.report-template.html";
     private const string DataPlaceholder = "/*__MTP_DATA__*/null";
+    private const string DataElementStart = "<script id=\"mtp-data\" type=\"application/json\">";
+    private const string DataElementEnd = "</script>";
     private const string GeneratorVersionPlaceholder = "__MTP_GENERATOR_VERSION__";
 
     public HtmlReportEngine(ReportEngineContext context)
@@ -26,16 +28,29 @@ internal sealed class HtmlReportEngine : ReportEngineBase
             HtmlReportGeneratorCommandLine.HtmlReportFileNameOptionName,
             "html");
 
-        string template = LoadTemplate();
         string json = BuildJson(results, finishTime);
-
-        string html = template
-            .Replace(GeneratorVersionPlaceholder, ExtensionVersion.DefaultSemVer)
-            .Replace(DataPlaceholder, json);
+        string html = RenderReport(json);
 
         byte[] bytes = Encoding.UTF8.GetBytes(html);
 
         return await WriteAsync(finalPath, bytes).ConfigureAwait(false);
+    }
+
+    internal static string RenderReport(string json)
+        => LoadTemplate()
+            .Replace(GeneratorVersionPlaceholder, ExtensionVersion.DefaultSemVer)
+            .Replace(DataPlaceholder, json);
+
+    internal static string ExtractReportJson(string html)
+    {
+        int dataStart = html.IndexOf(DataElementStart, StringComparison.Ordinal);
+        dataStart = dataStart >= 0
+            ? dataStart + DataElementStart.Length
+            : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(html));
+        int dataEnd = html.IndexOf(DataElementEnd, dataStart, StringComparison.Ordinal);
+        return dataEnd >= 0
+            ? html.Substring(dataStart, dataEnd - dataStart)
+            : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(html));
     }
 
     private async Task<(string FileName, string? Warning)> WriteAsync(string finalPath, byte[] bytes)

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
@@ -18,9 +18,18 @@ public static class HtmlReportExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     public static void AddHtmlReportProvider(this ITestApplicationBuilder builder)
-        => ReportProviderRegistration.AddReportProvider(
+    {
+        if (builder is not IArtifactPostProcessingApplicationBuilder artifactPostProcessingBuilder)
+        {
+            throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
+        }
+
+        ReportProviderRegistration.AddReportProvider(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
             () => new HtmlReportGeneratorCommandLine(),
             serviceProvider => new HtmlReportGenerator(serviceProvider));
+
+        artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new HtmlArtifactPostProcessor());
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Testing.Extensions.HtmlReport;
 
 internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenerator, CapturedTestResult>
 {
+    internal const string HtmlArtifactKind = "microsoft.testing.html";
+
     public HtmlReportGenerator(IServiceProvider serviceProvider)
         : base(serviceProvider, HtmlReportGeneratorCommandLine.HtmlReportOptionName)
     {
@@ -24,7 +26,7 @@ internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenera
 
     protected override string ArtifactDisplayName => ExtensionResources.HtmlReportArtifactDisplayName;
 
-    protected override string? ArtifactKind => "microsoft.testing.html";
+    protected override string? ArtifactKind => HtmlArtifactKind;
 
     protected override string ArtifactDescription => ExtensionResources.HtmlReportArtifactDescription;
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -48,12 +48,14 @@ internal static class HtmlReportMerger
             latestEndTime = latestEndTime is null || endTime > latestEndTime ? endTime : latestEndTime;
         }
 
-        foreach (ParsedHtmlReport parsedReport in parsedReports.OrderBy(report => report.StartTime).ThenBy(report => report.OriginalIndex))
+        foreach (ParsedHtmlReport parsedReport in parsedReports)
         {
             HtmlReportMergeInput input = parsedReport.Input;
             JsonObject report = parsedReport.Report;
-            foreach (JsonNode? test in (JsonArray)report["tests"]!)
+            var reportTests = (JsonArray)report["tests"]!;
+            for (int i = 0; i < reportTests.Count; i++)
             {
+                JsonNode? test = reportTests[i];
                 var testObject = (JsonObject)test!.DeepClone();
                 tests.Add(new MergedTest(
                     testObject,
@@ -62,13 +64,25 @@ internal static class HtmlReportMerger
                         ?? ReadOptionalString(report, "testApplication"),
                     ReadOptionalString(testObject, "targetFramework") ?? input.TargetFramework,
                     ReadOptionalString(testObject, "architecture") ?? input.Architecture,
-                    ReadOptionalString(testObject, "executionId") ?? input.ExecutionId));
+                    ReadOptionalString(testObject, "executionId") ?? input.ExecutionId,
+                    TryReadTimestamp(testObject, "sourceReportStartTime", out DateTimeOffset sourceReportStartTime)
+                        ? sourceReportStartTime
+                        : parsedReport.StartTime,
+                    parsedReport.OriginalIndex,
+                    i));
             }
         }
 
         IReadOnlyList<JsonObject> reports = [.. parsedReports.Select(report => report.Report)];
+        MergedTest[] orderedTests =
+        [
+            .. tests
+                .OrderBy(test => test.SourceReportStartTime)
+                .ThenBy(test => test.OriginalReportIndex)
+                .ThenBy(test => test.OriginalTestIndex),
+        ];
         var countByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (MergedTest mergedTest in tests)
+        foreach (MergedTest mergedTest in orderedTests)
         {
             string identity = CreateTestIdentity(mergedTest);
             countByIdentity[identity] = countByIdentity.TryGetValue(identity, out int existing) ? existing + 1 : 1;
@@ -83,9 +97,9 @@ internal static class HtmlReportMerger
         int errored = 0;
         double totalDurationMs = 0;
 
-        for (int i = 0; i < tests.Count; i++)
+        for (int i = 0; i < orderedTests.Length; i++)
         {
-            MergedTest mergedTest = tests[i];
+            MergedTest mergedTest = orderedTests[i];
             JsonObject test = mergedTest.Test;
             string identity = CreateTestIdentity(mergedTest);
             string outcome = ReadRequiredString(test, "outcome");
@@ -98,6 +112,7 @@ internal static class HtmlReportMerger
             AddOptionalString(test, "targetFramework", mergedTest.TargetFramework);
             AddOptionalString(test, "architecture", mergedTest.Architecture);
             AddOptionalString(test, "executionId", mergedTest.ExecutionId);
+            test["sourceReportStartTime"] = mergedTest.SourceReportStartTime.ToString("O", CultureInfo.InvariantCulture);
 
             int attemptOf = countByIdentity[identity];
             if (attemptOf > 1)
@@ -130,7 +145,7 @@ internal static class HtmlReportMerger
             ["tests"] = mergedTests,
             ["summary"] = new JsonObject
             {
-                ["total"] = tests.Count,
+                ["total"] = orderedTests.Length,
                 ["passed"] = passed,
                 ["failed"] = failed,
                 ["skipped"] = skipped,
@@ -243,13 +258,16 @@ internal static class HtmlReportMerger
             : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
 
     private static DateTimeOffset ReadRequiredTimestamp(JsonObject owner, string propertyName)
+        => TryReadTimestamp(owner, propertyName, out DateTimeOffset timestamp)
+                ? timestamp
+                : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
+
+    private static bool TryReadTimestamp(JsonObject owner, string propertyName, out DateTimeOffset timestamp)
         => DateTimeOffset.TryParse(
             ReadOptionalString(owner, propertyName),
             CultureInfo.InvariantCulture,
             DateTimeStyles.RoundtripKind,
-            out DateTimeOffset timestamp)
-                ? timestamp
-                : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
+            out timestamp);
 
     private static string CreateTestIdentity(MergedTest test)
         => string.Join(
@@ -361,5 +379,8 @@ internal static class HtmlReportMerger
         string? ProducingTestModule,
         string? TargetFramework,
         string? Architecture,
-        string? ExecutionId);
+        string? ExecutionId,
+        DateTimeOffset SourceReportStartTime,
+        int OriginalReportIndex,
+        int OriginalTestIndex);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -82,9 +82,8 @@ internal static class HtmlReportMerger
                 .ThenBy(test => test.OriginalTestIndex),
         ];
         var countByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (MergedTest mergedTest in orderedTests)
+        foreach (string identity in orderedTests.Select(CreateTestIdentity))
         {
-            string identity = CreateTestIdentity(mergedTest);
             countByIdentity[identity] = countByIdentity.TryGetValue(identity, out int existing) ? existing + 1 : 1;
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -54,12 +54,15 @@ internal static class HtmlReportMerger
             JsonObject report = parsedReport.Report;
             foreach (JsonNode? test in (JsonArray)report["tests"]!)
             {
+                var testObject = (JsonObject)test!.DeepClone();
                 tests.Add(new MergedTest(
-                    (JsonObject)test!.DeepClone(),
-                    input.ProducingTestModule ?? ReadOptionalString(report, "testApplication"),
-                    input.TargetFramework,
-                    input.Architecture,
-                    input.ExecutionId));
+                    testObject,
+                    ReadOptionalString(testObject, "testApplication")
+                        ?? input.ProducingTestModule
+                        ?? ReadOptionalString(report, "testApplication"),
+                    ReadOptionalString(testObject, "targetFramework") ?? input.TargetFramework,
+                    ReadOptionalString(testObject, "architecture") ?? input.Architecture,
+                    ReadOptionalString(testObject, "executionId") ?? input.ExecutionId));
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -1,0 +1,350 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using Microsoft.Testing.Extensions.HtmlReport.Resources;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+
+namespace Microsoft.Testing.Extensions.HtmlReport;
+
+internal static class HtmlReportMerger
+{
+    private const string GeneratorName = "Microsoft.Testing.Extensions.HtmlReport";
+
+    internal static string Merge(IReadOnlyList<string> inputReports)
+    {
+        IReadOnlyList<string> reports = inputReports ?? throw new ArgumentNullException(nameof(inputReports));
+
+        return Merge([.. reports.Select(report => new HtmlReportMergeInput(report, null, null, null, null))]);
+    }
+
+    private static string Merge(IReadOnlyList<HtmlReportMergeInput> inputs)
+    {
+        if (inputs is null)
+        {
+            throw new ArgumentNullException(nameof(inputs));
+        }
+
+        if (inputs.Count == 0)
+        {
+            throw new ArgumentException(ExtensionResources.HtmlReportsRequired, nameof(inputs));
+        }
+
+        var reports = new List<JsonObject>(inputs.Count);
+        var tests = new List<MergedTest>();
+        DateTimeOffset? earliestStartTime = null;
+        DateTimeOffset? latestEndTime = null;
+
+        foreach (HtmlReportMergeInput input in inputs)
+        {
+            JsonObject report = ParseReport(input.Html);
+            reports.Add(report);
+
+            DateTimeOffset startTime = ReadRequiredTimestamp(report, "startTime");
+            DateTimeOffset endTime = ReadRequiredTimestamp(report, "endTime");
+            earliestStartTime = earliestStartTime is null || startTime < earliestStartTime ? startTime : earliestStartTime;
+            latestEndTime = latestEndTime is null || endTime > latestEndTime ? endTime : latestEndTime;
+
+            foreach (JsonNode? test in (JsonArray)report["tests"]!)
+            {
+                tests.Add(new MergedTest(
+                    (JsonObject)test!.DeepClone(),
+                    input.ProducingTestModule ?? ReadOptionalString(report, "testApplication"),
+                    input.TargetFramework,
+                    input.Architecture,
+                    input.ExecutionId));
+            }
+        }
+
+        var countByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (MergedTest mergedTest in tests)
+        {
+            string identity = CreateTestIdentity(mergedTest);
+            countByIdentity[identity] = countByIdentity.TryGetValue(identity, out int existing) ? existing + 1 : 1;
+        }
+
+        var emittedByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
+        var mergedTests = new JsonArray();
+        int passed = 0;
+        int failed = 0;
+        int skipped = 0;
+        int timedOut = 0;
+        int errored = 0;
+        double totalDurationMs = 0;
+
+        for (int i = 0; i < tests.Count; i++)
+        {
+            MergedTest mergedTest = tests[i];
+            JsonObject test = mergedTest.Test;
+            string identity = CreateTestIdentity(mergedTest);
+            string outcome = ReadRequiredString(test, "outcome");
+            double durationMs = ReadRequiredDouble(test, "durationMs");
+
+            test["rowKey"] = i;
+            _ = test.Remove("attemptIndex");
+            _ = test.Remove("attemptOf");
+            AddOptionalString(test, "testApplication", mergedTest.ProducingTestModule);
+            AddOptionalString(test, "targetFramework", mergedTest.TargetFramework);
+            AddOptionalString(test, "architecture", mergedTest.Architecture);
+            AddOptionalString(test, "executionId", mergedTest.ExecutionId);
+
+            int attemptOf = countByIdentity[identity];
+            if (attemptOf > 1)
+            {
+                int attemptIndex = emittedByIdentity.TryGetValue(identity, out int emitted) ? emitted + 1 : 1;
+                emittedByIdentity[identity] = attemptIndex;
+                test["attemptIndex"] = attemptIndex;
+                test["attemptOf"] = attemptOf;
+            }
+
+            CountOutcome(outcome, ref passed, ref failed, ref skipped, ref timedOut, ref errored);
+            totalDurationMs += durationMs;
+            mergedTests.Add((JsonNode)test);
+        }
+
+        bool hasCommonFramework = TryGetCommonFramework(reports, out string framework, out string frameworkUid, out string frameworkVersion);
+        var merged = new JsonObject
+        {
+            ["schemaVersion"] = "1",
+            ["generator"] = GeneratorName,
+            ["generatorVersion"] = ExtensionVersion.DefaultSemVer,
+            ["testApplication"] = GetCommonString(reports, "testApplication") ?? ExtensionResources.HtmlMergedReportName,
+            ["machineName"] = GetCommonString(reports, "machineName") ?? string.Empty,
+            ["userName"] = GetCommonString(reports, "userName") ?? string.Empty,
+            ["framework"] = hasCommonFramework ? framework : string.Empty,
+            ["frameworkUid"] = hasCommonFramework ? frameworkUid : string.Empty,
+            ["frameworkVersion"] = hasCommonFramework ? frameworkVersion : string.Empty,
+            ["startTime"] = earliestStartTime!.Value.ToString("O", CultureInfo.InvariantCulture),
+            ["endTime"] = latestEndTime!.Value.ToString("O", CultureInfo.InvariantCulture),
+            ["tests"] = mergedTests,
+            ["summary"] = new JsonObject
+            {
+                ["total"] = tests.Count,
+                ["passed"] = passed,
+                ["failed"] = failed,
+                ["skipped"] = skipped,
+                ["timedOut"] = timedOut,
+                ["errored"] = errored,
+                ["totalDurationMs"] = totalDurationMs,
+            },
+        };
+
+        if (TryGetCommonInt(reports, "exitCode", out int exitCode))
+        {
+            merged["exitCode"] = exitCode;
+        }
+
+        return HtmlReportEngine.RenderReport(merged.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
+    }
+
+    internal static async Task MergeToFileAsync(
+        IReadOnlyList<InputArtifact> inputs,
+        string outputPath,
+        CancellationToken cancellationToken)
+    {
+        if (inputs is null)
+        {
+            throw new ArgumentNullException(nameof(inputs));
+        }
+
+        if (outputPath is null)
+        {
+            throw new ArgumentNullException(nameof(outputPath));
+        }
+
+        if (inputs.Count == 0)
+        {
+            throw new ArgumentException(ExtensionResources.HtmlReportsRequired, nameof(inputs));
+        }
+
+        string[] inputPaths = [.. inputs.Select(input => input.Path)];
+        MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(inputPaths, outputPath);
+
+        var reports = new List<HtmlReportMergeInput>(inputs.Count);
+        foreach (InputArtifact input in inputs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+#if NETCOREAPP
+            string html = await File.ReadAllTextAsync(input.Path, cancellationToken).ConfigureAwait(false);
+#else
+            string html = File.ReadAllText(input.Path);
+#endif
+            reports.Add(new HtmlReportMergeInput(
+                html,
+                input.ProducingTestModule,
+                input.TargetFramework,
+                input.Architecture,
+                input.ExecutionId));
+        }
+
+        byte[] mergedBytes = Encoding.UTF8.GetBytes(Merge(reports));
+        string? outputDirectory = Path.GetDirectoryName(outputPath);
+        if (outputDirectory is { Length: > 0 })
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+
+        await MergeOutputFileHelper.WriteViaTemporarySiblingAsync(outputPath, async tempPath =>
+        {
+#if NETCOREAPP
+            await File.WriteAllBytesAsync(tempPath, mergedBytes, cancellationToken).ConfigureAwait(false);
+#else
+            File.WriteAllBytes(tempPath, mergedBytes);
+            await Task.CompletedTask.ConfigureAwait(false);
+#endif
+        }).ConfigureAwait(false);
+    }
+
+    private static JsonObject ParseReport(string html)
+    {
+        JsonObject report;
+        try
+        {
+            report = JsonNode.Parse(HtmlReportEngine.ExtractReportJson(html)) as JsonObject
+                ?? throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(html));
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(html), ex);
+        }
+
+        bool isValidReport =
+            string.Equals(ReadOptionalString(report, "schemaVersion"), "1", StringComparison.Ordinal)
+            && string.Equals(ReadOptionalString(report, "generator"), GeneratorName, StringComparison.Ordinal)
+            && report["tests"] is JsonArray tests
+            && tests.All(test => test is JsonObject);
+
+        return isValidReport
+            ? report
+            : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(html));
+    }
+
+    private static string ReadRequiredString(JsonObject owner, string propertyName)
+        => ReadOptionalString(owner, propertyName)
+            ?? throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
+
+    private static string? ReadOptionalString(JsonObject owner, string propertyName)
+        => owner[propertyName] is JsonValue value && value.TryGetValue(out string? text) ? text : null;
+
+    private static double ReadRequiredDouble(JsonObject owner, string propertyName)
+        => owner[propertyName] is JsonValue value && value.TryGetValue(out double number)
+            ? number
+            : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
+
+    private static DateTimeOffset ReadRequiredTimestamp(JsonObject owner, string propertyName)
+        => DateTimeOffset.TryParse(
+            ReadOptionalString(owner, propertyName),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out DateTimeOffset timestamp)
+                ? timestamp
+                : throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(owner));
+
+    private static string CreateTestIdentity(MergedTest test)
+        => string.Join(
+            "\0",
+            ReadRequiredString(test.Test, "uid"),
+            test.ProducingTestModule ?? string.Empty,
+            test.TargetFramework ?? string.Empty,
+            test.Architecture ?? string.Empty);
+
+    private static void AddOptionalString(JsonObject owner, string propertyName, string? value)
+    {
+        if (value is not null)
+        {
+            owner[propertyName] = value;
+        }
+    }
+
+    private static string? GetCommonString(IReadOnlyList<JsonObject> reports, string propertyName)
+    {
+        string? common = ReadOptionalString(reports[0], propertyName);
+        for (int i = 1; i < reports.Count; i++)
+        {
+            if (!string.Equals(common, ReadOptionalString(reports[i], propertyName), StringComparison.Ordinal))
+            {
+                return null;
+            }
+        }
+
+        return common;
+    }
+
+    private static bool TryGetCommonFramework(
+        IReadOnlyList<JsonObject> reports,
+        out string framework,
+        out string frameworkUid,
+        out string frameworkVersion)
+    {
+        framework = GetCommonString(reports, "framework") ?? string.Empty;
+        frameworkUid = GetCommonString(reports, "frameworkUid") ?? string.Empty;
+        frameworkVersion = GetCommonString(reports, "frameworkVersion") ?? string.Empty;
+        if (framework.Length == 0 || frameworkUid.Length == 0 || frameworkVersion.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (JsonObject report in reports)
+        {
+            if (!string.Equals(ReadOptionalString(report, "framework"), framework, StringComparison.Ordinal)
+                || !string.Equals(ReadOptionalString(report, "frameworkUid"), frameworkUid, StringComparison.Ordinal)
+                || !string.Equals(ReadOptionalString(report, "frameworkVersion"), frameworkVersion, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetCommonInt(IReadOnlyList<JsonObject> reports, string propertyName, out int common)
+    {
+        if (reports[0][propertyName] is not JsonValue first || !first.TryGetValue(out common))
+        {
+            common = default;
+            return false;
+        }
+
+        for (int i = 1; i < reports.Count; i++)
+        {
+            if (reports[i][propertyName] is not JsonValue value
+                || !value.TryGetValue(out int candidate)
+                || candidate != common)
+            {
+                common = default;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void CountOutcome(string outcome, ref int passed, ref int failed, ref int skipped, ref int timedOut, ref int errored)
+    {
+        switch (outcome)
+        {
+            case "passed": passed++; break;
+            case "failed": failed++; break;
+            case "skipped": skipped++; break;
+            case "timedOut": timedOut++; break;
+            case "errored": errored++; break;
+            default: throw new ArgumentException(ExtensionResources.HtmlReportInputIsNotValid, nameof(outcome));
+        }
+    }
+
+    private sealed record HtmlReportMergeInput(
+        string Html,
+        string? ProducingTestModule,
+        string? TargetFramework,
+        string? Architecture,
+        string? ExecutionId);
+
+    private sealed record MergedTest(
+        JsonObject Test,
+        string? ProducingTestModule,
+        string? TargetFramework,
+        string? Architecture,
+        string? ExecutionId);
+}

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -32,21 +32,26 @@ internal static class HtmlReportMerger
             throw new ArgumentException(ExtensionResources.HtmlReportsRequired, nameof(inputs));
         }
 
-        var reports = new List<JsonObject>(inputs.Count);
+        var parsedReports = new List<ParsedHtmlReport>(inputs.Count);
         var tests = new List<MergedTest>();
         DateTimeOffset? earliestStartTime = null;
         DateTimeOffset? latestEndTime = null;
 
-        foreach (HtmlReportMergeInput input in inputs)
+        for (int i = 0; i < inputs.Count; i++)
         {
+            HtmlReportMergeInput input = inputs[i];
             JsonObject report = ParseReport(input.Html);
-            reports.Add(report);
-
             DateTimeOffset startTime = ReadRequiredTimestamp(report, "startTime");
             DateTimeOffset endTime = ReadRequiredTimestamp(report, "endTime");
+            parsedReports.Add(new ParsedHtmlReport(input, report, startTime, i));
             earliestStartTime = earliestStartTime is null || startTime < earliestStartTime ? startTime : earliestStartTime;
             latestEndTime = latestEndTime is null || endTime > latestEndTime ? endTime : latestEndTime;
+        }
 
+        foreach (ParsedHtmlReport parsedReport in parsedReports.OrderBy(report => report.StartTime).ThenBy(report => report.OriginalIndex))
+        {
+            HtmlReportMergeInput input = parsedReport.Input;
+            JsonObject report = parsedReport.Report;
             foreach (JsonNode? test in (JsonArray)report["tests"]!)
             {
                 tests.Add(new MergedTest(
@@ -58,6 +63,7 @@ internal static class HtmlReportMerger
             }
         }
 
+        IReadOnlyList<JsonObject> reports = [.. parsedReports.Select(report => report.Report)];
         var countByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
         foreach (MergedTest mergedTest in tests)
         {
@@ -340,6 +346,12 @@ internal static class HtmlReportMerger
         string? TargetFramework,
         string? Architecture,
         string? ExecutionId);
+
+    private sealed record ParsedHtmlReport(
+        HtmlReportMergeInput Input,
+        JsonObject Report,
+        DateTimeOffset StartTime,
+        int OriginalIndex);
 
     private sealed record MergedTest(
         JsonObject Test,

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,26 @@
 #nullable enable
+const Microsoft.Testing.Extensions.HtmlReport.HtmlReportGenerator.HtmlArtifactKind = "microsoft.testing.html" -> string!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.Description.get -> string!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.DisplayName.get -> string!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.HtmlArtifactPostProcessor() -> void
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.ProcessAsync(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, string! outputDirectory, Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ArtifactPostProcessingContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.ProcessedArtifact?>!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.SupportedFileExtensionsFallback.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.SupportedKinds.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.SupportsTruncatedRuns.get -> bool
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.Uid.get -> string!
+Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.Version.get -> string!
+static Microsoft.Testing.Extensions.HtmlReport.HtmlArtifactPostProcessor.CreateMergeId(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs) -> string!
+static Microsoft.Testing.Extensions.HtmlReport.HtmlReportEngine.ExtractReportJson(string! html) -> string!
+static Microsoft.Testing.Extensions.HtmlReport.HtmlReportEngine.RenderReport(string! json) -> string!
+Microsoft.Testing.Extensions.HtmlReport.HtmlReportMerger
+static Microsoft.Testing.Extensions.HtmlReport.HtmlReportMerger.Merge(System.Collections.Generic.IReadOnlyList<string!>! inputReports) -> string!
+static Microsoft.Testing.Extensions.HtmlReport.HtmlReportMerger.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, string! outputPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.MergeOutputFileHelper
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.BuildCaseFoldedProbePath(string! directory, string! probeFileName) -> string!
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAliasInput(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath) -> void
+static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
 virtual Microsoft.Testing.Extensions.ReportGeneratorBase<TGenerator, TCapturedTestResult>.ArtifactKind.get -> string?
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectoryNotWritableErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -37,6 +37,10 @@ $(CommonProductDescription)]]></PackageDescription>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
   </ItemGroup>
 
@@ -53,6 +57,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TargetFrameworkMonikerHelper.cs" Link="Helpers\TargetFrameworkMonikerHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Resources\PlatformResources.cs" Link="Resources\PlatformResources.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\MergeOutputFileHelper.cs" Link="Helpers\MergeOutputFileHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/PACKAGE.md
@@ -20,6 +20,7 @@ This package extends Microsoft.Testing.Platform with:
 - **Triage-friendly UX**: failed tests first, outcome filter, free-text search, sort by name / duration / outcome, expandable per-test detail panel with error message, stack trace, standard output and standard error
 - **Light and dark theme** that follows the user's system preference
 - **Performance**: pagination keeps the report usable even for very large runs
+- **Automatic consolidation**: reports from multi-process, multi-target-framework and retry runs are merged into one HTML summary while the original per-process reports remain available
 
 Enable the report via the `--report-html` command line option. The report file name can be overridden with `--report-html-filename <name>.html`.
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/ExtensionResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/ExtensionResources.resx
@@ -66,6 +66,34 @@
     <value>HTML Report</value>
     <comment>Do not localize {Locked="HTML"}.</comment>
   </data>
+  <data name="HtmlArtifactPostProcessorDescription" xml:space="preserve">
+    <value>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</value>
+    <comment>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</comment>
+  </data>
+  <data name="HtmlArtifactPostProcessorDisplayName" xml:space="preserve">
+    <value>HTML report merger</value>
+    <comment>Do not localize format name {Locked="HTML"}.</comment>
+  </data>
+  <data name="HtmlMergedArtifactDescription" xml:space="preserve">
+    <value>{0} HTML report files merged</value>
+    <comment>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</comment>
+  </data>
+  <data name="HtmlMergedArtifactDisplayName" xml:space="preserve">
+    <value>HTML report (merged)</value>
+    <comment>Do not localize format name {Locked="HTML"}.</comment>
+  </data>
+  <data name="HtmlMergedReportName" xml:space="preserve">
+    <value>Merged HTML report</value>
+    <comment>Do not localize format name {Locked="HTML"}.</comment>
+  </data>
+  <data name="HtmlReportInputIsNotValid" xml:space="preserve">
+    <value>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</value>
+    <comment>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</comment>
+  </data>
+  <data name="HtmlReportsRequired" xml:space="preserve">
+    <value>At least one HTML report is required to merge.</value>
+    <comment>Do not localize format name {Locked="HTML"}.</comment>
+  </data>
   <data name="HtmlReportFileExistsAndWillBeOverwritten" xml:space="preserve">
     <value>Warning: HTML report file '{0}' already exists and will be overwritten.</value>
     <comment>{0} is the {Locked="HTML"} report file path.</comment>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.cs.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Samostatná testovací sestava HTML</target>
@@ -56,6 +81,11 @@ Příklad: MyReport_{tfm}.html</target>
         <target state="translated">Generátor sestav HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">Možnost „--report-html“ nejde povolit, pokud se používá možnost „--list-tests“</target>
@@ -65,6 +95,11 @@ Příklad: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Povolit generování sestavy HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.de.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Eigenständiger HTML-Testbericht</target>
@@ -56,6 +81,11 @@ Beispiel: MyReport_{tfm}.html</target>
         <target state="translated">HTML-Bericht-Generator</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">„--report-html“ kann bei Verwendung von „--list-tests“ nicht aktiviert werden</target>
@@ -65,6 +95,11 @@ Beispiel: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Das Erstellen eines HTML-Berichts aktivieren</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.es.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Informe de prueba HTML independiente</target>
@@ -56,6 +81,11 @@ Ejemplo: MyReport_{tfm}.html</target>
         <target state="translated">Generador de informes HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">'--report-html' no se puede habilitar cuando se usa '--list-tests'</target>
@@ -65,6 +95,11 @@ Ejemplo: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Habilitar la generación de un informe HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.fr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Rapport de test HTML autonome</target>
@@ -56,6 +81,11 @@ Exemple : MyReport_{tfm}.html</target>
         <target state="translated">Générateur de rapports HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">« --report-html » ne peut pas être activé lors de l’utilisation de « --list-tests »</target>
@@ -65,6 +95,11 @@ Exemple : MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Activer la génération d’un rapport HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.it.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Report di test HTML autonomo</target>
@@ -56,6 +81,11 @@ Esempio: MyReport_{tfm}.html</target>
         <target state="translated">Generatore di report HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">Non è possibile abilitare "--report-html" quando si usa "--list-tests"</target>
@@ -65,6 +95,11 @@ Esempio: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Abilita la generazione di un report HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ja.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">自己完結型の HTML テスト レポート</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">HTML レポート生成プログラム</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">'--list-tests' を使用している場合、'--report-html' を有効にすることはできません</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">HTML レポートの生成を有効にする</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ko.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">자체 포함 HTML 테스트 보고서</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">HTML 보고서 생성기</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">'--list-tests'를 사용하는 경우 '--report-html'을 사용하도록 설정할 수 없습니다.</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">HTML 보고서 생성 사용</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pl.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Samodzielny raport testowy HTML</target>
@@ -56,6 +81,11 @@ Przykład: MyReport_{tfm}.html</target>
         <target state="translated">Generator raportów HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">Nie można włączyć opcji „--report-html” w przypadku używania polecenia „--list-tests”</target>
@@ -65,6 +95,11 @@ Przykład: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Włącz generowanie raportu HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.pt-BR.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Relatório de teste HTML autossuficiente</target>
@@ -56,6 +81,11 @@ Exemplo: MyReport_{tfm}.html</target>
         <target state="translated">Gerador de relatório HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">Não é possível habilitar "--report-html" ao usar "--list-tests"</target>
@@ -65,6 +95,11 @@ Exemplo: MyReport_{tfm}.html</target>
         <source>Enable generating an HTML report</source>
         <target state="translated">Habilitar a geração de um relatório HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.ru.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Автономный тестовый отчет в формате HTML</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">Генератор отчетов в формате HTML</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">Параметр "--report-html" нельзя включить при использовании "--list-tests"</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">Включить создание отчета в формате HTML</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.tr.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">Bağımsız HTML test raporu</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">HTML rapor oluşturucusu</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">'--list-tests' kullanılırken '--report-html' etkinleştirilemez</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">HTML raporu oluşturmayı etkinleştirin</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hans.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">独立 HTML 测试报告</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">HTML 报表生成器</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">使用 "--list-tests" 时无法启用 "--report-html"</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">启用生成 HTML 报表</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Resources/xlf/ExtensionResources.zh-Hant.xlf
@@ -2,6 +2,31 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ExtensionResources.resx">
     <body>
+      <trans-unit id="HtmlArtifactPostProcessorDescription">
+        <source>Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</source>
+        <target state="new">Merges HTML reports produced by Microsoft.Testing.Extensions.HtmlReport</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlArtifactPostProcessorDisplayName">
+        <source>HTML report merger</source>
+        <target state="new">HTML report merger</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDescription">
+        <source>{0} HTML report files merged</source>
+        <target state="new">{0} HTML report files merged</target>
+        <note>{0} is the number of merged files. Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedArtifactDisplayName">
+        <source>HTML report (merged)</source>
+        <target state="new">HTML report (merged)</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlMergedReportName">
+        <source>Merged HTML report</source>
+        <target state="new">Merged HTML report</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportArtifactDescription">
         <source>Self-contained HTML test report</source>
         <target state="translated">獨立式 HTML 測試報告</target>
@@ -56,6 +81,11 @@ Example: MyReport_{tfm}.html</source>
         <target state="translated">HTML 報告產生器</target>
         <note>Do not localize {Locked="HTML"}.</note>
       </trans-unit>
+      <trans-unit id="HtmlReportInputIsNotValid">
+        <source>The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</source>
+        <target state="new">The input is not a valid HTML report produced by Microsoft.Testing.Extensions.HtmlReport.</target>
+        <note>Do not localize format name {Locked="HTML"} or assembly name {Locked="Microsoft.Testing.Extensions.HtmlReport"}.</note>
+      </trans-unit>
       <trans-unit id="HtmlReportIsNotValidForDiscovery">
         <source>'--report-html' cannot be enabled when using '--list-tests'</source>
         <target state="translated">使用 '--list-tests' 時，無法啟用 '--report-html'</target>
@@ -65,6 +95,11 @@ Example: MyReport_{tfm}.html</source>
         <source>Enable generating an HTML report</source>
         <target state="translated">啟用產生 HTML 報告</target>
         <note>Do not localize option name {Locked="--report-html"} or format name {Locked="HTML"}.</note>
+      </trans-unit>
+      <trans-unit id="HtmlReportsRequired">
+        <source>At least one HTML report is required to merge.</source>
+        <target state="new">At least one HTML report is required to merge.</target>
+        <note>Do not localize format name {Locked="HTML"}.</note>
       </trans-unit>
       <trans-unit id="InvalidTestApplicationBuilderType">
         <source>HTML report generator only works with builders of type 'Microsoft.Testing.Platform.Builder.TestApplicationBuilder'</source>

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Templates/report-template.html
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Templates/report-template.html
@@ -762,6 +762,9 @@ footer {
           (t.displayName || "") + "\n" +
           (t.className || "") + "\n" +
           (t.methodName || "") + "\n" +
+          (t.testApplication || "") + "\n" +
+          (t.targetFramework || "") + "\n" +
+          (t.architecture || "") + "\n" +
           (t.errorMessage || "") + "\n" +
           (t.exceptionType || "");
         if (hay.toLowerCase().indexOf(q) === -1) continue;
@@ -1042,6 +1045,16 @@ footer {
         + (t.className && t.methodName ? "." : "")
         + (t.methodName || "");
       name.appendChild(qual);
+    }
+    if (t.testApplication || t.targetFramework || t.architecture) {
+      var source = document.createElement("span");
+      source.className = "qualified";
+      var sourceParts = [];
+      if (t.testApplication) sourceParts.push(t.testApplication);
+      if (t.targetFramework) sourceParts.push(t.targetFramework);
+      if (t.architecture) sourceParts.push(t.architecture);
+      source.textContent = sourceParts.join(" · ");
+      name.appendChild(source);
     }
     row.appendChild(name);
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DotnetTestPipe/DotnetTestPipeArtifactPostProcessingTests.cs
@@ -55,7 +55,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                 "ArtifactPostProcessor",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.HostType]);
             Assert.AreEqual(
-                "microsoft.testing.ctrf;microsoft.testing.trx;test.summary;test.xml",
+                "microsoft.testing.ctrf;microsoft.testing.html;microsoft.testing.trx;test.summary;test.xml",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
             Assert.AreEqual(
                 "test.summary",
@@ -118,7 +118,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
             result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
             Assert.IsNotNull(result.ReceivedHandshake);
             Assert.AreEqual(
-                "microsoft.testing.ctrf;microsoft.testing.trx;test.summary;test.xml",
+                "microsoft.testing.ctrf;microsoft.testing.html;microsoft.testing.trx;test.summary;test.xml",
                 result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
 
             RawMessage[] artifactFrames = [.. result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.FileArtifactMessages)];
@@ -135,6 +135,65 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
 
             using var merged = JsonDocument.Parse(File.ReadAllText(artifacts[0].FullPath!));
             Assert.AreEqual(2, merged.RootElement.GetProperty("results").GetProperty("tests").GetArrayLength());
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task Dispatcher_AdvertisesHtmlCapabilityAndReturnsMergedArtifact()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"artifact-dispatcher-html-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            WriteMinimalHtmlReport(firstPath, "first");
+            WriteMinimalHtmlReport(secondPath, "second");
+            string manifestPath = Path.Combine(directory, "manifest.json");
+            File.WriteAllText(
+                manifestPath,
+                JsonSerializer.Serialize(new
+                {
+                    schemaVersion = 1,
+                    outputDirectory = directory,
+                    inputs = new[]
+                    {
+                        new { path = firstPath, kind = "microsoft.testing.html", executionId = "execution-1" },
+                        new { path = secondPath, kind = "microsoft.testing.html", executionId = "execution-2" },
+                    },
+                }));
+
+            var testHost = TestInfrastructure.TestHost.LocateFrom(
+                AssetFixture.TargetAssetPath,
+                AssetName,
+                TargetFrameworks.NetCurrent);
+            FakeDotnetTestSdkResult result = await FakeDotnetTestSdk.RunAsync(
+                testHost,
+                extraArguments: $"--manifest \"{manifestPath}\"",
+                supportedProtocolVersions: "1.4.0",
+                toolName: "internal-merge-artifacts",
+                cancellationToken: TestContext.CancellationToken);
+
+            result.TestHostResult.AssertExitCodeIs(ExitCode.Success);
+            Assert.IsNotNull(result.ReceivedHandshake);
+            Assert.AreEqual(
+                "microsoft.testing.ctrf;microsoft.testing.html;microsoft.testing.trx;test.summary;test.xml",
+                result.ReceivedHandshake[DotnetTestPipeProtocol.HandshakeProperties.SupportedPostProcessorKinds]);
+
+            RawMessage artifactFrame = Assert.ContainsSingle(
+                result.MessagesWithSerializerId(DotnetTestPipeProtocol.SerializerIds.FileArtifactMessages));
+            FileArtifact artifact = Assert.ContainsSingle(DotnetTestPipeProtocol.DecodeFileArtifacts(artifactFrame.Body));
+            Assert.AreEqual("microsoft.testing.html", artifact.Kind);
+            Assert.IsNotNull(artifact.FullPath);
+            Assert.IsTrue(File.Exists(artifact.FullPath));
+            Assert.IsNotNull(artifact.InputArtifactPaths);
+            Assert.AreSequenceEqual(
+                [Path.GetFullPath(firstPath), Path.GetFullPath(secondPath)],
+                artifact.InputArtifactPaths);
         }
         finally
         {
@@ -465,6 +524,30 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
             .Save(path);
     }
 
+    private static void WriteMinimalHtmlReport(string path, string name)
+        => File.WriteAllText(
+            path,
+            $"<!DOCTYPE html><script id=\"mtp-data\" type=\"application/json\">{JsonSerializer.Serialize(new
+            {
+                schemaVersion = "1",
+                generator = "Microsoft.Testing.Extensions.HtmlReport",
+                generatorVersion = "1.0.0",
+                testApplication = $"{name}.dll",
+                machineName = "machine",
+                userName = "user",
+                framework = "MSTest",
+                frameworkUid = "MSTest",
+                frameworkVersion = "1.0.0",
+                startTime = "2026-08-09T10:00:00.0000000+00:00",
+                endTime = "2026-08-09T10:00:01.0000000+00:00",
+                exitCode = 0,
+                tests = new[]
+                {
+                    new { rowKey = 0, uid = name, displayName = name, outcome = "passed", durationMs = 1d },
+                },
+                summary = new { },
+            })}</script>");
+
     private static void WriteMinimalCtrfReport(string path, string name)
         => File.WriteAllText(
             path,
@@ -506,6 +589,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
               <ItemGroup>
                 <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
                 <PackageReference Include="Microsoft.Testing.Extensions.CtrfReport" Version="$MicrosoftTestingExtensionsCtrfReportVersion$" />
+                <PackageReference Include="Microsoft.Testing.Extensions.HtmlReport" Version="$MicrosoftTestingPlatformVersion$" />
                 <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$MicrosoftTestingPlatformVersion$" />
               </ItemGroup>
             </Project>
@@ -523,6 +607,7 @@ public sealed class DotnetTestPipeArtifactPostProcessingTests
                 {
                     ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
                     builder.AddCtrfReportProvider();
+                    builder.AddHtmlReportProvider();
                     builder.AddTrxReportProvider();
                     ((IArtifactPostProcessingApplicationBuilder)builder).ArtifactPostProcessing
                         .AddArtifactPostProcessor(_ => new SummaryArtifactPostProcessor());

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
@@ -247,6 +247,54 @@ public sealed class HtmlArtifactPostProcessorTests
     }
 
     [TestMethod]
+    public async Task ProcessAsync_WhenInputIsAlreadyMerged_OrdersAttemptsByOriginalSourceStartTime()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string thirdPath = Path.Combine(directory, "third.html");
+            File.WriteAllText(firstPath, CreateReport("tests.dll", "MSTest", Epoch.AddMinutes(1), Epoch.AddMinutes(2), Test("same", "attempt 1", "failed", 1)));
+            File.WriteAllText(thirdPath, CreateReport("tests.dll", "MSTest", Epoch.AddMinutes(3), Epoch.AddMinutes(4), Test("same", "attempt 3", "passed", 1)));
+
+            HtmlArtifactPostProcessor processor = new();
+            ProcessedArtifact? firstMerge = await processor.ProcessAsync(
+                [
+                    CreateInput(firstPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-1"),
+                    CreateInput(thirdPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-3"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+            Assert.IsNotNull(firstMerge);
+
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(secondPath, CreateReport("tests.dll", "MSTest", Epoch.AddMinutes(2), Epoch.AddMinutes(3), Test("same", "attempt 2", "failed", 1)));
+            ProcessedArtifact? secondMerge = await processor.ProcessAsync(
+                [
+                    CreateInput(firstMerge.Path),
+                    CreateInput(secondPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-2"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(secondMerge);
+            var tests = (JsonArray)ParseReport(File.ReadAllText(secondMerge.Path))["tests"]!;
+            Assert.AreEqual("attempt 1", (string?)tests[0]!["displayName"]);
+            Assert.AreEqual(1, (int?)tests[0]!["attemptIndex"]);
+            Assert.AreEqual("attempt 2", (string?)tests[1]!["displayName"]);
+            Assert.AreEqual(2, (int?)tests[1]!["attemptIndex"]);
+            Assert.AreEqual("attempt 3", (string?)tests[2]!["displayName"]);
+            Assert.AreEqual(3, (int?)tests[2]!["attemptIndex"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public async Task ProcessAsync_WhenModuleMetadataIsMissing_UsesEmbeddedApplicationForProvenanceAndAttemptIdentity()
     {
         string directory = CreateTemporaryDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
@@ -1,0 +1,364 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+using Microsoft.Testing.Extensions.HtmlReport;
+using Microsoft.Testing.Extensions.HtmlReport.Resources;
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+#pragma warning disable TPEXP // Artifact post-processing is experimental.
+
+[TestClass]
+public sealed class HtmlArtifactPostProcessorTests
+{
+    private static readonly DateTimeOffset Epoch = new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void Capabilities_DescribeHtmlArtifacts()
+    {
+        HtmlArtifactPostProcessor processor = new();
+
+        Assert.AreSequenceEqual(new[] { HtmlReportGenerator.HtmlArtifactKind }, processor.SupportedKinds);
+        Assert.IsEmpty(processor.SupportedFileExtensionsFallback);
+        Assert.IsFalse(processor.SupportsTruncatedRuns);
+    }
+
+    [TestMethod]
+    public async Task AddHtmlReportProvider_RegistersArtifactPostProcessor()
+    {
+        var builder = new TestApplicationBuilder(
+            new ApplicationLoggingState(LogLevel.None, new CommandLineParseResult(null, [], [])),
+            DateTimeOffset.UtcNow,
+            new TestApplicationOptions(),
+            new Mock<IUnhandledExceptionsHandler>().Object,
+            []);
+
+        builder.AddHtmlReportProvider();
+        IReadOnlyList<IArtifactPostProcessor> processors =
+            await ((ArtifactPostProcessingManager)builder.ArtifactPostProcessing).BuildAsync(new ServiceProvider());
+
+        Assert.HasCount(1, processors);
+        Assert.IsInstanceOfType<HtmlArtifactPostProcessor>(processors[0]);
+    }
+
+    [TestMethod]
+    public void AddHtmlReportProvider_RequiresArtifactPostProcessingBuilder()
+    {
+        ITestApplicationBuilder builder = new Mock<ITestApplicationBuilder>().Object;
+
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => builder.AddHtmlReportProvider());
+
+        Assert.AreEqual(ExtensionResources.InvalidTestApplicationBuilderType, exception.Message);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithFewerThanTwoInputs_ReturnsNull()
+    {
+        HtmlArtifactPostProcessor processor = new();
+        InputArtifact input = CreateInput("input.html");
+
+        Assert.IsNull(await processor.ProcessAsync(
+            [input],
+            Path.GetTempPath(),
+            new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+            CancellationToken.None));
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithTwoInputs_WritesMergedReport()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(
+                firstPath,
+                CreateReport(
+                    "first.dll",
+                    "MSTest",
+                    new DateTimeOffset(2026, 8, 9, 10, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 8, 9, 10, 1, 0, TimeSpan.Zero),
+                    Test("duplicate", "Failed <script>", "failed", 10)));
+            File.WriteAllText(
+                secondPath,
+                CreateReport(
+                    "second.dll",
+                    "Other",
+                    new DateTimeOffset(2026, 8, 9, 9, 0, 0, TimeSpan.Zero),
+                    new DateTimeOffset(2026, 8, 9, 11, 0, 0, TimeSpan.Zero),
+                    Test("duplicate", "Passed </script><img src=x>", "passed", 20)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [
+                    CreateInput(firstPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-1"),
+                    CreateInput(secondPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-2"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            Assert.AreEqual(HtmlReportGenerator.HtmlArtifactKind, output.Kind);
+            Assert.AreEqual(ExtensionResources.HtmlMergedArtifactDisplayName, output.DisplayName);
+            Assert.AreEqual(
+                string.Format(CultureInfo.CurrentCulture, ExtensionResources.HtmlMergedArtifactDescription, 2),
+                output.Description);
+            Assert.MatchesRegex(new Regex("^merged-[0-9a-f]{32}\\.html$", RegexOptions.CultureInvariant), Path.GetFileName(output.Path));
+            Assert.AreEqual("merged", Path.GetFileName(Path.GetDirectoryName(output.Path)));
+
+            string mergedHtml = File.ReadAllText(output.Path);
+            Assert.DoesNotContain("</script><img", mergedHtml);
+            JsonObject merged = ParseReport(mergedHtml);
+            Assert.AreEqual(ExtensionResources.HtmlMergedReportName, (string?)merged["testApplication"]);
+            Assert.AreEqual(string.Empty, (string?)merged["framework"]);
+            Assert.AreEqual("machine", (string?)merged["machineName"]);
+            Assert.AreEqual("2026-08-09T09:00:00.0000000+00:00", (string?)merged["startTime"]);
+            Assert.AreEqual("2026-08-09T11:00:00.0000000+00:00", (string?)merged["endTime"]);
+
+            var tests = (JsonArray)merged["tests"]!;
+            Assert.HasCount(2, tests);
+            Assert.AreEqual(0, (int?)tests[0]!["rowKey"]);
+            Assert.AreEqual(1, (int?)tests[1]!["rowKey"]);
+            Assert.AreEqual(1, (int?)tests[0]!["attemptIndex"]);
+            Assert.AreEqual(2, (int?)tests[1]!["attemptIndex"]);
+            Assert.AreEqual(2, (int?)tests[0]!["attemptOf"]);
+            Assert.AreEqual(2, (int?)tests[1]!["attemptOf"]);
+            Assert.AreEqual("tests.dll", (string?)tests[0]!["testApplication"]);
+            Assert.AreEqual("net8.0", (string?)tests[0]!["targetFramework"]);
+            Assert.AreEqual("x64", (string?)tests[0]!["architecture"]);
+            Assert.AreEqual("execution-1", (string?)tests[0]!["executionId"]);
+            Assert.AreEqual("Passed </script><img src=x>", (string?)tests[1]!["displayName"]);
+
+            var summary = (JsonObject)merged["summary"]!;
+            Assert.AreEqual(2, (int?)summary["total"]);
+            Assert.AreEqual(1, (int?)summary["passed"]);
+            Assert.AreEqual(1, (int?)summary["failed"]);
+            Assert.AreEqual(30d, (double?)summary["totalDurationMs"]);
+            Assert.AreSequenceEqual(
+                new[] { "first.html", "second.html" },
+                Directory.GetFiles(directory, "*.html").Select(Path.GetFileName).OrderBy(name => name, StringComparer.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenModuleMetadataIsMissing_UsesEmbeddedApplicationForProvenanceAndAttemptIdentity()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            string thirdPath = Path.Combine(directory, "third.html");
+            File.WriteAllText(firstPath, CreateReport("same.dll", "MSTest", Epoch, Epoch, Test("same", "first", "failed", 1)));
+            File.WriteAllText(secondPath, CreateReport("same.dll", "MSTest", Epoch, Epoch, Test("same", "second", "passed", 2)));
+            File.WriteAllText(thirdPath, CreateReport("other.dll", "MSTest", Epoch, Epoch, Test("same", "third", "passed", 3)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath), CreateInput(thirdPath)],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            var tests = (JsonArray)ParseReport(File.ReadAllText(output.Path))["tests"]!;
+            Assert.AreEqual("same.dll", (string?)tests[0]!["testApplication"]);
+            Assert.AreEqual("same.dll", (string?)tests[1]!["testApplication"]);
+            Assert.AreEqual("other.dll", (string?)tests[2]!["testApplication"]);
+            Assert.AreEqual(2, (int?)tests[0]!["attemptOf"]);
+            Assert.AreEqual(2, (int?)tests[1]!["attemptOf"]);
+            Assert.IsNull(tests[2]!["attemptIndex"]);
+            Assert.IsNull(tests[2]!["attemptOf"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_SameUidFromDifferentTargetFrameworks_DoesNotLabelRowsAsAttempts()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("tests.dll", "MSTest", Epoch, Epoch, Test("same", "net8", "passed", 1)));
+            File.WriteAllText(secondPath, CreateReport("tests.dll", "MSTest", Epoch, Epoch, Test("same", "net9", "failed", 2)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [
+                    CreateInput(firstPath, module: "tests.dll", targetFramework: "net8.0", architecture: "x64"),
+                    CreateInput(secondPath, module: "tests.dll", targetFramework: "net9.0", architecture: "x64"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            var tests = (JsonArray)ParseReport(File.ReadAllText(output.Path))["tests"]!;
+            Assert.IsNull(tests[0]!["attemptIndex"]);
+            Assert.IsNull(tests[0]!["attemptOf"]);
+            Assert.IsNull(tests[1]!["attemptIndex"]);
+            Assert.IsNull(tests[1]!["attemptOf"]);
+            Assert.AreEqual("net8.0", (string?)tests[0]!["targetFramework"]);
+            Assert.AreEqual("net9.0", (string?)tests[1]!["targetFramework"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WithReorderedInputs_ProducesIdenticalOutput()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("same.dll", "MSTest", Epoch, Epoch, Test("a", "A", "passed", 1)));
+            File.WriteAllText(secondPath, CreateReport("same.dll", "MSTest", Epoch, Epoch, Test("b", "B", "failed", 2)));
+            HtmlArtifactPostProcessor processor = new();
+            InputArtifact first = CreateInput(firstPath, executionId: "execution-1");
+            InputArtifact second = CreateInput(secondPath, executionId: "execution-2");
+
+            ProcessedArtifact? output = await processor.ProcessAsync(
+                [first, second],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+            Assert.IsNotNull(output);
+            byte[] firstMerge = File.ReadAllBytes(output.Path);
+
+            ProcessedArtifact? retriedOutput = await processor.ProcessAsync(
+                [second, first],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(retriedOutput);
+            Assert.AreEqual(output.Path, retriedOutput.Path);
+            Assert.AreSequenceEqual(firstMerge, File.ReadAllBytes(retriedOutput.Path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenAnInputIsNotAnHtmlReport_Throws()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("same.dll", "MSTest", Epoch, Epoch, Test("a", "A", "passed", 1)));
+            File.WriteAllText(secondPath, "<html>not a report</html>");
+
+            await Assert.ThrowsExactlyAsync<ArgumentException>(
+                () => new HtmlArtifactPostProcessor().ProcessAsync(
+                    [CreateInput(firstPath), CreateInput(secondPath)],
+                    directory,
+                    new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                    CancellationToken.None));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void CreateMergeId_IncludesExecutionProvenance()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "report.html");
+        InputArtifact first = CreateInput(path, module: "module.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-1");
+        InputArtifact second = CreateInput(path, module: "module.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-2");
+
+        Assert.AreNotEqual(
+            HtmlArtifactPostProcessor.CreateMergeId([first]),
+            HtmlArtifactPostProcessor.CreateMergeId([second]));
+    }
+
+    private static JsonObject Test(string uid, string displayName, string outcome, double durationMs)
+        => new()
+        {
+            ["rowKey"] = 0,
+            ["uid"] = uid,
+            ["displayName"] = displayName,
+            ["outcome"] = outcome,
+            ["durationMs"] = durationMs,
+        };
+
+    private static string CreateReport(
+        string testApplication,
+        string framework,
+        DateTimeOffset startTime,
+        DateTimeOffset endTime,
+        params JsonObject[] tests)
+    {
+        var testArray = new JsonArray();
+        foreach (JsonObject test in tests)
+        {
+            testArray.Add(test);
+        }
+
+        var report = new JsonObject
+        {
+            ["schemaVersion"] = "1",
+            ["generator"] = "Microsoft.Testing.Extensions.HtmlReport",
+            ["generatorVersion"] = "1.0.0",
+            ["testApplication"] = testApplication,
+            ["machineName"] = "machine",
+            ["userName"] = "user",
+            ["framework"] = framework,
+            ["frameworkUid"] = framework,
+            ["frameworkVersion"] = "1.0.0",
+            ["startTime"] = startTime.ToString("O", CultureInfo.InvariantCulture),
+            ["endTime"] = endTime.ToString("O", CultureInfo.InvariantCulture),
+            ["exitCode"] = 0,
+            ["tests"] = testArray,
+            ["summary"] = new JsonObject(),
+        };
+
+        return $"<!DOCTYPE html><script id=\"mtp-data\" type=\"application/json\">{report.ToJsonString()}</script>";
+    }
+
+    private static JsonObject ParseReport(string html)
+        => (JsonObject)JsonNode.Parse(HtmlReportEngine.ExtractReportJson(html))!;
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"html-post-processor-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static InputArtifact CreateInput(
+        string path,
+        string? module = null,
+        string? targetFramework = null,
+        string? architecture = null,
+        string? executionId = null)
+        => new(path, HtmlReportGenerator.HtmlArtifactKind, module, targetFramework, architecture, executionId);
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
@@ -197,6 +197,56 @@ public sealed class HtmlArtifactPostProcessorTests
     }
 
     [TestMethod]
+    public async Task ProcessAsync_WhenInputIsAlreadyMerged_PreservesEmbeddedRowProvenance()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(directory, "first.html");
+            string secondPath = Path.Combine(directory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("first.dll", "MSTest", Epoch, Epoch, Test("first", "first", "passed", 1)));
+            File.WriteAllText(secondPath, CreateReport("second.dll", "MSTest", Epoch, Epoch, Test("second", "second", "passed", 1)));
+
+            HtmlArtifactPostProcessor processor = new();
+            ProcessedArtifact? firstMerge = await processor.ProcessAsync(
+                [
+                    CreateInput(firstPath, module: "first.dll", targetFramework: "net8.0", architecture: "x64", executionId: "execution-1"),
+                    CreateInput(secondPath, module: "second.dll", targetFramework: "net9.0", architecture: "arm64", executionId: "execution-2"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+            Assert.IsNotNull(firstMerge);
+
+            string thirdPath = Path.Combine(directory, "third.html");
+            File.WriteAllText(thirdPath, CreateReport("third.dll", "MSTest", Epoch, Epoch, Test("third", "third", "passed", 1)));
+            ProcessedArtifact? secondMerge = await processor.ProcessAsync(
+                [
+                    CreateInput(firstMerge.Path, module: "outer.dll", targetFramework: "net10.0", architecture: "x86", executionId: "outer-execution"),
+                    CreateInput(thirdPath, module: "third.dll", targetFramework: "net10.0", architecture: "x64", executionId: "execution-3"),
+                ],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(secondMerge);
+            var tests = (JsonArray)ParseReport(File.ReadAllText(secondMerge.Path))["tests"]!;
+            Assert.AreEqual("first.dll", (string?)tests[0]!["testApplication"]);
+            Assert.AreEqual("net8.0", (string?)tests[0]!["targetFramework"]);
+            Assert.AreEqual("x64", (string?)tests[0]!["architecture"]);
+            Assert.AreEqual("execution-1", (string?)tests[0]!["executionId"]);
+            Assert.AreEqual("second.dll", (string?)tests[1]!["testApplication"]);
+            Assert.AreEqual("net9.0", (string?)tests[1]!["targetFramework"]);
+            Assert.AreEqual("arm64", (string?)tests[1]!["architecture"]);
+            Assert.AreEqual("execution-2", (string?)tests[1]!["executionId"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public async Task ProcessAsync_WhenModuleMetadataIsMissing_UsesEmbeddedApplicationForProvenanceAndAttemptIdentity()
     {
         string directory = CreateTemporaryDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
@@ -138,8 +138,10 @@ public sealed class HtmlArtifactPostProcessorTests
             Assert.AreEqual("tests.dll", (string?)tests[0]!["testApplication"]);
             Assert.AreEqual("net8.0", (string?)tests[0]!["targetFramework"]);
             Assert.AreEqual("x64", (string?)tests[0]!["architecture"]);
-            Assert.AreEqual("execution-1", (string?)tests[0]!["executionId"]);
-            Assert.AreEqual("Passed </script><img src=x>", (string?)tests[1]!["displayName"]);
+            Assert.AreEqual("execution-2", (string?)tests[0]!["executionId"]);
+            Assert.AreEqual("Passed </script><img src=x>", (string?)tests[0]!["displayName"]);
+            Assert.AreEqual("execution-1", (string?)tests[1]!["executionId"]);
+            Assert.AreEqual("Failed <script>", (string?)tests[1]!["displayName"]);
 
             var summary = (JsonObject)merged["summary"]!;
             Assert.AreEqual(2, (int?)summary["total"]);
@@ -149,6 +151,44 @@ public sealed class HtmlArtifactPostProcessorTests
             Assert.AreSequenceEqual(
                 new[] { "first.html", "second.html" },
                 Directory.GetFiles(directory, "*.html").Select(Path.GetFileName).OrderBy(name => name, StringComparer.Ordinal));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_OrdersAttemptsByEmbeddedStartTime()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string attempt10Directory = Path.Combine(directory, "10");
+            string attempt2Directory = Path.Combine(directory, "2");
+            Directory.CreateDirectory(attempt10Directory);
+            Directory.CreateDirectory(attempt2Directory);
+            string attempt10Path = Path.Combine(attempt10Directory, "report.html");
+            string attempt2Path = Path.Combine(attempt2Directory, "report.html");
+            File.WriteAllText(
+                attempt10Path,
+                CreateReport("tests.dll", "MSTest", Epoch.AddMinutes(10), Epoch.AddMinutes(11), Test("same", "attempt 10", "passed", 1)));
+            File.WriteAllText(
+                attempt2Path,
+                CreateReport("tests.dll", "MSTest", Epoch.AddMinutes(2), Epoch.AddMinutes(3), Test("same", "attempt 2", "failed", 1)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [CreateInput(attempt10Path), CreateInput(attempt2Path)],
+                directory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNotNull(output);
+            var tests = (JsonArray)ParseReport(File.ReadAllText(output.Path))["tests"]!;
+            Assert.AreEqual("attempt 2", (string?)tests[0]!["displayName"]);
+            Assert.AreEqual(1, (int?)tests[0]!["attemptIndex"]);
+            Assert.AreEqual("attempt 10", (string?)tests[1]!["displayName"]);
+            Assert.AreEqual(2, (int?)tests[1]!["attemptIndex"]);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- add an `IArtifactPostProcessor` for HTML reports
- merge embedded report data deterministically while preserving module, target-framework, architecture, and execution provenance
- keep retry annotations scoped to the same module/TFM/architecture and retain original per-host artifacts
- add localized metadata, package documentation, and focused merger/registration coverage

## Validation
- affected extension unit-test project builds across all configured target frameworks
- 59 HTML report unit tests pass on `net8.0`
- three code-review rounds completed and all findings addressed

Fixes #10514