### PR TITLE
Cache regex assertion patterns safely

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +7,12 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 
 public sealed partial class Assert
 {
+    // Match the runtime's default static Regex cache size while bounding retained user-provided pattern text.
+    private const int RegexCacheSize = 15;
+    private const int MaximumCachedRegexPatternLength = 512;
+
+    private static readonly BoundedRegexCache RegexCache = new();
+
     #region MatchesRegex
 
     /// <summary>
@@ -195,9 +201,79 @@ public sealed partial class Assert
 
     #endregion // DoesNotMatchRegex
 
-    private static Regex? ToRegex([NotNull] string? pattern)
+    private static Regex ToRegex([NotNull] string? pattern)
     {
         CheckParameterNotNull(pattern, "Assert.MatchesRegex", "pattern");
-        return new Regex(pattern);
+        if (pattern.Length > MaximumCachedRegexPatternLength)
+        {
+            return new Regex(pattern);
+        }
+
+        string cultureName = CultureInfo.CurrentCulture.Name;
+        if (RegexCache.TryGet(pattern, cultureName, out Regex? cachedRegex))
+        {
+            return cachedRegex;
+        }
+
+        Regex regex = new(pattern);
+        return RegexCache.AddOrGetExisting(pattern, cultureName, regex);
+    }
+
+    private sealed class BoundedRegexCache
+    {
+#if NET9_0_OR_GREATER
+        private readonly Lock _lock = new();
+#else
+        private readonly object _lock = new();
+#endif
+
+        private readonly RegexCacheEntry?[] _entries = new RegexCacheEntry[RegexCacheSize];
+
+        private int _nextInsertionIndex;
+
+        public bool TryGet(string pattern, string cultureName, [NotNullWhen(true)] out Regex? regex)
+        {
+            int nextInsertionIndex = Volatile.Read(ref _nextInsertionIndex);
+            for (int offset = 1; offset <= RegexCacheSize; offset++)
+            {
+                int index = (nextInsertionIndex - offset + RegexCacheSize) % RegexCacheSize;
+                RegexCacheEntry? entry = Volatile.Read(ref _entries[index]);
+                if (entry is not null
+                    && string.Equals(entry.Pattern, pattern, StringComparison.Ordinal)
+                    && string.Equals(entry.CultureName, cultureName, StringComparison.Ordinal))
+                {
+                    regex = entry.Regex;
+                    return true;
+                }
+            }
+
+            regex = null;
+            return false;
+        }
+
+        public Regex AddOrGetExisting(string pattern, string cultureName, Regex regex)
+        {
+            lock (_lock)
+            {
+                if (TryGet(pattern, cultureName, out Regex? cachedRegex))
+                {
+                    return cachedRegex;
+                }
+
+                int insertionIndex = _nextInsertionIndex;
+                Volatile.Write(ref _entries[insertionIndex], new RegexCacheEntry(pattern, cultureName, regex));
+                Volatile.Write(ref _nextInsertionIndex, (insertionIndex + 1) % RegexCacheSize);
+                return regex;
+            }
+        }
+    }
+
+    private sealed class RegexCacheEntry(string pattern, string cultureName, Regex regex)
+    {
+        public string Pattern { get; } = pattern;
+
+        public string CultureName { get; } = cultureName;
+
+        public Regex Regex { get; } = regex;
     }
 }

--- a/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Matches.cs
@@ -210,7 +210,7 @@ public sealed partial class Assert
         }
 
         string cultureName = CultureInfo.CurrentCulture.Name;
-        if (RegexCache.TryGet(pattern, cultureName, out Regex? cachedRegex))
+        if (RegexCache.TryGet(pattern, cultureName, out Regex cachedRegex))
         {
             return cachedRegex;
         }
@@ -231,7 +231,7 @@ public sealed partial class Assert
 
         private int _nextInsertionIndex;
 
-        public bool TryGet(string pattern, string cultureName, [NotNullWhen(true)] out Regex? regex)
+        public bool TryGet(string pattern, string cultureName, out Regex regex)
         {
             int nextInsertionIndex = Volatile.Read(ref _nextInsertionIndex);
             for (int offset = 1; offset <= RegexCacheSize; offset++)
@@ -247,7 +247,7 @@ public sealed partial class Assert
                 }
             }
 
