### PR TITLE
Fix broken changelog comparison links

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## <a name="2.4.0" />[2.4.0] - UNRELEASED
 
-See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...v4.4.0)
+See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...main)
 
 ### Added
 
@@ -1022,7 +1022,7 @@ See full log [of v1.4.3...v1.5.0](https://github.com/microsoft/testfx/compare/v1
 
 ## <a name="1.4.3" />[1.4.3] - 2024-11-12
 
-See full log [of v1.4.2...v1.4.3](https://github.com/microsoft/testanywhere/compare/v1.4.2...v1.4.3)
+See full log [of v1.4.2...v1.4.3](https://github.com/microsoft/testfx/compare/a945cf69c1...a6b6696371)
 
 ### Fixed
 
@@ -1045,7 +1045,7 @@ See full log [of v1.4.2...v1.4.3](https://github.com/microsoft/testanywhere/comp
 
 ## <a name="1.4.2" />[1.4.2] - 2024-10-31
 
-See full log [of v1.4.1...v1.4.2](https://github.com/microsoft/testanywhere/compare/v1.4.1...v1.4.2)
+See full log [of v1.4.1...v1.4.2](https://github.com/microsoft/testfx/compare/dba3aeeb5d...a945cf69c1)
 
 ### Fixed
 
@@ -1068,7 +1068,7 @@ See full log [of v1.4.1...v1.4.2](https://github.com/microsoft/testanywhere/comp
 
 ## <a name="1.4.1" />[1.4.1] - 2024-10-03
 
-See full log [of v1.4.0...v1.4.1](https://github.com/microsoft/testanywhere/compare/v1.4.0...v1.4.1)
+See full log [of v1.4.0...v1.4.1](https://github.com/microsoft/testfx/compare/cebfeb7f80...dba3aeeb5d)
 
 ### Fixed
 
@@ -1091,7 +1091,7 @@ See full log [of v1.4.0...v1.4.1](https://github.com/microsoft/testanywhere/comp
 
 ## <a name="1.4.0" />[1.4.0] - 2024-09-11
 
-See full log [of v1.3.2...v1.4.0](https://github.com/microsoft/testanywhere/compare/v1.3.2...v1.4.0)
+See full log [of v1.3.2...v1.4.0](https://github.com/microsoft/testfx/compare/a99d437f8e...cebfeb7f80)
 
 ### Added
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## <a name="4.4.0" />[4.4.0] - UNRELEASED
 
-See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...v4.4.0)
+See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...main)
 
 ### Added
 


### PR DESCRIPTION
The changelogs contain six broken comparison links: unreleased entries target a tag that does not exist yet, while historical Microsoft.Testing.Platform entries reference unavailable release tags in the archived `testanywhere` repository.

Update unreleased comparisons to use `main`, and use the actual `testfx` release changelog commits for the historical MTP ranges. The commit ranges are intentional because `testfx` does not have the proposed MTP `v1.4.x` tags.

Fixes #10664