### PR TITLE
Add hierarchical configuration sections

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTest.TestAdapter/InternalAPI/InternalAPI.Unshipped.txt
@@ -12,11 +12,13 @@ Microsoft.Testing.Extensions.RunSettingsCommandLineOptionsProviderBase.RunSettin
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.BuildAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! commandLineParseResult) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Configurations.IConfigurationProvider!>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.Description.get -> string!
+Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.LoadAsync() -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.Order.get -> int
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.RunSettingsConfigurationProviderBase() -> void
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.TryGet(string! key, out string? value) -> bool
+Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.TryGetScalar(string! key, out string? value) -> bool
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.Description.get -> string!
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.DisplayName.get -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/InternalAPI.Unshipped.txt
@@ -10,11 +10,13 @@ Microsoft.Testing.Extensions.RunSettingsCommandLineOptionsProviderBase.RunSettin
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.BuildAsync(Microsoft.Testing.Platform.CommandLine.CommandLineParseResult! commandLineParseResult) -> System.Threading.Tasks.Task<Microsoft.Testing.Platform.Configurations.IConfigurationProvider!>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.Description.get -> string!
+Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.LoadAsync() -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.Order.get -> int
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.RunSettingsConfigurationProviderBase() -> void
 Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.TryGet(string! key, out string? value) -> bool
