### PR TITLE
Fix apphost DOTNET_ROOT path assertion

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -399,7 +399,17 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             environmentVariables: CreateEnvironmentVariables(),
             cancellationToken: TestContext.CancellationToken);
 
-        derivedResult.AssertOutputContains($"[env] {dotnetRootVariableName}={dotnetRoot}");
+        string dotnetRootOutputPrefix = $"[env] {dotnetRootVariableName}=";
+        string? dotnetRootOutput = derivedResult.StandardOutputLines
+            .Select(line => line.TrimStart())
+            .FirstOrDefault(line => line.StartsWith(dotnetRootOutputPrefix, StringComparison.Ordinal));
+        Assert.IsNotNull(dotnetRootOutput, derivedResult.ToString());
+        // DOTNET_HOST_PATH can preserve different drive-letter casing than RootFinder on Windows.
+        Assert.AreEqual(
+            dotnetRoot,
+            dotnetRootOutput[dotnetRootOutputPrefix.Length..],
+            ignoreCase: OperatingSystem.IsWindows(),
+            derivedResult.ToString());
 
         DotnetMuxerResult explicitResult = await DotnetCli.RunAsync(
             $"build -t:Test -p:TestingPlatformCaptureOutput=False -p:ExplicitDotnetRoot=\"{dotnetRoot}\" \"{testAsset.TargetAssetPath}\"",


### PR DESCRIPTION
Compare the derived Windows path without drive-letter case sensitivity. `DOTNET_HOST_PATH` can use a lowercase drive letter while `RootFinder` returns uppercase, even though both resolve to the same directory.

Verified: the affected `net11.0|x64` acceptance test passes locally.

🤖