### PR TITLE
Optimize VSTestBridge property lookup

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/ObjectModelConverters.cs
@@ -270,7 +270,7 @@ internal static class ObjectModelConverters
     {
         // Because this project is the actually registered test adapter, we need to replace test framework executor
         // URI by ours.
-        if (!testCase.Properties.Any(x => x.Id == OriginalExecutorUriProperty.Id))
+        if (!testCase.GetProperties().Any(static property => property.Key.Id == OriginalExecutorUriProperty.Id))
         {
             testCase.SetPropertyValue(OriginalExecutorUriProperty, testCase.ExecutorUri);
         }

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Testing.Extensions.VSTestBridge.UnitTests.ObjectModel;
 public sealed class ObjectModelConvertersTests
 {
     private static readonly IClientInfo ClientInfo = new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: false));
+    private static readonly TestProperty OriginalExecutorUriProperty = TestProperty.Register(
+        VSTestTestNodeProperties.OriginalExecutorUriPropertyName,
+        VSTestTestNodeProperties.OriginalExecutorUriPropertyName,
+        typeof(Uri),
+        typeof(TestCase));
 
     [TestMethod]
     [DataRow(true)]
@@ -289,6 +294,58 @@ public sealed class ObjectModelConvertersTests
         StandardErrorProperty[] standardErrorProperties = [.. testNode.Properties.OfType<StandardErrorProperty>()];
         Assert.HasCount(1, standardErrorProperties);
         Assert.AreEqual($"message1{Environment.NewLine}message2", standardErrorProperties[0].StandardError);
+    }
+
+    [TestMethod]
+    public void FixUpTestCase_WhenOriginalExecutorUriPropertyExists_DoesNotOverwriteIt()
+    {
+        var originalExecutorUri = new Uri("executor://original");
+        var testCase = new TestCase("SomeFqn", new("executor://current"), "source.cs");
+        testCase.SetPropertyValue(OriginalExecutorUriProperty, originalExecutorUri);
+
+        testCase.FixUpTestCase();
+
+        Assert.AreEqual(originalExecutorUri, testCase.GetPropertyValue(OriginalExecutorUriProperty));
+    }
+
+    [TestMethod]
+    public void FixUpTestCase_WhenOriginalExecutorUriPropertyIsMissing_CapturesItExactlyOnce()
+    {
+        var originalExecutorUri = new Uri("executor://original");
+        var testCase = new TestCase("SomeFqn", originalExecutorUri, "source.cs");
+
+        testCase.FixUpTestCase();
+        testCase.FixUpTestCase();
+
+        KeyValuePair<TestProperty, object?>[] originalExecutorUriProperties =
+            [.. testCase.GetProperties().Where(static property => property.Key.Id == VSTestTestNodeProperties.OriginalExecutorUriPropertyName)];
+        Assert.HasCount(1, originalExecutorUriProperties);
+        Assert.AreEqual(originalExecutorUri, originalExecutorUriProperties[0].Value);
+    }
+
+    [TestMethod]
+    public void FixUpTestCase_ReplacesExecutorUriWithVSTestBridgeExecutorUri()
+    {
+        var testCase = new TestCase("SomeFqn", new("executor://original"), "source.cs");
+
+        testCase.FixUpTestCase();
+
+        Assert.AreEqual(new Uri(Constants.ExecutorUri), testCase.ExecutorUri);
+    }
+
+    [TestMethod]
+    public void FixUpTestCase_WhenOriginalExecutorUriPropertyHasNullValue_StillTreatsItAsExisting()
+    {
+        var testCase = new TestCase("SomeFqn", new("executor://original"), "source.cs");
+        object? nullValue = null;
+        testCase.SetPropertyValue(OriginalExecutorUriProperty, nullValue);
+
+        testCase.FixUpTestCase();
+
+        KeyValuePair<TestProperty, object?>[] originalExecutorUriProperties =
+            [.. testCase.GetProperties().Where(static property => property.Key.Id == VSTestTestNodeProperties.OriginalExecutorUriPropertyName)];
+        Assert.HasCount(1, originalExecutorUriProperties);
+        Assert.IsNull(originalExecutorUriProperties[0].Value);
     }
 
     private sealed class NamedFeatureCapabilityWithVSTestProvider : INamedFeatureCapability


### PR DESCRIPTION
## Summary

- scan only custom `TestCase` properties when preserving the original executor URI
- avoid `TestCase.Properties` concatenation and key-snapshot allocations on the per-test-case hot path
- preserve existing behavior for repeated fixups, stored `null` values, and executor URI replacement
- add focused regression coverage

## Performance

Independent .NET 9 measurements used `Microsoft.TestPlatform.ObjectModel` 18.8.0, four custom properties, five 5,000,000-call repetitions, and hit-first/hit-last/no-hit scenarios. The original non-capturing predicate was confirmed to be cached; the savings come from avoiding `TestCase.Properties` enumeration.

| Scenario | Before | After | Before allocation | After allocation |
| --- | ---: | ---: | ---: | ---: |
| hit-first custom | 542 ns/call | 55 ns/call | 200 B/call | 64 B/call |
| hit-last custom | 593 ns/call | 190 ns/call | 200 B/call | 64 B/call |
| no hit | 585 ns/call | 202 ns/call | 200 B/call | 64 B/call |

A manual loop retained the same allocations as each corresponding LINQ path, so this keeps the simpler `Any` expression.

## Testing

- warning-free build for `net462`, `net8.0`, and `net9.0`
- full `Microsoft.Testing.Extensions.VSTestBridge.UnitTests` suites: 69/69 (`net462`), 74/74 (`net8.0`), 74/74 (`net9.0`)

Closes #10585