### PR TITLE
Cache MSTest MTP node properties

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -33,38 +33,15 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 internal static class MSTestTestNodeConverter
 {
     /// <summary>
-    /// Caches the parsed pieces of a <see cref="TestMethod"/>'s managed name.
+    /// Caches the immutable base representation used to create every node for a test element.
     /// </summary>
     /// <remarks>
-    /// The parse is a pure function of <see cref="TestMethod.ManagedTypeName"/> and
-    /// <see cref="TestMethod.ManagedMethodName"/>, both immutable for the lifetime of the instance, and it scans the
-    /// managed method signature and allocates the namespace/type substrings. The same <see cref="TestMethod"/> is
-    /// converted several times per executed test (the in-progress node, then one result node per data row), so the
-    /// parse is paid once per test method rather than once per node.
-    /// <para>
-    /// The resulting <see cref="TestMethodIdentifierProperty"/> is cached alongside the parse only for
-    /// parameterless test methods. That type publicly exposes its
-    /// <see cref="TestMethodIdentifierProperty.ParameterTypeFullNames"/> array, so sharing one instance is safe
-    /// exactly when that array is empty and therefore cannot be mutated; every other field is an immutable string
-    /// or int. A parameterized method must keep getting a fresh property carrying a fresh array copy, otherwise a
-    /// consumer that writes to the array would corrupt every other node built from the same test method (see
-    /// <see cref="ParsedManagedName.ToProperty"/>).
-    /// </para>
-    /// <para>
-    /// The cache lives here rather than as a lazy property on <see cref="TestMethod"/> (the way
-    /// <see cref="TestMethod.ManagedTypeName"/> caches itself) because <see cref="TestMethodIdentifierProperty"/>
-    /// is a Microsoft.Testing.Platform type, and MSTestAdapter.PlatformServices - where <see cref="TestMethod"/>
-    /// lives - does not reference the platform at all. Even within this assembly the platform is only reachable
-    /// from this folder, through the file-level RS0030 suppression above (see this project's BannedSymbols.txt).
-    /// </para>
-    /// <para>
-    /// The table holds only weak references to its keys, so entries disappear as soon as the
-    /// <see cref="TestMethod"/> becomes unreachable. <c>GetValue</c> is thread-safe: concurrent misses may each run
-    /// the factory, but a single value is published to every caller.
-    /// </para>
+    /// A conversion still creates a distinct <see cref="TestNode"/> and <see cref="PropertyBag"/> for every message.
+    /// Only immutable properties are shared. Properties that expose mutable arrays are materialized from private
+    /// snapshots for each node. The weak key naturally bounds the cache to the lifetime of the element.
     /// </remarks>
 #pragma warning disable IDE0028 // ConditionalWeakTable is not collection-expression-constructible on .NET Framework (CS9174).
-    private static readonly ConditionalWeakTable<TestMethod, ParsedManagedName> ParsedManagedNameCache = new();
+    private static readonly ConditionalWeakTable<UnitTestElement, BaseTestNodeData> BaseTestNodeDataCache = new();
 #pragma warning restore IDE0028
 
     /// <summary>
@@ -103,7 +80,7 @@ internal static class MSTestTestNodeConverter
     /// </summary>
     public static TestNode ToResultTestNode(UnitTestElement element, FrameworkTestResult result, DateTimeOffset startTime, DateTimeOffset endTime, bool isTrxEnabled, MSTestSettings settings)
     {
-        TestNode testNode = CreateBaseTestNode(element, isTrxEnabled, result.DisplayName, out TestMethodIdentifierProperty? testMethodIdentifier);
+        TestNode testNode = CreateBaseTestNode(element, isTrxEnabled, result.DisplayName, out BaseTestNodeData baseData);
 
         // Mirror TestResultExtensions.ToTestResult: the reported error message prefers the exception message and
         // falls back to the ignore reason; the stack trace comes straight from the framework result.
@@ -124,7 +101,7 @@ internal static class MSTestTestNodeConverter
 
         if (isTrxEnabled)
         {
-            AddTrxResultProperties(testNode, element, errorMessage, errorStackTrace, testMethodIdentifier);
+            AddTrxResultProperties(testNode, baseData, errorMessage, errorStackTrace);
         }
 
         AddMessagesAndOutput(testNode, result, isTrxEnabled);
@@ -144,74 +121,186 @@ internal static class MSTestTestNodeConverter
         return testNode;
     }
 
-    private static TestNode CreateBaseTestNode(UnitTestElement element, bool isTrxEnabled, string? displayNameOverride, out TestMethodIdentifierProperty? testMethodIdentifier)
+    private static TestNode CreateBaseTestNode(UnitTestElement element, bool isTrxEnabled, string? displayNameOverride, out BaseTestNodeData baseData)
     {
-        TestMethod testMethod = element.TestMethod;
+        baseData = BaseTestNodeDataCache.GetValue(element, BaseTestNodeData.Create);
 
         TestNode testNode = new()
         {
-            Uid = new TestNodeUid(element.GetTestId().ToString()),
-
-            // TestMethod.DisplayName is always initialized (the constructor sets it to displayName ?? name), so
-            // displayNameOverride is the only real fallback needed here.
-            DisplayName = displayNameOverride ?? testMethod.DisplayName,
+            Uid = baseData.Uid,
+            DisplayName = displayNameOverride ?? baseData.DisplayName,
         };
 
-        AddCategoriesAndTraits(testNode, element, isTrxEnabled);
-
-        if (element.DeclaringFilePath is not null)
-        {
-            var position = new LinePosition(element.DeclaringLineNumber ?? -1, -1);
-            testNode.Properties.Add(new TestFileLocationProperty(element.DeclaringFilePath, new(position, position)));
-        }
-
-        testMethodIdentifier = AddTestMethodIdentifier(testNode, testMethod);
+        baseData.AddProperties(testNode.Properties, isTrxEnabled);
 
         return testNode;
     }
 
-    private static void AddCategoriesAndTraits(TestNode testNode, UnitTestElement element, bool isTrxEnabled)
+    private sealed class BaseTestNodeData
     {
-        if (element.TestCategory is { Length: > 0 } categories)
+        private readonly TestMetadataProperty[] _categoryMetadata;
+        private readonly TestMetadataProperty[] _traitMetadata;
+        private readonly string[]? _trxCategories;
+        private readonly TestFileLocationProperty? _fileLocation;
+        private readonly ParsedManagedName? _parsedManagedName;
+        private readonly string _testMethodName;
+        private readonly string? _trxFullyQualifiedTypeName;
+        private TrxFullyQualifiedTypeNameProperty? _trxFullyQualifiedTypeNameProperty;
+        private TrxTestDefinitionName? _trxTestDefinitionName;
+
+        private BaseTestNodeData(
+            TestNodeUid uid,
+            string displayName,
+            TestMetadataProperty[] categoryMetadata,
+            TestMetadataProperty[] traitMetadata,
+            string[]? trxCategories,
+            TestFileLocationProperty? fileLocation,
+            ParsedManagedName? parsedManagedName,
+            string testMethodName,
+            string? trxFullyQualifiedTypeName)
         {
-            if (isTrxEnabled)
+            Uid = uid;
+            DisplayName = displayName;
+            _categoryMetadata = categoryMetadata;
+            _traitMetadata = traitMetadata;
+            _trxCategories = trxCategories;
+            _fileLocation = fileLocation;
+            _parsedManagedName = parsedManagedName;
+            _testMethodName = testMethodName;
+            _trxFullyQualifiedTypeName = trxFullyQualifiedTypeName;
+        }
+
+        public TestNodeUid Uid { get; }
+
+        public string DisplayName { get; }
+
+        public static BaseTestNodeData Create(UnitTestElement element)
+        {
+            TestMethod testMethod = element.TestMethod;
+
+            string[]? categories = element.TestCategory is { Length: > 0 } testCategories
+                ? [.. testCategories]
+                : null;
+            TestMetadataProperty[] categoryMetadata;
+            if (categories is null)
             {
-                testNode.Properties.Add(new TrxCategoriesProperty(categories));
+                categoryMetadata = [];
+            }
+            else
+            {
+                categoryMetadata = new TestMetadataProperty[categories.Length];
+                for (int i = 0; i < categoryMetadata.Length; i++)
+                {
+                    categoryMetadata[i] = new TestMetadataProperty(categories[i], string.Empty);
+                }
             }
 
-            foreach (string category in categories)
+            TestTrait[]? traits = element.Traits;
+            TestMetadataProperty[] traitMetadata;
+            if (traits is null)
             {
-                testNode.Properties.Add(new TestMetadataProperty(category, string.Empty));
+                traitMetadata = [];
+            }
+            else
+            {
+                traitMetadata = new TestMetadataProperty[traits.Length];
+                for (int i = 0; i < traitMetadata.Length; i++)
+                {
+                    traitMetadata[i] = new TestMetadataProperty(traits[i].Name, traits[i].Value);
+                }
+            }
+
+            TestFileLocationProperty? fileLocation = null;
+            if (element.DeclaringFilePath is not null)
+            {
+                var position = new LinePosition(element.DeclaringLineNumber ?? -1, -1);
+                fileLocation = new TestFileLocationProperty(element.DeclaringFilePath, new(position, position));
+            }
+
+            ParsedManagedName? parsedManagedName = GetParsedManagedName(testMethod);
+            string? trxFullyQualifiedTypeName = parsedManagedName?.FullyQualifiedTypeName;
+            if (trxFullyQualifiedTypeName is null && !StringEx.IsNullOrEmpty(testMethod.FullClassName))
+            {
+                trxFullyQualifiedTypeName = testMethod.FullClassName;
+            }
+
+            return new BaseTestNodeData(
+                new TestNodeUid(element.GetTestId().ToString()),
+                testMethod.DisplayName,
+                categoryMetadata,
+                traitMetadata,
+                categories,
+                fileLocation,
+                parsedManagedName,
+                testMethod.Name,
+                trxFullyQualifiedTypeName);
+        }
+
+        public void AddProperties(PropertyBag properties, bool isTrxEnabled)
+        {
+            if (isTrxEnabled && _trxCategories is not null)
+            {
+                properties.Add(new TrxCategoriesProperty([.. _trxCategories]));
+            }
+
+            for (int i = 0; i < _categoryMetadata.Length; i++)
+            {
+                properties.Add(_categoryMetadata[i]);
+            }
+
+            for (int i = 0; i < _traitMetadata.Length; i++)
+            {
+                properties.Add(_traitMetadata[i]);
+            }
+
+            if (_fileLocation is not null)
+            {
+                properties.Add(_fileLocation);
+            }
+
+            if (_parsedManagedName is not null)
+            {
+                properties.Add(_parsedManagedName.ToProperty());
             }
         }
 
-        if (element.Traits is { Length: > 0 } traits)
+        public TrxTestDefinitionName GetTrxTestDefinitionName()
         {
-            foreach (TestTrait trait in traits)
+            if (_trxTestDefinitionName is { } cached)
             {
-                testNode.Properties.Add(new TestMetadataProperty(trait.Name, trait.Value));
+                return cached;
             }
+
+            var created = new TrxTestDefinitionName(DisplayName);
+            return Interlocked.CompareExchange(ref _trxTestDefinitionName, created, null) ?? created;
+        }
+
+        public TrxFullyQualifiedTypeNameProperty GetTrxFullyQualifiedTypeNameProperty()
+        {
+            if (_trxFullyQualifiedTypeName is null)
+            {
+                throw new InvalidOperationException($"The test method '{_testMethodName}' does not have a fully qualified class name.");
+            }
+
+            if (_trxFullyQualifiedTypeNameProperty is { } cached)
+            {
+                return cached;
+            }
+
+            var created = new TrxFullyQualifiedTypeNameProperty(_trxFullyQualifiedTypeName);
+            return Interlocked.CompareExchange(ref _trxFullyQualifiedTypeNameProperty, created, null) ?? created;
         }
     }
 
-    private static TestMethodIdentifierProperty? AddTestMethodIdentifier(TestNode testNode, TestMethod testMethod)
-    {
-        // NOTE: ManagedMethodName, in case of MSTest, carries the parameter types, so we prefer it to display the
-        // parameter types in Test Explorer. This mirrors what the VSTest bridge did in AddAdditionalProperties.
-        if (!testMethod.HasManagedMethodAndTypeProperties || StringEx.IsNullOrEmpty(testMethod.ManagedTypeName))
-        {
-            return null;
-        }
-
-        // The method group conversion is cached by the compiler, so the lookup does not allocate a delegate.
-        TestMethodIdentifierProperty testMethodIdentifier = ParsedManagedNameCache.GetValue(testMethod, ParsedManagedName.Parse).ToProperty();
-        testNode.Properties.Add(testMethodIdentifier);
-        return testMethodIdentifier;
-    }
+    // ManagedMethodName carries the parameter types, so prefer it to match the VSTest bridge's test identity.
+    private static ParsedManagedName? GetParsedManagedName(TestMethod testMethod)
+        => !testMethod.HasManagedMethodAndTypeProperties || StringEx.IsNullOrEmpty(testMethod.ManagedTypeName)
+            ? null
+            : ParsedManagedName.Parse(testMethod);
 
     /// <summary>
-    /// The parsed pieces of a <see cref="TestMethod"/>'s managed type and method names, cached by
-    /// <see cref="ParsedManagedNameCache"/>.
+    /// The parsed pieces of a <see cref="TestMethod"/>'s managed type and method names, retained by
+    /// <see cref="BaseTestNodeData"/>.
     /// </summary>
     private sealed class ParsedManagedName
     {
@@ -263,8 +352,8 @@ internal static class MSTestTestNodeConverter
         {
             // A parameterless property is fully immutable - every field is a string or int, and the empty array
             // cannot be mutated - so the same instance is handed to every node. This is the common case, and the
-            // ParsedManagedName is cached per TestMethod, so the several nodes one executed test produces (the
-            // in-progress node, then one result node per data row and per in-process retry attempt) share it.
+            // ParsedManagedName is retained by the element's base descriptor, so the several nodes one executed
+            // test produces (the in-progress node, then one result node per data row and retry attempt) share it.
             if (_parameterlessProperty is not null)
             {
                 return _parameterlessProperty;
@@ -276,6 +365,9 @@ internal static class MSTestTestNodeConverter
             return new TestMethodIdentifierProperty(
                 assemblyFullName: string.Empty, _namespace, _typeName, _methodName, _arity, [.. _parameterTypeFullNames], returnTypeFullName: string.Empty);
         }
+
+        public string FullyQualifiedTypeName
+            => StringEx.IsNullOrEmpty(_namespace) ? _typeName : $"{_namespace}.{_typeName}";
     }
 
     private static void AddOutcome(TestNode testNode, TestOutcome outcome, string? errorMessage, string? errorStackTrace)
@@ -306,35 +398,15 @@ internal static class MSTestTestNodeConverter
         }
     }
 
