### PR TITLE
Add retry argument builder unit tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryArgumentsBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryArgumentsBuilderTests.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public sealed class RetryArgumentsBuilderTests
 {
+    // Mirrors RetryArgumentsBuilder.CommandLineLengthLimit and RetryArgumentsBuilder.PerArgumentOverhead: the
+    // builder falls back to a response file once the predicted command line exceeds the limit, and each failed
+    // UID contributes its own length plus the per-argument overhead to that prediction.
+    private const int CommandLineLengthLimit = 30_000;
+    private const int PerArgumentOverhead = 3;
+
     [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, "50")]
     [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, "5")]
     [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName, "1s")]
@@ -35,11 +41,68 @@ public sealed class RetryArgumentsBuilderTests
         List<int> actual = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
 
         int[] expected = [1, 2, 3, 4];
-        Assert.HasCount(expected.Length, actual);
-        foreach (int expectedIndex in expected)
-        {
-            Assert.Contains(expectedIndex, actual);
-        }
+        Assert.AreSequenceEqual(expected, actual, SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void ComputeIndicesToCleanup_WithoutOptionalOptions_ReturnsOnlyRetryOptionIndices()
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            "--keep",
+            "value",
+        ];
+
+        List<int> actual = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+
+        int[] expected = [1, 2];
+        Assert.AreSequenceEqual(expected, actual, SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void ComputeIndicesToCleanup_WithAllOptionalOptions_ReturnsEveryOptionAndValueIndex()
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName}",
+            "50",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName}",
+            "5",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName}",
+            "1s",
+            $"--{PlatformCommandLineProvider.ResultDirectoryOptionKey}",
+            "results",
+            "--keep",
+            "value",
+        ];
+
+        List<int> actual = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+
+        int[] expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        Assert.AreSequenceEqual(expected, actual, SequenceOrder.InAnyOrder);
+    }
+
+    [TestMethod]
+    public void ComputeIndicesToCleanup_WithDelayOptionAsLastArgument_DoesNotReturnIndexBeyondArguments()
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName}",
+        ];
+
+        List<int> actual = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+
+        int[] expected = [1, 2, 3];
+        Assert.AreSequenceEqual(expected, actual, SequenceOrder.InAnyOrder);
     }
 
     [TestMethod]
@@ -93,11 +156,21 @@ public sealed class RetryArgumentsBuilderTests
     }
 
     [TestMethod]
-    public async Task BuildAttemptArgumentsAsync_OverLengthArguments_WritesFailedIdsToResponseFile()
+    public Task BuildAttemptArgumentsAsync_WithNullFailedIds_KeepsOriginalFiltersAndMinimumExpectedTests()
+        => AssertFirstAttemptKeepsOriginalFiltersAsync(lastListOfFailedId: null);
+
+    [TestMethod]
+    public Task BuildAttemptArgumentsAsync_WithEmptyFailedIds_KeepsOriginalFiltersAndMinimumExpectedTests()
+        => AssertFirstAttemptKeepsOriginalFiltersAsync(lastListOfFailedId: []);
+
+    [TestMethod]
+    public async Task BuildAttemptArgumentsAsync_OverLengthFailedIds_WritesFailedIdsToResponseFile()
     {
         string retryRoot = Path.Combine("results", "Retries", "run");
         string responseFilePath = Path.Combine(retryRoot, "retry-filter-uids-2.rsp");
-        string[] failedIds = ["uid with whitespace", "#comment-like-uid"];
+        string[] executableArguments = ["test.dll"];
+        string[] failedIds = CreateOverLengthFailedIds("uid with whitespace", "#comment-like-uid");
+        AssertOnlyFailedIdsExceedLengthLimit(executableArguments, failedIds);
         using var memoryStream = new MemoryStream();
         var fileStream = new Mock<IFileStream>(MockBehavior.Strict);
         fileStream.SetupGet(stream => stream.Stream).Returns(memoryStream);
@@ -109,7 +182,7 @@ public sealed class RetryArgumentsBuilderTests
 
         List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
             fileSystem.Object,
-            [CreateOverLengthArgument()],
+            executableArguments,
             [],
             Path.Combine(retryRoot, "2"),
             retryRoot,
@@ -119,9 +192,15 @@ public sealed class RetryArgumentsBuilderTests
 
         Assert.Contains($"@{responseFilePath}", actual);
         Assert.DoesNotContain($"--{PlatformCommandLineProvider.FilterUidOptionKey}", actual);
-        Assert.AreEqual(
-            $"--{PlatformCommandLineProvider.FilterUidOptionKey} \"{failedIds[0]}\" \"{failedIds[1]}\"{Environment.NewLine}",
-            Encoding.UTF8.GetString(memoryStream.ToArray()));
+
+        var expectedResponseFileContent = new StringBuilder($"--{PlatformCommandLineProvider.FilterUidOptionKey}");
+        foreach (string failedId in failedIds)
+        {
+            expectedResponseFileContent.Append(" \"").Append(failedId).Append('"');
+        }
+
+        expectedResponseFileContent.Append(Environment.NewLine);
+        Assert.AreEqual(expectedResponseFileContent.ToString(), Encoding.UTF8.GetString(memoryStream.ToArray()));
         fileSystem.Verify(
             fs => fs.NewFileStream(responseFilePath, FileMode.Create, FileAccess.Write),
             Times.Once);
@@ -129,23 +208,29 @@ public sealed class RetryArgumentsBuilderTests
     }
 
     [TestMethod]
