### PR TITLE
Optimize TRX reparse point confinement checks

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -7,7 +7,6 @@ const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPa
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.Merge(System.Collections.Generic.IReadOnlyList<System.Xml.Linq.XDocument!>! inputReports, System.Guid runId, string! runName) -> System.Xml.Linq.XDocument!
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Guid runId, string! runName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.GetReparsePointStatus(string! path, System.Func<string!, System.IO.FileAttributes>! getAttributes) -> bool?
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory.CreateCommandLine() -> Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxMergeToolCommandLine!
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory.CreateTool(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxMergeTool!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -7,6 +7,7 @@ const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.InputArtifactPa
 const Microsoft.Testing.Platform.IPC.FileArtifactMessageFieldsId.Kind = 7 -> ushort
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.Merge(System.Collections.Generic.IReadOnlyList<System.Xml.Linq.XDocument!>! inputReports, System.Guid runId, string! runName) -> System.Xml.Linq.XDocument!
 static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.MergeToFileAsync(System.Collections.Generic.IReadOnlyList<string!>! inputPaths, string! outputPath, System.Guid runId, string! runName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+static Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxReportEngine.GetReparsePointStatus(string! path, System.Func<string!, System.IO.FileAttributes>! getAttributes) -> bool?
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory.CreateCommandLine() -> Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxMergeToolCommandLine!
 Microsoft.Testing.Extensions.TrxReport.Abstractions.ToolTrxMergeFactory.CreateTool(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxMergeTool!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.Attachments.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.Attachments.cs
@@ -40,7 +40,17 @@ internal sealed partial class TrxReportEngine
         // On a reused output directory the merged 'In' root could pre-exist as a junction/symlink that
         // would redirect every copy below it outside the confined merged root. Remove such a link so a
         // fresh, real directory is created instead.
-        if (Directory.Exists(mergedInRoot) && IsReparsePoint(mergedInRoot))
+        bool? mergedInRootIsReparsePoint = GetReparsePointStatus(
+            mergedInRoot,
+            static path => File.GetAttributes(path));
+        if (mergedInRootIsReparsePoint is null)
+        {
+            // Do not delete an entry whose type cannot be established, and do not write through it.
+            DropAllReferences(reports);
+            return;
+        }
+
+        if (mergedInRootIsReparsePoint is true)
         {
             try
             {

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.Attachments.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.Attachments.cs
@@ -19,6 +19,23 @@ internal sealed partial class TrxReportEngine
     /// cannot be relocated is dropped rather than left dangling or pointing outside the deployment root.
     /// </summary>
     private static void RelocateAttachments(IReadOnlyList<string> inputPaths, IReadOnlyList<XDocument> reports, string outputDirectory, Guid runId, string runName, CancellationToken cancellationToken)
+        => RelocateAttachments(
+            inputPaths,
+            reports,
+            outputDirectory,
+            runId,
+            runName,
+            cancellationToken,
+            static path => File.GetAttributes(path));
+
+    private static void RelocateAttachments(
+        IReadOnlyList<string> inputPaths,
+        IReadOnlyList<XDocument> reports,
+        string outputDirectory,
+        Guid runId,
+        string runName,
+        CancellationToken cancellationToken,
+        Func<string, FileAttributes> getAttributes)
     {
         string outputFull = Path.GetFullPath(outputDirectory);
         string mergedDeploymentRoot = GetConfinedDeploymentRootLeaf(runId, runName);
@@ -42,7 +59,7 @@ internal sealed partial class TrxReportEngine
         // fresh, real directory is created instead.
         bool? mergedInRootIsReparsePoint = GetReparsePointStatus(
             mergedInRoot,
-            static path => File.GetAttributes(path));
+            getAttributes);
         if (mergedInRootIsReparsePoint is null)
         {
             // Do not delete an entry whose type cannot be established, and do not write through it.

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
@@ -56,9 +56,6 @@ internal sealed partial class TrxReportEngine
     private static bool IsReparsePoint(string path)
         => (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
 
-    private static bool IsReparsePointOrInaccessible(string path)
-        => GetReparsePointStatus(path, static path => File.GetAttributes(path)) is not false;
-
     /// <summary>
     /// Returns whether <paramref name="path"/> is a reparse point, or <see langword="null"/> when its
     /// attributes cannot be read. A missing entry returns <see langword="false"/> because callers may
@@ -91,13 +88,22 @@ internal sealed partial class TrxReportEngine
     /// such trees.
     /// </summary>
     private static bool HasReparsePointComponent(string candidateFullPath, string baseDirectory)
+        => HasReparsePointComponent(
+            candidateFullPath,
+            baseDirectory,
+            static path => File.GetAttributes(path));
+
+    private static bool HasReparsePointComponent(
+        string candidateFullPath,
+        string baseDirectory,
+        Func<string, FileAttributes> getAttributes)
     {
         string baseFull = Path.GetFullPath(baseDirectory);
         string current = candidateFullPath;
 
         while (!string.Equals(current, baseFull, PathComparison) && IsUnderDirectory(current, baseFull))
         {
-            if (IsReparsePointOrInaccessible(current))
+            if (GetReparsePointStatus(current, getAttributes) is not false)
             {
                 return true;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Security;
+
 using Microsoft.Testing.Platform;
 
 namespace Microsoft.Testing.Extensions.TrxReport.Abstractions;
@@ -54,12 +56,39 @@ internal sealed partial class TrxReportEngine
     private static bool IsReparsePoint(string path)
         => (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
 
+    private static bool IsReparsePointOrInaccessible(string path)
+        => GetReparsePointStatus(path, static path => File.GetAttributes(path)) is not false;
+
     /// <summary>
-    /// Returns <see langword="true"/> if any existing directory component strictly below
+    /// Returns whether <paramref name="path"/> is a reparse point, or <see langword="null"/> when its
+    /// attributes cannot be read. A missing entry returns <see langword="false"/> because callers may
+    /// safely create missing output components after inspecting their existing ancestors.
+    /// </summary>
+    internal static bool? GetReparsePointStatus(string path, Func<string, FileAttributes> getAttributes)
+    {
+        try
+        {
+            return (getAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // Missing output components are safe: callers create them after validating existing ancestors.
+            return false;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SecurityException)
+        {
+            // If an existing entry cannot be inspected, it cannot be proven confined.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if any existing file-system component strictly below
     /// <paramref name="baseDirectory"/> up to and including <paramref name="candidateFullPath"/> is a
-    /// reparse point (symlink/junction). Both paths are expected to be normalized full paths with
-    /// <paramref name="candidateFullPath"/> under <paramref name="baseDirectory"/>. A symlinked ancestor
-    /// can redirect reads/writes outside a lexically-confined path, so callers reject such trees.
+    /// reparse point (symlink/junction), or cannot be inspected. Both paths are expected to be normalized
+    /// full paths with <paramref name="candidateFullPath"/> under <paramref name="baseDirectory"/>.
+    /// A symlinked ancestor can redirect reads/writes outside a lexically-confined path, so callers reject
+    /// such trees.
     /// </summary>
     private static bool HasReparsePointComponent(string candidateFullPath, string baseDirectory)
     {
@@ -68,7 +97,7 @@ internal sealed partial class TrxReportEngine
 
         while (!string.Equals(current, baseFull, PathComparison) && IsUnderDirectory(current, baseFull))
         {
-            if (Directory.Exists(current) && IsReparsePoint(current))
+            if (IsReparsePointOrInaccessible(current))
             {
                 return true;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Merge.PathHelpers.cs
@@ -64,7 +64,7 @@ internal sealed partial class TrxReportEngine
     /// attributes cannot be read. A missing entry returns <see langword="false"/> because callers may
     /// safely create missing output components after inspecting their existing ancestors.
     /// </summary>
-    internal static bool? GetReparsePointStatus(string path, Func<string, FileAttributes> getAttributes)
+    private static bool? GetReparsePointStatus(string path, Func<string, FileAttributes> getAttributes)
     {
         try
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Security;
+
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 
 namespace Microsoft.Testing.Extensions.UnitTests;
@@ -40,6 +42,96 @@ public sealed class TrxReportEngineMergeTests
             }
         }
     }
+
+    [TestMethod]
+    public void GetReparsePointStatus_ReadsAttributesOnceAndDetectsReparsePoint()
+    {
+        int callCount = 0;
+
+        bool? result = TrxReportEngine.GetReparsePointStatus(
+            "link",
+            path =>
+            {
+                Assert.AreEqual("link", path);
+                callCount++;
+                return FileAttributes.ReparsePoint;
+            });
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, callCount);
+    }
+
+    [TestMethod]
+    public void GetReparsePointStatus_WhenEntryIsARegularFile_ReturnsFalse()
+    {
+        bool? result = TrxReportEngine.GetReparsePointStatus(
+            "file",
+            _ => FileAttributes.Archive);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void GetReparsePointStatus_WhenEntryIsMissing_ReturnsFalse()
+    {
+        Assert.IsFalse(TrxReportEngine.GetReparsePointStatus(
+            "missing-file",
+            _ => throw new FileNotFoundException()));
+        Assert.IsFalse(TrxReportEngine.GetReparsePointStatus(
+            "missing-directory",
+            _ => throw new DirectoryNotFoundException()));
+    }
+
+    [TestMethod]
+    public void GetReparsePointStatus_WhenAttributesCannotBeRead_ReturnsNull()
+    {
+        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+            "inaccessible",
+            _ => throw new UnauthorizedAccessException()));
+        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+            "io-failure",
+            _ => throw new IOException()));
+        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+            "security-failure",
+            _ => throw new SecurityException()));
+    }
+
+    [TestMethod]
+    public void GetReparsePointStatus_WhenUnexpectedExceptionOccurs_Propagates()
+        => Assert.ThrowsExactly<InvalidOperationException>(
+            () => TrxReportEngine.GetReparsePointStatus(
+                "invalid",
+                _ => throw new InvalidOperationException()));
+
+#if NETCOREAPP
+    [TestMethod]
+    public void GetReparsePointStatus_WhenDirectoryLinkIsDangling_ReturnsTrue()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"trx-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            string link = Path.Combine(tempDirectory, "link");
+            string missingTarget = Path.Combine(tempDirectory, "missing");
+            try
+            {
+                Directory.CreateSymbolicLink(link, missingTarget);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            Assert.IsTrue(TrxReportEngine.GetReparsePointStatus(link, static path => File.GetAttributes(path)));
+            Assert.IsFalse(Directory.Exists(missingTarget));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+#endif
 
     [TestMethod]
     public void Merge_CarriesRunLevelOutputMessages()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Security;
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
@@ -11,6 +13,8 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 public sealed class TrxReportEngineMergeTests
 {
     private static readonly XNamespace Ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+    private static readonly MethodInfo GetReparsePointStatusMethod = typeof(TrxReportEngine)
+        .GetMethod("GetReparsePointStatus", BindingFlags.NonPublic | BindingFlags.Static)!;
 
     [TestMethod]
     public void Merge_WithNullReports_ThrowsArgumentNullException()
@@ -48,7 +52,7 @@ public sealed class TrxReportEngineMergeTests
     {
         int callCount = 0;
 
-        bool? result = TrxReportEngine.GetReparsePointStatus(
+        bool? result = GetReparsePointStatus(
             "link",
             path =>
             {
@@ -64,7 +68,7 @@ public sealed class TrxReportEngineMergeTests
     [TestMethod]
     public void GetReparsePointStatus_WhenEntryIsARegularFile_ReturnsFalse()
     {
-        bool? result = TrxReportEngine.GetReparsePointStatus(
+        bool? result = GetReparsePointStatus(
             "file",
             _ => FileAttributes.Archive);
 
@@ -74,10 +78,10 @@ public sealed class TrxReportEngineMergeTests
     [TestMethod]
     public void GetReparsePointStatus_WhenEntryIsMissing_ReturnsFalse()
     {
-        Assert.IsFalse(TrxReportEngine.GetReparsePointStatus(
+        Assert.IsFalse(GetReparsePointStatus(
             "missing-file",
             _ => throw new FileNotFoundException()));
-        Assert.IsFalse(TrxReportEngine.GetReparsePointStatus(
+        Assert.IsFalse(GetReparsePointStatus(
             "missing-directory",
             _ => throw new DirectoryNotFoundException()));
     }
@@ -85,13 +89,13 @@ public sealed class TrxReportEngineMergeTests
     [TestMethod]
     public void GetReparsePointStatus_WhenAttributesCannotBeRead_ReturnsNull()
     {
-        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+        Assert.IsNull(GetReparsePointStatus(
             "inaccessible",
             _ => throw new UnauthorizedAccessException()));
-        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+        Assert.IsNull(GetReparsePointStatus(
             "io-failure",
             _ => throw new IOException()));
-        Assert.IsNull(TrxReportEngine.GetReparsePointStatus(
+        Assert.IsNull(GetReparsePointStatus(
             "security-failure",
             _ => throw new SecurityException()));
     }
@@ -99,7 +103,7 @@ public sealed class TrxReportEngineMergeTests
     [TestMethod]
     public void GetReparsePointStatus_WhenUnexpectedExceptionOccurs_Propagates()
         => Assert.ThrowsExactly<InvalidOperationException>(
-            () => TrxReportEngine.GetReparsePointStatus(
+            () => GetReparsePointStatus(
                 "invalid",
                 _ => throw new InvalidOperationException()));
 
@@ -123,7 +127,7 @@ public sealed class TrxReportEngineMergeTests
                 return;
             }
 
-            Assert.IsTrue(TrxReportEngine.GetReparsePointStatus(link, static path => File.GetAttributes(path)));
+            Assert.IsTrue(GetReparsePointStatus(link, static path => File.GetAttributes(path)));
             Assert.IsFalse(Directory.Exists(missingTarget));
         }
         finally
@@ -132,6 +136,19 @@ public sealed class TrxReportEngineMergeTests
         }
     }
 #endif
+
+    private static bool? GetReparsePointStatus(string path, Func<string, FileAttributes> getAttributes)
+    {
+        try
+        {
+            return (bool?)GetReparsePointStatusMethod.Invoke(null, [path, getAttributes]);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            throw;
+        }
+    }
 
     [TestMethod]
     public void Merge_CarriesRunLevelOutputMessages()

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportEngineMergeTests.cs
@@ -16,6 +16,14 @@ public sealed class TrxReportEngineMergeTests
     private static readonly MethodInfo GetReparsePointStatusMethod = typeof(TrxReportEngine)
         .GetMethod("GetReparsePointStatus", BindingFlags.NonPublic | BindingFlags.Static)!;
 
+    private static readonly MethodInfo HasReparsePointComponentMethod = typeof(TrxReportEngine)
+        .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+        .Single(method => method.Name == "HasReparsePointComponent" && method.GetParameters().Length == 3);
+
+    private static readonly MethodInfo RelocateAttachmentsMethod = typeof(TrxReportEngine)
+        .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+        .Single(method => method.Name == "RelocateAttachments" && method.GetParameters().Length == 7);
+
     [TestMethod]
     public void Merge_WithNullReports_ThrowsArgumentNullException()
         => Assert.ThrowsExactly<ArgumentNullException>(() => TrxReportEngine.Merge(null!, Guid.NewGuid(), "run"));
@@ -107,6 +115,83 @@ public sealed class TrxReportEngineMergeTests
                 "invalid",
                 _ => throw new InvalidOperationException()));
 
+    [TestMethod]
+    public void HasReparsePointComponent_WhenAttributesCannotBeRead_RejectsComponent()
+    {
+        string baseDirectory = Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"trx-merge-{Guid.NewGuid():N}"));
+        string candidate = Path.Combine(baseDirectory, "child");
+        int callCount = 0;
+
+        bool result = HasReparsePointComponent(
+            candidate,
+            baseDirectory,
+            _ =>
+            {
+                callCount++;
+                throw new UnauthorizedAccessException();
+            });
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, callCount);
+    }
+
+    [TestMethod]
+    public void RelocateAttachments_WhenMergedInRootAttributesCannotBeRead_DropsReferencesWithoutDeletingRoot()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), $"trx-merge-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        try
+        {
+            var runId = Guid.NewGuid();
+            const string runName = "run";
+            string outputDirectory = Path.Combine(tempDirectory, "out");
+            string mergedInRoot = Path.Combine(outputDirectory, $"{runName}.{runId:N}", "In");
+            Directory.CreateDirectory(mergedInRoot);
+            string markerFile = Path.Combine(mergedInRoot, "marker.txt");
+            File.WriteAllText(markerFile, "keep");
+
+            string inputDirectory = Path.Combine(tempDirectory, "input");
+            string sourceInRoot = Path.Combine(inputDirectory, "dep", "In");
+            Directory.CreateDirectory(sourceInRoot);
+            File.WriteAllText(Path.Combine(sourceInRoot, "relative.txt"), "attachment");
+            string inputPath = Path.Combine(inputDirectory, "input.trx");
+
+            var collectorDataEntries = new XElement(
+                Ns + "CollectorDataEntries",
+                new XElement(
+                    Ns + "Collector",
+                    new XElement(
+                        Ns + "UriAttachments",
+                        new XElement(Ns + "UriAttachment", new XElement(Ns + "A", new XAttribute("href", "relative.txt"))))));
+            XDocument report = BuildReport(resultSummaryChildren: [collectorDataEntries]);
+            report.Root!.Add(new XElement(
+                Ns + "TestSettings",
+                new XAttribute("name", "default"),
+                new XElement(Ns + "Deployment", new XAttribute("runDeploymentRoot", "dep"))));
+
+            RelocateAttachments(
+                [inputPath],
+                [report],
+                outputDirectory,
+                runId,
+                runName,
+                CancellationToken.None,
+                path => path == mergedInRoot
+                    ? throw new UnauthorizedAccessException()
+                    : File.GetAttributes(path));
+
+            Assert.IsEmpty(report.Descendants().Where(element => element.Name.LocalName == "A"));
+            Assert.IsTrue(Directory.Exists(mergedInRoot));
+            Assert.IsTrue(File.Exists(markerFile));
+            Assert.IsEmpty(Directory.GetDirectories(mergedInRoot));
+            Assert.HasCount(1, Directory.GetFiles(mergedInRoot));
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
 #if NETCOREAPP
     [TestMethod]
     public void GetReparsePointStatus_WhenDirectoryLinkIsDangling_ReturnsTrue()
@@ -138,10 +223,41 @@ public sealed class TrxReportEngineMergeTests
 #endif
 
     private static bool? GetReparsePointStatus(string path, Func<string, FileAttributes> getAttributes)
+        => (bool?)InvokePrivate(GetReparsePointStatusMethod, path, getAttributes);
+
+    private static bool HasReparsePointComponent(
+        string candidateFullPath,
+        string baseDirectory,
+        Func<string, FileAttributes> getAttributes)
+        => (bool)InvokePrivate(
+            HasReparsePointComponentMethod,
+            candidateFullPath,
+            baseDirectory,
+            getAttributes)!;
+
+    private static void RelocateAttachments(
+        IReadOnlyList<string> inputPaths,
+        IReadOnlyList<XDocument> reports,
+        string outputDirectory,
+        Guid runId,
+        string runName,
+        CancellationToken cancellationToken,
+        Func<string, FileAttributes> getAttributes)
+        => InvokePrivate(
+            RelocateAttachmentsMethod,
+            inputPaths,
+            reports,
+            outputDirectory,
+            runId,
+            runName,
+            cancellationToken,
+            getAttributes);
+
+    private static object? InvokePrivate(MethodInfo method, params object?[] arguments)
     {
         try
         {
-            return (bool?)GetReparsePointStatusMethod.Invoke(null, [path, getAttributes]);
+            return method.Invoke(null, arguments);
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {


### PR DESCRIPTION
## Summary

- replace the TRX confinement walk's `Directory.Exists` plus `File.GetAttributes` pair with one attribute read per component
- preserve missing-path behavior while treating I/O, access, and .NET Framework security failures as unsafe
- keep attachment-file reparse checks unchanged and cover one-call, missing, inaccessible, regular-file, and dangling-link semantics
- keep the new probe private; tests use the repository's established reflection pattern, so no internal API is added

## Security and efficiency

Existing path components now require one filesystem metadata probe instead of two. Missing components still require one probe. This narrows, but does not eliminate, the existing TOCTOU window; the merge path continues to revalidate destination ancestors and copy without overwrite.

Only `FileNotFoundException` and `DirectoryNotFoundException` mean an entry is absent. `IOException`, `UnauthorizedAccessException`, and `SecurityException` fail closed. An unreadable merged `In` root is never deleted.

## Validation

- Microsoft.Testing.Extensions unit tests: net8.0, net9.0, net462, net472
- repository pack
- focused `merge-trx` acceptance tests: 3 passed
- independent security and correctness reviews, including final reviews after removing the internal API test seam

Closes #10643