-    private static void AddTrxResultProperties(TestNode testNode, UnitTestElement element, string? errorMessage, string? errorStackTrace, TestMethodIdentifierProperty? testMethodIdentifierProperty)
+    private static void AddTrxResultProperties(TestNode testNode, BaseTestNodeData baseData, string? errorMessage, string? errorStackTrace)
     {
         if (!StringEx.IsNullOrEmpty(errorMessage) || !StringEx.IsNullOrEmpty(errorStackTrace))
         {
             testNode.Properties.Add(new TrxExceptionProperty(errorMessage, errorStackTrace));
         }
 
-        TestMethod testMethod = element.TestMethod;
-
-        // TestMethod.DisplayName is always initialized (constructor sets it to displayName ?? name).
-        testNode.Properties.Add(new TrxTestDefinitionName(testMethod.DisplayName));
-
-        if (testMethodIdentifierProperty is not null)
-        {
-            testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(
-                StringEx.IsNullOrEmpty(testMethodIdentifierProperty.Namespace)
-                    ? testMethodIdentifierProperty.TypeName
-                    : $"{testMethodIdentifierProperty.Namespace}.{testMethodIdentifierProperty.TypeName}"));
-        }
-        else if (!StringEx.IsNullOrEmpty(testMethod.FullClassName))
-        {
-            // FullClassName is the source of truth for the type name, so use it directly instead of re-parsing it out
-            // of a "FullClassName.Name" string.
-            testNode.Properties.Add(new TrxFullyQualifiedTypeNameProperty(testMethod.FullClassName));
-        }
-        else
-        {
-            throw new InvalidOperationException($"The test method '{testMethod.Name}' does not have a fully qualified class name.");
-        }
+        testNode.Properties.Add(baseData.GetTrxTestDefinitionName());
+        testNode.Properties.Add(baseData.GetTrxFullyQualifiedTypeNameProperty());
     }
 
     private static void AddMessagesAndOutput(TestNode testNode, FrameworkTestResult result, bool isTrxEnabled)

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -148,8 +148,8 @@ internal static class MSTestTestNodeConverter
         private readonly string[]? _trxCategories;
         private readonly TestFileLocationProperty? _fileLocation;
         private readonly ParsedManagedName? _parsedManagedName;