-    public async Task BuildAttemptArgumentsAsync_OverLengthArgumentsWithQuotedUid_KeepsFailedIdsInline()
+    public async Task BuildAttemptArgumentsAsync_OverLengthFailedIdsWithQuotedUid_KeepsFailedIdsInline()
     {
+        // ResponseFileHelper.SplitCommandLine strips '"' from tokens, so a UID containing a literal quote
+        // cannot round-trip through a response file and must stay inline even when the payload is over length.
         const string QuotedUid = "uid with a \"quoted\" value";
+        string[] executableArguments = ["test.dll"];
+        string[] failedIds = CreateOverLengthFailedIds(QuotedUid);
+        AssertOnlyFailedIdsExceedLengthLimit(executableArguments, failedIds);
         var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
 
         List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
             fileSystem.Object,
-            [CreateOverLengthArgument()],
+            executableArguments,
             [],
             "retry-root-2",
             "retry-root",
             "pipe-name",
-            [QuotedUid],
+            failedIds,
             attemptCount: 2).ConfigureAwait(false);
 
-        Assert.Contains($"--{PlatformCommandLineProvider.FilterUidOptionKey}", actual);
-        Assert.Contains(QuotedUid, actual);
+        int filterUidIndex = actual.IndexOf($"--{PlatformCommandLineProvider.FilterUidOptionKey}");
+        Assert.IsGreaterThanOrEqualTo(0, filterUidIndex);
+        Assert.AreSequenceEqual(failedIds, actual.Skip(filterUidIndex + 1));
         Assert.DoesNotContain(
             argument => argument.StartsWith("@", StringComparison.Ordinal),
             actual);
@@ -154,8 +239,93 @@ public sealed class RetryArgumentsBuilderTests
             Times.Never);
     }
 
