### PR TITLE
Reduce assertion telemetry contention

### DIFF
--- a/src/TestFramework/TestFramework/Internal/TelemetryCollector.cs
+++ b/src/TestFramework/TestFramework/Internal/TelemetryCollector.cs
@@ -15,7 +15,7 @@ internal static class TelemetryCollector
     // happens at most once per process.
     private static readonly Lazy<bool> IsEnabled = new(IsTelemetryEnabledFromEnvironment, LazyThreadSafetyMode.ExecutionAndPublication);
 
-    private static ConcurrentDictionary<string, long> s_assertionCallCounts = new();
+    private static ConcurrentDictionary<string, StrongBox<long>> s_assertionCallCounts = new();
 
     /// <summary>
     /// Records that an assertion method was called. This is on the hot path of every assertion,
@@ -26,16 +26,23 @@ internal static class TelemetryCollector
     /// </summary>
     /// <param name="assertionName">The full name of the assertion (e.g. "Assert.AreEqual", "CollectionAssert.Contains").</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void TrackAssertionCall(string assertionName)
+    internal static void TrackAssertionCall(string assertionName) =>
+        TrackAssertionCall(assertionName, IsEnabled.Value);
+
+#pragma warning disable RS0051 // Internal overload keeps unit tests independent from process-wide telemetry opt-out.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void TrackAssertionCall(string assertionName, bool isEnabled)
+#pragma warning restore RS0051
     {
-        if (!IsEnabled.Value)
+        if (!isEnabled)
         {
             return;
         }
 
         try
         {
-            s_assertionCallCounts.AddOrUpdate(assertionName, 1, static (_, count) => count + 1);
+            StrongBox<long> counter = s_assertionCallCounts.GetOrAdd(assertionName, static _ => new StrongBox<long>());
+            Interlocked.Increment(ref counter.Value);
         }
         catch
         {
@@ -46,20 +53,26 @@ internal static class TelemetryCollector
     /// <summary>
     /// Gets a snapshot of all assertion call counts and resets the counters.
     /// This is thread-safe but best-effort: it atomically swaps the dictionary and copies the old one.
-    /// In-flight calls to <see cref="TrackAssertionCall"/> that race with the swap may be lost.
+    /// In-flight calls to <see cref="TrackAssertionCall(string)"/> that race with the swap may be lost.
     /// This is acceptable for telemetry where approximate counts are sufficient.
     /// </summary>
     /// <returns>A dictionary mapping assertion names to their (best-effort) call counts.</returns>
     internal static Dictionary<string, long> DrainAssertionCallCounts()
     {
-        ConcurrentDictionary<string, long> old = Interlocked.Exchange(ref s_assertionCallCounts, new ConcurrentDictionary<string, long>());
+        ConcurrentDictionary<string, StrongBox<long>> old = Interlocked.Exchange(
+            ref s_assertionCallCounts,
+            new ConcurrentDictionary<string, StrongBox<long>>());
+        var snapshot = new Dictionary<string, long>(old.Count);
+        foreach ((string assertionName, StrongBox<long> counter) in old)
+        {
+            long count = Volatile.Read(ref counter.Value);
+            if (count > 0)
+            {
+                snapshot[assertionName] = count;
+            }
+        }
 
-        // Use the explicit Dictionary(IEnumerable<KeyValuePair>) ctor so we get a stable
-        // snapshot of the swapped-out instance. A collection-expression spread would be
-        // semantically equivalent but the explicit ctor reads more clearly here.
-#pragma warning disable IDE0028 // Simplify collection initialization
-        return new Dictionary<string, long>(old);
-#pragma warning restore IDE0028
+        return snapshot;
     }
 
     private static bool IsTelemetryEnabledFromEnvironment()

--- a/test/UnitTests/TestFramework.UnitTests/TelemetryCollectorTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/TelemetryCollectorTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using AwesomeAssertions;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using TestFramework.ForTestingMSTest;
+
+namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
+
+public sealed class TelemetryCollectorTests : TestContainer
+{
+    public void TrackAssertionCall_AccumulatesCounts()
+    {
+        TelemetryCollector.DrainAssertionCallCounts();
+
+        TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.First", isEnabled: true);
+        TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.First", isEnabled: true);
+        TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Second", isEnabled: true);
+
+        Dictionary<string, long> counts = TelemetryCollector.DrainAssertionCallCounts();
+        counts["TelemetryCollectorTests.First"].Should().Be(2);
+        counts["TelemetryCollectorTests.Second"].Should().Be(1);
+    }
+
+    public void TrackAssertionCall_ConcurrentCallsDoNotLoseUpdates()
+    {
+        const int CallCount = 100_000;
+        TelemetryCollector.DrainAssertionCallCounts();
+
+        Parallel.For(
+            0,
+            CallCount,
+            static _ => TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Concurrent", isEnabled: true));
+
+        Dictionary<string, long> counts = TelemetryCollector.DrainAssertionCallCounts();
+        counts["TelemetryCollectorTests.Concurrent"].Should().Be(CallCount);
+    }
+
+    public void DrainAssertionCallCounts_ResetsCounts()
+    {
+        TelemetryCollector.DrainAssertionCallCounts();
+        TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Reset", isEnabled: true);
+
+        Dictionary<string, long> first = TelemetryCollector.DrainAssertionCallCounts();
+        Dictionary<string, long> second = TelemetryCollector.DrainAssertionCallCounts();
+
+        first["TelemetryCollectorTests.Reset"].Should().Be(1);
+        second.Should().NotContainKey("TelemetryCollectorTests.Reset");
+    }
+
+    public void ConcurrentDrains_PartitionCompletedUpdatesWithoutDuplication()
+    {
+        const int CallCount = 100_000;
+        TelemetryCollector.DrainAssertionCallCounts();
+        for (int i = 0; i < CallCount; i++)
+        {
+            TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.ConcurrentDrain", isEnabled: true);
+        }
+
+        using var start = new ManualResetEventSlim();
+        Task<Dictionary<string, long>> firstDrain = Task.Run(() =>
+        {
+            start.Wait();
+            return TelemetryCollector.DrainAssertionCallCounts();
+        });
+        Task<Dictionary<string, long>> secondDrain = Task.Run(() =>
+        {
+            start.Wait();
+            return TelemetryCollector.DrainAssertionCallCounts();
+        });
+
+        start.Set();
+        Task.WaitAll(firstDrain, secondDrain);
+
+        firstDrain.Result.TryGetValue("TelemetryCollectorTests.ConcurrentDrain", out long firstCount);
+        secondDrain.Result.TryGetValue("TelemetryCollectorTests.ConcurrentDrain", out long secondCount);
+        (firstCount + secondCount).Should().Be(CallCount);
+    }
+
+    public void TrackingWhileDraining_DoesNotDuplicateUpdates()
+    {
+        const int WorkerCount = 4;
+        const int CallsPerWorker = 25_000;
+        const int ExpectedCallCount = WorkerCount * CallsPerWorker;
+        TelemetryCollector.DrainAssertionCallCounts();
+
+        long drainedCount = 0;
+        var workers = new Task[WorkerCount];
+        for (int worker = 0; worker < workers.Length; worker++)
+        {
+            workers[worker] = Task.Run(() =>
+            {
+                for (int i = 0; i < CallsPerWorker; i++)
+                {
+                    TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.RacingDrain", isEnabled: true);
+                }
+            });
+        }
+
+        while (!Task.WaitAll(workers, millisecondsTimeout: 0))
+        {
+            Dictionary<string, long> counts = TelemetryCollector.DrainAssertionCallCounts();
+            if (counts.TryGetValue("TelemetryCollectorTests.RacingDrain", out long count))
+            {
+                drainedCount += count;
+            }
+        }
+
+        Dictionary<string, long> finalCounts = TelemetryCollector.DrainAssertionCallCounts();
+        if (finalCounts.TryGetValue("TelemetryCollectorTests.RacingDrain", out long finalCount))
+        {
+            drainedCount += finalCount;
+        }
+
+        drainedCount.Should().BeLessThanOrEqualTo(ExpectedCallCount);
+    }
+
+    public void TrackAssertionCall_WhenDisabled_DoesNotRecordCount()
+    {
+        TelemetryCollector.DrainAssertionCallCounts();
+
+        TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Disabled", isEnabled: false);
+
+        TelemetryCollector.DrainAssertionCallCounts().Should().NotContainKey("TelemetryCollectorTests.Disabled");
+    }
+
+#if NET8_0_OR_GREATER
+    public void TrackAssertionCall_DoesNotAllocateAfterCounterExists()
+    {
+        TelemetryCollector.DrainAssertionCallCounts();
+        for (int i = 0; i < 1_000; i++)
+        {
+            TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Allocations", isEnabled: true);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 10_000; i++)
+        {
+            TelemetryCollector.TrackAssertionCall("TelemetryCollectorTests.Allocations", isEnabled: true);
+        }
+
+        long allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        allocatedBytes.Should().Be(0);
+        TelemetryCollector.DrainAssertionCallCounts()["TelemetryCollectorTests.Allocations"].Should().Be(11_000);
+    }
+#endif
+}


### PR DESCRIPTION
## Summary

- replace contended `ConcurrentDictionary.AddOrUpdate` calls with allocation-free steady-state lookup plus `Interlocked.Increment`
- preserve best-effort drain semantics with atomic dictionary swaps and volatile counter reads
- add coverage for concurrent updates/drains, telemetry opt-out behavior, reset behavior, and steady-state allocations

## Performance

Standalone .NET 9 Release measurements over 5,000,000 operations (median of 7, five pre-populated assertion names):

| Scenario | Current | Updated |
| --- | ---: | ---: |
| Single thread | 280.26 ms | 101.72 ms |
| 4 contending threads | 371.49 ms | 106.45 ms |
| Steady-state allocation | 0 B | 0 B |

An eager `GetOrAdd(key, new StrongBox<long>())` candidate was rejected because argument evaluation allocated 120 MB over the same 5,000,000 calls.

## Validation

- TestFramework unit-test project builds across all target frameworks with 0 warnings and 0 errors
- 1,513 TestFramework unit tests pass on `net8.0`
- two independent concurrency/allocation reviews completed, with all findings addressed

Closes #10559
