### PR TITLE
Deduplicate report identity key encoding

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.RetryCollapsing.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.RetryCollapsing.cs
@@ -3,6 +3,8 @@
 
 using System.Text.Json.Nodes;
 
+using Microsoft.Testing.Platform.Helpers;
+
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
 /// <summary>
@@ -143,7 +145,8 @@ internal static partial class CtrfReportMerger
                 // A suite segment is normally a string, but the document is untrusted. Fall back to the
                 // segment's JSON text so a non-string segment still contributes a distinct, deterministic part
                 // of the key instead of throwing on the string conversion.
-                AppendIdentityComponent(
+                identity.Append('\u001f');
+                IdentityKeyBuilder.AppendLengthPrefixedComponent(
                     identity,
                     segment is JsonValue segmentValue && segmentValue.TryGetValue(out string? segmentText)
                         ? segmentText
@@ -151,14 +154,14 @@ internal static partial class CtrfReportMerger
             }
         }
 
-        AppendIdentityComponent(identity, name);
-        AppendIdentityComponent(identity, ReadString(test, "filePath"));
-        AppendIdentityComponent(identity, test["parameters"]?.ToJsonString());
+        identity.Append('\u001f');
+        IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, name);
+        identity.Append('\u001f');
+        IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, ReadString(test, "filePath"));
+        identity.Append('\u001f');
+        IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, test["parameters"]?.ToJsonString());
         return identity.ToString();
     }
-
-    private static void AppendIdentityComponent(StringBuilder identity, string? component)
-        => identity.Append('\u001f').Append(component?.Length ?? -1).Append(':').Append(component);
 
     private static JsonNode BuildCollapsedTest(JsonObject final, List<JsonObject> priors)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
 using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
@@ -87,11 +88,11 @@ internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
         var identity = new StringBuilder();
         foreach (InputArtifact input in orderedInputs)
         {
-            AppendIdentityPart(identity, Path.GetFullPath(input.Path));
-            AppendIdentityPart(identity, input.ProducingTestModule);
-            AppendIdentityPart(identity, input.TargetFramework);
-            AppendIdentityPart(identity, input.Architecture);
-            AppendIdentityPart(identity, input.ExecutionId);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, Path.GetFullPath(input.Path));
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.ProducingTestModule);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.TargetFramework);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.Architecture);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.ExecutionId);
         }
 
         using var sha256 = SHA256.Create();
@@ -111,17 +112,4 @@ internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
             .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
             .ThenBy(input => input.Architecture, StringComparer.Ordinal)
             .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
-
-    private static void AppendIdentityPart(StringBuilder builder, string? value)
-    {
-        if (value is null)
-        {
-            builder.Append("-1:");
-            return;
-        }
-
-        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
-        builder.Append(':');
-        builder.Append(value);
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
 using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
@@ -94,11 +95,11 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
         var identity = new StringBuilder(mode.ToString());
         foreach (InputArtifact input in orderedInputs)
         {
-            AppendIdentityPart(identity, Path.GetFullPath(input.Path));
-            AppendIdentityPart(identity, input.ProducingTestModule);
-            AppendIdentityPart(identity, input.TargetFramework);
-            AppendIdentityPart(identity, input.Architecture);
-            AppendIdentityPart(identity, input.ExecutionId);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, Path.GetFullPath(input.Path));
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.ProducingTestModule);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.TargetFramework);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.Architecture);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, input.ExecutionId);
         }
 
         using var sha256 = SHA256.Create();
@@ -118,17 +119,4 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
             .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
             .ThenBy(input => input.Architecture, StringComparer.Ordinal)
             .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
