### PR TITLE
Optimize non-generic collection count assertions

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.HasCount.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.HasCount.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -214,7 +214,26 @@ public sealed partial class Assert
     }
 
     private static void HasCount(string assertionName, int expected, IEnumerable collection, string? message, string collectionExpression)
-        => HasCount(assertionName, expected, collection.Cast<object>(), message, collectionExpression);
+    {
+        // Cast<object>() previously validated null before entering the generic helper and tracking telemetry.
+        if (collection is null)
+        {
+            _ = collection!.Cast<object>();
+            return;
+        }
+
+        TelemetryCollector.TrackAssertionCall(GetTrackedAssertionName(assertionName));
+
+        int actualCount = collection is ICollection nonGenericCollection
+            ? nonGenericCollection.Count
+            : collection.Cast<object>().Count();
+        if (actualCount == expected)
+        {
+            return;
+        }
+
+        ReportAssertCountFailed(assertionName, expected, actualCount, message, collectionExpression);
+    }
 
 #if NETCOREAPP3_1_OR_GREATER
     private static void HasCount<T>(string assertionName, int expected, ReadOnlySpan<T> collection, string? message, string collectionExpression)

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TelemetryTests.cs
@@ -50,6 +50,8 @@ public sealed class TelemetryTests : AcceptanceTestBase<TelemetryTests.TestAsset
         Assert.IsTrue(Regex.IsMatch(content, "mstest\\.attribute_usage"), $"Expected attribute_usage in telemetry.\n{content}");
         Assert.IsTrue(Regex.IsMatch(content, "mstest\\.config_source"), $"Expected config_source in telemetry.\n{content}");
         Assert.IsTrue(Regex.IsMatch(content, "mstest\\.assertion_usage"), $"Expected assertion_usage in telemetry.\n{content}");
+        Assert.IsTrue(Regex.IsMatch(content, "\"Assert\\.HasCount\":1(?:,|})"), $"Expected exactly one Assert.HasCount telemetry call.\n{content}");
+        Assert.IsTrue(Regex.IsMatch(content, "\"Assert\\.IsEmpty\":1(?:,|})"), $"Expected exactly one Assert.IsEmpty telemetry call.\n{content}");
 
         // Regression guard: discovery + execution data must ship in a single sessionexit event,
         // not split across two (an earlier iteration of this code did the latter).
@@ -275,6 +277,9 @@ Diagnostic file \(level '{level}' with {flushType} flush\): {diagPathPattern}
 </Project>
 
 #file UnitTest1.cs
+using System;
+using System.Collections;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
@@ -297,6 +302,34 @@ public class UnitTest1
     [Timeout(30000)]
     public void TestWithTimeout()
     {
+    }
+
+    [TestMethod]
+    public void NonGenericCountAssertions()
+    {
+        IEnumerable populated = new ArrayList { 1 };
+        IEnumerable empty = new ArrayList();
+
+        Assert.HasCount(1, populated);
+        Assert.IsEmpty(empty);
+
+        try
+        {
+            Assert.HasCount(0, (IEnumerable)null!);
+            throw new InvalidOperationException("Assert.HasCount should reject a null collection.");
+        }
+        catch (ArgumentNullException ex) when (ex.ParamName == "source")
+        {
+        }
+
+        try
+        {
+            Assert.IsEmpty((IEnumerable)null!);
+            throw new InvalidOperationException("Assert.IsEmpty should reject a null collection.");
+        }
+        catch (ArgumentNullException ex) when (ex.ParamName == "source")
+        {
+        }
     }
 }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -1,6 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections;
 using System.Globalization;
 
 using AwesomeAssertions;
