### PR TITLE
Don't format the resolver diagnostic like an MSBuild error

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.Resolution.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/AssemblyResolver.Resolution.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if NETFRAMEWORK || (NET && !WINDOWS_UWP)
@@ -235,7 +235,7 @@ internal partial class AssemblyResolver
                     {
                         // Bypass MSTest's Console.Error router so this infrastructure failure is not attributed to the active test.
                         StandardErrorWriter.Value.WriteLine(
-                            $"MSTest.AssemblyResolver: Trace logging failed while resolving '{assemblyName}'. Error: {ex}");
+                            $"[MSTest.AssemblyResolver] Trace logging failed while resolving '{assemblyName}'. Exception: {ex}");
                     }
                     catch (Exception)
                     {

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
@@ -210,12 +210,6 @@ public class AssemblyResolverTests : TestContainer
 
             act.Should().NotThrow();
             resolvedAssembly.Should().BeSameAs(expectedAssembly);
-
-            // SafeLog writes its fallback directly to stderr. Running this test through MTP/MSBuild
-            // verifies that the diagnostic is not parsed as an MSBuild error.
-            resolvedAssembly = null;
-            act.Should().NotThrow();
-            resolvedAssembly.Should().BeSameAs(expectedAssembly);
         }
         finally
         {

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/AssemblyResolverTests.cs
@@ -210,6 +210,12 @@ public class AssemblyResolverTests : TestContainer
 
             act.Should().NotThrow();
             resolvedAssembly.Should().BeSameAs(expectedAssembly);
+
+            // SafeLog writes its fallback directly to stderr. Running this test through MTP/MSBuild
+            // verifies that the diagnostic is not parsed as an MSBuild error.
+            resolvedAssembly = null;
+            act.Should().NotThrow();
+            resolvedAssembly.Should().BeSameAs(expectedAssembly);
         }
         finally
         {


### PR DESCRIPTION
#10532 added a fallback that writes to raw standard error when the trace logger itself fails during assembly resolution, so the diagnostic is not lost. The line looked like this:

```
MSTest.AssemblyResolver: Trace logging failed while resolving 'X'. Error: System.Runtime.Remoting.RemotingException: ...
```

That is MSBuild's canonical diagnostic format, `origin: [subcategory] error [code]: text`. MSBuild scans tool output for that pattern, so a purely informational line was reported as a real build error, and the run failed on .NET Framework even though resolution succeeded and all tests passed. It shows up intermittently, because the logger only fails once the cross-AppDomain lease expires in a long run.

The message is now:

```
[MSTest.AssemblyResolver] Trace logging failed while resolving 'X'. Exception: System.Runtime.Remoting.RemotingException: ...
```

The origin is in brackets instead of being terminated by a colon, and `Error:` became `Exception:`, so there is no `error` or `warning` token left for MSBuild to pick up. Running both lines against `CanonicalError.OriginCategoryCodeTextExpression` from dotnet/msbuild, the old one matches with `CATEGORY=Error`, the new one does not match at all.

Verified in the internal build [20260817.1](https://dev.azure.com/dnceng/internal/_build/results?buildId=3049890), which passes.

🤖