### PR TITLE
Enable Stryker.NET mutation testing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "dotnet-coverage"
       ],
       "rollForward": false
+    },
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,44 @@
+name: Mutation testing
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-testing
+  cancel-in-progress: false
+
+jobs:
+  stryker:
+    name: Run Stryker.NET
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build repository
+        run: ./build.sh --binaryLog
+
+      - name: Restore local tools
+        run: ./.dotnet/dotnet tool restore
+
+      - name: Run mutation tests
+        working-directory: test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests
+        env:
+          MutationTesting: true
+        run: |
+          "$GITHUB_WORKSPACE/.dotnet/dotnet" stryker --output "$GITHUB_WORKSPACE/artifacts/mutation-testing" --skip-version-check
+
+      - name: Upload mutation report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-testing-report
+          path: artifacts/mutation-testing/
+          if-no-files-found: error
+          retention-days: 30

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -137,6 +137,7 @@
   <!-- Sign config -->
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <StrongNameKeyId Condition="'$(MutationTesting)' == 'true' and ('$(MSBuildProjectName)' == 'Microsoft.Testing.Platform.ServerMode.Client.Sources' or '$(MSBuildProjectName)' == 'Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests')">Open</StrongNameKeyId>
   </PropertyGroup>
 
   <!-- Test config -->

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -191,6 +191,31 @@ For Linux and macOS:
 
 Note that `-test` allows to run the unit tests and `-integrationTest` allows to run the two kinds of integration tests. Acceptance integration tests require the NuGet packages to have been produced hence the `-pack` flag.
 
+### Mutation testing
+
+The repository uses [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) to mutation-test the server-mode client sources. Restore the pinned local tool and run it from the configured unit-test project:
+
+On Windows PowerShell:
+
+```powershell
+dotnet tool restore
+Set-Location test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests
+$env:MutationTesting = "true"
+dotnet stryker --output ../../../artifacts/mutation-testing
+```
+
+On Linux and macOS:
+
+```shell
+dotnet tool restore
+cd test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests
+MutationTesting=true dotnet stryker --output ../../../artifacts/mutation-testing
+```
+
+The opt-in property selects Arcade's open strong-name key for the mutated assembly because Stryker's in-memory compiler cannot complete Microsoft delay signing.
+
+The HTML and JSON reports are written to `artifacts/mutation-testing`. The [mutation testing workflow](../.github/workflows/mutation-testing.yml) also runs weekly and can be started manually.
+
 ## Working with Visual Studio
 
 If you are working with Visual Studio, we recommend opening it through the `open-vs.cmd` script at the repo root. This script will set all the required environment variables required so that Visual Studio picks up the locally downloaded version of the .NET SDK. If you prefer to use your machine-wide configuration, you can open Visual Studio directly.

--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj
@@ -193,7 +193,8 @@
 
   <!-- The client types are internal (they compile into each consumer). Grant the unit tests access. -->
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests" Key="$(VsPublicKey)" Condition="'$(MutationTesting)' != 'true'" />
+    <InternalsVisibleTo Include="Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests" Key="$(OpenPublicKey)" Condition="'$(MutationTesting)' == 'true'" />
     <!-- The MSTest acceptance project drives the client against a real packed MTP app (P4). It references
          this project via a non-global `serverclient` extern alias to avoid TestNode name clashes. -->
     <InternalsVisibleTo Include="MSTest.Acceptance.IntegrationTests" Key="$(VsPublicKey)" />

--- a/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/stryker-config.json
+++ b/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/stryker-config.json
@@ -1,0 +1,22 @@
+{
+  "stryker-config": {
+    "project": "Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj",
+    "target-framework": "net8.0",
+    "test-runner": "mtp",
+    "mutation-level": "Standard",
+    "mutate": [
+      "Client/**/*.cs"
+    ],
+    "reporters": [
+      "html",
+      "json",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "break-on-initial-test-failure": true
+  }
+}


### PR DESCRIPTION
## Summary

- pin Stryker.NET 4.16.0 in the repository-local tool manifest
- configure mutation testing for the server-mode client sources using the MTP runner
- add an opt-in open strong-name path for Stryker's in-memory compilation
- run mutation testing weekly or manually and publish HTML/JSON reports
- document local Windows, Linux, and macOS usage

## Validation

- completed a Stryker run across 27 tests: 2,860 mutants discovered, 133 executed, and reports generated
- confirmed the normal signed `net8.0` unit-test build remains successful
- passed the repository action-pin audit and parsed the workflow/config files