+        private readonly string _fullClassName;
         private readonly string _testMethodName;
-        private readonly string? _trxFullyQualifiedTypeName;
         private TrxFullyQualifiedTypeNameProperty? _trxFullyQualifiedTypeNameProperty;
         private TrxTestDefinitionName? _trxTestDefinitionName;
 
@@ -161,8 +161,8 @@ internal static class MSTestTestNodeConverter
             string[]? trxCategories,
             TestFileLocationProperty? fileLocation,
             ParsedManagedName? parsedManagedName,
-            string testMethodName,
-            string? trxFullyQualifiedTypeName)
+            string fullClassName,
+            string testMethodName)
         {
             Uid = uid;
             DisplayName = displayName;
@@ -171,8 +171,8 @@ internal static class MSTestTestNodeConverter
             _trxCategories = trxCategories;
             _fileLocation = fileLocation;
             _parsedManagedName = parsedManagedName;
+            _fullClassName = fullClassName;
             _testMethodName = testMethodName;
-            _trxFullyQualifiedTypeName = trxFullyQualifiedTypeName;
         }
 
         public TestNodeUid Uid { get; }
@@ -223,12 +223,6 @@ internal static class MSTestTestNodeConverter
             }
 
             ParsedManagedName? parsedManagedName = GetParsedManagedName(testMethod);
