### PR TITLE
Skip the binlog steps when the integration suite produced no binlogs

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -165,6 +165,25 @@ extends:
                   # mapping is required; the history service no-ops if the token or endpoints are unavailable.
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+              # The integration suite only creates artifacts/tmp/$(_BuildConfig)/testsuite once it runs, and
+              # CopyFiles@2 hard-fails when SourceFolder does not exist. A Test failure early enough to skip
+              # the suite therefore reported one real problem as three failed steps: Test, Copy binlogs, and
+              # Publish integration tests binlogs all failed in
+              # https://dev.azure.com/dnceng/internal/_build/results?buildId=3045544. Probe for the binlogs so
+              # both steps skip when there are none. When the suite did produce binlogs they are copied and
+              # published exactly as before, including on a failed run, which is why these use always().
+              - pwsh: |
+                  $testsuite = Join-Path '$(Build.SourcesDirectory)' 'artifacts/tmp/$(_BuildConfig)/testsuite'
+                  $hasBinlogs = 'false'
+                  if (Test-Path -LiteralPath $testsuite -PathType Container) {
+                    $binlog = Get-ChildItem -LiteralPath $testsuite -Filter '*.binlog' -Recurse -File -ErrorAction SilentlyContinue | Select-Object -First 1
+                    if ($null -ne $binlog) { $hasBinlogs = 'true' }
+                  }
+                  Write-Host "Integration tests binlogs under '$testsuite': $hasBinlogs"
+                  Write-Host "##vso[task.setvariable variable=HasIntegrationTestBinlogs]$hasBinlogs"
+                displayName: 'Check for integration tests binlogs'
+                condition: always()
+
               - task: CopyFiles@2
                 displayName: 'Copy binlogs'
                 inputs:
@@ -172,14 +191,14 @@ extends:
                   Contents: |
                     **/*.binlog
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-                condition: always()
+                condition: and(always(), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish integration tests binlogs'
                 inputs:
                   PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
                   ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
-                condition: always()
+                condition: and(always(), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
               # Remove temporary artifacts to avoid finding binskim issues for exes we don't own.
               - pwsh: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -764,6 +764,25 @@ stages:
               ArtifactName: TestResults_Windows_$(_BuildConfig)_Attempt$(System.JobAttempt)
             condition: always()
 
+          # The integration suite only creates artifacts/tmp/$(_BuildConfig)/testsuite once it runs, and
+          # CopyFiles@2 hard-fails when SourceFolder does not exist. A Test failure early enough to skip the
+          # suite therefore reported one real problem as three failed steps: Test, Copy binlogs, and Publish
+          # integration tests binlogs all failed in
+          # https://dev.azure.com/dnceng/internal/_build/results?buildId=3045544. Probe for the binlogs so
+          # both steps skip when there are none. When the suite did produce binlogs they are copied and
+          # published exactly as before, including on a failed run, which is why these use always().
+          - pwsh: |
+              $testsuite = Join-Path '$(Build.SourcesDirectory)' 'artifacts/tmp/$(_BuildConfig)/testsuite'
+              $hasBinlogs = 'false'
+              if (Test-Path -LiteralPath $testsuite -PathType Container) {
+                $binlog = Get-ChildItem -LiteralPath $testsuite -Filter '*.binlog' -Recurse -File -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -ne $binlog) { $hasBinlogs = 'true' }
+              }
+              Write-Host "Integration tests binlogs under '$testsuite': $hasBinlogs"
+              Write-Host "##vso[task.setvariable variable=HasIntegrationTestBinlogs]$hasBinlogs"
+            displayName: 'Check for integration tests binlogs'
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+
           - task: CopyFiles@2
             displayName: 'Copy binlogs'
             inputs:
@@ -771,14 +790,14 @@ stages:
               Contents: |
                 **/*.binlog
               TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish integration tests binlogs'
             inputs:
               PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
               ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish local dumps'

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -79,6 +79,24 @@ steps:
     ArtifactName: TestResults_${{ parameters.osName }}_$(_BuildConfig)_Attempt$(System.JobAttempt)
   condition: always()
 
