### PR TITLE
Fix TRX lifetime handshake race

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxProcessLifetimeHandler.cs
@@ -119,16 +119,17 @@ internal sealed class TrxProcessLifetimeHandler :
 
     [UnsupportedOSPlatform("BROWSER")]
     private void BeforeTestHostProcessStartCore(CancellationToken cancellationToken)
-        => _waitConnectionTask = _task.Run(
-            async () =>
-            {
-                _singleConnectionNamedPipeServer = new(_pipeNameDescription, CallbackAsync, _environment, _logger, _task, cancellationToken);
-                _singleConnectionNamedPipeServer.RegisterSerializer(new ReportFileNameRequestSerializer(), typeof(ReportFileNameRequest));
-                _singleConnectionNamedPipeServer.RegisterSerializer(new TestAdapterInformationRequestSerializer(), typeof(TestAdapterInformationRequest));
-                _singleConnectionNamedPipeServer.RegisterSerializer(new TrxStreamLocationRequestSerializer(), typeof(TrxStreamLocationRequest));
-                _singleConnectionNamedPipeServer.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
-                await _singleConnectionNamedPipeServer.WaitConnectionAsync(cancellationToken).TimeoutAfterAsync(TimeoutHelper.DefaultHangTimeSpanTimeout, cancellationToken).ConfigureAwait(false);
-            }, cancellationToken);
+    {
+        _singleConnectionNamedPipeServer = new(_pipeNameDescription, CallbackAsync, _environment, _logger, _task, cancellationToken);
+        _singleConnectionNamedPipeServer.RegisterSerializer(new ReportFileNameRequestSerializer(), typeof(ReportFileNameRequest));
+        _singleConnectionNamedPipeServer.RegisterSerializer(new TestAdapterInformationRequestSerializer(), typeof(TestAdapterInformationRequest));
+        _singleConnectionNamedPipeServer.RegisterSerializer(new TrxStreamLocationRequestSerializer(), typeof(TrxStreamLocationRequest));
+        _singleConnectionNamedPipeServer.RegisterSerializer(new VoidResponseSerializer(), typeof(VoidResponse));
+
+        _waitConnectionTask = _task.Run(
+            () => _singleConnectionNamedPipeServer.WaitConnectionAsync(cancellationToken).TimeoutAfterAsync(TimeoutHelper.DefaultHangTimeSpanTimeout, cancellationToken),
+            cancellationToken);
+    }
 
     public async Task OnTestHostProcessStartedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellationToken)
     {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TrxTests.cs
@@ -38,6 +38,32 @@ Out of process file artifacts produced:
         await AssertTrxReportWasGeneratedAsync(testHostResult, trxPathPattern, 1);
     }
 
+    [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task Trx_WhenOutOfProcessReportHasNoSelectedTests_LifetimeHandshakeCompletes(string tfm)
+    {
+        string fileName = $"{Guid.NewGuid():N}.trx";
+        string testResultsPath = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, tfm);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--filter-uid 2 --ignore-exit-code 8 --crashdump --report-trx --report-trx-filename {fileName} --results-directory \"{testResultsPath}\"",
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.Success);
+        testHostResult.AssertOutputDoesNotContain("The operation has timed out.");
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 0, skipped: 0);
+
+        string[] trxFiles = Directory.GetFiles(testResultsPath, fileName, SearchOption.AllDirectories);
+        Assert.HasCount(1, trxFiles, $"Expected exactly one trx file but found {trxFiles.Length}: {string.Join(", ", trxFiles)}");
+
+        var trxDocument = XDocument.Parse(File.ReadAllText(trxFiles[0]));
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        XElement counters = trxDocument.Descendants(ns + "Counters").Single();
+        Assert.AreEqual("0", counters.Attribute("total")?.Value, trxDocument.ToString());
+        Assert.AreEqual("0", counters.Attribute("executed")?.Value, trxDocument.ToString());
+    }
+
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
     public async Task Trx_WhenReportTrxAndResultsDirectoryAreSpecifiedWithArtifact_ArtifactIsCopiedUnderRelativeResultsDirectory(string tfm)
@@ -341,6 +367,7 @@ using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Requests;
 using Microsoft.Testing.Platform.Services;
 
 public class Program
