### PR TITLE
Skip the binlog steps when there are no binlogs

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -165,6 +165,28 @@ extends:
                   # mapping is required; the history service no-ops if the token or endpoints are unavailable.
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+              # artifacts/tmp/<config>/testsuite is created by the acceptance tests as they run, so it does not
+              # exist yet when the build or the test step fails before reaching them. Both binlog steps below
+              # hard-fail on a missing folder ('Not found SourceFolder' / 'Not found PathtoPublish'), so every
+              # failed build used to report two extra red steps that have nothing to do with the real failure.
+              # Detect the binlogs up front and let the two steps skip when there is nothing to collect, so a
+              # failed build only shows the step that actually broke.
+              - pwsh: |
+                  $testsuiteDirectory = "$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite"
+                  $binlogs = @()
+                  if (Test-Path $testsuiteDirectory) {
+                    # SilentlyContinue: this task defaults to $ErrorActionPreference = 'Stop', so an unreadable
+                    # or too-long path under the generated test assets would otherwise fail the step.
+                    $binlogs = @(Get-ChildItem $testsuiteDirectory -Filter *.binlog -File -Recurse -ErrorAction SilentlyContinue)
+                  }
+
+                  Write-Host "Found $($binlogs.Count) integration test binlog(s) under $testsuiteDirectory."
+                  if ($binlogs.Count -gt 0) {
+                    Write-Host "##vso[task.setvariable variable=IntegrationTestBinlogsFound]true"
+                  }
+                displayName: 'Detect integration tests binlogs'
+                condition: always()
+
               - task: CopyFiles@2
                 displayName: 'Copy binlogs'
                 inputs:
@@ -172,14 +194,14 @@ extends:
                   Contents: |
                     **/*.binlog
                   TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-                condition: always()
+                condition: and(always(), eq(variables['IntegrationTestBinlogsFound'], 'true'))
 
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish integration tests binlogs'
                 inputs:
                   PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
                   ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
-                condition: always()
+                condition: and(always(), eq(variables['IntegrationTestBinlogsFound'], 'true'))
 
               # Remove temporary artifacts to avoid finding binskim issues for exes we don't own.
               - pwsh: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -764,6 +764,28 @@ stages:
               ArtifactName: TestResults_Windows_$(_BuildConfig)_Attempt$(System.JobAttempt)
             condition: always()
 
+          # artifacts/tmp/<config>/testsuite is created by the acceptance tests as they run, so it does not
+          # exist yet when the build or the test step fails before reaching them. Both binlog steps below
+          # hard-fail on a missing folder ('Not found SourceFolder' / 'Not found PathtoPublish'), so every
+          # failed build used to report two extra red steps that have nothing to do with the real failure.
+          # Detect the binlogs up front and let the two steps skip when there is nothing to collect, so a
+          # failed build only shows the step that actually broke.
+          - pwsh: |
+              $testsuiteDirectory = "$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite"
+              $binlogs = @()
+              if (Test-Path $testsuiteDirectory) {
+                # SilentlyContinue: this task defaults to $ErrorActionPreference = 'Stop', so an unreadable
+                # or too-long path under the generated test assets would otherwise fail the step.
+                $binlogs = @(Get-ChildItem $testsuiteDirectory -Filter *.binlog -File -Recurse -ErrorAction SilentlyContinue)
+              }
+
+              Write-Host "Found $($binlogs.Count) integration test binlog(s) under $testsuiteDirectory."
+              if ($binlogs.Count -gt 0) {
+                Write-Host "##vso[task.setvariable variable=IntegrationTestBinlogsFound]true"
+              }
+            displayName: 'Detect integration tests binlogs'
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+
           - task: CopyFiles@2
             displayName: 'Copy binlogs'
             inputs:
@@ -771,14 +793,14 @@ stages:
               Contents: |
                 **/*.binlog
               TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables['IntegrationTestBinlogsFound'], 'true'))
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish integration tests binlogs'
             inputs:
               PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
               ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
-            condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+            condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables['IntegrationTestBinlogsFound'], 'true'))
 
           - task: PublishBuildArtifacts@1
             displayName: 'Publish local dumps'

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -79,6 +79,26 @@ steps:
     ArtifactName: TestResults_${{ parameters.osName }}_$(_BuildConfig)_Attempt$(System.JobAttempt)
   condition: always()
 
+# artifacts/tmp/<config>/testsuite is created by the acceptance tests as they run, so it does not exist
+# yet when the build or the test step fails before reaching them. Both binlog steps below hard-fail on a
+# missing folder ('Not found SourceFolder' / 'Not found PathtoPublish'), so every failed build used to
+# report two extra red steps that have nothing to do with the real failure. Detect the binlogs up front
+# and let the two steps skip when there is nothing to collect, so a failed build only shows the step that
+# actually broke.
+#
+# `find | grep -q .` (instead of a `$(...)` command substitution) keeps the script free of the `$(...)`
+# syntax that Azure Pipelines expands as a macro before bash ever sees it.
+- bash: |
+    testsuiteDirectory="$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/testsuite"
+    if [ -d "$testsuiteDirectory" ] && find "$testsuiteDirectory" -type f -name '*.binlog' | grep -q .; then
+      echo "Found integration test binlogs under $testsuiteDirectory."
+      echo "##vso[task.setvariable variable=IntegrationTestBinlogsFound]true"
+    else
+      echo "No integration test binlogs under $testsuiteDirectory; skipping the binlog copy and publish steps."
+    fi
+  displayName: 'Detect integration tests binlogs'
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+
 - task: CopyFiles@2
   displayName: 'Copy binlogs'
   inputs:
@@ -86,11 +106,11 @@ steps:
     Contents: |
       **/*.binlog
     TargetFolder: '$(Build.ArtifactStagingDirectory)/binlogs'
-  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables['IntegrationTestBinlogsFound'], 'true'))
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish integration tests binlogs'
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)/binlogs'
     ArtifactName: Integration_Tests_${{ parameters.osName }}_Binlogs_$(_BuildConfig)
-  condition: and(always(), eq(variables._BuildConfig, 'Debug'))
+  condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables['IntegrationTestBinlogsFound'], 'true'))


### PR DESCRIPTION
`artifacts/tmp/<config>/testsuite` is only created once the acceptance tests actually run, so it is still missing whenever a build or test failure happens before that point. `CopyFiles@2` and `PublishBuildArtifacts` both hard-fail on a missing folder ("Not found SourceFolder" / "Not found PathtoPublish"), so every failed build got two extra red steps on top of the step that actually broke:

- `Copy binlogs` — fails on the missing `testsuite` folder. Arcade pre-creates `artifacts/tmp/<config>` (`Create-Directory $TempDir` in `eng/common/tools.ps1`) but nothing creates the `testsuite` subfolder until an acceptance test does.
- `Publish integration tests binlogs` — then fails because the copy never created the staging folder.

Neither tells you anything about the failure, and in the official build they sit right next to the real one.

Now a detection step looks for binlogs first and both steps skip when there is nothing to collect, so a failed build only shows the step that broke. When binlogs do exist nothing changes — same artifact, same layout. It also fixes the case where a run that otherwise passed got failed by these two steps because no binlogs happened to be produced.

The same two steps exist in the Windows and Linux/macOS PR jobs with the same failure mode, so they get the same treatment (`pwsh` on Windows, `bash` on the others). The Windows application-model template already handled this by pre-creating its staging directory, so it is untouched.

I checked the detection logic against the three cases — folder missing, folder present but no binlogs, nested binlog present — for both the PowerShell and the bash version, and verified the bash one is safe under `set -e`.

🤖