-            regex = null;
+            regex = null!;
             return false;
         }
 
@@ -255,7 +255,7 @@ public sealed partial class Assert
         {
             lock (_lock)
             {
-                if (TryGet(pattern, cultureName, out Regex? cachedRegex))
+                if (TryGet(pattern, cultureName, out Regex cachedRegex))
                 {
                     return cachedRegex;
                 }

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
@@ -39,21 +39,40 @@ public partial class AssertTests
         ToRegex(pattern).Should().BeSameAs(ToRegex(pattern));
     }
 
-    public void MatchesRegex_WithMoreThanCacheSizeDistinctStringPatterns_EvictsOldestRegex()
+    public void MatchesRegex_WithCaseDistinctStringPatterns_DoesNotReuseRegex()
+    {
+        string patternPrefix = Guid.NewGuid().ToString("N");
+        string lowercasePattern = $"^{patternPrefix}-a$";
+        string uppercasePattern = $"^{patternPrefix}-A$";
+
+        ToRegex(lowercasePattern).Should().NotBeSameAs(ToRegex(uppercasePattern));
+    }
+
+    public void MatchesRegex_WhenOldestRegexIsReusedBeforeCapacityIsExceeded_StillEvictsOldestRegex()
     {
         string patternPrefix = Guid.NewGuid().ToString("N");
         string oldestPattern = $"^{patternPrefix}-oldest$";
         Regex oldestRegex = ToRegex(oldestPattern);
 
-        for (int i = 0; i < RegexCacheSize; i++)
+        for (int i = 0; i < RegexCacheSize - 1; i++)
         {
             _ = ToRegex($"^{patternPrefix}-{i}$");
         }
 
+        ToRegex(oldestPattern).Should().BeSameAs(oldestRegex);
+        _ = ToRegex($"^{patternPrefix}-newest$");
+
         ToRegex(oldestPattern).Should().NotBeSameAs(oldestRegex);
     }
 
-    public void MatchesRegex_WithLongStringPattern_DoesNotCacheRegex()
+    public void MatchesRegex_WithMaximumLengthStringPattern_ReusesRegex()
+    {
+        string pattern = new('a', MaximumCachedRegexPatternLength);
+
+        ToRegex(pattern).Should().BeSameAs(ToRegex(pattern));
+    }
+
+    public void MatchesRegex_WithOverMaximumLengthStringPattern_DoesNotCacheRegex()
     {
         string pattern = new('a', MaximumCachedRegexPatternLength + 1);
 
@@ -82,13 +101,51 @@ public partial class AssertTests
         }
     }
 
