### PR TITLE
Preserve generated attributes for async tests

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionDataProvider.cs
@@ -78,7 +78,9 @@ internal class SourceGeneratedReflectionDataProvider
 
     /// <summary>
     /// Gets complete attribute sets for successfully resolved methods, keyed by the
-    /// <see cref="MethodInfo"/> instance that the source generator resolved at startup. Keying by
+    /// <see cref="MethodInfo"/> instance that the source generator resolved at startup. These sets
+    /// contain source-generated user-declared attributes plus required compiler-synthesized metadata
+    /// merged during registration. Keying by
     /// <see cref="MethodInfo"/> (rather than method name) distinguishes overloads. Dictionary
     /// presence is authoritative, including an empty array; missing entries require reflection
     /// fallback because resolution or complete materialization was unavailable.

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -20,7 +20,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Sou
 /// via the richer
 /// <see cref="ReflectionMetadataHook.Register(Assembly, Type[], IReadOnlyDictionary{Type, MethodInfo[]}, IReadOnlyDictionary{Type, Attribute[]}, object[])"/>
 /// family of overloads. Missing entries—including unresolved members and incompletely materialized
-/// attribute sets—fall back to runtime reflection. Reflection-free mode emits constructor
+/// attribute sets—fall back to runtime reflection. For complete async methods, registration keeps
+/// generated declared attributes authoritative and performs a targeted runtime merge of
+/// compiler-special <see cref="AsyncStateMachineAttribute"/> and
+/// <see cref="DebuggerStepThroughAttribute"/> metadata. Reflection-free mode emits constructor
 /// invocation and applicable property-setter delegates, but general constructor/property
 /// enumeration and lookup remain reflective; navigation data remains unpopulated.
 /// MethodInfo keys (and PropertyInfo keys for emitted setters) are resolved with bounded reflection

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -60,6 +60,7 @@ internal static class MetadataRegistryEmitter
                 sb.AppendLine("/// <summary>True when this method is a <c>[TestMethod]</c> (used to populate the test-method roots); false for fixtures and other registered methods.</summary>");
                 sb.AppendLine("public bool IsTestMethod { get; set; }");
                 sb.AppendLine("public bool IsStatic { get; set; }");
+                sb.AppendLine("public bool IsAsync { get; set; }");
                 sb.AppendLine("public bool ReturnsTask { get; set; }");
                 sb.AppendLine("public bool ReturnsValueTask { get; set; }");
                 sb.AppendLine("public bool ReturnsVoid { get; set; }");
@@ -245,6 +246,7 @@ internal static class MetadataRegistryEmitter
                     sb.AppendLine($"Name = \"{Escape(method.Name)}\",");
                     sb.AppendLine($"IsTestMethod = {Bool(method.IsTestMethod)},");
                     sb.AppendLine($"IsStatic = {Bool(method.IsStatic)},");
+                    sb.AppendLine($"IsAsync = {Bool(method.IsAsync)},");
                     sb.AppendLine($"ReturnsTask = {Bool(method.ReturnsTask)},");
                     sb.AppendLine($"ReturnsValueTask = {Bool(method.ReturnsValueTask)},");
                     sb.AppendLine($"ReturnsVoid = {Bool(method.ReturnsVoid)},");

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
@@ -40,6 +40,7 @@ internal static class RuntimeRegistrationEmitter
         sb.AppendLine();
         sb.AppendLine("using System;");
         sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("using System.Diagnostics;");
         sb.AppendLine("using System.Diagnostics.CodeAnalysis;");
         sb.AppendLine("using System.Reflection;");
         sb.AppendLine("using System.Runtime.CompilerServices;");
