### PR TITLE
Test MSTest.Sdk ReadyToRun publishing

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ReadyToRunAssertions.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/ReadyToRunAssertions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace MSTest.Acceptance.IntegrationTests;
+
+/// <summary>
+/// Helper that proves a published managed assembly contains ReadyToRun native code.
+/// </summary>
+/// <remarks>
+/// This intentionally checks the non-composite image format produced by a standard RID-specific,
+/// framework-dependent publish. Its CLR Managed Native Header directory points to a
+/// READYTORUN_HEADER whose signature is the four bytes 'R', 'T', 'R', '\0'.
+/// See https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/botr/readytorun-format.md.
+/// </remarks>
+internal static class ReadyToRunAssertions
+{
+    // READYTORUN_SIGNATURE from the runtime's readytorun.h.
+    private const uint ReadyToRunSignature = 0x00525452;
+
+    /// <summary>
+    /// Asserts that the assembly at <paramref name="assemblyPath"/> is a managed PE image that
+    /// contains a genuine ReadyToRun native code header (and not merely IL).
+    /// </summary>
+    public static void AssertIsReadyToRunImage(string assemblyPath)
+    {
+        Assert.IsTrue(File.Exists(assemblyPath), $"Expected published managed assembly was not found at '{assemblyPath}'.");
+
+        using FileStream stream = File.OpenRead(assemblyPath);
+        using PEReader peReader = new(stream);
+
+        CorHeader? corHeader = peReader.PEHeaders.CorHeader;
+        Assert.IsNotNull(corHeader, $"'{assemblyPath}' has no CLR (COR20) header, so it is not a managed assembly at all.");
+
+        DirectoryEntry managedNativeHeaderDirectory = corHeader.ManagedNativeHeaderDirectory;
+        Assert.IsGreaterThanOrEqualTo(
+            sizeof(uint),
+            managedNativeHeaderDirectory.Size,
+            $"'{assemblyPath}' does not contain a complete Managed Native Header directory entry.");
+
+        PEMemoryBlock nativeHeaderBlock = peReader.GetSectionData(managedNativeHeaderDirectory.RelativeVirtualAddress);
+        Assert.IsGreaterThanOrEqualTo(
+            sizeof(uint),
+            nativeHeaderBlock.Length,
+            $"Could not locate a complete Managed Native Header in '{assemblyPath}'.");
+
+        BlobReader blobReader = nativeHeaderBlock.GetReader();
+        uint signature = blobReader.ReadUInt32();
+        Assert.AreEqual(
+            ReadyToRunSignature,
+            signature,
+            $"'{assemblyPath}' Managed Native Header does not start with the expected ReadyToRun 'RTR\\0' signature " +
+            $"(found 0x{signature:X8} instead). The assembly may not genuinely be ReadyToRun-compiled.");
+    }
+}

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -368,6 +368,37 @@ namespace MSTestSdkTest
     }
 
     [TestMethod]
+    public async Task PublishReadyToRun_Smoke_Test()
+    {
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            AssetName,
+            SingleTestSourceCode
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+            .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
+            .PatchCodeWithReplace("$ExtraProperties$", """
+                <PublishReadyToRun>true</PublishReadyToRun>
+                <SelfContained>false</SelfContained>
+                <EnableMicrosoftTestingExtensionsCodeCoverage>false</EnableMicrosoftTestingExtensionsCodeCoverage>
+                """),
+            addPublicFeeds: true);
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
+            $"publish -r {RID} -f {TargetFrameworks.NetCurrent} {testAsset.TargetAssetPath}",
+            warnAsError: true,
+            cancellationToken: TestContext.CancellationToken);
+        compilationResult.AssertExitCodeIs(0);
+
+        var testHost = TestHost.LocateFrom(testAsset.TargetAssetPath, AssetName, TargetFrameworks.NetCurrent, RID, Verb.publish);
+
+        string publishedAssemblyPath = Path.Combine(testHost.DirectoryName, $"{AssetName}.dll");
+        ReadyToRunAssertions.AssertIsReadyToRunImage(publishedAssemblyPath);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
+    }
+
+    [TestMethod]
     public async Task SettingIsTestApplicationToFalseReducesAddedExtensionsAndMakesProjectNotExecutable()
     {
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(


### PR DESCRIPTION
## Summary

- add MSTest.Sdk acceptance coverage for framework-dependent, RID-specific ReadyToRun publishing
- inspect the published managed PE image and require a valid `READYTORUN_HEADER` signature
- execute the published test application and verify its test summary

## Validation

- `build.cmd -pack -c Release -bl`: succeeded with 0 warnings and 0 errors
- filtered `PublishReadyToRun_Smoke_Test` run on `net11.0|x64`: 1 passed, 0 failed, 0 skipped

ReadyToRun validation is functional only; it does not use timing thresholds.