-            string? trxFullyQualifiedTypeName = parsedManagedName?.FullyQualifiedTypeName;
-            if (trxFullyQualifiedTypeName is null && !StringEx.IsNullOrEmpty(testMethod.FullClassName))
-            {
-                trxFullyQualifiedTypeName = testMethod.FullClassName;
-            }
-
             return new BaseTestNodeData(
                 new TestNodeUid(element.GetTestId().ToString()),
                 testMethod.DisplayName,
@@ -237,8 +231,8 @@ internal static class MSTestTestNodeConverter
                 categories,
                 fileLocation,
                 parsedManagedName,
-                testMethod.Name,
-                trxFullyQualifiedTypeName);
+                testMethod.FullClassName,
+                testMethod.Name);
         }
 
         public void AddProperties(PropertyBag properties, bool isTrxEnabled)
@@ -282,17 +276,18 @@ internal static class MSTestTestNodeConverter
 
         public TrxFullyQualifiedTypeNameProperty GetTrxFullyQualifiedTypeNameProperty()
         {
-            if (_trxFullyQualifiedTypeName is null)
-            {
-                throw new InvalidOperationException($"The test method '{_testMethodName}' does not have a fully qualified class name.");
-            }
-
             if (_trxFullyQualifiedTypeNameProperty is { } cached)
             {
                 return cached;
             }
 
-            var created = new TrxFullyQualifiedTypeNameProperty(_trxFullyQualifiedTypeName);
+            string fullyQualifiedTypeName = _parsedManagedName is not null
+                ? _parsedManagedName.FullyQualifiedTypeName
+                : !StringEx.IsNullOrEmpty(_fullClassName)
+                    ? _fullClassName
+                    : throw new InvalidOperationException($"The test method '{_testMethodName}' does not have a fully qualified class name.");
+
+            var created = new TrxFullyQualifiedTypeNameProperty(fullyQualifiedTypeName);
             return Interlocked.CompareExchange(ref _trxFullyQualifiedTypeNameProperty, created, null) ?? created;
         }
     }

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -39,6 +39,11 @@ internal static class MSTestTestNodeConverter
     /// A conversion still creates a distinct <see cref="TestNode"/> and <see cref="PropertyBag"/> for every message.
     /// Only immutable properties are shared. Properties that expose mutable arrays are materialized from private
     /// snapshots for each node. The weak key naturally bounds the cache to the lifetime of the element.