@@ -162,7 +163,22 @@ internal static class RuntimeRegistrationEmitter
                     sb.AppendLine("methodInvokers[methodInfo] = method.Invoke;");
                     using (sb.Block("if (method.AreAttributesComplete)"))
                     {
-                        sb.AppendLine("methodAttributes[methodInfo] = method.Attributes;");
+                        sb.AppendLine("Attribute[] attributes = method.Attributes;");
+                        using (sb.Block("if (method.IsAsync)"))
+                        {
+                            sb.AppendLine("object[] asyncStateMachineAttributes = methodInfo.GetCustomAttributes(typeof(AsyncStateMachineAttribute), inherit: false);");
+                            sb.AppendLine("object[] debuggerStepThroughAttributes = methodInfo.GetCustomAttributes(typeof(DebuggerStepThroughAttribute), inherit: false);");
+                            using (sb.Block("if (asyncStateMachineAttributes.Length + debuggerStepThroughAttributes.Length > 0)"))
+                            {
+                                sb.AppendLine("var attributesWithCompilerMetadata = new Attribute[attributes.Length + asyncStateMachineAttributes.Length + debuggerStepThroughAttributes.Length];");
+                                sb.AppendLine("Array.Copy(attributes, attributesWithCompilerMetadata, attributes.Length);");
+                                sb.AppendLine("Array.Copy(asyncStateMachineAttributes, 0, attributesWithCompilerMetadata, attributes.Length, asyncStateMachineAttributes.Length);");
+                                sb.AppendLine("Array.Copy(debuggerStepThroughAttributes, 0, attributesWithCompilerMetadata, attributes.Length + asyncStateMachineAttributes.Length, debuggerStepThroughAttributes.Length);");
+                                sb.AppendLine("attributes = attributesWithCompilerMetadata;");
+                            }
+                        }
+
+                        sb.AppendLine("methodAttributes[methodInfo] = attributes;");
                     }
 
                     using (sb.Block("if (method.IsTestMethod)"))

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -26,6 +26,9 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Sou
 /// </remarks>
 internal static class TestClassModelBuilder
 {
+    private const string AsyncStateMachineAttributeName = "global::System.Runtime.CompilerServices.AsyncStateMachineAttribute";
+    private const string DebuggerStepThroughAttributeName = "global::System.Diagnostics.DebuggerStepThroughAttribute";
+
     public static TestClassModel Build(INamedTypeSymbol typeSymbol, List<DiagnosticInfo> diagnostics)
     {
         // Methods / properties are walked across the full inheritance chain (excluding
@@ -157,24 +160,29 @@ internal static class TestClassModelBuilder
         bool returnsVoid = returnType.SpecialType == SpecialType.System_Void;
 
         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
+        ImmutableArray<AttributeData> attributesToMaterialize = method.IsAsync
+            ? inheritedAttributes.Where(static attribute => !IsCompilerSpecialAsyncAttribute(attribute)).ToImmutableArray()
+            : inheritedAttributes;
         AttributeMaterializationHelper.AttributeMaterializationResult methodAttributes =
-            AttributeMaterializationHelper.BuildAttributesWithCompleteness(inheritedAttributes, consumingAssembly);
+            AttributeMaterializationHelper.BuildAttributesWithCompleteness(attributesToMaterialize, consumingAssembly);
 
         return new TestMethodModel(
             Name: method.Name,
             IsStatic: method.IsStatic,
+            IsAsync: method.IsAsync,
             ReturnsTask: returnsTask,
             ReturnsValueTask: returnsValueTask,
             ReturnsVoid: returnsVoid,
             IsTestMethod: TestMemberValidationHelper.IsTestMethodAttributePresent(method),
             Parameters: BuildParameters(method),
             Attributes: methodAttributes.Attributes,
-            // AsyncStateMachineAttribute is synthesized during lowering and is not returned by
-            // IMethodSymbol.GetAttributes(). Keep async entries non-authoritative so runtime
-            // reflection can observe it, including when rejecting async-void test methods.
-            AreAttributesComplete: methodAttributes.IsComplete && !method.IsAsync,
+            AreAttributesComplete: methodAttributes.IsComplete,
             DynamicDataSources: DynamicDataSourceBuilder.BuildDynamicDataSources(inheritedAttributes, method, consumingAssembly));
     }
+
+    private static bool IsCompilerSpecialAsyncAttribute(AttributeData attribute)
+        => attribute.AttributeClass?.ToDisplayString(SymbolDisplayFormats.FullyQualified) is
+            AsyncStateMachineAttributeName or DebuggerStepThroughAttributeName;
 
     private static TestPropertyModel BuildProperty(IPropertySymbol property, IAssemblySymbol consumingAssembly)
         => new(

--- a/src/Analyzers/MSTest.SourceGeneration/Models/TestClassModel.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Models/TestClassModel.cs
@@ -66,6 +66,7 @@ internal sealed record DynamicDataSourceModel(
 internal sealed record TestMethodModel(
     string Name,
     bool IsStatic,
+    bool IsAsync,
     bool ReturnsTask,
     bool ReturnsValueTask,
     bool ReturnsVoid,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -25,6 +25,7 @@ public class NativeAotTests : AcceptanceTestBase<NopAssetFixture>
         <LangVersion>preview</LangVersion>
         <EnableMSTestRunner>true</EnableMSTestRunner>
         <PublishAot>true</PublishAot>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <!-- Reflection-free is now the default, but pin it so the test stays meaningful even if the
              product default ever changes again. -->
         <MSTestSourceGenMode>ReflectionFree</MSTestSourceGenMode>
@@ -150,6 +151,19 @@ public sealed class AsyncVoidTests
         {
             compilationResult.AssertOutputDoesNotContain(fileName);
         }
+
+        string registryPath = Directory.GetFiles(
+            generator.TargetAssetPath,
+            "MSTestReflectionMetadata.Registry.g.cs",
+            SearchOption.AllDirectories).Single();
+        string registry = File.ReadAllText(registryPath);
+        int asyncMethodIndex = registry.IndexOf("Name = \"TestMethod3\"", StringComparison.Ordinal);
+        int nextMethodIndex = registry.IndexOf("Name = \"TestMethod4\"", asyncMethodIndex, StringComparison.Ordinal);
+        Assert.IsGreaterThan(-1, asyncMethodIndex);
+        Assert.IsGreaterThan(asyncMethodIndex, nextMethodIndex);
+        StringAssert.Contains(
+            registry.Substring(asyncMethodIndex, nextMethodIndex - asyncMethodIndex),
+            "AreAttributesComplete = true");
 
         var testHost = TestHost.LocateFrom(generator.TargetAssetPath, "MSTestNativeAotTests", tfm, RID, Verb.publish);
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -68,8 +68,28 @@ public class UnitTest1
     }
 
     [TestMethod]
+    [TestCategory("AsyncGenerated")]
+    [DataRow(1, "small", true)]
+    public async Task TestMethod3(int size, string category, bool enabled)
+    {
+        await Task.Yield();
+        Assert.AreEqual(1, size);
+        Assert.AreEqual("small", category);
+        Assert.IsTrue(enabled);
+    }
+
+    [TestMethod]
+    [TestCategory("AsyncGenerated")]
+    [DataRow((object)new object[] { 1, 2 })]
+    public async Task TestMethod4(object[] values)
+    {
+        await Task.Yield();
+        CollectionAssert.AreEqual(new[] { 1, 2 }, values);
+    }
+
+    [TestMethod]
     [DynamicData(nameof(Data))]
-    public void TestMethod3(int a, int b)
+    public void TestMethod5(int a, int b)
     {
     }
 
@@ -78,6 +98,26 @@ public class UnitTest1
         {
            new object[] { 1, 2 }
         };
+}
+""";
+
+    private const string AsyncVoidSourceCode = """
+
+#file AsyncVoidTests.cs
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyTests;
+
+[TestClass]
+public sealed class AsyncVoidTests
+{
+#pragma warning disable MSTEST0003 // Deliberately invalid to verify generated async metadata preserves async-void rejection.
+    [TestMethod]
+    public async void InvalidAsyncVoidTest()
+    {
+        await Task.Yield();
+    }
+#pragma warning restore MSTEST0003
 }
 """;
 
@@ -114,8 +154,40 @@ public class UnitTest1
         var testHost = TestHost.LocateFrom(generator.TargetAssetPath, "MSTestNativeAotTests", tfm, RID, Verb.publish);
 
         TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        result.AssertOutputContainsSummary(failed: 0, passed: 3, skipped: 0);
+        result.AssertOutputContainsSummary(failed: 0, passed: 5, skipped: 0);
         result.AssertExitCodeIs(0);
+
+        TestHostResult asyncGeneratedResult = await testHost.ExecuteAsync(
+            "--filter TestCategory=AsyncGenerated",
+            cancellationToken: TestContext.CancellationToken);
+        asyncGeneratedResult.AssertOutputContainsSummary(failed: 0, passed: 2, skipped: 0);
+        asyncGeneratedResult.AssertExitCodeIs(0);
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)]
+    [DataRow("net10.0")]
+    public async Task NativeAotTests_RejectsAsyncVoidTestMethods(string tfm)
+    {
+        using TestAsset generator = await TestAsset.GenerateAssetAsync(
+            $"MSTestNativeAotAsyncVoidTests_{tfm}",
+            (SourceCode + AsyncVoidSourceCode)
+            .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+            .PatchCodeWithReplace("$TargetFramework$", tfm)
+            .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+            .PatchCodeWithReplace("$MSTestSourceGenerationVersion$", MSTestSourceGenerationVersion),
+            addPublicFeeds: true);
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
+            $"publish {generator.TargetAssetPath} -r {RID} -f {tfm}",
+            warnAsError: true,
+            cancellationToken: TestContext.CancellationToken);
+        compilationResult.AssertOutputContains("Generating native code");
+
+        var testHost = TestHost.LocateFrom(generator.TargetAssetPath, "MSTestNativeAotTests", tfm, RID, Verb.publish);
+        TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+        result.AssertStandardErrorContains("UTA007: Method InvalidAsyncVoidTest");
+        result.AssertExitCodeIsNot(0);
     }
 
     public TestContext TestContext { get; set; }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SourceGenerationNonAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SourceGenerationNonAotTests.cs
@@ -79,6 +79,16 @@ public class UnitTest1
     }
 
     [TestMethod]
+    [DataRow(1, "managed", true)]
+    public async Task TestMethod4(int size, string category, bool enabled)
+    {
+        await Task.Yield();
+        Assert.AreEqual(1, size);
+        Assert.AreEqual("managed", category);
+        Assert.IsTrue(enabled);
+    }
+
+    [TestMethod]
     public void Overload()
     {
     }
@@ -178,6 +188,8 @@ public class UnitTest1
         string registration = File.ReadAllText(generatedFiles.Single(path => path.EndsWith("MSTestReflectionMetadata.Registration.g.cs", StringComparison.Ordinal)));
         StringAssert.Contains(registration, "availableMethods ??= type.GetMethods(memberFlags)");
         StringAssert.Contains(registration, "ResolveMethod(availableMethods, method.Name, method.ParameterTypes)");
+        StringAssert.Contains(registration, "methodInfo.GetCustomAttributes(typeof(AsyncStateMachineAttribute), inherit: false)");
+        StringAssert.Contains(registration, "methodInfo.GetCustomAttributes(typeof(DebuggerStepThroughAttribute), inherit: false)");
 
         // Behavioral evidence: tests still discover and run when the source-generated
         // ReflectionMetadataHook is the only metadata provider wired in at module init.
@@ -186,7 +198,7 @@ public class UnitTest1
         // catch silent discovery regressions where tests are not picked up.)
         var testHost = TestHost.LocateFrom(generator.TargetAssetPath, AssetName, tfm, buildConfiguration: BuildConfiguration.Release);
         TestHostResult testHostResult = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 6, skipped: 0);
+        testHostResult.AssertOutputContainsSummary(failed: 0, passed: 7, skipped: 0);
         testHostResult.AssertExitCodeIs(0);
     }
 

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -3017,7 +3017,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
-    public void GeneratedMethodAttributes_MarkAsyncMetadataIncomplete()
+    public void GeneratedMethodAttributes_KeepAsyncDeclaredMetadataComplete()
     {
         const string userCode = """
             using System.Threading.Tasks;
@@ -3029,7 +3029,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 public sealed class Tests
                 {
                     [TestMethod]
-                    public async Task AsyncTaskTest()
+                    [TestCategory("Async")]
+                    [DataRow(1, "small", true)]
+                    public async Task AsyncTaskTest(int size, string category, bool enabled)
                         => await Task.Yield();
 
                     [TestMethod]
@@ -3045,12 +3047,58 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         string registry = GetRegistry(result);
         int asyncTaskIndex = registry.IndexOf("Name = \"AsyncTaskTest\"", System.StringComparison.Ordinal);
         int asyncVoidIndex = registry.IndexOf("Name = \"AsyncVoidTest\"", System.StringComparison.Ordinal);
-        int asyncTaskIncompleteIndex = registry.IndexOf("AreAttributesComplete = false", asyncTaskIndex, System.StringComparison.Ordinal);
-        int asyncVoidIncompleteIndex = registry.IndexOf("AreAttributesComplete = false", asyncVoidIndex, System.StringComparison.Ordinal);
+        int asyncTaskCompleteIndex = registry.IndexOf("AreAttributesComplete = true", asyncTaskIndex, System.StringComparison.Ordinal);
+        int asyncVoidCompleteIndex = registry.IndexOf("AreAttributesComplete = true", asyncVoidIndex, System.StringComparison.Ordinal);
         asyncTaskIndex.Should().BeGreaterThan(-1);
         asyncVoidIndex.Should().BeGreaterThan(asyncTaskIndex);
-        asyncTaskIncompleteIndex.Should().BeGreaterThan(asyncTaskIndex).And.BeLessThan(asyncVoidIndex);
-        asyncVoidIncompleteIndex.Should().BeGreaterThan(asyncVoidIndex);
+        asyncTaskCompleteIndex.Should().BeGreaterThan(asyncTaskIndex).And.BeLessThan(asyncVoidIndex);
+        asyncVoidCompleteIndex.Should().BeGreaterThan(asyncVoidIndex);
+        registry.Should().Contain("IsAsync = true");
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute(\"Async\")");
+        registry.Should().Contain("new global::Microsoft.VisualStudio.TestTools.UnitTesting.DataRowAttribute(1, new object[] { \"small\", true })");
+        string registration = result.GeneratedSources
+            .Single(s => s.HintName == "MSTestReflectionMetadata.Registration.g.cs")
+            .SourceText.ToString();
+        registration.Should().Contain("if (method.IsAsync)");
+        registration.Should().Contain("methodInfo.GetCustomAttributes(typeof(AsyncStateMachineAttribute), inherit: false)");
+        registration.Should().Contain("methodInfo.GetCustomAttributes(typeof(DebuggerStepThroughAttribute), inherit: false)");
+        registration.Should().Contain("attributesWithCompilerMetadata");
+    }
+
+    [TestMethod]
+    public void GeneratedMethodAttributes_LeaveExplicitCompilerSpecialAsyncMetadataToTargetedReflection()
+    {
+        const string userCode = """
+            using System.Diagnostics;
+            using System.Runtime.CompilerServices;
+            using System.Threading.Tasks;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public sealed class Tests
+                {
+                    [TestMethod]
+                    [AsyncStateMachine(typeof(Tests))]
+                    [DebuggerStepThrough]
+                    public async Task AsyncTaskTest()
+                        => await Task.Yield();
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", System.StringComparison.Ordinal))
+            .ToString();
+        registry.Should().NotContain("new global::System.Runtime.CompilerServices.AsyncStateMachineAttribute");
+        registry.Should().NotContain("new global::System.Diagnostics.DebuggerStepThroughAttribute");
+        registry.Should().Contain("AreAttributesComplete = true");
     }
 
     [TestMethod]
@@ -3079,7 +3127,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registration.Should().Contain("var methodAttributes = new Dictionary<MethodInfo, Attribute[]>(");
         int resolvedGuard = registration.IndexOf("if (methodInfo is not null)", System.StringComparison.Ordinal);
         int completenessGuard = registration.IndexOf("if (method.AreAttributesComplete)", resolvedGuard, System.StringComparison.Ordinal);
-        int assignment = registration.IndexOf("methodAttributes[methodInfo] = method.Attributes;", completenessGuard, System.StringComparison.Ordinal);
+        int assignment = registration.IndexOf("methodAttributes[methodInfo] = attributes;", completenessGuard, System.StringComparison.Ordinal);
         resolvedGuard.Should().BeGreaterThan(-1);
         completenessGuard.Should().BeGreaterThan(resolvedGuard);
         assignment.Should().BeGreaterThan(completenessGuard);
@@ -3151,7 +3199,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
         registry.Should().Contain("Attributes = Array.Empty<Attribute>()");
         registry.Should().Contain("AreAttributesComplete = true");
-        registration.Should().Contain("methodAttributes[methodInfo] = method.Attributes;");
+        registration.Should().Contain("methodAttributes[methodInfo] = attributes;");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/SourceGeneration/SourceGeneratedReflectionOperationsTests.cs
@@ -5,8 +5,11 @@ using System.Threading.Tasks;
 
 using AwesomeAssertions;
 
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Discovery;
+using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Resources;
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using TestFramework.ForTestingMSTest;
 
@@ -217,6 +220,31 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
         operations.GetAttributes<MarkerAttribute>(method).Should().ContainSingle().Which.Should().BeSameAs(generated);
     }
 
+    public void RegisteredAsyncMethodAttributes_PreserveDeclaredAttributesAndRejectAsyncVoid()
+    {
+        MethodInfo method = typeof(AsyncAttributedSample).GetMethod(nameof(AsyncAttributedSample.AsyncVoidMethod))!;
+        var generatedMarker = new MarkerAttribute("generated");
+        AsyncStateMachineAttribute asyncStateMachineAttribute = method.GetCustomAttribute<AsyncStateMachineAttribute>()!;
+        var debuggerStepThroughAttribute = new DebuggerStepThroughAttribute();
+        var provider = new SourceGeneratedReflectionDataProvider
+        {
+            TypeMethodAttributes = new Dictionary<MethodInfo, Attribute[]>
+            {
+                [method] = [new TestMethodAttribute(), generatedMarker, asyncStateMachineAttribute, debuggerStepThroughAttribute],
+            },
+        };
+        var operations = new SourceGeneratedReflectionOperations(provider);
+
+        operations.GetAttributes<MarkerAttribute>(method).Should().ContainSingle().Which.Should().BeSameAs(generatedMarker);
+        operations.GetFirstAttributeOrDefault<AsyncStateMachineAttribute>(method).Should().BeSameAs(asyncStateMachineAttribute);
+        operations.GetFirstAttributeOrDefault<DebuggerStepThroughAttribute>(method).Should().BeSameAs(debuggerStepThroughAttribute);
+
+        var validator = new TestMethodValidator(new SourceGeneratedReflectHelper(operations), discoverInternals: false);
+        var warnings = new List<string>();
+        validator.IsValidTestMethod(method, typeof(AsyncAttributedSample), warnings).Should().BeFalse();
+        warnings.Should().ContainSingle();
+    }
+
     public void MethodAttributeHelpers_GetSingleAttributeOrDefault_ThrowsLocalizedErrorOnDuplicates()
     {
         MethodInfo method = typeof(AttributedSample).GetMethod(nameof(AttributedSample.AttributedMethod))!;
@@ -337,4 +365,20 @@ public sealed class SourceGeneratedReflectionOperationsTests : TestContainer
     }
 
     private sealed class DerivedMarkerAttribute(string value) : MarkerAttribute(value);
+
+    private sealed class SourceGeneratedReflectHelper(SourceGeneratedReflectionOperations operations) : ReflectHelper
+    {
+        public override bool IsAttributeDefined<TAttribute>(ICustomAttributeProvider attributeProvider)
+            => operations.IsAttributeDefined<TAttribute>(attributeProvider);
+
+        public override TAttribute? GetFirstAttributeOrDefault<TAttribute>(ICustomAttributeProvider attributeProvider)
+            where TAttribute : class
+            => operations.GetFirstAttributeOrDefault<TAttribute>(attributeProvider);
+    }
+
+    private sealed class AsyncAttributedSample
+    {
+        [SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Verifies async-void rejection.")]
+        public async void AsyncVoidMethod() => await Task.Yield();
+    }
 }


### PR DESCRIPTION
Fixes #10698

## Summary

- keep source-generated user-declared method attributes authoritative for async methods
- merge only compiler-special `AsyncStateMachineAttribute` and `DebuggerStepThroughAttribute` metadata during runtime registration
- cover async multi-argument and one-argument `object[]` DataRows in NativeAOT while retaining synchronous DataRow and DynamicData coverage
- verify managed ReflectionFree execution and NativeAOT async-void rejection

## Validation

- `.\build.cmd -c Release -pack`
- MSTest.SourceGeneration.UnitTests: 126 passed
- MSTestAdapter.PlatformServices.UnitTests: 1,072 passed
- NativeAOT net8.0 and net10.0: 5 passed, including 2 async generated-metadata rows
- NativeAOT net10.0 async-void rejection: UTA007 verified
- managed ReflectionFree net8.0 and net10.0: 7 passed
- three independent read-only review rounds completed; all high-confidence findings resolved