+# The integration suite only creates artifacts/tmp/$(_BuildConfig)/testsuite once it runs, and CopyFiles@2
+# hard-fails when SourceFolder does not exist. A Test failure early enough to skip the suite therefore
+# reported one real problem as three failed steps: Test, Copy binlogs, and Publish integration tests binlogs
+# all failed in https://dev.azure.com/dnceng/internal/_build/results?buildId=3045544. Probe for the binlogs so
+# both steps skip when there are none. When the suite did produce binlogs they are copied and published
+# exactly as before, including on a failed run, which is why these use always().
+- pwsh: |
+    $testsuite = Join-Path '$(Build.SourcesDirectory)' 'artifacts/tmp/$(_BuildConfig)/testsuite'
+    $hasBinlogs = 'false'
+    if (Test-Path -LiteralPath $testsuite -PathType Container) {
+      $binlog = Get-ChildItem -LiteralPath $testsuite -Filter '*.binlog' -Recurse -File -ErrorAction SilentlyContinue | Select-Object -First 1
+      if ($null -ne $binlog) { $hasBinlogs = 'true' }
+    }
+    Write-Host "Integration tests binlogs under '$testsuite': $hasBinlogs"
+    Write-Host "##vso[task.setvariable variable=HasIntegrationTestBinlogs]$hasBinlogs"
+  displayName: 'Check for integration tests binlogs'
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+
 - task: CopyFiles@2
   displayName: 'Copy binlogs'
   inputs:
@@ -86,11 +104,11 @@ steps:
     Contents: |
       **/*.binlog
     TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish integration tests binlogs'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
     ArtifactName: Integration_Tests_${{ parameters.osName }}_Binlogs_$(_BuildConfig)
-  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))


### PR DESCRIPTION
`CopyFiles@2` hard-fails when `SourceFolder` does not exist, and the integration suite only creates `artifacts/tmp/<config>/testsuite` once it actually runs. A `Test` step that failed before that point reported one real problem as three failed steps: in [build 20260811.6](https://dev.azure.com/dnceng/internal/_build/results?buildId=3045544&view=results) only `Test` was real, while `Copy binlogs` failed on a missing `SourceFolder` and `Publish integration tests binlogs` then failed on the `PathtoPublish` the copy never created.

Probe for the binlogs first and gate the copy and the publish on the result. When the suite did produce binlogs they are copied and published exactly as before, including on a failed run, which is the whole point of running these under `always()`. The paths were never wrong, so nothing about them changes: `SourceFolder`, `TargetFolder`, `PathtoPublish` and every `ArtifactName` are untouched.

Same change in the official, public, and non-Windows pipelines. The non-Windows probe uses `pwsh` with `Join-Path` and forward slashes so it runs on Linux and macOS.

No `continueOnError`: that would leave the step orange and would also hide a genuine copy failure. When there is nothing to publish the two steps are skipped instead.

Verified: the three files parse with PyYAML 6.0.3, which accepts the `${{ }}` template expressions in them. The probe script was extracted from each file and run on pwsh 7.6.5, covering missing `testsuite`, empty `testsuite`, files but no binlogs, a binlog nested in subfolders, a binlog directly in `testsuite`, many binlogs, a path containing spaces and brackets, and a binlog outside `testsuite`. All 9 cases behave as intended in all 3 files.

Not verified: I ran the probe only on Windows, and I cannot run the internal pipeline from a pull request, so nothing here proves the fix against definition 1218. This PR's own public run is the real cross-platform check, since the Windows, Linux and macOS jobs all have a Debug leg and this change counts as a product change for `DetectChanges`. That run exercises the probe on all three operating systems, but only on the path where binlogs exist, because the skip path needs a run where the integration suite never starts.

🤖