### PR TITLE
Publish the stack-frame regex once instead of racing on lazy init

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
@@ -43,13 +43,13 @@ internal static class StackTraceHelper
 
     private static bool TryGetStackFrameLocation(string stackFrame, out int line, [NotNullWhen(true)] out string? file, out string? place)
     {
-        InitializeRegex();
+        Regex regex = GetOrCreateRegex();
 
         // stack frame looks like this '   at Program.<Main>$(String[] args) in S:\t\ConsoleApp81\ConsoleApp81\Program.cs:line 9'
         Match match;
         try
         {
-            match = s_regex.Match(stackFrame);
+            match = regex.Match(stackFrame);
         }
         catch (RegexMatchTimeoutException)
         {
@@ -78,18 +78,22 @@ internal static class StackTraceHelper
         return hasLocation;
     }
 
-    [MemberNotNull(nameof(s_regex))]
-    private static void InitializeRegex()
+    private static Regex GetOrCreateRegex()
     {
-        if (s_regex is not null)
+        Regex? regex = Volatile.Read(ref s_regex);
+        if (regex is not null)
         {
-            return;
+            return regex;
         }
 
         // Keep this location-only pattern because MSBuild only reports frames that can provide a file and line.
-        s_regex = new Regex(
+        regex = new Regex(
             StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: false),
             RegexOptions.Compiled,
             StackTraceRegexHelper.MatchTimeout);
+
+        // Racing callers may each build an instance. Publish the first one and let every caller share it, so callers
+        // always observe the same object and the expensive RegexOptions.Compiled construction is paid for once.
+        return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
@@ -79,21 +79,11 @@ internal static class StackTraceHelper
     }
 
     private static Regex GetOrCreateRegex()
-    {
-        Regex? regex = Volatile.Read(ref s_regex);
-        if (regex is not null)
-        {
-            return regex;
-        }
-
-        // Keep this location-only pattern because MSBuild only reports frames that can provide a file and line.
-        regex = new Regex(
-            StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: false),
-            RegexOptions.Compiled,
-            StackTraceRegexHelper.MatchTimeout);
-
-        // Racing callers on first use may each build an instance. Publish the first one and return it to all of them,
-        // so every caller observes the same object, and once it is published no caller builds the regex again.
-        return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
-    }
+        => LazyInitializer.EnsureInitialized(
+            ref s_regex,
+            // Keep this location-only pattern because MSBuild only reports frames that can provide a file and line.
+            static () => new Regex(
+                StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: false),
+                RegexOptions.Compiled,
+                StackTraceRegexHelper.MatchTimeout))!;
 }

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/Tasks/StackTraceHelper.cs
@@ -92,8 +92,8 @@ internal static class StackTraceHelper
             RegexOptions.Compiled,
             StackTraceRegexHelper.MatchTimeout);
 
-        // Racing callers may each build an instance. Publish the first one and let every caller share it, so callers
-        // always observe the same object and the expensive RegexOptions.Compiled construction is paid for once.
+        // Racing callers on first use may each build an instance. Publish the first one and return it to all of them,
+        // so every caller observes the same object, and once it is published no caller builds the regex again.
         return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
     }
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
@@ -30,8 +30,8 @@ internal static partial class StackTraceHelper
             StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: true),
             RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
-        // Racing callers may each build an instance. Publish the first one and let every caller share it, so callers
-        // always observe the same object and the expensive RegexOptions.Compiled construction is paid for once.
+        // Racing callers on first use may each build an instance. Publish the first one and return it to all of them,
+        // so every caller observes the same object, and once it is published no caller builds the regex again.
         return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
     }
 #endif

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
@@ -16,20 +16,23 @@ internal static partial class StackTraceHelper
 #else
     private static Regex? s_regex;
 
