### PR TITLE
Make the markdownlint gate pass now that the action is allowed

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -132,6 +132,10 @@
     // MD051: Link fragments should be valid
     "MD051": true,
 
+    // MD060: Table column style - disabled. Purely cosmetic pipe padding, added in
+    // markdownlint v0.41, that no existing table in the repository follows.
+    "MD060": false,
+
     // proper-names: Enforce proper capitalization of names
     "proper-names": {
       "code_blocks": false,

--- a/docs/RFCs/016-JUnit-Report.md
+++ b/docs/RFCs/016-JUnit-Report.md
@@ -158,7 +158,7 @@ Writing the stack trace alone would **not** be equivalent to Java's output: .NET
 
 The `message` and `type` attributes are still written, so consumers that read them directly are unaffected. The resulting duplication between the `message` attribute and the body is exactly what every Maven/Surefire report already exhibits, so consumers that render both have long handled it.
 
-Each part degrades gracefully: a missing exception type drops the header prefix, a missing message drops the `: ` separator, and a missing stack trace yields a header-only body.
+Each part degrades gracefully: a missing exception type drops the header prefix, a missing message drops the colon-space separator, and a missing stack trace yields a header-only body.
 
 ### The `type` attribute
 

--- a/docs/RFCs/017-TestHost-Launcher.md
+++ b/docs/RFCs/017-TestHost-Launcher.md
@@ -289,6 +289,7 @@ Loopback exemptions (`CheckNetIsolation LoopbackExempt`) are explicitly *not* pa
 apply to network loopback sockets, not to named-pipe DACLs, and would not help here.
 
 ### Contract requirements on the launcher
+
 - The launched host **must** end up with the values in `context.EnvironmentVariables` (so it connects
   back on the controller pipe) and **must** receive `context.Arguments`. *How* those values reach the
   host is left to the launcher — they can be inherited from the environment, passed as activation

--- a/docs/RFCs/020-Resource-Lock-Attribute.md
+++ b/docs/RFCs/020-Resource-Lock-Attribute.md
@@ -256,7 +256,7 @@ it. With `Workers = 4`, four dequeued chunks contending on one exclusive key lea
 parked and the rest of the queue stalled — even though those queued chunks declare no locks and
 could otherwise run. So `[ResourceLock]` guarantees *correct mutual exclusion*, not that unrelated
 tests always keep running; heavy contention still reduces effective parallelism. Keep locked tests a
-small fraction of the suite (see the speedup math under [Granularity guidance](#granularity-guidance)).
+small fraction of the suite (see the speedup math under [Granularity guidance](#guidance-granularity)).
 Lock-aware dispatch — skipping over a chunk whose locks are unavailable and taking the next one — is
 [Future work](#future-work); it is deliberately not attempted in v1 because a naive version can
 livelock without a bounded retry policy.

--- a/docs/RFCs/021-Per-Test-Temporary-Directory.md
+++ b/docs/RFCs/021-Per-Test-Temporary-Directory.md
@@ -283,10 +283,10 @@ contain characters illegal in paths and can be very long. Scheme:
    are cryptographically negligible — a full 128-bit GUID makes two contexts choosing the same
    suffix effectively impossible even at very large scales (millions of contexts).
 5. **Create with collision retry**: attempt `Directory.CreateDirectory` for the candidate; if the
-   directory already exists, regenerate the suffix and retry a bounded number of times. `Directory.Exists`
-   + `CreateDirectory` is not an atomic exclusive create, so the retry is only a belt-and-braces
-   guard — the actual uniqueness guarantee comes from the 128-bit suffix, whose birthday-collision
-   probability is negligible, not from the pre-check.
+   directory already exists, regenerate the suffix and retry a bounded number of times.
+   `Directory.Exists` + `CreateDirectory` is not an atomic exclusive create, so the retry is only a
+   belt-and-braces guard — the actual uniqueness guarantee comes from the 128-bit suffix, whose
+   birthday-collision probability is negligible, not from the pre-check.
 
 If the test name is empty, whitespace-only, made up entirely of invalid characters, or the adaptive
 budget has collapsed to zero, the sanitized prefix is empty and the directory name is **just the


### PR DESCRIPTION
The markdownlint gate ran for the first time since 2026-07-25 today, because `DavidAnson/markdownlint-cli2-action` is now permitted by the organization allowed-actions list. It starts, creates a job, and fails: 278 issues in 7 files. This makes it pass.

## Why it was dead

The workflow ended in `startup_failure` on 435 consecutive runs. No job is created, so there is no check run and `runs/<id>/logs` returns 404 — the failure was invisible everywhere except the run page itself, which is why it went unnoticed for three weeks. The error, verbatim from [run 31674560655](https://github.com/microsoft/testfx/actions/runs/31674560655):

> The action davidanson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff is not allowed in microsoft/testfx because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: DavidAnson/markdownlint-cli2-action@v18, dotnet/arcade/.github/workflows/\*, peter-evans/create-pull-request@\*.

The allow-list permitted the literal tag `@v18` and nothing else. That matches the history exactly: [#10163](https://github.com/microsoft/testfx/pull/10163) bumped v18 to v24 and broke it, [#10196](https://github.com/microsoft/testfx/pull/10196) reverted to v18 as a side effect of an unrelated MSBuildCache change and it worked again, and [#10214](https://github.com/microsoft/testfx/pull/10214) re-bumped to v24.1.0 and broke it for good.

That cause is fixed outside this repository, so `.github/workflows/markdownlint.yml` is unchanged here and no Dependabot ignore is needed.

## What this changes

Enabling the gate exposes 278 issues, 273 of them `MD060/table-column-style` — cosmetic pipe padding added in markdownlint v0.41 that no table in the repository follows. It is disabled in `.markdownlint-cli2.jsonc` next to the existing `MD013` opt-out rather than reformatting 273 table cells across 6 RFCs. One or the other, not both.

The 5 genuine violations are fixed: `MD004`, `MD022`, `MD032`, `MD038`, and an `MD051` link fragment that pointed at `#granularity-guidance` when the heading is `## Guidance (granularity)`.

Verified: `markdownlint-cli2@0.23.2` reports 0 issues across 86 files, the same file count as before, and `python .github/scripts/check_action_pins.py` exits 0 across 2272 references.

🤖