-    public void MatchesRegex_WithSameStringPatternConcurrently_ReusesThreadSafeRegex()
+    public void MatchesRegex_WithConcurrentCandidateRegexes_ConvergesOnSingleCachedRegex()
     {
         string pattern = $"^{Guid.NewGuid():N}$";
-        var regexes = new Regex[64];
+        string cultureName = CultureInfo.CurrentCulture.Name;
+        const int ThreadCount = 8;
+        var regexes = new Regex[ThreadCount];
+        var exceptions = new Exception?[ThreadCount];
+        using var ready = new CountdownEvent(ThreadCount);
+        using var start = new ManualResetEventSlim();
+        Type cacheType = typeof(Assert).GetNestedType("BoundedRegexCache", BindingFlags.NonPublic)!;
+        object cache = Activator.CreateInstance(cacheType, nonPublic: true)!;
+        var addOrGetExisting = (Func<string, string, Regex, Regex>)cacheType
+            .GetMethod("AddOrGetExisting", BindingFlags.Instance | BindingFlags.Public)!
+            .CreateDelegate(typeof(Func<string, string, Regex, Regex>), cache);
+        var threads = new Thread[ThreadCount];
 
-        Parallel.For(0, regexes.Length, i => regexes[i] = ToRegex(pattern));
+        for (int i = 0; i < threads.Length; i++)
+        {
+            int index = i;
+            threads[i] = new Thread(() =>
+            {
+                try
+                {
+                    var candidate = new Regex(pattern);
+                    ready.Signal();
+                    start.Wait();
+                    regexes[index] = addOrGetExisting(pattern, cultureName, candidate);
+                }
+                catch (Exception ex)
+                {
+                    exceptions[index] = ex;
+                }
+            });
+            threads[i].Start();
+        }
 
+        ready.Wait();
+        start.Set();
+
+        foreach (Thread thread in threads)
+        {
+            thread.Join();
+        }
+
+        exceptions.Should().BeEquivalentTo(new Exception?[ThreadCount]);
         regexes.Should().OnlyContain(regex => ReferenceEquals(regexes[0], regex));
     }
 

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.MatchesRegex.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.RegularExpressions;
@@ -9,6 +9,21 @@ namespace Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests;
 
 public partial class AssertTests
 {
+    private static readonly int RegexCacheSize =
+        (int)typeof(Assert)
+            .GetField("RegexCacheSize", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetRawConstantValue()!;
+
+    private static readonly int MaximumCachedRegexPatternLength =
+        (int)typeof(Assert)
+            .GetField("MaximumCachedRegexPatternLength", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetRawConstantValue()!;
+
+    private static readonly Func<string?, Regex> ToRegex =
+        (Func<string?, Regex>)typeof(Assert)
+            .GetMethod("ToRegex", BindingFlags.Static | BindingFlags.NonPublic)!
+            .CreateDelegate(typeof(Func<string?, Regex>));
+
     public void MatchesRegex_WithRegexPattern_OnSuccess_DoesNotThrow()
         => FluentActions.Invoking(() => Assert.MatchesRegex(new Regex("^he"), "hello"))
             .Should().NotThrow();
@@ -16,6 +31,105 @@ public partial class AssertTests
     public void MatchesRegex_WithStringPattern_OnSuccess_DoesNotThrow()
         => FluentActions.Invoking(() => Assert.MatchesRegex("^he", "hello"))
             .Should().NotThrow();
+
+    public void MatchesRegex_WithRepeatedStringPattern_ReusesRegex()
+    {
+        string pattern = $"^{Guid.NewGuid():N}$";
+
+        ToRegex(pattern).Should().BeSameAs(ToRegex(pattern));
+    }
+
+    public void MatchesRegex_WithMoreThanCacheSizeDistinctStringPatterns_EvictsOldestRegex()
+    {
+        string patternPrefix = Guid.NewGuid().ToString("N");
+        string oldestPattern = $"^{patternPrefix}-oldest$";
+        Regex oldestRegex = ToRegex(oldestPattern);
+
+        for (int i = 0; i < RegexCacheSize; i++)
+        {
+            _ = ToRegex($"^{patternPrefix}-{i}$");
+        }
+
+        ToRegex(oldestPattern).Should().NotBeSameAs(oldestRegex);
+    }
+
+    public void MatchesRegex_WithLongStringPattern_DoesNotCacheRegex()
+    {
+        string pattern = new('a', MaximumCachedRegexPatternLength + 1);
+
+        ToRegex(pattern).Should().NotBeSameAs(ToRegex(pattern));
+    }
+
+    public void MatchesRegex_WithCultureSensitivePattern_DoesNotReuseRegexAcrossCultures()
+    {
+        const string Pattern = "(?i)^i$";
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            Regex enUsRegex = ToRegex(Pattern);
+            enUsRegex.IsMatch("I").Should().BeTrue();
+
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("tr-TR");
+            Regex trTrRegex = ToRegex(Pattern);
+            trTrRegex.Should().NotBeSameAs(enUsRegex);
+            trTrRegex.IsMatch("I").Should().BeFalse();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    public void MatchesRegex_WithSameStringPatternConcurrently_ReusesThreadSafeRegex()
+    {
+        string pattern = $"^{Guid.NewGuid():N}$";
+        var regexes = new Regex[64];
+
+        Parallel.For(0, regexes.Length, i => regexes[i] = ToRegex(pattern));
+
+        regexes.Should().OnlyContain(regex => ReferenceEquals(regexes[0], regex));
+    }
+
+    public void MatchesRegex_WithInvalidStringPatternAndNullValue_ThrowsPatternExceptionFirst()
+    {
+        Action action = () => Assert.MatchesRegex("[", null);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    public void DoesNotMatchRegex_WithInvalidStringPatternAndNullValue_ThrowsPatternExceptionFirst()
+    {
+        Action action = () => Assert.DoesNotMatchRegex("[", null);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    public void MatchesRegex_WithValidStringPatternAndNullValue_ThrowsAssertFailedException()
+    {
+        Action action = () => Assert.MatchesRegex("valid", null);
+
+        action.Should().Throw<AssertFailedException>();
+    }
+
+    public void DoesNotMatchRegex_WithValidStringPatternAndNullValue_ThrowsAssertFailedException()
+    {
+        Action action = () => Assert.DoesNotMatchRegex("valid", null);
+
+        action.Should().Throw<AssertFailedException>();
+    }
+
+    public void MatchesRegex_WithRegexPattern_BypassesStringPatternCache()
+    {
+        const string Pattern = "^abc$";
+        Regex cachedRegex = ToRegex(Pattern);
+        var suppliedRegex = new Regex(Pattern, RegexOptions.IgnoreCase);
+
+        Assert.MatchesRegex(suppliedRegex, "ABC");
+        ToRegex(Pattern).Should().BeSameAs(cachedRegex);
+        suppliedRegex.Should().NotBeSameAs(cachedRegex);
+    }
 
     public void MatchesRegex_WithRegexPattern_OnFailure_UsesStructuredMessageAndPayload()
     {


### PR DESCRIPTION
## Summary

- reuse string-pattern regular expressions through a private, bounded cache
- keep cache hits lock-free while synchronizing only duplicate-check and insertion
- preserve the caller-supplied `Regex` overload path and existing exception/telemetry ordering

## Memory and behavior safety

The cache is a fixed 15-slot FIFO ring, matching the runtime's default static regex cache size. Only patterns up to 512 UTF-16 code units are admitted, so retained pattern text and regex count are both bounded; larger patterns are constructed per call and never retained. High-cardinality input overwrites old slots rather than growing process-lifetime state.

Entries are keyed by ordinal pattern text and the current culture name because default case-insensitive regex behavior captures culture when the `Regex` is constructed. Default options and timeout semantics remain those of `new Regex(pattern)`. Construction remains in `ToRegex`, before assertion telemetry and value validation, preserving invalid-pattern/null ordering and exception stack shape. The overloads accepting a caller-created `Regex` bypass this cache unchanged.

Concurrent hits use volatile reads. Misses construct outside the lock, then perform a synchronized second lookup and fixed-slot insertion, so unrelated regex parsing is not serialized and concurrent callers converge on one cached instance.

## Benchmarks

Independent Release microbenchmark, seven runs with median reported, telemetry opted out. The baseline mirrors the previous `new Regex(pattern).IsMatch(value)` path; the candidate invokes the public string assertion overload.

| Runtime / scenario | Baseline | Candidate | Allocated baseline | Allocated candidate |
| --- | ---: | ---: | ---: | ---: |
| net8.0, 500k repeated | 1,221 ms | 128 ms | 1,684 MB | 0 B |
| net9.0, 500k repeated | 1,227 ms | 134 ms | 1,692 MB | 0 B |
| net8.0, 50k unique | 60 ms | 91 ms | 114.4 MB | 116.4 MB |
| net9.0, 50k unique | 59 ms | 87 ms | 115.2 MB | 117.2 MB |

The repeated-pattern case is about 9–10x faster and allocation-free after warmup. The deliberately adversarial unique-pattern case pays the expected bounded lookup/insertion cost (about 27–31 ms and 2 MB across 50,000 calls) while a second 50,000-pattern sweep retained only the fixed cache footprint (approximately 240 bytes net measured growth after full GC).

## Validation

- full `TestFramework.UnitTests` build and execution on `net48`, `net8.0`, `net9.0`, and `net8.0-windows10.0.18362.0`
- focused coverage for reuse, FIFO eviction, long-pattern bypass, culture separation, concurrent convergence, invalid-pattern/null ordering, and caller-supplied `Regex` bypass
- two independent memory/concurrency/API reviews, followed by two post-fix reviews
- binary log captured at `artifacts/log/Debug/Build.binlog`

Closes #10659
