### PR TITLE
Reduce MTP command-line validation allocations

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.RegistrationValidation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.RegistrationValidation.cs
@@ -108,11 +108,6 @@ internal static partial class CommandLineOptionsValidator
 
                 if (registration.DuplicateProviders is null)
                 {
-                    if (EqualityComparer<ICommandLineOptionsProvider>.Default.Equals(registration.FirstProvider, provider))
-                    {
-                        continue;
-                    }
-
                     registration.DuplicateProviders = [registration.FirstProvider];
                 }
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.RegistrationValidation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.RegistrationValidation.cs
@@ -89,38 +89,47 @@ internal static partial class CommandLineOptionsValidator
         Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> extensionOptionsByProvider,
         Dictionary<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> systemOptionsByProvider)
     {
-        // Use a dictionary to track option names and their distinct providers. OrdinalIgnoreCase
-        // ensures we catch case-differing duplicates (e.g. "Timeout" vs "timeout") with a friendly
-        // error rather than a later ArgumentException when building the lookup dictionary.
-        // We cover both extension and system providers so that any pair of case-differing
-        // duplicates — extension/extension, extension/system, or system/system — surfaces as a
-        // ValidationResult.Invalid rather than crashing the platform.
-        var optionNameToProviders = new Dictionary<string, HashSet<ICommandLineOptionsProvider>>(StringComparer.OrdinalIgnoreCase);
+        // Most options are unique, so retain only their first provider. Allocate a HashSet only
+        // after finding a provider collision, while preserving the registration order used by
+        // diagnostics. OrdinalIgnoreCase ensures we catch case-differing duplicates (e.g.
+        // "Timeout" vs "timeout") with a friendly error rather than a later ArgumentException.
+        var optionNameToProviders = new Dictionary<string, (ICommandLineOptionsProvider FirstProvider, HashSet<ICommandLineOptionsProvider>? DuplicateProviders)>(StringComparer.OrdinalIgnoreCase);
         foreach (KeyValuePair<ICommandLineOptionsProvider, IReadOnlyCollection<CommandLineOption>> kvp in extensionOptionsByProvider.Concat(systemOptionsByProvider))
         {
             ICommandLineOptionsProvider provider = kvp.Key;
             foreach (CommandLineOption option in kvp.Value)
             {
                 string name = option.Name;
-                if (!optionNameToProviders.TryGetValue(name, out HashSet<ICommandLineOptionsProvider>? providers))
+                if (!optionNameToProviders.TryGetValue(name, out (ICommandLineOptionsProvider FirstProvider, HashSet<ICommandLineOptionsProvider>? DuplicateProviders) registration))
                 {
-                    providers = [];
-                    optionNameToProviders[name] = providers;
+                    optionNameToProviders.Add(name, (provider, null));
+                    continue;
                 }
 
-                providers.Add(provider);
+                if (registration.DuplicateProviders is null)
+                {
+                    if (EqualityComparer<ICommandLineOptionsProvider>.Default.Equals(registration.FirstProvider, provider))
+                    {
+                        continue;
+                    }
+
+                    registration.DuplicateProviders = [registration.FirstProvider];
+                }
+
+                registration.DuplicateProviders.Add(provider);
+                optionNameToProviders[name] = registration;
             }
         }
 
         // Check for duplications
         StringBuilder? stringBuilder = null;
-        foreach (KeyValuePair<string, HashSet<ICommandLineOptionsProvider>> kvp in optionNameToProviders)
+        foreach (KeyValuePair<string, (ICommandLineOptionsProvider FirstProvider, HashSet<ICommandLineOptionsProvider>? DuplicateProviders)> kvp in optionNameToProviders)
         {
-            if (kvp.Value.Count > 1)
+            if (kvp.Value.DuplicateProviders is { Count: > 1 } providers)
             {
                 string duplicatedOption = kvp.Key;
                 stringBuilder ??= new();
-                IEnumerable<string> faultyProvidersDisplayNames = kvp.Value.Select(p => p.DisplayName);
+                IEnumerable<string> faultyProvidersDisplayNames = providers.Select(p => p.DisplayName);
                 stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineOptionIsDeclaredByMultipleProviders, duplicatedOption, string.Join("', '", faultyProvidersDisplayNames)));
             }
         }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -586,7 +586,8 @@ public sealed class CommandLineHandlerTests
         ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
         [
             new ExtensionCommandLineProviderMockWithNamedOption("userOption", "ProviderOne"),
-            new ExtensionCommandLineProviderMockWithNamedOption("userOption", "ProviderTwo")
+            new ExtensionCommandLineProviderMockWithNamedOption("userOption", "ProviderTwo"),
+            new ExtensionCommandLineProviderMockWithNamedOption("userOption", "ProviderThree")
         ];
 
         // Act
@@ -595,7 +596,7 @@ public sealed class CommandLineHandlerTests
 
         // Assert
         Assert.IsFalse(result.IsValid);
-        Assert.Contains("Option '--userOption' is declared by multiple providers: 'ProviderOne', 'ProviderTwo'", result.ErrorMessage);
+        Assert.Contains("Option '--userOption' is declared by multiple providers: 'ProviderOne', 'ProviderTwo', 'ProviderThree'", result.ErrorMessage);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

- defer duplicate-provider `HashSet` allocation until an option name is actually repeated
- preserve case-insensitive duplicate detection, provider ordering, and existing diagnostics
- strengthen coverage to verify diagnostics retain all providers across multiple collisions

## Performance

A controlled in-process benchmark ran command-line validation 1,000 times with 100 unique options:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Allocated bytes per validation | 50,872 B | 36,072 B | -14,800 B (-29.1%) |

Repeated zero-match process startup remained neutral within Windows launch noise: mean 928.23 ms to 927.27 ms and median 888.02 ms to 875.36 ms over 30 warm runs.

## Validation

- built `Microsoft.Testing.Platform.UnitTests.csproj` for all target frameworks (`netstandard2.0`, `net8.0`, `net9.0`, `net462`)
- passed all 2,198 `Microsoft.Testing.Platform.UnitTests` on `net8.0`
- completed three review rounds, including MTP-specific, independent correctness, and adversarial behavioral-equivalence passes