+    /// <para>
+    /// Although <see cref="UnitTestElement"/> is mutable while discovery constructs it, the element is fully
+    /// specialized before its first node is published. Data-row and source transformations create distinct element
+    /// clones, so later lifecycle messages for one element observe the same base metadata captured here.
+    /// </para>
     /// </remarks>
 #pragma warning disable IDE0028 // ConditionalWeakTable is not collection-expression-constructible on .NET Framework (CS9174).
     private static readonly ConditionalWeakTable<UnitTestElement, BaseTestNodeData> BaseTestNodeDataCache = new();

--- a/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/ObjectModel/UnitTestElement.cs
@@ -135,6 +135,9 @@ internal sealed class UnitTestElement
     {
         var clone = (UnitTestElement)MemberwiseClone();
         clone.TestMethod = TestMethod.Clone();
+        // Discovery specializes clones into individual data rows after cloning. Clear the cached id so changes to
+        // DataType/TestCaseIndex cannot reuse the parent test's identity when the parent was converted first.
+        clone.CachedTestNodeUid = null;
         return clone;
     }
 

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -148,6 +148,171 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
             .Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>().Should().BeTrue();
     }
 
+    public void RepeatedConversions_ReuseImmutableBaseProperties_WithoutSharingNodesOrPropertyBags()
+    {
+        UnitTestElement element = CreateElement();
+        element.DeclaringFilePath = "C:\\src\\MyClass.cs";
+        element.DeclaringLineNumber = 42;
+        element.TestCategory = ["CategoryA"];
+        element.Traits = [new TestTrait("Owner", "Alice")];
+
+        TestNode discovered = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+        TestNode inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false);
+        TestNode result = MSTestTestNodeConverter.ToResultTestNode(
+            element,
+            new FrameworkTestResult { Outcome = UnitTestOutcome.Passed },
+            DateTimeOffset.Now,
+            DateTimeOffset.Now,
+            isTrxEnabled: false,
+            new MSTestSettings());
+
+        discovered.Should().NotBeSameAs(inProgress);
+        inProgress.Should().NotBeSameAs(result);
+        discovered.Properties.Should().NotBeSameAs(inProgress.Properties);
+        inProgress.Properties.Should().NotBeSameAs(result.Properties);
+
+        inProgress.Uid.Should().BeSameAs(discovered.Uid);
+        result.Uid.Should().BeSameAs(discovered.Uid);
+        inProgress.Properties.Single<TestFileLocationProperty>().Should().BeSameAs(discovered.Properties.Single<TestFileLocationProperty>());
+        result.Properties.Single<TestFileLocationProperty>().Should().BeSameAs(discovered.Properties.Single<TestFileLocationProperty>());
+        inProgress.Properties.OfType<TestMetadataProperty>().Should().Equal(discovered.Properties.OfType<TestMetadataProperty>());
+        result.Properties.OfType<TestMetadataProperty>().Should().Equal(discovered.Properties.OfType<TestMetadataProperty>());
+        inProgress.Properties.Single<TestMethodIdentifierProperty>().Should().BeSameAs(discovered.Properties.Single<TestMethodIdentifierProperty>());
+        result.Properties.Single<TestMethodIdentifierProperty>().Should().BeSameAs(discovered.Properties.Single<TestMethodIdentifierProperty>());
+
+        discovered.Properties.Add(new TestMetadataProperty("MessageOnly", "discovered"));
+        inProgress.Properties.Any<TestMetadataProperty>().Should().BeTrue();
+        inProgress.Properties.OfType<TestMetadataProperty>().Should().NotContain(p => p.Key == "MessageOnly");
+    }
+
+    public void TrxCategories_AreCopiedPerNode_AndCannotCrossMutate()
+    {
+        UnitTestElement element = CreateElement();
+        element.TestCategory = ["CategoryA", "CategoryB"];
+        element.Traits = [new TestTrait("Owner", "Alice")];
+
+        TestNode first = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: true);
+        TestNode second = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: true);
+
+        Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty firstCategories =
+            first.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>();
+        Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty secondCategories =
+            second.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>();
+
+        firstCategories.Should().NotBeSameAs(secondCategories);
+        firstCategories.Categories.Should().NotBeSameAs(secondCategories.Categories);
+        firstCategories.Categories[0] = "Mutated";
+        secondCategories.Categories.Should().Equal("CategoryA", "CategoryB");
+
+        TestMetadataProperty[] firstMetadata = first.Properties.OfType<TestMetadataProperty>();
+        TestMetadataProperty[] secondMetadata = second.Properties.OfType<TestMetadataProperty>();
+        secondMetadata.Should().Equal(firstMetadata);
+        for (int i = 0; i < firstMetadata.Length; i++)
+        {
+            secondMetadata[i].Should().BeSameAs(firstMetadata[i]);
+        }
+    }
+
+    public void ResultDisplayNameOverride_RemainsPerResult_WhileTrxDefinitionUsesTestDefinitionName()
+    {
+        UnitTestElement element = CreateElement();
+        element.TestMethod.DisplayName = "Test definition";
+
+        TestNode first = MSTestTestNodeConverter.ToResultTestNode(
+            element,
+            new FrameworkTestResult { Outcome = UnitTestOutcome.Passed, DisplayName = "Data row 1" },
+            DateTimeOffset.Now,
+            DateTimeOffset.Now,
+            isTrxEnabled: true,
+            new MSTestSettings());
+        TestNode second = MSTestTestNodeConverter.ToResultTestNode(
+            element,
+            new FrameworkTestResult { Outcome = UnitTestOutcome.Passed, DisplayName = "Data row 2" },
+            DateTimeOffset.Now,
+            DateTimeOffset.Now,
+            isTrxEnabled: true,
+            new MSTestSettings());
+
+        first.DisplayName.Should().Be("Data row 1");
+        second.DisplayName.Should().Be("Data row 2");
+        first.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxTestDefinitionName>().TestDefinitionName.Should().Be("Test definition");
+        second.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxTestDefinitionName>().TestDefinitionName.Should().Be("Test definition");
+    }
+
+    public void CloneSpecializedAsDataRow_DoesNotReuseParentCachedIdentityOrMetadata()
+    {
+        UnitTestElement element = CreateElement();
+        element.TestCategory = ["Parent"];
+        Guid parentId = element.GetTestId();
+        MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        UnitTestElement dataRow = element.Clone();
+        dataRow.TestMethod.DisplayName = "Data row";
+        dataRow.TestMethod.DataType = DynamicDataType.ITestDataSource;
+        dataRow.TestMethod.TestCaseIndex = 1;
+        dataRow.TestCategory = ["Row"];
+
+        TestNode dataRowNode = MSTestTestNodeConverter.ToDiscoveredTestNode(dataRow, isTrxEnabled: false);
+
+        dataRowNode.Uid.Value.Should().NotBe(parentId.ToString());
+        dataRowNode.DisplayName.Should().Be("Data row");
+        dataRowNode.Properties.OfType<TestMetadataProperty>().Should().ContainSingle(p => p.Key == "Row");
+        dataRowNode.Properties.OfType<TestMetadataProperty>().Should().NotContain(p => p.Key == "Parent");
+    }
+
+    public void SourceUpdatedClone_DoesNotReuseOriginalCachedBaseData()
+    {
+        UnitTestElement element = CreateElement();
+        TestNode original = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false);
+
+        UnitTestElement relocated = element.CloneWithSource("OtherAssembly.dll");
+        relocated.DeclaringFilePath = "C:\\deployed\\MyClass.cs";
+        TestNode updated = MSTestTestNodeConverter.ToDiscoveredTestNode(relocated, isTrxEnabled: false);
+
+        updated.Uid.Value.Should().NotBe(original.Uid.Value);
+        updated.Properties.Single<TestFileLocationProperty>().FilePath.Should().Be("C:\\deployed\\MyClass.cs");
+    }
+
+    public void ConcurrentConversions_AreSafeAndPreserveIndependentMutableProperties()
+    {
+        UnitTestElement element = CreateElement(managedMethodName: "MyMethod(System.String)");
+        element.TestCategory = ["CategoryA"];
+        var nodes = new TestNode[128];
+
+        Parallel.For(0, nodes.Length, i => nodes[i] = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: true));
+
+        nodes.Select(node => node.Uid.Value).Should().OnlyContain(uid => uid == nodes[0].Uid.Value);
+        nodes.Select(node => node.Properties).Distinct().Should().HaveCount(nodes.Length);
+
+        string[][] parameterTypes = [.. nodes.Select(node => node.Properties.Single<TestMethodIdentifierProperty>().ParameterTypeFullNames)];
+        parameterTypes.Distinct().Should().HaveCount(nodes.Length);
+
+        string[][] categories = [.. nodes.Select(node => node.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>().Categories)];
+        categories.Distinct().Should().HaveCount(nodes.Length);
+    }
+
+    public void BaseDataCache_DoesNotKeepElementAlive()
+    {
+        WeakReference elementReference = CreateWeakReferenceToConvertedElement();
+
+        for (int i = 0; elementReference.IsAlive && i < 5; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        elementReference.IsAlive.Should().BeFalse();
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference CreateWeakReferenceToConvertedElement()
+    {
+        UnitTestElement element = CreateElement();
+        MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: true);
+        return new WeakReference(element);
+    }
+
     // --- Result node: outcomes --------------------------------------------------------------------------------
     public void ToResultTestNode_MapsPassedOutcome()
     {
@@ -330,11 +495,11 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         node.Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxMessagesProperty>().Should().BeFalse();
     }
 
-    // --- TestMethodIdentifier caching -------------------------------------------------------------------------
+    // --- Base-property caching ---------------------------------------------------------------------------------
     public void ToResultTestNode_ReusesCachedManagedNameParse_FromInProgressNode()
     {
-        // The managed-name parse is cached per TestMethod, so the in-progress node and every result node must
-        // still agree on every field of the identifier.
+        // The managed-name parse is retained by the element's base descriptor, so the in-progress node and every
+        // result node must still agree on every field of the identifier.
         UnitTestElement element = CreateElement();
 
         TestMethodIdentifierProperty inProgress = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: false)
@@ -355,7 +520,7 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     public void ToResultTestNode_ReusesTestMethodIdentifierInstance_ForParameterlessTestMethod()
     {
         // A parameterless identifier is fully immutable (readonly strings plus an empty parameter array, which
-        // cannot be mutated), so the cached parse hands back the very same property instance instead of
+        // cannot be mutated), so the cached descriptor hands back the very same property instance instead of
         // allocating a new one for every node built from the same test method.
         UnitTestElement element = CreateElement();
 
@@ -465,16 +630,14 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         clone.CachedTestNodeUid.Should().BeNull();
     }
 
-    public void Clone_PreservesCachedTestId()
+    public void Clone_InvalidatesCachedTestId_SoTheCloneCanBeSpecializedAsADataRow()
     {
         UnitTestElement element = CreateElement();
-        Guid original = element.GetTestId();
+        element.GetTestId();
 
         UnitTestElement clone = element.Clone();
 
-        // Clone() does not touch any hash input, so the cached id must be preserved.
-        clone.CachedTestNodeUid.Should().Be(original);
-        clone.GetTestId().Should().Be(original);
+        clone.CachedTestNodeUid.Should().BeNull();
     }
 
     // --- Seams ------------------------------------------------------------------------------------------------

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -641,11 +641,12 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     public void Clone_InvalidatesCachedTestId_SoTheCloneCanBeSpecializedAsADataRow()
     {
         UnitTestElement element = CreateElement();
-        element.GetTestId();
+        Guid original = element.GetTestId();
 
         UnitTestElement clone = element.Clone();
 
         clone.CachedTestNodeUid.Should().BeNull();
+        element.CachedTestNodeUid.Should().Be(original);
     }
 
     // --- Seams ------------------------------------------------------------------------------------------------

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -175,8 +175,17 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         result.Uid.Should().BeSameAs(discovered.Uid);
         inProgress.Properties.Single<TestFileLocationProperty>().Should().BeSameAs(discovered.Properties.Single<TestFileLocationProperty>());
         result.Properties.Single<TestFileLocationProperty>().Should().BeSameAs(discovered.Properties.Single<TestFileLocationProperty>());
-        inProgress.Properties.OfType<TestMetadataProperty>().Should().Equal(discovered.Properties.OfType<TestMetadataProperty>());
-        result.Properties.OfType<TestMetadataProperty>().Should().Equal(discovered.Properties.OfType<TestMetadataProperty>());
+        TestMetadataProperty[] discoveredMetadata = discovered.Properties.OfType<TestMetadataProperty>();
+        TestMetadataProperty[] inProgressMetadata = inProgress.Properties.OfType<TestMetadataProperty>();
+        TestMetadataProperty[] resultMetadata = result.Properties.OfType<TestMetadataProperty>();
+        inProgressMetadata.Should().BeEquivalentTo(discoveredMetadata);
+        resultMetadata.Should().BeEquivalentTo(discoveredMetadata);
+        foreach (TestMetadataProperty metadata in discoveredMetadata)
+        {
+            inProgressMetadata.Single(candidate => candidate.Equals(metadata)).Should().BeSameAs(metadata);
+            resultMetadata.Single(candidate => candidate.Equals(metadata)).Should().BeSameAs(metadata);
+        }
+
         inProgress.Properties.Single<TestMethodIdentifierProperty>().Should().BeSameAs(discovered.Properties.Single<TestMethodIdentifierProperty>());
         result.Properties.Single<TestMethodIdentifierProperty>().Should().BeSameAs(discovered.Properties.Single<TestMethodIdentifierProperty>());
 
@@ -206,10 +215,10 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
 
         TestMetadataProperty[] firstMetadata = first.Properties.OfType<TestMetadataProperty>();
         TestMetadataProperty[] secondMetadata = second.Properties.OfType<TestMetadataProperty>();
-        secondMetadata.Should().Equal(firstMetadata);
-        for (int i = 0; i < firstMetadata.Length; i++)
+        secondMetadata.Should().BeEquivalentTo(firstMetadata);
+        foreach (TestMetadataProperty metadata in firstMetadata)
         {
-            secondMetadata[i].Should().BeSameAs(firstMetadata[i]);
+            secondMetadata.Single(candidate => candidate.Equals(metadata)).Should().BeSameAs(metadata);
         }
     }
 