-    private static string CreateOverLengthArgument()
-        => new('x', 40_000);
+    private static async Task AssertFirstAttemptKeepsOriginalFiltersAsync(string[]? lastListOfFailedId)
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            "--keep",
+            "value",
+            $"--{PlatformCommandLineProvider.FilterUidOptionKey}",
+            "old-1",
+            "old-2",
+            $"--{TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter}",
+            "/old-filter",
+            $"--{PlatformCommandLineProvider.MinimumExpectedTestsOptionKey}",
+            "10",
+        ];
+        List<int> indicesToCleanup = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+
+        List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
+            fileSystem.Object,
+            executableArguments,
+            indicesToCleanup,
+            "retry-root-1",
+            "retry-root",
+            "pipe-name",
+            lastListOfFailedId,
+            attemptCount: 1).ConfigureAwait(false);
+
+        AssertArguments(
+            [
+                "test.dll",
+                "--keep",
+                "value",
+                $"--{PlatformCommandLineProvider.FilterUidOptionKey}",
+                "old-1",
+                "old-2",
+                $"--{TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter}",
+                "/old-filter",
+                $"--{PlatformCommandLineProvider.MinimumExpectedTestsOptionKey}",
+                "10",
+                $"--{PlatformCommandLineProvider.ResultDirectoryOptionKey}",
+                "retry-root-1",
+                $"--{RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName}",
+                "pipe-name",
+            ],
+            actual);
+        fileSystem.Verify(
+            fs => fs.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Builds a realistic failed-test payload whose UIDs alone push the predicted command line past the limit,
+    /// so the response-file fallback is driven by the failed UIDs rather than by an over-long original argument.
+    /// </summary>
+    private static string[] CreateOverLengthFailedIds(params string[] leadingUids)
+    {
+        List<string> uids = [.. leadingUids];
+        int predictedLength = uids.Sum(uid => uid.Length + PerArgumentOverhead);
+        while (predictedLength <= CommandLineLengthLimit)
+        {
+            string uid = $"Contoso.Widgets.Tests.CalculatorTests.Add(first: {uids.Count}, second: {uids.Count})";
+            uids.Add(uid);
+            predictedLength += uid.Length + PerArgumentOverhead;
+        }
+
+        return [.. uids];
+    }
+
+    /// <summary>
+    /// Guards the fixture itself: the original command line must stay under the limit and the failed-UID payload
+    /// must cross it on its own. Otherwise the over-length tests would keep passing even if the builder stopped
+    /// counting UID lengths when predicting the command-line length.
+    /// </summary>
+    private static void AssertOnlyFailedIdsExceedLengthLimit(string[] executableArguments, string[] failedIds)
+    {
+        Assert.IsLessThan(
+            CommandLineLengthLimit,
+            executableArguments.Sum(argument => argument.Length + PerArgumentOverhead),
+            "The original arguments must stay under the limit so they cannot trigger the response file on their own.");
+        Assert.IsGreaterThan(
+            CommandLineLengthLimit,
+            failedIds.Sum(uid => uid.Length + PerArgumentOverhead),
+            "The failed-UID payload must exceed the limit on its own.");
+    }
 
     private static void AssertArguments(IReadOnlyList<string> expected, IReadOnlyList<string> actual)
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryArgumentsBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryArgumentsBuilderTests.cs
@@ -1,0 +1,168 @@
+﻿#pragma warning disable IDE0073 // The file header does not match the required text
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+#pragma warning restore IDE0073 // The file header does not match the required text
+
+using Microsoft.Testing.Extensions.Policy;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Helpers;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class RetryArgumentsBuilderTests
+{
+    [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsMaxPercentageOptionName, "50")]
+    [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsMaxTestsOptionName, "5")]
+    [DataRow(RetryCommandLineOptionsProvider.RetryFailedTestsDelayOptionName, "1s")]
+    [DataRow(PlatformCommandLineProvider.ResultDirectoryOptionKey, "results")]
+    [TestMethod]
+    public void ComputeIndicesToCleanup_WithOptionalOption_ReturnsOptionAndValueIndices(string optionalOptionName, string optionalOptionValue)
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"-{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            $"--{optionalOptionName}",
+            optionalOptionValue,
+            "--keep",
+            "value",
+        ];
+
+        List<int> actual = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+
+        int[] expected = [1, 2, 3, 4];
+        Assert.HasCount(expected.Length, actual);
+        foreach (int expectedIndex in expected)
+        {
+            Assert.Contains(expectedIndex, actual);
+        }
+    }
+
+    [TestMethod]
+    public async Task BuildAttemptArgumentsAsync_WithFailedIds_ReplacesFiltersAndMinimumExpectedTests()
+    {
+        string[] executableArguments =
+        [
+            "test.dll",
+            $"--{RetryCommandLineOptionsProvider.RetryFailedTestsOptionName}",
+            "3",
+            "--keep",
+            "value",
+            $"--{PlatformCommandLineProvider.FilterUidOptionKey}",
+            "old-1",
+            "old-2",
+            $"--{TreeNodeFilterCommandLineOptionsProvider.TreenodeFilter}",
+            "/old-filter",
+            $"--{PlatformCommandLineProvider.MinimumExpectedTestsOptionKey}",
+            "10",
+        ];
+        List<int> indicesToCleanup = RetryArgumentsBuilder.ComputeIndicesToCleanup(executableArguments);
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+
+        List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
+            fileSystem.Object,
+            executableArguments,
+            indicesToCleanup,
+            "retry-root-2",
+            "retry-root",
+            "pipe-name",
+            ["failed uid", "failed-2"],
+            attemptCount: 2).ConfigureAwait(false);
+
+        AssertArguments(
+            [
+                "test.dll",
+                "--keep",
+                "value",
+                $"--{PlatformCommandLineProvider.ResultDirectoryOptionKey}",
+                "retry-root-2",
+                $"--{RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName}",
+                "pipe-name",
+                $"--{PlatformCommandLineProvider.FilterUidOptionKey}",
+                "failed uid",
+                "failed-2",
+            ],
+            actual);
+        fileSystem.Verify(
+            fs => fs.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task BuildAttemptArgumentsAsync_OverLengthArguments_WritesFailedIdsToResponseFile()
+    {
+        string retryRoot = Path.Combine("results", "Retries", "run");
+        string responseFilePath = Path.Combine(retryRoot, "retry-filter-uids-2.rsp");
+        string[] failedIds = ["uid with whitespace", "#comment-like-uid"];
+        using var memoryStream = new MemoryStream();
+        var fileStream = new Mock<IFileStream>(MockBehavior.Strict);
+        fileStream.SetupGet(stream => stream.Stream).Returns(memoryStream);
+        fileStream.Setup(stream => stream.Dispose());
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        fileSystem
+            .Setup(fs => fs.NewFileStream(responseFilePath, FileMode.Create, FileAccess.Write))
+            .Returns(fileStream.Object);
+
+        List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
+            fileSystem.Object,
+            [CreateOverLengthArgument()],
+            [],
+            Path.Combine(retryRoot, "2"),
+            retryRoot,
+            "pipe-name",
+            failedIds,
+            attemptCount: 2).ConfigureAwait(false);
+
+        Assert.Contains($"@{responseFilePath}", actual);
+        Assert.DoesNotContain($"--{PlatformCommandLineProvider.FilterUidOptionKey}", actual);
+        Assert.AreEqual(
+            $"--{PlatformCommandLineProvider.FilterUidOptionKey} \"{failedIds[0]}\" \"{failedIds[1]}\"{Environment.NewLine}",
+            Encoding.UTF8.GetString(memoryStream.ToArray()));
+        fileSystem.Verify(
+            fs => fs.NewFileStream(responseFilePath, FileMode.Create, FileAccess.Write),
+            Times.Once);
+        fileStream.Verify(stream => stream.Dispose(), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task BuildAttemptArgumentsAsync_OverLengthArgumentsWithQuotedUid_KeepsFailedIdsInline()
+    {
+        const string QuotedUid = "uid with a \"quoted\" value";
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+
+        List<string> actual = await RetryArgumentsBuilder.BuildAttemptArgumentsAsync(
+            fileSystem.Object,
+            [CreateOverLengthArgument()],
+            [],
+            "retry-root-2",
+            "retry-root",
+            "pipe-name",
+            [QuotedUid],
+            attemptCount: 2).ConfigureAwait(false);
+
+        Assert.Contains($"--{PlatformCommandLineProvider.FilterUidOptionKey}", actual);
+        Assert.Contains(QuotedUid, actual);
+        Assert.DoesNotContain(
+            argument => argument.StartsWith("@", StringComparison.Ordinal),
+            actual);
+        fileSystem.Verify(
+            fs => fs.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>()),
+            Times.Never);
+    }
+
+    private static string CreateOverLengthArgument()
+        => new('x', 40_000);
+
+    private static void AssertArguments(IReadOnlyList<string> expected, IReadOnlyList<string> actual)
+    {
+        Assert.HasCount(expected.Count, actual);
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.AreEqual(expected[i], actual[i], $"Argument at index {i} differs.");
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryOrchestratorHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryOrchestratorHelperTests.cs
@@ -1,0 +1,42 @@
+﻿#pragma warning disable IDE0073 // The file header does not match the required text
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+#pragma warning restore IDE0073 // The file header does not match the required text
+
+using Microsoft.Testing.Extensions.Policy;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class RetryOrchestratorHelperTests
+{
+    [TestMethod]
+    public void RemoveOption_AllSupportedForms_RemovesOccurrencesAndValues()
+    {
+        List<string> arguments =
+        [
+            "before",
+            "--target",
+            "long-value",
+            "-target",
+            "short-value",
+            "--target=long-equals",
+            "long-equals-trailing-value",
+            "--target:long-colon",
+            "long-colon-trailing-value",
+            "-target=short-equals",
+            "short-equals-trailing-value",
+            "-target:short-colon",
+            "short-colon-trailing-value",
+            "--other",
+            "after",
+        ];
+
+        RetryOrchestratorHelper.RemoveOption(arguments, "target");
+
+        Assert.HasCount(3, arguments);
+        Assert.AreEqual("before", arguments[0]);
+        Assert.AreEqual("--other", arguments[1]);
+        Assert.AreEqual("after", arguments[2]);
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryOrchestratorHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryOrchestratorHelperTests.cs
@@ -39,4 +39,61 @@ public sealed class RetryOrchestratorHelperTests
         Assert.AreEqual("--other", arguments[1]);
         Assert.AreEqual("after", arguments[2]);
     }
+
+    [TestMethod]
+    public void GetOptionArgumentIndex_WithLongForm_ReturnsOptionIndex()
+    {
+        string[] executableArguments = ["test.dll", "--target", "value"];
+
+        Assert.AreEqual(1, RetryOrchestratorHelper.GetOptionArgumentIndex("target", executableArguments));
+    }
+
+    [TestMethod]
+    public void GetOptionArgumentIndex_WithShortForm_ReturnsOptionIndex()
+    {
+        string[] executableArguments = ["test.dll", "-target", "value"];
+
+        Assert.AreEqual(1, RetryOrchestratorHelper.GetOptionArgumentIndex("target", executableArguments));
+    }
+
+    [TestMethod]
+    public void GetOptionArgumentIndex_WithBothForms_PrefersShortForm()
+    {
+        string[] executableArguments = ["--target", "long-value", "-target", "short-value"];
+
+        Assert.AreEqual(2, RetryOrchestratorHelper.GetOptionArgumentIndex("target", executableArguments));
+    }
+
+    [TestMethod]
+    public void GetOptionArgumentIndex_WithPrefixOnlyMatch_ReturnsMinusOne()
+    {
+        // Only exact matches count, so an option that merely starts with the searched name is not a hit.
+        string[] executableArguments = ["test.dll", "--target-extended", "value"];
+
+        Assert.AreEqual(-1, RetryOrchestratorHelper.GetOptionArgumentIndex("target", executableArguments));
+    }
+
+    [DataRow(0, "0ms")]
+    [DataRow(500, "500ms")]
+    [DataRow(999, "999ms")]
+    [DataRow(1000, "1s")]
+    [DataRow(1500, "1500ms")]
+    [DataRow(60_000, "60s")]
+    [DataRow(90_500, "90500ms")]
+    [TestMethod]
+    public void FormatDelay_RendersValueTheWayTheDelayOptionAcceptsIt(int milliseconds, string expected)
+        => Assert.AreEqual(expected, RetryOrchestratorHelper.FormatDelay(TimeSpan.FromMilliseconds(milliseconds)));
+
+    [DataRow(0, "0ms")]
+    [DataRow(240, "240ms")]
+    [DataRow(999, "999ms")]
+    [DataRow(1000, "1s 000ms")]
+    [DataRow(1240, "1s 240ms")]
+    [DataRow(59_999, "59s 999ms")]
+    [DataRow(60_000, "1m 00s")]
+    [DataRow(123_000, "2m 03s")]
+    [DataRow(3_600_000, "60m 00s")]
+    [TestMethod]
+    public void FormatDuration_RendersCompactHumanFriendlyDuration(int milliseconds, string expected)
+        => Assert.AreEqual(expected, RetryOrchestratorHelper.FormatDuration(TimeSpan.FromMilliseconds(milliseconds)));
 }


### PR DESCRIPTION
Add direct unit tests for retry argument cleanup and failed-test argument rebuilding. This covers short and long option forms, stale filter and `--minimum-expected-tests` removal, the first-attempt path where there are no failed IDs, the response-file fallback, and quoted UIDs that must stay inline.

The over-length scenario is driven by the failed-UID payload rather than by an over-long original argument, so it actually exercises the UID-length accounting in `predictedLength`. Verified by deleting that accumulation from `RetryArgumentsBuilder`: `BuildAttemptArgumentsAsync_OverLengthFailedIds_WritesFailedIdsToResponseFile` fails without it and passes with it restored.

Validated with the full unit test build.

Fix #10563

🤖