### PR TITLE
Test File.CreateSymbolicLink target path handling

### DIFF
--- a/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/SharedFileSystemPathInTestAnalyzerTests.cs
@@ -508,6 +508,32 @@ public sealed class SharedFileSystemPathInTestAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenTestMethodCreatesFileSymbolicLinkToConstantTarget_NoDiagnostic()
+    {
+        // Only 'path' is created by File.CreateSymbolicLink; 'pathToTarget' merely names the file the link points at,
+        // so a constant target - like a shared fixture file - must not be flagged.
+        string code = """
+            using System.IO;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void MyTestMethod()
+                {
+                    string link = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                    File.CreateSymbolicLink(link, "shared-fixture.txt");
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(code);
+    }
+
+    [TestMethod]
     [DataRow("AppendAllTextAsync", "\"shared.txt\", \"entry\"")]
     [DataRow("AppendAllLinesAsync", "\"shared.txt\", new[] { \"line\" }")]
     [DataRow("WriteAllBytesAsync", "\"shared.txt\", new byte[] { 1 }")]


### PR DESCRIPTION
## Summary

- add regression coverage for `File.CreateSymbolicLink` with a constant target path
- verify MSTEST0077 treats only the created link path as mutated

## Validation

- `.\build.cmd -test -projects "test\UnitTests\MSTest.Analyzers.UnitTests\MSTest.Analyzers.UnitTests.csproj" -binaryLog`

Closes #10533