@@ -295,11 +304,10 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
     {
         WeakReference elementReference = CreateWeakReferenceToConvertedElement();
 
-        for (int i = 0; elementReference.IsAlive && i < 5; i++)
+        for (int i = 0; elementReference.IsAlive && i < 10; i++)
         {
-            GC.Collect();
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true);
             GC.WaitForPendingFinalizers();
-            GC.Collect();
         }
 
         elementReference.IsAlive.Should().BeFalse();


### PR DESCRIPTION
## Summary

- cache the immutable base Microsoft.Testing.Platform node representation per `UnitTestElement` using weak lifetime
- reuse UID, file location, metadata, method identity, and TRX identity properties without sharing `TestNode` or `PropertyBag` instances
- defensively materialize mutable parameter and TRX category arrays for every message
- invalidate cloned element UID state before data-row specialization

## Validation

- `MSTestAdapter.UnitTests` Release suite passed on `net462`, `net48`, `net8.0`, `net9.0`, and `net8.0-windows10.0.18362.0`
- focused Release `net8.0` benchmark, 600,000 discovery/in-progress/result conversions with parameterless and parameterized methods and TRX enabled:
  - before: 436.8 MB allocated, 728.00 B/conversion, 678,076 conversions/s
  - after: 280.0 MB allocated, 466.67 B/conversion, 2,145,954 conversions/s
  - allocation reduction: 35.9%
- DataDriven process scenario (10,000 executions, three samples) was noisy: median 1.146s before vs 1.257s after; no wall-clock improvement is claimed
- three independent read-only review passes found no high-confidence issues