+Microsoft.Testing.Extensions.RunSettingsConfigurationProviderBase.TryGetScalar(string! key, out string? value) -> bool
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.Description.get -> string!
 Microsoft.Testing.Extensions.RunSettingsEnvironmentVariableProviderBase.DisplayName.get -> string!

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -68,12 +68,9 @@ internal sealed class AggregatedConfiguration(
 
         AddChildKeys(ConfigurationProviderHelpers.GetChildKeys(ComputedConfigurationKeys, parentPath));
 
-        foreach (IConfigurationProvider provider in _configurationProviders)
+        foreach (IHierarchicalConfigurationProvider hierarchicalProvider in _configurationProviders.OfType<IHierarchicalConfigurationProvider>())
         {
-            if (provider is IHierarchicalConfigurationProvider hierarchicalProvider)
-            {
-                AddChildKeys(hierarchicalProvider.GetChildKeys(parentPath));
-            }
+            AddChildKeys(hierarchicalProvider.GetChildKeys(parentPath));
         }
 
         childKeys.Sort(ConfigurationKeyComparer.Instance);
@@ -103,11 +100,11 @@ internal sealed class AggregatedConfiguration(
 
     internal bool TryGetSectionValue(string key, out string? value)
     {
-        if (key is PlatformConfigurationConstants.PlatformResultDirectory
-            or PlatformConfigurationConstants.PlatformCurrentWorkingDirectory
-            or PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)
+        string? computedKey = ComputedConfigurationKeys.FirstOrDefault(
+            computedKey => string.Equals(computedKey, key, StringComparison.OrdinalIgnoreCase));
+        if (computedKey is not null)
         {
-            value = this[key];
+            value = this[computedKey];
             return true;
         }
 

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/AggregatedConfiguration.cs
@@ -14,8 +14,15 @@ internal sealed class AggregatedConfiguration(
     ITestApplicationModuleInfo testApplicationModuleInfo,
     IFileSystem fileSystem,
     IEnvironment environment,
-    CommandLineParseResult commandLineParseResult) : IConfiguration
+    CommandLineParseResult commandLineParseResult) : IConfigurationRoot
 {
+    private static readonly string[] ComputedConfigurationKeys =
+    [
+        PlatformConfigurationConstants.PlatformCurrentWorkingDirectory,
+        PlatformConfigurationConstants.PlatformResultDirectory,
+        PlatformConfigurationConstants.PlatformTestHostWorkingDirectory,
+    ];
+
     public const string DefaultTestResultFolderName = "TestResults";
     private readonly IConfigurationProvider[] _configurationProviders = configurationProviders;
     private readonly ITestApplicationModuleInfo _testApplicationModuleInfo = testApplicationModuleInfo;
@@ -44,6 +51,83 @@ internal sealed class AggregatedConfiguration(
             // Fallback to calculating from configuration providers.
             return CalculateFromConfigurationProviders(key);
         }
+    }
+
+    public IConfigurationSection GetSection(string key)
+    {
+        _ = key ?? throw new ArgumentNullException(nameof(key));
+        return new ConfigurationSection(this, key);
+    }
+
+    public IEnumerable<IConfigurationSection> GetChildren() => GetChildren(parentPath: null);
+
+    internal IEnumerable<IConfigurationSection> GetChildren(string? parentPath)
+    {
+        List<string> childKeys = [];
+        HashSet<string> seenChildKeys = [with(StringComparer.OrdinalIgnoreCase)];
+
+        AddChildKeys(ConfigurationProviderHelpers.GetChildKeys(ComputedConfigurationKeys, parentPath));
+
+        foreach (IConfigurationProvider provider in _configurationProviders)
+        {
+            if (provider is IHierarchicalConfigurationProvider hierarchicalProvider)
+            {
+                AddChildKeys(hierarchicalProvider.GetChildKeys(parentPath));
+            }
+        }
+
+        childKeys.Sort(ConfigurationKeyComparer.Instance);
+
+        var children = new IConfigurationSection[childKeys.Count];
+        for (int i = 0; i < childKeys.Count; i++)
+        {
+            string path = parentPath is null
+                ? childKeys[i]
+                : parentPath + PlatformConfigurationConstants.KeyDelimiter + childKeys[i];
+            children[i] = new ConfigurationSection(this, path);
+        }
+
+        return children;
+
+        void AddChildKeys(IEnumerable<string> keys)
+        {
+            foreach (string childKey in keys)
+            {
+                if (seenChildKeys.Add(childKey))
+                {
+                    childKeys.Add(childKey);
+                }
+            }
+        }
+    }
+
+    internal bool TryGetSectionValue(string key, out string? value)
+    {
+        if (key is PlatformConfigurationConstants.PlatformResultDirectory
+            or PlatformConfigurationConstants.PlatformCurrentWorkingDirectory
+            or PlatformConfigurationConstants.PlatformTestHostWorkingDirectory)
+        {
+            value = this[key];
+            return true;
+        }
+
+        foreach (IConfigurationProvider provider in _configurationProviders)
+        {
+            if (provider is IHierarchicalConfigurationProvider hierarchicalProvider)
+            {
+                if (hierarchicalProvider.TryGetScalar(key, out value))
+                {
+                    return true;
+                }
+            }
+            else if (provider.TryGet(key, out value))
+            {
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
     }
 
     private string? CalculateFromConfigurationProviders(string key)
@@ -287,5 +371,45 @@ internal sealed class AggregatedConfiguration(
 
         // then fallback to the actual working directory.
         return _testApplicationModuleInfo.GetCurrentTestApplicationDirectory();
+    }
+
+    private sealed class ConfigurationKeyComparer : IComparer<string>
+    {
+        public static readonly ConfigurationKeyComparer Instance = new();
+
+        public int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            bool xIsInteger = int.TryParse(x, NumberStyles.None, CultureInfo.InvariantCulture, out int xInteger);
+            bool yIsInteger = int.TryParse(y, NumberStyles.None, CultureInfo.InvariantCulture, out int yInteger);
+
+            if (xIsInteger && yIsInteger)
+            {
+                int integerComparison = xInteger.CompareTo(yInteger);
+                return integerComparison != 0
+                    ? integerComparison
+                    : StringComparer.OrdinalIgnoreCase.Compare(x, y);
+            }
+
+            return xIsInteger
+                ? -1
+                : yIsInteger
+                    ? 1
+                    : StringComparer.OrdinalIgnoreCase.Compare(x, y);
+        }
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/CommandLineConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/CommandLineConfigurationProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Testing.Platform.Configurations;
 /// produce.
 /// </para>
 /// </remarks>
-internal sealed class CommandLineConfigurationProvider : IConfigurationProvider
+internal sealed class CommandLineConfigurationProvider : IHierarchicalConfigurationProvider
 {
     private readonly Dictionary<string, string?> _data = [with(StringComparer.OrdinalIgnoreCase)];
 
@@ -67,4 +67,9 @@ internal sealed class CommandLineConfigurationProvider : IConfigurationProvider
     public Task LoadAsync() => Task.CompletedTask;
 
     public bool TryGet(string key, out string? value) => _data.TryGetValue(key, out value);
+
+    public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
+
+    public IEnumerable<string> GetChildKeys(string? parentPath)
+        => ConfigurationProviderHelpers.GetChildKeys(_data.Keys, parentPath);
 }

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationProviderHelpers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationProviderHelpers.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Configurations;
+
+internal static class ConfigurationProviderHelpers
+{
+    public static IEnumerable<string> GetChildKeys(IEnumerable<string> keys, string? parentPath)
+    {
+        string prefix = parentPath is null
+            ? string.Empty
+            : parentPath + PlatformConfigurationConstants.KeyDelimiter;
+        HashSet<string> childKeys = [with(StringComparer.OrdinalIgnoreCase)];
+
+        foreach (string key in keys)
+        {
+            if (!key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string remainder = key.Substring(prefix.Length);
+            if (remainder.Length == 0)
+            {
+                continue;
+            }
+
+            int delimiterIndex = remainder.IndexOf(PlatformConfigurationConstants.KeyDelimiter, StringComparison.Ordinal);
+            childKeys.Add(delimiterIndex < 0 ? remainder : remainder.Substring(0, delimiterIndex));
+        }
+
+        return childKeys;
+    }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationSection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/ConfigurationSection.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Configurations;
+
+internal sealed class ConfigurationSection : IConfigurationSection
+{
+    private readonly AggregatedConfiguration _root;
+
+    public ConfigurationSection(AggregatedConfiguration root, string path)
+    {
+        _root = root;
+        Path = path;
+
+        int delimiterIndex = path.LastIndexOf(PlatformConfigurationConstants.KeyDelimiter, StringComparison.Ordinal);
+        Key = delimiterIndex < 0 ? path : path.Substring(delimiterIndex + 1);
+    }
+
+    public string Key { get; }
+
+    public string Path { get; }
+
+    public bool HasValue => _root.TryGetSectionValue(Path, out _);
+
+    public string? Value => _root.TryGetSectionValue(Path, out string? value) ? value : null;
+
+    public string? this[string key]
+        => _root.TryGetSectionValue(CombinePath(Path, key), out string? value) ? value : null;
+
+    public IConfigurationSection GetSection(string key)
+    {
+        _ = key ?? throw new ArgumentNullException(nameof(key));
+        return new ConfigurationSection(_root, CombinePath(Path, key));
+    }
+
+    public IEnumerable<IConfigurationSection> GetChildren() => _root.GetChildren(Path);
+
+    private static string CombinePath(string path, string key)
+        => path + PlatformConfigurationConstants.KeyDelimiter + key;
+}

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/EnvironmentVariablesConfigurationProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Testing.Platform.Configurations;
 
 // Taken and adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
 [ExcludeFromCodeCoverage]
-internal sealed class EnvironmentVariablesConfigurationProvider : IConfigurationProvider
+internal sealed class EnvironmentVariablesConfigurationProvider : IHierarchicalConfigurationProvider
 {
     public static readonly string KeyDelimiter = ":";
     private const string MySqlServerPrefix = "MYSQLCONNSTR_";
@@ -78,6 +78,11 @@ internal sealed class EnvironmentVariablesConfigurationProvider : IConfiguration
         Ensure.NotEmpty(key);
         return _data.TryGetValue(key, out value);
     }
+
+    public IEnumerable<string> GetChildKeys(string? parentPath)
+        => ConfigurationProviderHelpers.GetChildKeys(_data.Keys, parentPath);
+
+    public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
 
     private void HandleMatchedConnectionStringPrefix(Dictionary<string, string?> data, string connectionStringPrefix, string? provider, string fullKey, string? value)
     {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationRoot.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationRoot.cs
@@ -11,12 +11,12 @@ public interface IConfigurationRoot : IConfiguration
     /// <summary>
     /// Gets the configuration section at the specified path.
     /// </summary>
-    /// <param name="key">The section path relative to the configuration root.</param>
+    /// <param name="key">The section path relative to the current configuration root or section.</param>
     /// <returns>The requested configuration section.</returns>
     IConfigurationSection GetSection(string key);
 
     /// <summary>
-    /// Gets the immediate child sections of the configuration root.
+    /// Gets the immediate child sections of the current configuration root or section.
     /// </summary>
     /// <remarks>
     /// Configuration providers must implement <see cref="IHierarchicalConfigurationProvider"/> for their keys

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationRoot.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationRoot.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Configurations;
+
+/// <summary>
+/// Represents the root of an aggregated hierarchical configuration.
+/// </summary>
+public interface IConfigurationRoot : IConfiguration
+{
+    /// <summary>
+    /// Gets the configuration section at the specified path.
+    /// </summary>
+    /// <param name="key">The section path relative to the configuration root.</param>
+    /// <returns>The requested configuration section.</returns>
+    IConfigurationSection GetSection(string key);
+
+    /// <summary>
+    /// Gets the immediate child sections of the configuration root.
+    /// </summary>
+    /// <remarks>
+    /// Configuration providers must implement <see cref="IHierarchicalConfigurationProvider"/> for their keys
+    /// to be discoverable through enumeration. Values from other providers remain accessible by requesting a
+    /// known section path.
+    /// </remarks>
+    /// <returns>The immediate child sections.</returns>
+    IEnumerable<IConfigurationSection> GetChildren();
+}

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSection.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSection.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Configurations;
+
+/// <summary>
+/// Represents a section of an aggregated hierarchical configuration.
+/// </summary>
+public interface IConfigurationSection : IConfigurationRoot
+{
+    /// <summary>
+    /// Gets the key occupying this section's final path segment.
+    /// </summary>
+    string Key { get; }
+
+    /// <summary>
+    /// Gets the full path to this section from the configuration root.
+    /// </summary>
+    string Path { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a provider supplied a scalar value for this section.
+    /// </summary>
+    bool HasValue { get; }
+
+    /// <summary>
+    /// Gets the scalar value associated with this section.
+    /// </summary>
+    string? Value { get; }
+}

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IHierarchicalConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IHierarchicalConfigurationProvider.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Configurations;
+
+/// <summary>
+/// Represents a configuration provider that exposes hierarchical configuration sections.
+/// </summary>
+[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
+public interface IHierarchicalConfigurationProvider : IConfigurationProvider
+{
+    /// <summary>
+    /// Tries to get the scalar value for the specified key.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">The associated scalar value.</param>
+    /// <returns><c>true</c> if a scalar value was found; <c>false</c> if the key is absent or represents only a container.</returns>
+    bool TryGetScalar(string key, out string? value);
+
+    /// <summary>
+    /// Gets the immediate child keys below the specified configuration path.
+    /// </summary>
+    /// <param name="parentPath">The parent path, or <see langword="null"/> for the configuration root.</param>
+    /// <returns>The immediate child keys.</returns>
+    IEnumerable<string> GetChildKeys(string? parentPath);
+}

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationProvider.Loading.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/JsonConfigurationProvider.Loading.cs
@@ -15,7 +15,7 @@ internal sealed partial class JsonConfigurationSource
         ITestApplicationModuleInfo testApplicationModuleInfo,
         IFileSystem fileSystem,
         CommandLineParseResult commandLineParseResult,
-        ILogger? logger) : IConfigurationProvider
+        ILogger? logger) : IHierarchicalConfigurationProvider
     {
         private readonly ITestApplicationModuleInfo _testApplicationModuleInfo = testApplicationModuleInfo;
         private readonly IFileSystem _fileSystem = fileSystem;
@@ -94,6 +94,26 @@ internal sealed partial class JsonConfigurationSource
         {
             value = null;
             return (_singleValueData != null && _singleValueData.TryGetValue(key, out value)) || (_propertyToAllChildren != null && _propertyToAllChildren.TryGetValue(key, out value));
+        }
+
+        public IEnumerable<string> GetChildKeys(string? parentPath)
+        {
+            IEnumerable<string> singleValueKeys = _singleValueData?.Keys ?? Enumerable.Empty<string>();
+            IEnumerable<string> propertyKeys = _propertyToAllChildren?.Keys ?? Enumerable.Empty<string>();
+            return ConfigurationProviderHelpers.GetChildKeys(singleValueKeys.Concat(propertyKeys), parentPath);
+        }
+
+        bool IHierarchicalConfigurationProvider.TryGetScalar(string key, out string? value)
+        {
+            if (_singleValueData is not null
+                && _singleValueData.TryGetValue(key, out value)
+                && value is not null)
+            {
+                return true;
+            }
+
+            value = null;
+            return false;
         }
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,24 @@
 #nullable enable
+Microsoft.Testing.Platform.Configurations.AggregatedConfiguration.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Configurations.IConfigurationSection!>!
+Microsoft.Testing.Platform.Configurations.AggregatedConfiguration.GetChildren(string? parentPath) -> System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Configurations.IConfigurationSection!>!
+Microsoft.Testing.Platform.Configurations.AggregatedConfiguration.GetSection(string! key) -> Microsoft.Testing.Platform.Configurations.IConfigurationSection!
+Microsoft.Testing.Platform.Configurations.AggregatedConfiguration.TryGetSectionValue(string! key, out string? value) -> bool
+Microsoft.Testing.Platform.Configurations.CommandLineConfigurationProvider.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Testing.Platform.Configurations.CommandLineConfigurationProvider.TryGetScalar(string! key, out string? value) -> bool
+Microsoft.Testing.Platform.Configurations.ConfigurationProviderHelpers
+Microsoft.Testing.Platform.Configurations.ConfigurationSection
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.ConfigurationSection(Microsoft.Testing.Platform.Configurations.AggregatedConfiguration! root, string! path) -> void
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Configurations.IConfigurationSection!>!
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.GetSection(string! key) -> Microsoft.Testing.Platform.Configurations.IConfigurationSection!
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.HasValue.get -> bool
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.Key.get -> string!
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.Path.get -> string!
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.Value.get -> string?
+Microsoft.Testing.Platform.Configurations.ConfigurationSection.this[string! key].get -> string?
+Microsoft.Testing.Platform.Configurations.EnvironmentVariablesConfigurationProvider.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.Testing.Platform.Configurations.EnvironmentVariablesConfigurationProvider.TryGetScalar(string! key, out string? value) -> bool
+Microsoft.Testing.Platform.Configurations.JsonConfigurationSource.JsonConfigurationProvider.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
+static Microsoft.Testing.Platform.Configurations.ConfigurationProviderHelpers.GetChildKeys(System.Collections.Generic.IEnumerable<string!>! keys, string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
 Microsoft.Testing.Platform.Helpers.IConsole.Write(System.Text.StringBuilder! value) -> void
 Microsoft.Testing.Platform.Helpers.IFileSystem.ReplaceFile(string! sourceFileName, string! destFileName) -> void
 Microsoft.Testing.Platform.Helpers.SystemConsole.Write(System.Text.StringBuilder! value) -> void

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,16 @@
 #nullable enable
+Microsoft.Testing.Platform.Configurations.IConfigurationRoot
+Microsoft.Testing.Platform.Configurations.IConfigurationRoot.GetChildren() -> System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Configurations.IConfigurationSection!>!
+Microsoft.Testing.Platform.Configurations.IConfigurationRoot.GetSection(string! key) -> Microsoft.Testing.Platform.Configurations.IConfigurationSection!
+Microsoft.Testing.Platform.Configurations.IConfigurationSection
+Microsoft.Testing.Platform.Configurations.IConfigurationSection.HasValue.get -> bool
+Microsoft.Testing.Platform.Configurations.IConfigurationSection.Key.get -> string!
+Microsoft.Testing.Platform.Configurations.IConfigurationSection.Path.get -> string!
+Microsoft.Testing.Platform.Configurations.IConfigurationSection.Value.get -> string?
+[TPEXP]Microsoft.Testing.Platform.Configurations.IHierarchicalConfigurationProvider
+[TPEXP]Microsoft.Testing.Platform.Configurations.IHierarchicalConfigurationProvider.GetChildKeys(string? parentPath) -> System.Collections.Generic.IEnumerable<string!>!
+[TPEXP]Microsoft.Testing.Platform.Configurations.IHierarchicalConfigurationProvider.TryGetScalar(string! key, out string? value) -> bool
+static Microsoft.Testing.Platform.Services.ServiceProviderExtensions.GetConfigurationRoot(this System.IServiceProvider! serviceProvider) -> Microsoft.Testing.Platform.Configurations.IConfigurationRoot!
 [TPEXP]Microsoft.Testing.Platform.Requests.CompositeTestExecutionFilter
 [TPEXP]Microsoft.Testing.Platform.Requests.CompositeTestExecutionFilter.CompositeTestExecutionFilter(Microsoft.Testing.Platform.Requests.TestExecutionFilterOperator operator, params Microsoft.Testing.Platform.Requests.ITestExecutionFilter![]! filters) -> void
 [TPEXP]Microsoft.Testing.Platform.Requests.CompositeTestExecutionFilter.Filters.get -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.Requests.ITestExecutionFilter!>!

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -74,6 +74,14 @@ public static class ServiceProviderExtensions
         => serviceProvider.GetRequiredService<IConfiguration>();
 
     /// <summary>
+    /// Gets the hierarchical configuration root from the <see cref="IServiceProvider"/>.
+    /// </summary>
+    /// <param name="serviceProvider">The service provider.</param>
+    /// <returns>The hierarchical configuration root.</returns>
+    public static IConfigurationRoot GetConfigurationRoot(this IServiceProvider serviceProvider)
+        => serviceProvider.GetRequiredService<IConfigurationRoot>();
+
+    /// <summary>
     /// Gets the artifact naming service from the <see cref="IServiceProvider"/>.
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>

--- a/src/Platform/SharedExtensionHelpers/RunSettingsConfigurationProviderBase.cs
+++ b/src/Platform/SharedExtensionHelpers/RunSettingsConfigurationProviderBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Testing.Extensions;
 /// Microsoft.Testing.Platform integration.
 /// </summary>
 [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "The shared helper is linked into projects that are allowed to use MTP APIs")]
-internal abstract class RunSettingsConfigurationProviderBase : IConfigurationSource, IConfigurationProvider
+internal abstract class RunSettingsConfigurationProviderBase : IConfigurationSource, IHierarchicalConfigurationProvider
 {
     private string? _runSettingsFileContent;
 
@@ -61,6 +61,20 @@ internal abstract class RunSettingsConfigurationProviderBase : IConfigurationSou
         value = null;
         return false;
     }
+
+    /// <inheritdoc />
+    public IEnumerable<string> GetChildKeys(string? parentPath)
+        => !TryGet(PlatformConfigurationConstants.PlatformResultDirectory, out _)
+            ? []
+            : parentPath switch
+            {
+                null => ["platformOptions"],
+                "platformOptions" => ["resultDirectory"],
+                _ => [],
+            };
+
+    /// <inheritdoc />
+    public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
 
     /// <inheritdoc />
     public Task<IConfigurationProvider> BuildAsync(CommandLineParseResult commandLineParseResult)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -237,9 +237,101 @@ public sealed class AggregatedConfigurationTests
         // Current working directory still comes from env var
         Assert.AreEqual(dotnetTestWorkingDir, aggregatedConfiguration[PlatformConfigurationConstants.PlatformCurrentWorkingDirectory]);
     }
+
+    [TestMethod]
+    public void GetChildren_MergesProvidersAndResolvesValuesByPrecedence()
+    {
+        DictionaryConfigurationProvider higherPriorityProvider = new(new()
+        {
+            ["codeCoverage:Configuration:includeTestAssembly"] = "False",
+            ["codeCoverage:Configuration:CodeCoverage:CollectFromChildProcesses"] = "True",
+        });
+        DictionaryConfigurationProvider lowerPriorityProvider = new(new()
+        {
+            ["codeCoverage:Configuration:IncludeTestAssembly"] = "True",
+            ["codeCoverage:Configuration:Format"] = "cobertura",
+            ["codeCoverage:Configuration:CodeCoverage:UseVerifiableInstrumentation"] = "True",
+        });
+        AggregatedConfiguration configuration = new(
+            [higherPriorityProvider, lowerPriorityProvider],
+            _testApplicationModuleInfoMock.Object,
+            _fileSystemMock.Object,
+            _environmentMock.Object,
+            CommandLineParseResult.Empty);
+
+        IConfigurationSection coverageConfiguration = configuration.GetSection("codeCoverage:Configuration");
+        IConfigurationSection[] children = coverageConfiguration.GetChildren().ToArray();
+
+        Assert.AreSequenceEqual(
+            ["CodeCoverage", "Format", "includeTestAssembly"],
+            children.Select(child => child.Key).ToArray());
+        Assert.AreEqual("False", coverageConfiguration.GetSection("IncludeTestAssembly").Value);
+        Assert.AreEqual("cobertura", coverageConfiguration.GetSection("Format").Value);
+        Assert.AreSequenceEqual(
+            ["CollectFromChildProcesses", "UseVerifiableInstrumentation"],
+            coverageConfiguration.GetSection("CodeCoverage").GetChildren().Select(child => child.Key).ToArray());
+    }
+
+    [TestMethod]
+    public void GetChildren_OrdersNumericKeysNumerically()
+    {
+        DictionaryConfigurationProvider provider = new(new()
+        {
+            ["items:10"] = "ten",
+            ["items:2"] = "two",
+            ["items:0"] = "zero",
+        });
+        AggregatedConfiguration configuration = new(
+            [provider],
+            _testApplicationModuleInfoMock.Object,
+            _fileSystemMock.Object,
+            _environmentMock.Object,
+            CommandLineParseResult.Empty);
+
+        Assert.AreSequenceEqual(
+            ["0", "2", "10"],
+            configuration.GetSection("items").GetChildren().Select(child => child.Key).ToArray());
+    }
+
+    [TestMethod]
+    public void GetChildren_IncludesComputedPlatformConfiguration()
+    {
+        _testApplicationModuleInfoMock.Setup(x => x.GetCurrentTestApplicationDirectory()).Returns("TestAppDir");
+        AggregatedConfiguration configuration = new(
+            [],
+            _testApplicationModuleInfoMock.Object,
+            _fileSystemMock.Object,
+            _environmentMock.Object,
+            CommandLineParseResult.Empty);
+
+        IConfigurationSection platformOptions = Assert.ContainsSingle(
+            configuration.GetChildren().Where(child => child.Key == "platformOptions"));
+        IConfigurationSection resultDirectory = platformOptions.GetSection("resultDirectory");
+
+        Assert.IsTrue(resultDirectory.HasValue);
+        Assert.AreEqual(Path.Combine("TestAppDir", "TestResults"), resultDirectory.Value);
+    }
+
+    [TestMethod]
+    public void GetSection_LegacyProviderValueRemainsAddressableWithoutEnumeration()
+    {
+        ScalarOnlyConfigurationProvider provider = new("custom:value", "from legacy provider");
+        AggregatedConfiguration configuration = new(
+            [provider],
+            _testApplicationModuleInfoMock.Object,
+            _fileSystemMock.Object,
+            _environmentMock.Object,
+            CommandLineParseResult.Empty);
+
+        IConfigurationSection value = configuration.GetSection("custom:value");
+
+        Assert.IsTrue(value.HasValue);
+        Assert.AreEqual("from legacy provider", value.Value);
+        Assert.DoesNotContain("custom", configuration.GetChildren().Select(child => child.Key));
+    }
 }
 
-internal sealed class FakeConfigurationProvider : IConfigurationProvider
+internal sealed class FakeConfigurationProvider : IHierarchicalConfigurationProvider
 {
     private readonly string _path;
 
@@ -261,5 +353,50 @@ internal sealed class FakeConfigurationProvider : IConfigurationProvider
             default:
                 return false;
         }
+    }
+
+    public IEnumerable<string> GetChildKeys(string? parentPath)
+        => ConfigurationProviderHelpers.GetChildKeys(
+            [
+                PlatformConfigurationConstants.PlatformResultDirectory,
+                PlatformConfigurationConstants.PlatformCurrentWorkingDirectory,
+                PlatformConfigurationConstants.PlatformTestHostWorkingDirectory,
+            ],
+            parentPath);
+
+    public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
+}
+
+internal sealed class DictionaryConfigurationProvider : IHierarchicalConfigurationProvider
+{
+    private readonly Dictionary<string, string?> _entries;
+
+    public DictionaryConfigurationProvider(Dictionary<string, string?> entries)
+        => _entries = new Dictionary<string, string?>(entries, StringComparer.OrdinalIgnoreCase);
+
+    public Task LoadAsync() => Task.CompletedTask;
+
+    public bool TryGet(string key, out string? value) => _entries.TryGetValue(key, out value);
+
+    public IEnumerable<string> GetChildKeys(string? parentPath)
+        => ConfigurationProviderHelpers.GetChildKeys(_entries.Keys, parentPath);
+
+    public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
+}
+
+internal sealed class ScalarOnlyConfigurationProvider(string key, string value) : IConfigurationProvider
+{
+    public Task LoadAsync() => Task.CompletedTask;
+
+    public bool TryGet(string requestedKey, out string? result)
+    {
+        if (string.Equals(requestedKey, key, StringComparison.OrdinalIgnoreCase))
+        {
+            result = value;
+            return true;
+        }
+
+        result = null;
+        return false;
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/AggregatedConfigurationTests.cs
@@ -313,6 +313,23 @@ public sealed class AggregatedConfigurationTests
     }
 
     [TestMethod]
+    public void GetSection_ComputedPlatformConfigurationIsCaseInsensitive()
+    {
+        _testApplicationModuleInfoMock.Setup(x => x.GetCurrentTestApplicationDirectory()).Returns("TestAppDir");
+        AggregatedConfiguration configuration = new(
+            [],
+            _testApplicationModuleInfoMock.Object,
+            _fileSystemMock.Object,
+            _environmentMock.Object,
+            CommandLineParseResult.Empty);
+
+        IConfigurationSection resultDirectory = configuration.GetSection("PLATFORMOPTIONS:RESULTDIRECTORY");
+
+        Assert.IsTrue(resultDirectory.HasValue);
+        Assert.AreEqual(Path.Combine("TestAppDir", "TestResults"), resultDirectory.Value);
+    }
+
+    [TestMethod]
     public void GetSection_LegacyProviderValueRemainsAddressableWithoutEnumeration()
     {
         ScalarOnlyConfigurationProvider provider = new("custom:value", "from legacy provider");

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/CommandLineConfigurationProviderTests.cs
@@ -253,10 +253,15 @@ public sealed class CommandLineConfigurationProviderTests
         Assert.IsFalse(configuration.TryGetCommandLineOptionArguments("hangdump", out _));
     }
 
-    private sealed class InMemoryConfigurationProvider(Dictionary<string, string?> entries) : IConfigurationProvider
+    private sealed class InMemoryConfigurationProvider(Dictionary<string, string?> entries) : IHierarchicalConfigurationProvider
     {
         public Task LoadAsync() => Task.CompletedTask;
 
         public bool TryGet(string key, out string? value) => entries.TryGetValue(key, out value);
+
+        public IEnumerable<string> GetChildKeys(string? parentPath)
+            => ConfigurationProviderHelpers.GetChildKeys(entries.Keys, parentPath);
+
+        public bool TryGetScalar(string key, out string? value) => TryGet(key, out value);
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationManagerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Configuration/ConfigurationManagerTests.cs
@@ -264,6 +264,45 @@ public sealed class ConfigurationManagerTests
         Assert.AreEqual("True", entries.Single(e => e.Key == "ENABLED").Value);
     }
 
+    [TestMethod]
+    public async ValueTask ConfigurationSection_TraversesCommentedJsonWithoutExposingRawJson()
+    {
+        AggregatedConfiguration configuration = await BuildAggregatedConfigurationAsync(
+            """
+            {
+              "codeCoverage": {
+                "Configuration": {
+                  "IncludeTestAssembly": true, // Include the test assembly.
+                  "CodeCoverage": {
+                    "CollectFromChildProcesses": true,
+                  },
+                },
+              },
+            }
+            """);
+
+        IConfigurationSection coverageConfiguration = configuration
+            .GetSection("codeCoverage")
+            .GetSection("Configuration");
+
+        Assert.AreEqual("Configuration", coverageConfiguration.Key);
+        Assert.AreEqual("codeCoverage:Configuration", coverageConfiguration.Path);
+        Assert.IsFalse(coverageConfiguration.HasValue);
+        Assert.IsNull(coverageConfiguration.Value);
+        Assert.AreEqual("True", coverageConfiguration["IncludeTestAssembly"]);
+        Assert.IsNull(coverageConfiguration["CodeCoverage"]);
+
+        IConfigurationSection includeTestAssembly = coverageConfiguration.GetSection("IncludeTestAssembly");
+        Assert.IsTrue(includeTestAssembly.HasValue);
+        Assert.AreEqual("True", includeTestAssembly.Value);
+
+        IConfigurationSection codeCoverage = Assert.ContainsSingle(
+            coverageConfiguration.GetChildren().Where(child => child.Key == "CodeCoverage"));
+        Assert.AreEqual(
+            "True",
+            codeCoverage.GetSection("CollectFromChildProcesses").Value);
+    }
+
     private static async Task<AggregatedConfiguration> BuildAggregatedConfigurationAsync(string jsonFileContent)
     {
         Mock<IFileSystem> fileSystem = new();


### PR DESCRIPTION
## Summary

- expose a read-only, source-neutral configuration hierarchy through `IConfigurationRoot` and `IConfigurationSection`
- add an opt-in `IHierarchicalConfigurationProvider` capability without breaking existing `IConfigurationProvider` implementations
- merge child sections across providers with existing precedence, case-insensitive keys, and numeric array ordering
- keep container values out of scalar section access so extensions can traverse nested configuration without reparsing source-specific JSON

## Motivation

Extensions currently need to reopen and parse `testconfig.json` when consuming nested configuration. That duplicates parsing behavior and bypasses MTP's aggregate of JSON, environment variables, command-line values, runsettings, and future providers. The new section model exposes the resolved logical tree independently of the underlying source format.

Related to #10584.

## Validation

- 77 focused configuration tests
- `Microsoft.Testing.Platform` built across all configured target frameworks
- `MSTest.TestAdapter` built across all configured target frameworks
- `Microsoft.Testing.Extensions.VSTestBridge` built across all configured target frameworks
- analyzers and public/internal API checks enabled with zero warnings or errors