-    [MemberNotNull(nameof(s_regex))]
     public static Regex GetFrameRegex()
     {
-        if (s_regex is not null)
+        Regex? regex = Volatile.Read(ref s_regex);
+        if (regex is not null)
         {
-            return s_regex;
+            return regex;
         }
 
         // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
         // thread suspends, so the regex gets blamed incorrectly.
-        s_regex = new Regex(
+        regex = new Regex(
             StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: true),
             RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-        return s_regex;
+
+        // Racing callers may each build an instance. Publish the first one and let every caller share it, so callers
+        // always observe the same object and the expensive RegexOptions.Compiled construction is paid for once.
+        return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
     }
 #endif
 }

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/StackTraceHelper.cs
@@ -17,22 +17,12 @@ internal static partial class StackTraceHelper
     private static Regex? s_regex;
 
     public static Regex GetFrameRegex()
-    {
-        Regex? regex = Volatile.Read(ref s_regex);
-        if (regex is not null)
-        {
-            return regex;
-        }
-
-        // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
-        // thread suspends, so the regex gets blamed incorrectly.
-        regex = new Regex(
-            StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: true),
-            RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-
-        // Racing callers on first use may each build an instance. Publish the first one and return it to all of them,
-        // so every caller observes the same object, and once it is published no caller builds the regex again.
-        return Interlocked.CompareExchange(ref s_regex, regex, null) ?? regex;
-    }
+        => LazyInitializer.EnsureInitialized(
+            ref s_regex,
+            // Specifying no timeout, the regex is linear. And the timeout does not measure the regex only, but measures also any
+            // thread suspends, so the regex gets blamed incorrectly.
+            static () => new Regex(
+                StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation: true),
+                RegexOptions.Compiled | RegexOptions.ExplicitCapture))!;
 #endif
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/StackTraceRegexHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/StackTraceRegexHelperTests.cs
@@ -116,21 +116,6 @@ public sealed class StackTraceRegexHelperTests
 #endif
     }
 
-    [TestMethod]
-    public void GetFrameRegex_ConcurrentCallers_ShareASingleInstance()
-    {
-        // This is a supplement to the Assert.AreSame above rather than a replacement for it: if another test in the
-        // assembly already initialized the regex, every caller here takes the fast path and the test passes trivially.
-        var instances = new Regex[32];
-
-        Parallel.For(0, instances.Length, i => instances[i] = StackTraceHelper.GetFrameRegex());
-
-        foreach (Regex instance in instances)
-        {
-            Assert.AreSame(instances[0], instance);
-        }
-    }
-
     private static Regex CreateRegex(bool matchFramesWithoutLocation)
         => new(
             StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation),

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/StackTraceRegexHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/StackTraceRegexHelperTests.cs
@@ -116,6 +116,21 @@ public sealed class StackTraceRegexHelperTests
 #endif
     }
 
+    [TestMethod]
+    public void GetFrameRegex_ConcurrentCallers_ShareASingleInstance()
+    {
+        // This is a supplement to the Assert.AreSame above rather than a replacement for it: if another test in the
+        // assembly already initialized the regex, every caller here takes the fast path and the test passes trivially.
+        var instances = new Regex[32];
+
+        Parallel.For(0, instances.Length, i => instances[i] = StackTraceHelper.GetFrameRegex());
+
+        foreach (Regex instance in instances)
+        {
+            Assert.AreSame(instances[0], instance);
+        }
+    }
+
     private static Regex CreateRegex(bool matchFramesWithoutLocation)
         => new(
             StackTraceRegexHelper.CreateFrameRegexPattern(matchFramesWithoutLocation),


### PR DESCRIPTION
`GetFrameRegex()` could hand a different `Regex` to each concurrent caller on targets that don't use `[GeneratedRegex]`. The check and assignment were not atomic, so threads racing on first use could each observe a different instance.

Use `LazyInitializer.EnsureInitialized` for the pre-.NET 7 cache. This delegates thread-safe publication to the framework primitive while preserving lazy construction and the existing regex options. The copy in `Microsoft.Testing.Platform.MSBuild` had the same initialization shape and now uses the same primitive.

The existing tests continue to verify the regex configuration and that repeated calls return the cached instance. The earlier probabilistic cold-start concurrency test was removed because other parallel tests could initialize the production static first; there is no longer a custom publication algorithm to exercise in isolation.

🤖