### PR TITLE
Add RetryArtifactProcessor.ProcessAsync unit tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -5,16 +5,20 @@
 
 using Microsoft.Testing.Extensions.Policy;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Extensions.RetryFailedTests.Serializers;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
 
 using Moq;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
+
+#pragma warning disable TPEXP // Artifact post-processing is experimental.
 
 [TestClass]
 public class RetryTests
@@ -44,6 +48,27 @@ public class RetryTests
     }
 
     [TestMethod]
+    public void SnapshotAttemptArtifacts_LeavesAttemptArtifactInPlace()
+    {
+        string retryRoot = Path.GetFullPath(Path.Combine("TR", "Retries", "abcde"));
+        string attemptDirectory = Path.Combine(retryRoot, "1");
+        string artifactPath = Path.Combine(attemptDirectory, "report.ctrf.json");
+        var fileSystem = new Mock<IFileSystem>();
+
+        RetryAttemptArtifact captured = Assert.ContainsSingle(RetryArtifactProcessor.SnapshotAttemptArtifacts(
+            fileSystem.Object,
+            [new ArtifactRequest(artifactPath, "microsoft.testing.ctrf")],
+            attempt: 1,
+            attemptDirectory,
+            retryRoot));
+
+        Assert.AreEqual(Path.GetFullPath(artifactPath), captured.Path);
+        Assert.IsNull(captured.DestinationPath);
+        fileSystem.Verify(fs => fs.CreateDirectory(It.IsAny<string>()), Times.Never);
+        fileSystem.Verify(fs => fs.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [TestMethod]
     public void PublishExternalArtifacts_UsesMergedReplacement()
     {
         string snapshotPath = Path.GetFullPath(Path.Combine("TR", "Retries", "abcde", "Artifacts", "2", "report.ctrf.json"));
@@ -60,6 +85,29 @@ public class RetryTests
 
         fileSystem.Verify(fs => fs.CreateDirectory(Path.GetDirectoryName(destinationPath)!), Times.Once);
         fileSystem.Verify(fs => fs.CopyFile(replacementPath, destinationPath, overwrite: true), Times.Once);
+    }
+
+    [TestMethod]
+    public void PublishExternalArtifacts_UsesFinalSnapshotWhenNoReplacementExists()
+    {
+        string finalSnapshotPath = Path.GetFullPath(Path.Combine("TR", "Retries", "abcde", "Artifacts", "2", "report.ctrf.json"));
+        string previousSnapshotPath = Path.GetFullPath(Path.Combine("TR", "Retries", "abcde", "Artifacts", "1", "report.ctrf.json"));
+        string destinationPath = Path.GetFullPath(Path.Combine("custom", "report.ctrf.json"));
+        var fileSystem = new Mock<IFileSystem>();
+
+        RetryArtifactProcessor.PublishExternalArtifacts(
+            fileSystem.Object,
+            [
+                new RetryAttemptArtifact(previousSnapshotPath, "microsoft.testing.ctrf", attempt: 1, destinationPath),
+                new RetryAttemptArtifact(finalSnapshotPath, "microsoft.testing.ctrf", attempt: 2, destinationPath),
+                new RetryAttemptArtifact("internal.ctrf.json", "microsoft.testing.ctrf", attempt: 2, destinationPath: null),
+            ],
+            finalAttempt: 2,
+            new Dictionary<string, string>());
+
+        fileSystem.Verify(fs => fs.CopyFile(finalSnapshotPath, destinationPath, overwrite: true), Times.Once);
+        fileSystem.Verify(fs => fs.CopyFile(previousSnapshotPath, It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        fileSystem.Verify(fs => fs.CopyFile("internal.ctrf.json", It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
     }
 
     [TestMethod]
@@ -95,6 +143,473 @@ public class RetryTests
 
         fileSystem.Verify(
             fs => fs.CopyFile(replacementFile, Path.Combine("TR", "report.xml"), overwrite: true),
+            Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_ProcessorWithoutRetryMode_IsNotCalled()
+    {
+        var processor = new TestArtifactPostProcessor(
+            supportedModes: [ArtifactPostProcessingMode.TestModules],
+            supportedKinds: ["report"],
+            supportedExtensions: []);
+        ServiceProvider serviceProvider = CreateServiceProvider(processor);
+
+        IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            [
+                new RetryAttemptArtifact("first.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("second.report", "report", attempt: 2, destinationPath: null),
+            ],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            CancellationToken.None);
+
+        Assert.IsEmpty(replacements);
+        Assert.AreEqual(0, processor.ProcessCallCount);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_SingleAttempt_IsNotProcessed()
+    {
+        var processor = new TestArtifactPostProcessor(
+            supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+            supportedKinds: ["report"],
+            supportedExtensions: []);
+        ServiceProvider serviceProvider = CreateServiceProvider(processor);
+
+        IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            [new RetryAttemptArtifact("first.report", "report", attempt: 1, destinationPath: null)],
+            attemptCount: 1,
+            Path.GetTempPath(),
+            CancellationToken.None);
+
+        Assert.IsEmpty(replacements);
+        Assert.AreEqual(0, processor.ProcessCallCount);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_CompleteArtifacts_UsesAttemptOrderAndMapsFinalArtifact()
+    {
+        string outputDirectory = CreateTemporaryDirectory();
+        try
+        {
+            string firstPath = Path.Combine(outputDirectory, "attempt-1.report");
+            string finalPath = Path.Combine(outputDirectory, "attempt-2.report");
+            string mergedPath = Path.Combine(outputDirectory, "merged.report");
+            IReadOnlyList<InputArtifact>? capturedInputs = null;
+            ArtifactPostProcessingContext? capturedContext = null;
+            CancellationToken capturedCancellationToken = default;
+            string? capturedOutputDirectory = null;
+            var processor = new TestArtifactPostProcessor(
+                supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+                supportedKinds: ["report"],
+                supportedExtensions: [],
+                (inputs, directory, context, cancellationToken) =>
+                {
+                    capturedInputs = inputs;
+                    capturedOutputDirectory = directory;
+                    capturedContext = context;
+                    capturedCancellationToken = cancellationToken;
+                    File.WriteAllText(mergedPath, "merged");
+                    return Task.FromResult<ProcessedArtifact?>(new ProcessedArtifact(
+                        mergedPath,
+                        "report",
+                        "Merged report",
+                        description: null));
+                });
+            ServiceProvider serviceProvider = CreateServiceProvider(processor);
+            var cancellationToken = new CancellationToken(canceled: false);
+
+            IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+                serviceProvider,
+                Mock.Of<IOutputDeviceDataProducer>(),
+                Mock.Of<IOutputDevice>(),
+                Mock.Of<ILogger>(),
+                [
+                    new RetryAttemptArtifact(finalPath, "report", attempt: 2, destinationPath: null),
+                    new RetryAttemptArtifact(firstPath, "report", attempt: 1, destinationPath: null),
+                ],
+                attemptCount: 2,
+                outputDirectory,
+                cancellationToken);
+
+            Assert.HasCount(1, replacements);
+            Assert.AreEqual(Path.GetFullPath(mergedPath), replacements[finalPath]);
+            Assert.IsNotNull(capturedInputs);
+            Assert.AreSequenceEqual([firstPath, finalPath], capturedInputs.Select(input => input.Path));
+            Assert.AreSequenceEqual(["report", "report"], capturedInputs.Select(input => input.Kind));
+            Assert.AreSequenceEqual(["1", "2"], capturedInputs.Select(input => input.ExecutionId));
+            Assert.IsTrue(capturedInputs.All(input =>
+                input.ProducingTestModule is null
+                && input.TargetFramework is null
+                && input.Architecture is null));
+            Assert.AreEqual(outputDirectory, capturedOutputDirectory);
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual(ArtifactPostProcessingMode.RetryAttempts, capturedContext.Mode);
+            Assert.AreEqual(ArtifactPostProcessingTruncationReason.None, capturedContext.TruncationReason);
+            Assert.AreEqual(cancellationToken, capturedCancellationToken);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [DataRow("report", "attempt.report", true)]
+    [DataRow(null, "attempt.REPORT", true)]
+    [DataRow(null, "attempt.txt", false)]
+    [DataRow("other", "attempt.report", false)]
+    [DataRow("REPORT", "attempt.report", false)]
+    [TestMethod]
+    public async Task ProcessAsync_MatchesProducerKindOrUntaggedExtension(
+        string? artifactKind,
+        string fileName,
+        bool shouldProcess)
+    {
+        string outputDirectory = CreateTemporaryDirectory();
+        try
+        {
+            string mergedPath = Path.Combine(outputDirectory, "merged.report");
+            var processor = new TestArtifactPostProcessor(
+                supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+                supportedKinds: ["report"],
+                supportedExtensions: [".report"],
+                (_, _, _, _) =>
+                {
+                    File.WriteAllText(mergedPath, "merged");
+                    return Task.FromResult<ProcessedArtifact?>(new ProcessedArtifact(
+                        mergedPath,
+                        "report",
+                        "Merged report",
+                        description: null));
+                });
+            ServiceProvider serviceProvider = CreateServiceProvider(processor);
+            string firstPath = Path.Combine(outputDirectory, "1", fileName);
+            string finalPath = Path.Combine(outputDirectory, "2", fileName);
+
+            IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+                serviceProvider,
+                Mock.Of<IOutputDeviceDataProducer>(),
+                Mock.Of<IOutputDevice>(),
+                Mock.Of<ILogger>(),
+                [
+                    new RetryAttemptArtifact(firstPath, artifactKind, attempt: 1, destinationPath: null),
+                    new RetryAttemptArtifact(finalPath, artifactKind, attempt: 2, destinationPath: null),
+                ],
+                attemptCount: 2,
+                outputDirectory,
+                CancellationToken.None);
+
+            Assert.AreEqual(shouldProcess ? 1 : 0, processor.ProcessCallCount);
+            Assert.AreEqual(shouldProcess, replacements.ContainsKey(finalPath));
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_ReplacementLookupUsesPlatformPathComparison()
+    {
+        string outputDirectory = CreateTemporaryDirectory();
+        try
+        {
+            string finalPath = Path.Combine(outputDirectory, "Attempt-2.report");
+            string mergedPath = Path.Combine(outputDirectory, "merged.report");
+            var processor = new TestArtifactPostProcessor(
+                supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+                supportedKinds: ["report"],
+                supportedExtensions: [],
+                (_, _, _, _) =>
+                {
+                    File.WriteAllText(mergedPath, "merged");
+                    return Task.FromResult<ProcessedArtifact?>(new ProcessedArtifact(
+                        mergedPath,
+                        "report",
+                        "Merged report",
+                        description: null));
+                });
+
+            IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+                CreateServiceProvider(processor),
+                Mock.Of<IOutputDeviceDataProducer>(),
+                Mock.Of<IOutputDevice>(),
+                Mock.Of<ILogger>(),
+                [
+                    new RetryAttemptArtifact(Path.Combine(outputDirectory, "attempt-1.report"), "report", attempt: 1, destinationPath: null),
+                    new RetryAttemptArtifact(finalPath, "report", attempt: 2, destinationPath: null),
+                ],
+                attemptCount: 2,
+                outputDirectory,
+                CancellationToken.None);
+
+            Assert.AreEqual(
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                replacements.ContainsKey(finalPath.ToUpperInvariant()));
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_IncompleteOrDuplicateAttemptArtifacts_AreNotProcessed()
+    {
+        var processor = new TestArtifactPostProcessor(
+            supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+            supportedKinds: ["report"],
+            supportedExtensions: []);
+        ServiceProvider serviceProvider = CreateServiceProvider(processor);
+
+        IReadOnlyDictionary<string, string> missingAttemptReplacements = await RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            [new RetryAttemptArtifact("attempt-1.report", "report", attempt: 1, destinationPath: null)],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            CancellationToken.None);
+        IReadOnlyDictionary<string, string> duplicateAttemptReplacements = await RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            [
+                new RetryAttemptArtifact("attempt-1-a.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("attempt-1-b.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("attempt-2.report", "report", attempt: 2, destinationPath: null),
+            ],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            CancellationToken.None);
+
+        Assert.IsEmpty(missingAttemptReplacements);
+        Assert.IsEmpty(duplicateAttemptReplacements);
+        Assert.AreEqual(0, processor.ProcessCallCount);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_ProcessorDeclinesMerge_ReturnsNoReplacement()
+    {
+        var processor = new TestArtifactPostProcessor(
+            supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+            supportedKinds: ["report"],
+            supportedExtensions: []);
+        ServiceProvider serviceProvider = CreateServiceProvider(processor);
+
+        IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            [
+                new RetryAttemptArtifact("attempt-1.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("attempt-2.report", "report", attempt: 2, destinationPath: null),
+            ],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            CancellationToken.None);
+
+        Assert.IsEmpty(replacements);
+        Assert.AreEqual(1, processor.ProcessCallCount);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_InvalidOutput_WarnsAndContinuesWithOtherKinds()
+    {
+        string outputDirectory = CreateTemporaryDirectory();
+        try
+        {
+            string validMergedPath = Path.Combine(outputDirectory, "valid-merged.report");
+            var invalidProcessor = new TestArtifactPostProcessor(
+                uid: "invalid-processor",
+                supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+                supportedKinds: ["invalid"],
+                supportedExtensions: [],
+                processAsync: (_, _, _, _) => Task.FromResult<ProcessedArtifact?>(new ProcessedArtifact(
+                    Path.Combine(outputDirectory, "missing.report"),
+                    "invalid",
+                    "Missing report",
+                    description: null)));
+            var validProcessor = new TestArtifactPostProcessor(
+                uid: "valid-processor",
+                supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+                supportedKinds: ["valid"],
+                supportedExtensions: [],
+                processAsync: (_, _, _, _) =>
+                {
+                    File.WriteAllText(validMergedPath, "merged");
+                    return Task.FromResult<ProcessedArtifact?>(new ProcessedArtifact(
+                        validMergedPath,
+                        "valid",
+                        "Merged report",
+                        description: null));
+                });
+            ServiceProvider serviceProvider = CreateServiceProvider(invalidProcessor, validProcessor);
+            var logger = new Mock<ILogger>();
+            var outputDevice = new Mock<IOutputDevice>();
+            var displayed = new List<IOutputDeviceData>();
+            outputDevice
+                .Setup(device => device.DisplayAsync(
+                    It.IsAny<IOutputDeviceDataProducer>(),
+                    It.IsAny<IOutputDeviceData>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>(
+                    (_, data, _) => displayed.Add(data))
+                .Returns(Task.CompletedTask);
+            string validFinalPath = Path.Combine(outputDirectory, "valid-2.report");
+
+            IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+                serviceProvider,
+                Mock.Of<IOutputDeviceDataProducer>(),
+                outputDevice.Object,
+                logger.Object,
+                [
+                    new RetryAttemptArtifact("invalid-1.report", "invalid", attempt: 1, destinationPath: null),
+                    new RetryAttemptArtifact("invalid-2.report", "invalid", attempt: 2, destinationPath: null),
+                    new RetryAttemptArtifact("valid-1.report", "valid", attempt: 1, destinationPath: null),
+                    new RetryAttemptArtifact(validFinalPath, "valid", attempt: 2, destinationPath: null),
+                ],
+                attemptCount: 2,
+                outputDirectory,
+                CancellationToken.None);
+
+            Assert.HasCount(1, replacements);
+            Assert.AreEqual(Path.GetFullPath(validMergedPath), replacements[validFinalPath]);
+            WarningMessageOutputDeviceData warning = Assert.IsInstanceOfType<WarningMessageOutputDeviceData>(
+                Assert.ContainsSingle(displayed));
+            Assert.Contains("invalid-processor", warning.Message);
+            logger.Verify(
+                logger => logger.Log(
+                    LogLevel.Warning,
+                    It.Is<string>(message =>
+                        message.Contains("invalid-processor", StringComparison.Ordinal)
+                        && message.Contains(nameof(InvalidOperationException), StringComparison.Ordinal)),
+                    null,
+                    It.IsAny<Func<string, Exception?, string>>()),
+                Times.Once);
+            Assert.AreEqual(1, invalidProcessor.ProcessCallCount);
+            Assert.AreEqual(1, validProcessor.ProcessCallCount);
+        }
+        finally
+        {
+            Directory.Delete(outputDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_CanceledProcessor_PropagatesWithoutWarning()
+    {
+        var cancellationToken = new CancellationToken(canceled: true);
+        var processor = new TestArtifactPostProcessor(
+            supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+            supportedKinds: ["report"],
+            supportedExtensions: [],
+            (_, _, _, _) => throw new OperationCanceledException(cancellationToken));
+        ServiceProvider serviceProvider = CreateServiceProvider(processor);
+        var logger = new Mock<ILogger>();
+        var outputDevice = new Mock<IOutputDevice>();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() => RetryArtifactProcessor.ProcessAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            outputDevice.Object,
+            logger.Object,
+            [
+                new RetryAttemptArtifact("attempt-1.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("attempt-2.report", "report", attempt: 2, destinationPath: null),
+            ],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            cancellationToken));
+
+        logger.Verify(
+            logger => logger.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<string>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<string, Exception?, string>>()),
+            Times.Never);
+        outputDevice.Verify(
+            device => device.DisplayAsync(
+                It.IsAny<IOutputDeviceDataProducer>(),
+                It.IsAny<IOutputDeviceData>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_UnrelatedCancellation_WarnsWithoutPropagating()
+    {
+        const string ProcessorUid = "canceling-processor";
+        const string ExceptionMessage = "The processor canceled its own operation.";
+        var processor = new TestArtifactPostProcessor(
+            uid: ProcessorUid,
+            supportedModes: [ArtifactPostProcessingMode.RetryAttempts],
+            supportedKinds: ["report"],
+            supportedExtensions: [],
+            processAsync: (_, _, _, _) => throw new OperationCanceledException(ExceptionMessage));
+        var logger = new Mock<ILogger>();
+        var outputDevice = new Mock<IOutputDevice>();
+        var producer = new Mock<IOutputDeviceDataProducer>();
+        WarningMessageOutputDeviceData? displayedWarning = null;
+        outputDevice
+            .Setup(device => device.DisplayAsync(
+                producer.Object,
+                It.IsAny<WarningMessageOutputDeviceData>(),
+                CancellationToken.None))
+            .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>(
+                (_, data, _) => displayedWarning = (WarningMessageOutputDeviceData)data)
+            .Returns(Task.CompletedTask);
+
+        IReadOnlyDictionary<string, string> replacements = await RetryArtifactProcessor.ProcessAsync(
+            CreateServiceProvider(processor),
+            producer.Object,
+            outputDevice.Object,
+            logger.Object,
+            [
+                new RetryAttemptArtifact("attempt-1.report", "report", attempt: 1, destinationPath: null),
+                new RetryAttemptArtifact("attempt-2.report", "report", attempt: 2, destinationPath: null),
+            ],
+            attemptCount: 2,
+            Path.GetTempPath(),
+            CancellationToken.None);
+
+        Assert.IsEmpty(replacements);
+        Assert.IsNotNull(displayedWarning);
+        Assert.AreEqual(
+            string.Format(
+                CultureInfo.CurrentCulture,
+                Policy.Resources.ExtensionResources.RetryArtifactPostProcessorFailed,
+                ProcessorUid,
+                ExceptionMessage),
+            displayedWarning.Message);
+        logger.Verify(
+            logger => logger.Log(
+                LogLevel.Warning,
+                It.Is<string>(message =>
+                    message.Contains(ProcessorUid, StringComparison.Ordinal)
+                    && message.Contains(nameof(OperationCanceledException), StringComparison.Ordinal)
+                    && message.Contains(ExceptionMessage, StringComparison.Ordinal)),
+                null,
+                It.IsAny<Func<string, Exception?, string>>()),
+            Times.Once);
+        outputDevice.Verify(
+            device => device.DisplayAsync(
+                producer.Object,
+                It.IsAny<WarningMessageOutputDeviceData>(),
+                CancellationToken.None),
             Times.Once);
     }
 
@@ -296,5 +811,78 @@ public class RetryTests
         ValidationResult validateOptionsResult = await provider.ValidateCommandLineOptionsAsync(new TestCommandLineOptions(options)).ConfigureAwait(false);
         Assert.IsTrue(validateOptionsResult.IsValid);
         Assert.IsTrue(string.IsNullOrEmpty(validateOptionsResult.ErrorMessage));
+    }
+
+    private static ServiceProvider CreateServiceProvider(params IArtifactPostProcessor[] processors)
+    {
+        ServiceProvider serviceProvider = new();
+        serviceProvider.AddServices(processors);
+        return serviceProvider;
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"retry-artifact-processor-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private sealed class TestArtifactPostProcessor : IArtifactPostProcessor
+    {
+        private readonly Func<
+            IReadOnlyList<InputArtifact>,
+            string,
+            ArtifactPostProcessingContext,
+            CancellationToken,
+            Task<ProcessedArtifact?>> _processAsync;
+
+        public TestArtifactPostProcessor(
+            IReadOnlyList<ArtifactPostProcessingMode> supportedModes,
+            IReadOnlyList<string> supportedKinds,
+            IReadOnlyList<string> supportedExtensions,
+            Func<
+                IReadOnlyList<InputArtifact>,
+                string,
+                ArtifactPostProcessingContext,
+                CancellationToken,
+                Task<ProcessedArtifact?>>? processAsync = null,
+            string uid = "test-processor")
+        {
+            SupportedModes = supportedModes;
+            SupportedKinds = supportedKinds;
+            SupportedFileExtensionsFallback = supportedExtensions;
+            Uid = uid;
+            _processAsync = processAsync ?? ((_, _, _, _) => Task.FromResult<ProcessedArtifact?>(null));
+        }
+
+        public string Uid { get; }
+
+        public string Version => "1.0.0";
+
+        public string DisplayName => Uid;
+
+        public string Description => Uid;
+
+        public IReadOnlyList<ArtifactPostProcessingMode> SupportedModes { get; }
+
+        public bool SupportsTruncatedRuns => false;
+
+        public IReadOnlyList<string> SupportedKinds { get; }
+
+        public IReadOnlyList<string> SupportedFileExtensionsFallback { get; }
+
+        public int ProcessCallCount { get; private set; }
+
+        public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+        public Task<ProcessedArtifact?> ProcessAsync(
+            IReadOnlyList<InputArtifact> inputs,
+            string outputDirectory,
+            ArtifactPostProcessingContext context,
+            CancellationToken cancellationToken)
+        {
+            ProcessCallCount++;
+            return _processAsync(inputs, outputDirectory, context, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add focused unit coverage for retry artifact processor selection, matching, and complete-attempt validation
- verify ordered processor inputs, replacement bookkeeping, external artifact publication, and platform path comparison
- cover null and invalid processor output, exact warning behavior, continuation, and cancellation semantics

## Testing

- `.\build.cmd -projects test\UnitTests\Microsoft.Testing.Extensions.UnitTests\Microsoft.Testing.Extensions.UnitTests.csproj -bl`
- `.\.dotnet\dotnet.exe test test\UnitTests\Microsoft.Testing.Extensions.UnitTests\Microsoft.Testing.Extensions.UnitTests.csproj -c Debug --no-build --no-restore -bl:artifacts\log\Debug\RetryArtifactProcessor.AllTfms.binlog`
  - 4,200 passed and 24 platform-specific skipped across `net462`, `net472`, `net8.0`, and `net9.0`

Closes #10578