-
-    private static void AppendIdentityPart(StringBuilder builder, string? value)
-    {
-        if (value is null)
-        {
-            builder.Append("-1:");
-            return;
-        }
-
-        builder.Append(value.Length.ToString(CultureInfo.InvariantCulture));
-        builder.Append(':');
-        builder.Append(value);
-    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
@@ -355,9 +356,7 @@ internal static class JUnitReportMerger
         var identity = new StringBuilder();
         foreach (string? component in components)
         {
-            identity.Append(component?.Length ?? -1)
-                .Append(':')
-                .Append(component);
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(identity, component);
         }
 
         return identity.ToString();

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/IdentityKeyBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/IdentityKeyBuilder.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Helpers;
+
+internal static class IdentityKeyBuilder
+{
+    internal static void AppendLengthPrefixedComponent(StringBuilder builder, string? component)
+    {
+        builder.Append((component?.Length ?? -1).ToString(CultureInfo.InvariantCulture));
+        builder.Append(':');
+        builder.Append(component);
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -196,10 +196,12 @@ static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSaniti
 static Microsoft.Testing.Platform.Services.CoverageThresholdExitCodePolicy.Apply(int exitCode, System.IServiceProvider! serviceProvider) -> int
 static Microsoft.Testing.Platform.Services.ExitCodeIgnorePolicy.Apply(int exitCode, Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.Testing.Platform.Helpers.IEnvironment! environment) -> int
 Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper
+Microsoft.Testing.Platform.Helpers.IdentityKeyBuilder
 Microsoft.Testing.Platform.Logging.FileLogger.FileLogger(Microsoft.Testing.Platform.Logging.FileLoggerOptions! options, Microsoft.Testing.Platform.Logging.LogLevel logLevel, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IConsole! console, Microsoft.Testing.Platform.Helpers.IFileSystem! fileSystem, Microsoft.Testing.Platform.Helpers.IFileStreamFactory! fileStreamFactory, System.TimeSpan? flushTimeout = null) -> void
 Microsoft.Testing.Platform.Logging.FileLogger.IsFileHandleReleased.get -> bool
 Microsoft.Testing.Platform.Messages.SingleConsumerUnboundedChannel<T>.WaitToRead() -> bool
 static Microsoft.Testing.Platform.Helpers.RuntimeFeatureHelper.IsMultiThreaded.get -> bool
+static Microsoft.Testing.Platform.Helpers.IdentityKeyBuilder.AppendLengthPrefixedComponent(System.Text.StringBuilder! builder, string? component) -> void
 const Microsoft.Testing.Platform.ServerMode.JsonRpcStrings.IsStateful = "isStateful" -> string!
 const Microsoft.Testing.Platform.ServerMode.JsonRpcStrings.SupportsTestCoverageMessages = "supportsTestCoverageMessages" -> string!
 Microsoft.Testing.Platform.Hosts.TestHostControlledHost.TestHostControlledHost(Microsoft.Testing.Platform.IPC.NamedPipeClient! testHostControllerPipeClient, Microsoft.Testing.Platform.Hosts.IHost! innerHost, System.Threading.CancellationToken cancellationToken, Microsoft.Testing.Platform.Services.TestApplicationResult? testApplicationResult = null) -> void

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/IdentityKeyBuilderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/IdentityKeyBuilderTests.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+[TestClass]
+public sealed class IdentityKeyBuilderTests
+{
+    [DataRow(null, "-1:")]
+    [DataRow("", "0:")]
+    [DataRow("a:b\u001f", "4:a:b\u001f")]
+    [TestMethod]
+    public void AppendLengthPrefixedComponent_EncodesComponent(string? component, string expected)
+    {
+        var builder = new StringBuilder();
+
+        IdentityKeyBuilder.AppendLengthPrefixedComponent(builder, component);
+
+        Assert.AreEqual(expected, builder.ToString());
+    }
+
+    [TestMethod]
+    public void AppendLengthPrefixedComponent_PreventsAmbiguousConcatenation()
+    {
+        string first = BuildIdentity("A", "B:C");
+        string second = BuildIdentity("A:B", "C");
+
+        Assert.AreNotEqual(first, second);
+    }
+
+    private static string BuildIdentity(params string?[] components)
+    {
+        var builder = new StringBuilder();
+        foreach (string? component in components)
+        {
+            IdentityKeyBuilder.AppendLengthPrefixedComponent(builder, component);
+        }
+
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
Report merging had four independent implementations of the same collision-safe, length-prefixed identity encoding. Keeping those copies in sync was error-prone, especially when handling null values and delimiter-containing components.

This change adds one internal `IdentityKeyBuilder` in Microsoft.Testing.Platform and reuses it for JUnit retry identities, JUnit and HTML artifact merge IDs, and CTRF retry identities. CTRF keeps its existing framing separator, while component lengths are now formatted consistently with invariant culture. Focused tests cover null, empty, delimiter-containing, and ambiguous component sequences.

Validation:
- Affected platform and reporting test projects build with no warnings or errors.
- Identity-key tests: 4 passed.
- Report merger and artifact post-processor tests: 88 passed, 1 expected filesystem-dependent skip.

Addresses #10597