@@ -391,6 +418,14 @@ public class DummyTestFramework : ITestFramework, IDataProducer
         if (Environment.GetEnvironmentVariable("CRASHPROCESS") == "1")
         {
             Environment.FailFast("CRASHPROCESS");
+        }
+
+        TestExecutionRequest request = (TestExecutionRequest)context.Request;
+        if (request.Filter is TestNodeUidListFilter uidFilter &&
+            !uidFilter.TestNodeUids.Any(nodeUid => nodeUid.Value == "0"))
+        {
+            context.Complete();
+            return;
         }
 
         var testMethodIdentifier = new TestMethodIdentifierProperty(string.Empty, string.Empty, "DummyClassName", "Test", 0, Array.Empty<string>(), string.Empty);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxProcessLifetimeHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxProcessLifetimeHandlerTests.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipes;
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.CrashDump;
+using Microsoft.Testing.Extensions.TrxReport;
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class TrxProcessLifetimeHandlerTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task BeforeTestHostProcessStartAsync_CreatesPipeBeforeSchedulingConnectionWait()
+    {
+        var commandLineOptions = new TestCommandLineOptions(new Dictionary<string, string[]>
+        {
+            [CrashDumpCommandLineOptions.CrashDumpOptionName] = [],
+            [TrxReportGeneratorCommandLine.TrxReportOptionName] = [],
+        });
+        Mock<IEnvironment> environment = new();
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+        Mock<IClock> clock = new();
+        clock.SetupGet(x => x.UtcNow).Returns(DateTimeOffset.UtcNow);
+        var task = new DeferredTask();
+        Assembly trxAssembly = typeof(TrxProcessLifetimeHandler).Assembly;
+        Type namedPipeServerType = trxAssembly.GetType("Microsoft.Testing.Platform.IPC.NamedPipeServer", throwOnError: true)!;
+        MethodInfo getPipeName = namedPipeServerType.GetMethod("GetPipeName", [typeof(string)])!;
+        object pipeName = getPipeName.Invoke(null, [Guid.NewGuid().ToString("N")])!;
+        ConstructorInfo constructor = typeof(TrxProcessLifetimeHandler).GetConstructors().Single();
+
+        using var handler = (TrxProcessLifetimeHandler)constructor.Invoke([
+            commandLineOptions,
+            environment.Object,
+            loggerFactory.Object,
+            new Mock<IMessageBus>().Object,
+            new Mock<IFileSystem>().Object,
+            new Mock<ITestApplicationModuleInfo>().Object,
+            new Mock<IConfiguration>().Object,
+            clock.Object,
+            task,
+            new Mock<IOutputDevice>().Object,
+            pipeName,
+        ]);
+
+        await handler.BeforeTestHostProcessStartAsync(TestContext.CancellationToken);
+
+        Assert.IsNotNull(task.DeferredFunction);
+        string pipeNameValue = (string)pipeName.GetType().GetProperty("Name")!.GetValue(pipeName)!;
+        using var client = new NamedPipeClientStream(".", pipeNameValue, PipeDirection.InOut, PipeOptions.Asynchronous);
+        await client.ConnectAsync(timeout: 5_000, TestContext.CancellationToken);
+        Assert.IsTrue(client.IsConnected);
+    }
+
+    private sealed class DeferredTask : ITask
+    {
+        public Func<Task>? DeferredFunction { get; private set; }
+
+        public Task Run(Func<Task> function, CancellationToken cancellationToken)
+        {
+            DeferredFunction = function;
+            return Task.CompletedTask;
+        }
+
+        public Task Run(Action action) => throw new NotSupportedException();
+
+        public Task<T> Run<T>(Func<Task<T>?> function, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task RunLongRunning(Func<Task> action, string name, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task WhenAll(params Task[] tasks) => Task.WhenAll(tasks);
+
+        public Task Delay(int millisecondDelay) => Task.Delay(millisecondDelay);
+
+        public Task Delay(TimeSpan timeSpan, CancellationToken cancellationToken) => Task.Delay(timeSpan, cancellationToken);
+    }
+}


### PR DESCRIPTION
Fixes #10667

## Summary

- create and configure the out-of-process TRX named-pipe server before scheduling its connection wait
- prevent fast zero-selection test applications from racing pipe creation under thread-pool contention
- add a deterministic unit regression that fails with the previous deferred setup
- add an acceptance reproducer covering zero selected tests with crash dump and TRX reporting enabled

## Validation

- packed the repository successfully
- passed all 1,156 Microsoft.Testing.Extensions unit tests (1,149 passed, 7 platform-specific skips)
- passed the focused regression on .NET 8 and .NET Framework 4.7.2
- passed the zero-selection acceptance test on net8.0 and net10.0