### PR TITLE
Reduce ServerMode notification allocations

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.TestNodeSerializers.cs
@@ -37,10 +37,25 @@ internal static partial class SerializerUtilities
         });
 
         // Serialize event types.
-        Serializers[typeof(TestNodeStateChangedEventArgs)] = new ObjectSerializer<TestNodeStateChangedEventArgs>(ev => new Dictionary<string, object?>
+        Serializers[typeof(TestNodeStateChangedEventArgs)] = new ObjectSerializer<TestNodeStateChangedEventArgs>(ev =>
         {
-            [JsonRpcStrings.RunId] = ev.RunId,
-            [JsonRpcStrings.Changes] = ev.Changes?.Select(ch => Serialize(ch)).ToList<object>(),
+            List<object>? changes = null;
+            if (ev.Changes is not null)
+            {
+#pragma warning disable IDE0028 // Collection initialization can be simplified - capacity hint is intentional.
+                changes = new(ev.Changes.Length);
+#pragma warning restore IDE0028
+                for (int i = 0; i < ev.Changes.Length; i++)
+                {
+                    changes.Add(Serialize(ev.Changes[i]));
+                }
+            }
+
+            return new Dictionary<string, object?>
+            {
+                [JsonRpcStrings.RunId] = ev.RunId,
+                [JsonRpcStrings.Changes] = changes,
+            };
         });
 
         Serializers[typeof(TestNode)] = new ObjectSerializer<TestNode>(

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TestNodeStateChangeAggregator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/TestNodeStateChangeAggregator.cs
@@ -42,12 +42,19 @@ internal sealed partial class ServerTestHost
 
             TestNodeUpdateMessage[] changes = terminalTestNodeUids is null
                 ? [.. _stateChanges]
-                : [.. _stateChanges.Where(stateChange =>
-                    stateChange.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>() is not InProgressTestNodeStateProperty
-                    || !terminalTestNodeUids.Contains(stateChange.TestNode.Uid))];
+                : FilterStateChanges(_stateChanges, terminalTestNodeUids);
 
             return new(RunId, changes);
         }
+
+        // Keep the captured LINQ predicate out of BuildAggregatedChange so batches without terminal states
+        // do not allocate its closure.
+        private static TestNodeUpdateMessage[] FilterStateChanges(
+            List<TestNodeUpdateMessage> stateChanges,
+            HashSet<TestNodeUid> terminalTestNodeUids)
+            => [.. stateChanges.Where(stateChange =>
+                stateChange.TestNode.Properties.SingleOrDefault<TestNodeStateProperty>() is not InProgressTestNodeStateProperty
+                || !terminalTestNodeUids.Contains(stateChange.TestNode.Uid))];
 
 #pragma warning disable CS0618, MTP0001
         private static bool IsTerminalState(TestNodeStateProperty? state)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/FormatterUtilitiesTests.cs
@@ -38,6 +38,57 @@ public sealed class FormatterUtilitiesTests
 #endif
 
     [TestMethod]
+    public async Task Serialize_TestNodeStateChangedEventArgs_NullChanges_PreservesNull()
+    {
+        TestNodeStateChangedEventArgs message = new(Guid.Empty, null);
+
+        IDictionary<string, object?> properties = SerializerUtilities.Serialize(message);
+        string serialized = (await _formatter.SerializeAsync(message)).Replace(" ", string.Empty);
+
+        Assert.IsNull(properties[JsonRpcStrings.Changes]);
+        Assert.AreEqual("""{"runId":"00000000-0000-0000-0000-000000000000","changes":null}""", serialized);
+    }
+
+    [TestMethod]
+    public async Task Serialize_TestNodeStateChangedEventArgs_EmptyChanges_PreservesEmptyObjectList()
+    {
+        TestNodeStateChangedEventArgs message = new(Guid.Empty, []);
+
+        IDictionary<string, object?> properties = SerializerUtilities.Serialize(message);
+        string serialized = (await _formatter.SerializeAsync(message)).Replace(" ", string.Empty);
+
+        List<object> changes = Assert.IsInstanceOfType<List<object>>(properties[JsonRpcStrings.Changes]);
+        Assert.IsEmpty(changes);
+        Assert.AreEqual("""{"runId":"00000000-0000-0000-0000-000000000000","changes":[]}""", serialized);
+    }
+
+    [TestMethod]
+    public async Task Serialize_TestNodeStateChangedEventArgs_Changes_PreservesOrderObjectTypesAndSource()
+    {
+        TestNodeUpdateMessage first = CreateTestNodeUpdate("first");
+        TestNodeUpdateMessage second = CreateTestNodeUpdate("second");
+        TestNodeUpdateMessage[] source = [first, second];
+        TestNodeStateChangedEventArgs message = new(Guid.Empty, source);
+
+        IDictionary<string, object?> properties = SerializerUtilities.Serialize(message);
+        string serialized = (await _formatter.SerializeAsync(message)).Replace(" ", string.Empty);
+
+        List<object> changes = Assert.IsInstanceOfType<List<object>>(properties[JsonRpcStrings.Changes]);
+        Assert.HasCount(2, changes);
+        IDictionary<string, object?> firstSerializedChange = Assert.IsInstanceOfType<IDictionary<string, object?>>(changes[0]);
+        IDictionary<string, object?> secondSerializedChange = Assert.IsInstanceOfType<IDictionary<string, object?>>(changes[1]);
+        IDictionary<string, object?> firstSerializedNode = Assert.IsInstanceOfType<IDictionary<string, object?>>(firstSerializedChange[JsonRpcStrings.Node]);
+        IDictionary<string, object?> secondSerializedNode = Assert.IsInstanceOfType<IDictionary<string, object?>>(secondSerializedChange[JsonRpcStrings.Node]);
+        Assert.AreEqual("first", firstSerializedNode[JsonRpcStrings.Uid]);
+        Assert.AreEqual("second", secondSerializedNode[JsonRpcStrings.Uid]);
+        Assert.AreSame(first, source[0]);
+        Assert.AreSame(second, source[1]);
+        Assert.AreEqual(
+            """{"runId":"00000000-0000-0000-0000-000000000000","changes":[{"node":{"uid":"first","display-name":"first","node-type":"group"},"parent":null},{"node":{"uid":"second","display-name":"second","node-type":"group"},"parent":null}]}""",
+            serialized);
+    }
+
+    [TestMethod]
     public void CanDeserializeTaskResponse()
     {
         RpcMessage msg = Deserialize<RpcMessage>("""
@@ -666,6 +717,15 @@ public sealed class FormatterUtilitiesTests
             return testNode;
         }
     }
+
+    private static TestNodeUpdateMessage CreateTestNodeUpdate(string uid)
+        => new(
+            default,
+            new TestNode
+            {
+                Uid = new TestNodeUid(uid),
+                DisplayName = uid,
+            });
 
     private object Deserialize(Type type, string instanceSerialized)
         => true switch

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
@@ -154,6 +154,30 @@ public sealed class TestNodeStateChangeAggregatorTests
         Assert.AreSame(terminal, secondAggregatedChange.Changes[0]);
     }
 
+    [TestMethod]
+    public void BuildAggregatedChange_DoesNotMutateBufferedChanges()
+    {
+        ServerTestHost.TestNodeStateChangeAggregator aggregator = new(Guid.NewGuid());
+        TestNodeUpdateMessage before = CreateUpdate("before");
+        TestNodeUpdateMessage inProgress = CreateUpdate("test", InProgressTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage terminal = CreateUpdate("test", PassedTestNodeStateProperty.CachedInstance);
+        aggregator.OnStateChange(before);
+        aggregator.OnStateChange(inProgress);
+        aggregator.OnStateChange(terminal);
+
+        TestNodeStateChangedEventArgs firstAggregatedChange = aggregator.BuildAggregatedChange();
+        TestNodeStateChangedEventArgs secondAggregatedChange = aggregator.BuildAggregatedChange();
+
+        Assert.IsNotNull(firstAggregatedChange.Changes);
+        Assert.IsNotNull(secondAggregatedChange.Changes);
+        Assert.HasCount(2, firstAggregatedChange.Changes);
+        Assert.HasCount(2, secondAggregatedChange.Changes);
+        Assert.AreSame(before, firstAggregatedChange.Changes[0]);
+        Assert.AreSame(terminal, firstAggregatedChange.Changes[1]);
+        Assert.AreSame(before, secondAggregatedChange.Changes[0]);
+        Assert.AreSame(terminal, secondAggregatedChange.Changes[1]);
+    }
+
     public static IEnumerable<object[]> TerminalStates()
     {
         yield return [PassedTestNodeStateProperty.CachedInstance];

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/TestNodeStateChangeAggregatorTests.cs
@@ -166,16 +166,18 @@ public sealed class TestNodeStateChangeAggregatorTests
         aggregator.OnStateChange(terminal);
 
         TestNodeStateChangedEventArgs firstAggregatedChange = aggregator.BuildAggregatedChange();
+        terminal.TestNode.Properties._testNodeStateProperty = DiscoveredTestNodeStateProperty.CachedInstance;
         TestNodeStateChangedEventArgs secondAggregatedChange = aggregator.BuildAggregatedChange();
 
         Assert.IsNotNull(firstAggregatedChange.Changes);
         Assert.IsNotNull(secondAggregatedChange.Changes);
         Assert.HasCount(2, firstAggregatedChange.Changes);
-        Assert.HasCount(2, secondAggregatedChange.Changes);
+        Assert.HasCount(3, secondAggregatedChange.Changes);
         Assert.AreSame(before, firstAggregatedChange.Changes[0]);
         Assert.AreSame(terminal, firstAggregatedChange.Changes[1]);
         Assert.AreSame(before, secondAggregatedChange.Changes[0]);
-        Assert.AreSame(terminal, secondAggregatedChange.Changes[1]);
+        Assert.AreSame(inProgress, secondAggregatedChange.Changes[1]);
+        Assert.AreSame(terminal, secondAggregatedChange.Changes[2]);
     }
 
     public static IEnumerable<object[]> TerminalStates()


### PR DESCRIPTION
## Summary

- replace the `TestNodeStateChangedEventArgs` array LINQ projection with a capacity-sized `List<object>` fill while preserving null/empty behavior and runtime collection typing
- isolate the aggregator's captured filtering predicate so batches without terminal states avoid its closure allocation
- preserve the existing filtered LINQ materialization because pre-sized array/list alternatives increased allocation for large, heavily suppressed batches
- add focused coverage for exact JSON shape/order, object typing, null and empty changes, retained identity/order, predicate behavior, and source immutability

## Performance

A standalone faithful-shape harness measured median time and allocation over null, empty, 1, 8, 128, and 1,024 item inputs on .NET 8 and .NET Framework 4.6.2.

- serializer, 8 items: 2,336 B -> 2,232 B on .NET 8; approximately 2,367 B -> 2,247 B on .NET Framework
- serializer, 1,024 items: 286,984 B -> 278,584 B on .NET 8; approximately 287,857 B -> 279,413 B on .NET Framework
- aggregator without terminal states: 24 B less allocation per batch on .NET 8, with the terminal/filtering path retaining its prior allocation shape

The serializer percentages are intentionally omitted because the harness models the container work faithfully but uses a smaller per-item payload than production. .NET Framework allocation values are approximate because its counter is AppDomain-wide.

## Validation

`.\build.cmd -projects .\test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj -test -bl`

Passed on `net8.0`, `net9.0`, and `net462` with 0 warnings and 0 errors.

Closes #10669
