### PR TITLE
Defer AppInsights initialization until first telemetry payload

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
@@ -130,23 +130,11 @@ internal sealed partial class AppInsightsProvider :
         _logger = loggerFactory.CreateLogger<AppInsightsProvider>();
     }
 
-    // Initialize the telemetry client and start ingesting events.
+    // Start ingesting events, initializing the telemetry client only when there is data to send.
     private async Task IngestLoopAsync()
     {
         if (_testApplicationCancellationTokenSource.CancellationToken.IsCancellationRequested)
         {
-            return;
-        }
-
-        try
-        {
-            _client = _telemetryClientFactory.Create(_currentSessionId, _environment.OsVersion);
-        }
-        catch (Exception e)
-        {
-            _client = null;
-
-            await _logger.LogErrorAsync("Failed to initialize telemetry client", e).ConfigureAwait(false);
             return;
         }
 
@@ -157,12 +145,27 @@ internal sealed partial class AppInsightsProvider :
         {
 #if NETCOREAPP
             while (await _payloads.Reader.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
+#else
+            while (await _payloads.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
+#endif
             {
+                if (_client is null)
+                {
+                    try
+                    {
+                        _client = _telemetryClientFactory.Create(_currentSessionId, _environment.OsVersion);
+                    }
+                    catch (Exception e)
+                    {
+                        await _logger.LogErrorAsync("Failed to initialize telemetry client", e).ConfigureAwait(false);
+                        return;
+                    }
+                }
+
+#if NETCOREAPP
                 {
                     (string eventName, IDictionary<string, object> paramsMap) = await _payloads.Reader.ReadAsync().ConfigureAwait(false);
 #else
-            while (await _payloads.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
-            {
                 while (_payloads.TryRead(out (string EventName, IDictionary<string, object> ParamsMap) payload))
                 {
                     if (_flushTimeoutOrStop.Token.IsCancellationRequested)

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
@@ -69,15 +69,18 @@ public sealed class AppInsightsProviderTests
     public async Task ClientInitializationFailure_IsLogged()
     {
         InvalidOperationException exception = new("Initialization failed");
+        using ManualResetEventSlim initializationFailureLogged = new(initialState: false);
         Mock<ITelemetryClientFactory> telemetryClientFactory = new();
         telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Throws(exception);
         Mock<ILogger> logger = new();
         logger
             .Setup(x => x.LogAsync(LogLevel.Error, It.IsAny<string>(), It.IsAny<Exception>(), LoggingExtensions.Formatter))
+            .Callback((LogLevel _, string _, Exception? _, Func<string, Exception?, string> _) => initializationFailureLogged.Set())
             .Returns(Task.CompletedTask);
 
         AppInsightsProvider appInsightsProvider = CreateProvider(telemetryClientFactory, logger.Object);
         await appInsightsProvider.LogEventAsync("Sample", new Dictionary<string, object>(), CancellationToken.None);
+        Assert.IsTrue(initializationFailureLogged.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken), "Telemetry client initialization failure was not logged within the timeout.");
 
 #if NETCOREAPP
         await appInsightsProvider.DisposeAsync();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
@@ -18,6 +18,113 @@ public sealed class AppInsightsProviderTests
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
+    public async Task DisposeWithoutPayload_DoesNotInitializeTelemetryClient()
+    {
+        Mock<ITelemetryClient> telemetryClient = new();
+        Mock<ITelemetryClientFactory> telemetryClientFactory = new();
+        telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Returns(telemetryClient.Object);
+
+        AppInsightsProvider appInsightsProvider = CreateProvider(telemetryClientFactory);
+
+#if NETCOREAPP
+        await appInsightsProvider.DisposeAsync();
+#else
+        appInsightsProvider.Dispose();
+#endif
+
+        telemetryClientFactory.Verify(x => x.Create(It.IsAny<string?>(), It.IsAny<string>()), Times.Never);
+        telemetryClient.Verify(x => x.Flush(), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task FirstPayload_InitializesTelemetryClientOnce()
+    {
+        using ManualResetEventSlim eventTracked = new(initialState: false);
+        Mock<ITelemetryClient> telemetryClient = new();
+        telemetryClient
+            .Setup(x => x.TrackEvent(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, double>>()))
+            .Callback((string _, Dictionary<string, string> _, Dictionary<string, double> _) => eventTracked.Set());
+        Mock<ITelemetryClientFactory> telemetryClientFactory = new();
+        telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Returns(telemetryClient.Object);
+
+        AppInsightsProvider appInsightsProvider = CreateProvider(telemetryClientFactory);
+        telemetryClientFactory.Verify(x => x.Create(It.IsAny<string?>(), It.IsAny<string>()), Times.Never);
+
+        await appInsightsProvider.LogEventAsync("Sample", new Dictionary<string, object>(), CancellationToken.None);
+        Assert.IsTrue(eventTracked.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken), "Telemetry consumer did not invoke TrackEvent within the timeout.");
+
+#if NETCOREAPP
+        await appInsightsProvider.DisposeAsync();
+#else
+        appInsightsProvider.Dispose();
+#endif
+
+        telemetryClientFactory.Verify(x => x.Create("sessionId", "osVersion"), Times.Once);
+        telemetryClient.Verify(
+            x => x.TrackEvent("Sample", It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, double>>()),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ClientInitializationFailure_IsLogged()
+    {
+        InvalidOperationException exception = new("Initialization failed");
+        Mock<ITelemetryClientFactory> telemetryClientFactory = new();
+        telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Throws(exception);
+        Mock<ILogger> logger = new();
+        logger
+            .Setup(x => x.LogAsync(LogLevel.Error, It.IsAny<string>(), It.IsAny<Exception>(), LoggingExtensions.Formatter))
+            .Returns(Task.CompletedTask);
+
+        AppInsightsProvider appInsightsProvider = CreateProvider(telemetryClientFactory, logger.Object);
+        await appInsightsProvider.LogEventAsync("Sample", new Dictionary<string, object>(), CancellationToken.None);
+
+#if NETCOREAPP
+        await appInsightsProvider.DisposeAsync();
+#else
+        appInsightsProvider.Dispose();
+#endif
+
+        telemetryClientFactory.Verify(x => x.Create("sessionId", "osVersion"), Times.Once);
+        logger.Verify(
+            x => x.LogAsync(LogLevel.Error, "Failed to initialize telemetry client", exception, LoggingExtensions.Formatter),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task FlushFailure_IsLogged()
+    {
+        InvalidOperationException exception = new("Flush failed");
+        using ManualResetEventSlim eventTracked = new(initialState: false);
+        Mock<ITelemetryClient> telemetryClient = new();
+        telemetryClient
+            .Setup(x => x.TrackEvent(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<Dictionary<string, double>>()))
+            .Callback((string _, Dictionary<string, string> _, Dictionary<string, double> _) => eventTracked.Set());
+        telemetryClient.Setup(x => x.Flush()).Throws(exception);
+        Mock<ITelemetryClientFactory> telemetryClientFactory = new();
+        telemetryClientFactory.Setup(x => x.Create(It.IsAny<string?>(), It.IsAny<string>())).Returns(telemetryClient.Object);
+        Mock<ILogger> logger = new();
+        logger.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(true);
+        logger
+            .Setup(x => x.LogAsync(LogLevel.Error, It.IsAny<string>(), It.IsAny<Exception>(), LoggingExtensions.Formatter))
+            .Returns(Task.CompletedTask);
+
+        AppInsightsProvider appInsightsProvider = CreateProvider(telemetryClientFactory, logger.Object);
+        await appInsightsProvider.LogEventAsync("Sample", new Dictionary<string, object>(), CancellationToken.None);
+        Assert.IsTrue(eventTracked.Wait(TimeSpan.FromSeconds(30), TestContext.CancellationToken), "Telemetry consumer did not invoke TrackEvent within the timeout.");
+
+#if NETCOREAPP
+        await appInsightsProvider.DisposeAsync();
+#else
+        appInsightsProvider.Dispose();
+#endif
+
+        logger.Verify(
+            x => x.LogAsync(LogLevel.Error, "Error during telemetry flush.", exception, LoggingExtensions.Formatter),
+            Times.Once);
+    }
+
+    [TestMethod]
     public void Platform_CancellationToken_Cancellation_Should_Exit_Gracefully()
     {
         Mock<IEnvironment> environment = new();
@@ -368,5 +475,26 @@ public sealed class AppInsightsProviderTests
         Assert.AreEqual("FirstEvent", trackedEvents[0]);
         Assert.AreEqual("SecondEvent", trackedEvents[1]);
         Assert.AreEqual(1, Volatile.Read(ref flushCallCount), "Flush should be invoked exactly once after the ingest loop drains.");
+    }
+
+    private static AppInsightsProvider CreateProvider(Mock<ITelemetryClientFactory> telemetryClientFactory, ILogger? logger = null)
+    {
+        Mock<IEnvironment> environment = new();
+        environment.Setup(x => x.OsVersion).Returns("osVersion");
+        Mock<ITestApplicationCancellationTokenSource> testApplicationCancellationTokenSource = new();
+        testApplicationCancellationTokenSource.Setup(x => x.CancellationToken).Returns(CancellationToken.None);
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(logger ?? new Mock<ILogger>().Object);
+
+        return new AppInsightsProvider(
+            environment.Object,
+            testApplicationCancellationTokenSource.Object,
+            new SystemTask(),
+            loggerFactory.Object,
+            new Mock<IClock>().Object,
+            new Mock<IConfiguration>().Object,
+            new Mock<ITelemetryInformation>().Object,
+            telemetryClientFactory.Object,
+            "sessionId");
     }
 }


### PR DESCRIPTION
## Summary

- delay Application Insights client creation until the telemetry channel has a payload to send
- let no-payload shutdown complete without creating or flushing an Application Insights client
- preserve cancellation, bounded disposal, browser/WASI behavior, event ordering, failure logging, and the single final flush
- add focused tests for no-payload disposal, first-payload initialization, initialization failures, flush failures, cancellation, and draining

## Validation

- `AppInsightsProviderTests` on `net8.0`: 11 passed
- `AppInsightsProviderTests` on `net472`: 11 passed
- targeted `net8.0` and `net472` builds completed with no warnings or errors

## Performance

A focused child-process reproduction measured a 678 ms median wall-time delta for Application Insights create/track/flush versus assembly load only. A payload-producing MTP host still pays the delivery cost, so this change specifically removes initialization and shutdown overhead when no telemetry payload is produced.