@@ -13,6 +14,67 @@ public partial class AssertTests
     {
         var collection = new List<int> { 1, 2, 3 };
         Assert.HasCount(3, collection);
+    }
+
+    public void Count_NonGenericICollection_ShouldUseCountWithoutEnumerating()
+    {
+        CountTrackingCollection collection = new(3);
+
+        Assert.HasCount(3, collection);
+
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void Count_NonGenericIEnumerable_ShouldEnumerate()
+    {
+        CountTrackingEnumerable collection = new(3);
+
+        Assert.HasCount(3, collection);
+
+        collection.EnumerationCount.Should().Be(1);
+    }
+
+    public void Count_NonGenericICollection_WhenCountDiffers_ShouldPreserveFailureMessage()
+    {
+        CountTrackingCollection collection = new(1);
+
+        Action action = () => Assert.HasCount(3, collection, "custom message", "collection");
+
+        action.Should().Throw<Exception>()
+            .WithMessage(
+                """
+                Assertion failed. Expected collection to contain a specific number of elements.
+                custom message
+
+                expected count: 3
+                actual count:   1
+
+                Assert.HasCount(3, collection)
+                """);
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void Count_NonGenericICollection_WhenCountThrows_ShouldPropagateWithoutEnumerating()
+    {
+        ThrowingCountCollection collection = new();
+
+        Action action = () => Assert.HasCount(0, collection);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("count boom");
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void Count_NonGenericNullCollection_ShouldPreserveException()
+    {
+        IEnumerable collection = null!;
+
+        Action hasCountAction = () => Assert.HasCount(0, collection);
+        Action isEmptyAction = () => Assert.IsEmpty(collection);
+        hasCountAction.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("source");
+        isEmptyAction.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("source");
     }
 
     public void Count_InterpolatedString_WhenCountIsSame_ShouldPass()
@@ -489,6 +551,25 @@ public partial class AssertTests
     public void NotAny_WhenEmpty_ShouldPass()
         => Assert.IsEmpty(Array.Empty<int>());
 
+    public void IsEmpty_NonGenericICollection_ShouldUseCountWithoutEnumerating()
+    {
+        CountTrackingCollection collection = new(0);
+
+        Assert.IsEmpty(collection);
+
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void IsEmpty_NonGenericIEnumerable_ShouldEnumerate()
+    {
+        CountTrackingEnumerable collection = new(0);
+
+        Assert.IsEmpty(collection);
+
+        collection.EnumerationCount.Should().Be(1);
+    }
+
     public void NotAny_InterpolatedString_WhenEmpty_ShouldPass()
     {
         DummyClassTrackingToStringCalls o = new();
@@ -688,5 +769,74 @@ public partial class AssertTests
                 Assert.IsNotEmpty(collection)
                 """);
         o.WasToStringCalled.Should().BeTrue();
+    }
+
+    private sealed class CountTrackingCollection(int count) : ICollection
+    {
+        public int Count
+        {
+            get
+            {
+                CountAccessCount++;
+                return count;
+            }
+        }
+
+        public int CountAccessCount { get; private set; }
+
+        public int EnumerationCount { get; private set; }
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot { get; } = new();
+
+        public void CopyTo(Array array, int index)
+            => throw new NotSupportedException();
+
+        public IEnumerator GetEnumerator()
+        {
+            EnumerationCount++;
+            throw new InvalidOperationException("The ICollection fast path should not enumerate.");
+        }
+    }
+
+    private sealed class CountTrackingEnumerable(int count) : IEnumerable
+    {
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator GetEnumerator()
+        {
+            EnumerationCount++;
+            return Enumerable.Range(0, count).GetEnumerator();
+        }
+    }
+
+    private sealed class ThrowingCountCollection : ICollection
+    {
+        public int Count
+        {
+            get
+            {
+                CountAccessCount++;
+                throw new InvalidOperationException("count boom");
+            }
+        }
+
+        public int CountAccessCount { get; private set; }
+
+        public int EnumerationCount { get; private set; }
+
+        public bool IsSynchronized => false;
+
+        public object SyncRoot { get; } = new();
+
+        public void CopyTo(Array array, int index)
+            => throw new NotSupportedException();
+
+        public IEnumerator GetEnumerator()
+        {
+            EnumerationCount++;
+            throw new InvalidOperationException("The ICollection fast path should not enumerate.");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- use `ICollection.Count` for non-generic `Assert.HasCount` and `Assert.IsEmpty` calls instead of enumerating through `Cast<object>()`
- preserve the original plain-`IEnumerable` fallback, null exception ordering, failure messages, and one telemetry event per assertion call
- cover side-effecting and throwing collection implementations, fallback enumeration, exact messages, null behavior, and process-isolated telemetry cardinality

## Performance

Release microbenchmark of the isolated count path over 1,000 elements (median of five 200,000-iteration samples):

| Workload | Before | After | Allocations before | Allocations after |
| --- | ---: | ---: | ---: | ---: |
| `ICollection` (`ArrayList`) | 11,147.0 ns/op | 8.2 ns/op | 104 B/op | 0 B/op |
| plain `IEnumerable` | 17,432.4 ns/op | 17,446.1 ns/op | 24,096 B/op | 24,096 B/op |

The fallback result is effectively unchanged; the collection path becomes O(1) and allocation-free.

## Validation

- multi-target TestFramework unit-test project build with binary log
- 1,513 net8.0 TestFramework unit tests passed with telemetry opted out
- Release pack completed with binary log
- net8.0 telemetry acceptance case passed and verified exactly one `Assert.HasCount` and one `Assert.IsEmpty` event

Closes #10573