### PR TITLE
Document and test custom retry extensibility

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -453,7 +453,23 @@ An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that
 
 ### Retry
 
-An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-runs failed tests a configurable number of times. Useful for reducing flakiness in CI environments.
+An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-runs failed tests a configurable number of times by restarting the test host and filtering each new run to the tests that failed previously. It is independent from MSTest's in-process [`RetryAttribute`](#retryattribute) and [`RetryBaseAttribute`](#retrybaseattribute). When both mechanisms are enabled, their attempt counts multiply, so avoid combining them unless that is intended.
+
+### RetryAttribute
+
+An MSTest attribute (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryAttribute`) that retries a failed or timed-out test within the same test-host run. It can be applied to a test method or test class and supports a maximum retry count, a delay between attempts, and constant or exponential backoff. It derives from [`RetryBaseAttribute`](#retrybaseattribute), which can be used to implement a custom retry policy. See also the process-level [`Microsoft.Testing.Extensions.Retry`](#retry) extension.
+
+### RetryBaseAttribute
+
+An experimental MSTest extensibility point (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute`, `[Experimental("MSTESTEXP")]`) for implementing custom in-process retry policies. A derived attribute overrides `ExecuteAsync(RetryContext)`, inspects the initial failed results, invokes the supplied test delegate for each retry attempt, and returns every attempt in a [`RetryResult`](#retryresult). The implementation owns the retry loop and decides when to stop. The attribute can be applied to a test method or test class; a method-level attribute takes precedence over a class-level attribute, and class-level attributes are not inherited.
+
+### RetryContext
+
+An experimental MSTest structure (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryContext`, `[Experimental("MSTESTEXP")]`) passed to `RetryBaseAttribute.ExecuteAsync`. `FirstRunResults` contains the results from the initial failed or timed-out execution, and `ExecuteTaskGetter` re-executes the test and returns the next attempt's results. See also [`RetryBaseAttribute`](#retrybaseattribute) and [`RetryResult`](#retryresult).
+
+### RetryResult
+
+An experimental MSTest class (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult`, `[Experimental("MSTESTEXP")]`) used by custom [`RetryBaseAttribute`](#retrybaseattribute) implementations to return retry attempts in execution order through `AddResult`. `AllResults` exposes every added attempt. Under Microsoft.Testing.Platform, earlier attempts are reported as superseded and the last attempt determines the test outcome; VSTest receives only the final attempt.
 
 ### RFC
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -453,7 +453,7 @@ An MTP class (`Microsoft.Testing.Platform.Extensions.Messages.PropertyBag`) that
 
 ### Retry
 
-An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-runs failed tests a configurable number of times by restarting the test host and filtering each new run to the tests that failed previously. It is independent from MSTest's in-process [`RetryAttribute`](#retryattribute) and [`RetryBaseAttribute`](#retrybaseattribute). When both mechanisms are enabled, their attempt counts multiply, so avoid combining them unless that is intended.
+An MTP extension (`Microsoft.Testing.Extensions.Retry`) that automatically re-runs failed tests a configurable number of times by restarting the test host and filtering each new run to the tests that failed previously. It is independent from MSTest's in-process [`RetryAttribute`](#retryattribute) and [`RetryBaseAttribute`](#retrybaseattribute). When both mechanisms are enabled, their attempt counts multiply: a test using `[Retry(n)]` can run up to `(n + 1) * (--retry-failed-tests + 1)` times, so avoid combining them unless that is intended.
 
 ### RetryAttribute
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -461,7 +461,7 @@ An MSTest attribute (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryAttribut
 
 ### RetryBaseAttribute
 
-An experimental MSTest extensibility point (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute`, `[Experimental("MSTESTEXP")]`) for implementing custom in-process retry policies. A derived attribute overrides `ExecuteAsync(RetryContext)`, inspects the initial failed results, invokes the supplied test delegate for each retry attempt, and returns every attempt in a [`RetryResult`](#retryresult). The implementation owns the retry loop and decides when to stop. The attribute can be applied to a test method or test class; a method-level attribute takes precedence over a class-level attribute, and class-level attributes are not inherited.
+An MSTest extensibility point (`Microsoft.VisualStudio.TestTools.UnitTesting.RetryBaseAttribute`) for implementing custom in-process retry policies. A derived attribute overrides the experimental `[Experimental("MSTESTEXP")]` method `ExecuteAsync(RetryContext)`, inspects the initial failed results, invokes the supplied test delegate for each retry attempt, and returns every attempt in a [`RetryResult`](#retryresult). The implementation owns the retry loop and decides when to stop. The attribute can be applied to a test method or test class; a method-level attribute takes precedence over a class-level attribute, and class-level attributes are not inherited.
 
 ### RetryContext
 

--- a/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.RunSingleTest.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/Execution/UnitTestRunner.RunSingleTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers;
@@ -348,7 +348,7 @@ internal sealed partial class UnitTestRunner
     /// consumers that collapse per test node uid keep observing the test's real outcome.
     /// </para>
     /// </remarks>
-    private static TestResult[] CombineRetryAttempts(TestResult[] firstAttempt, RetryResult retryResult)
+    internal static TestResult[] CombineRetryAttempts(TestResult[] firstAttempt, RetryResult retryResult)
     {
         IReadOnlyList<TestResult[]> retryAttempts = retryResult.AllResults;
         if (retryAttempts.Count == 0)

--- a/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Adapter/MSTestAdapter.PlatformServices/InternalAPI/InternalAPI.Unshipped.txt
@@ -116,6 +116,7 @@ static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestDepe
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ParameterMetadataScanCount.get -> int
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.ResetParameterMetadataCacheForTesting() -> void
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.TestMethodInfo.SetParameterMetadataScanCallbackForTesting(System.Action? callback) -> void
+static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner.CombineRetryAttempts(Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]! firstAttempt, Microsoft.VisualStudio.TestTools.UnitTesting.RetryResult! retryResult) -> Microsoft.VisualStudio.TestTools.UnitTesting.TestResult![]!
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner.CreateLiveOutputWriter(System.IO.Stream! standardOutput, System.Text.Encoding! encoding) -> System.IO.TextWriter!
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Helpers.RuntimeContext.IsMultiThreaded.get -> bool
 static Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.MSTestDiscovererHelpers.GetSettingsExceptionMessage(Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.AdapterSettingsException! ex) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
@@ -21,6 +21,8 @@ This package extends Microsoft.Testing.Platform with:
 
 Configure retry using `--retry-failed-tests <retries>`, and optionally limit retries with `--retry-failed-tests-max-percentage` or `--retry-failed-tests-max-tests`, or add a delay between retries with `--retry-failed-tests-delay` (e.g. `1s`, `2.5m`, `1h`).
 
+This extension restarts the test host for each retry. It is independent from MSTest's in-process `RetryAttribute` and custom `RetryBaseAttribute` implementations. When both mechanisms are enabled, their attempt counts multiply: a test using `[Retry(n)]` can run up to `(n + 1) * (--retry-failed-tests + 1)` times.
+
 ## Documentation
 
 For this extension, see <https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry>.

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/RetryTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -161,6 +161,166 @@ public class UnitTest1
     <CaptureTraceOutput>false</CaptureTraceOutput>
   </MSTest>
 </RunSettings>
+""";
+    }
+
+    public TestContext TestContext { get; set; }
+}
+
+[TestClass]
+public sealed class CustomRetryTests : AcceptanceTestBase<CustomRetryTests.TestAssetFixture>
+{
+    [TestMethod]
+    public async Task CustomRetryBaseAttribute_ControlsRetriesAndReportsEveryAttempt()
+    {
+        var testHost = TestHost.LocateFrom(AssetFixture.ProjectPath, TestAssetFixture.ProjectName, TargetFrameworks.NetCurrent);
+        string markerDirectory = Path.Combine(Path.GetTempPath(), "mstest-custom-retry-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(markerDirectory);
+
+        try
+        {
+            TestHostResult testHostResult = await testHost.ExecuteAsync(
+                environmentVariables: new() { [TestAssetFixture.MarkerDirectoryEnvVar] = markerDirectory },
+                cancellationToken: TestContext.CancellationToken);
+
+            testHostResult.AssertExitCodeIs(ExitCode.Success);
+            testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
+            testHostResult.AssertOutputContains("failed (try 1) FailsTwiceThenPasses");
+            testHostResult.AssertOutputContains("failed (try 2) FailsTwiceThenPasses");
+            testHostResult.AssertOutputContains("retried:");
+            testHostResult.AssertOutputContains("flaky: 1");
+
+            string markerFile = Path.Combine(markerDirectory, TestAssetFixture.MarkerFileName);
+            Assert.IsTrue(
+                File.Exists(markerFile),
+                $"Custom retry marker file not found. StandardOutput:\n{testHostResult.StandardOutput}");
+
+            string[] observations = File.ReadAllLines(markerFile);
+            Assert.Contains("TestExecutions=3", observations);
+            Assert.Contains("ExecuteAsyncCalls=1", observations);
+            Assert.Contains("ExecuteTaskGetterCalls=2", observations);
+            Assert.Contains("FirstRunResultCount=1", observations);
+            Assert.Contains("FirstRunOutcome=Failed", observations);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(markerDirectory, recursive: true);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Best-effort cleanup of the temporary marker directory.
+            }
+        }
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        public const string ProjectName = "CustomRetryTests";
+
+        public const string MarkerDirectoryEnvVar = "CUSTOMRETRY_MARKER_DIR";
+
+        public const string MarkerFileName = "custom-retry.marker";
+
+        public string ProjectPath => GetAssetPath(ProjectName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (ProjectName, ProjectName,
+                SourceCode
+                .PatchTargetFrameworks(TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+                .PatchCodeWithReplace("$MarkerDirectoryEnvVar$", MarkerDirectoryEnvVar)
+                .PatchCodeWithReplace("$MarkerFileName$", MarkerFileName));
+
+        private const string SourceCode = """
+#file CustomRetryTests.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" />
+    <PackageReference Include="MSTest.TestFramework" Version="$MSTestVersion$" />
+  </ItemGroup>
+</Project>
+
+#file UnitTest1.cs
+#pragma warning disable MSTESTEXP
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class RetryTwiceAttribute : RetryBaseAttribute
+{
+    public static int ExecuteAsyncCalls { get; private set; }
+
+    public static int ExecuteTaskGetterCalls { get; private set; }
+
+    public static int FirstRunResultCount { get; private set; }
+
+    public static UnitTestOutcome FirstRunOutcome { get; private set; }
+
+    protected override async Task<RetryResult> ExecuteAsync(RetryContext retryContext)
+    {
+        ExecuteAsyncCalls++;
+        FirstRunResultCount = retryContext.FirstRunResults.Length;
+        FirstRunOutcome = retryContext.FirstRunResults[0].Outcome;
+
+        var retryResult = new RetryResult();
+        for (int i = 0; i < 2; i++)
+        {
+            ExecuteTaskGetterCalls++;
+            retryResult.AddResult(await retryContext.ExecuteTaskGetter());
+        }
+
+        return retryResult;
+    }
+}
+
+[TestClass]
+public class CustomRetryTestClass
+{
+    private static int _testExecutions;
+
+    [TestMethod]
+    [RetryTwice]
+    public void FailsTwiceThenPasses()
+    {
+        _testExecutions++;
+        if (_testExecutions < 3)
+        {
+            Assert.Fail($"Custom failure from execution {_testExecutions}");
+        }
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanup()
+    {
+        string markerDirectory = Environment.GetEnvironmentVariable("$MarkerDirectoryEnvVar$");
+        if (string.IsNullOrEmpty(markerDirectory))
+        {
+            return;
+        }
+
+        File.WriteAllLines(
+            Path.Combine(markerDirectory, "$MarkerFileName$"),
+            new[]
+            {
+                $"TestExecutions={_testExecutions}",
+                $"ExecuteAsyncCalls={RetryTwiceAttribute.ExecuteAsyncCalls}",
+                $"ExecuteTaskGetterCalls={RetryTwiceAttribute.ExecuteTaskGetterCalls}",
+                $"FirstRunResultCount={RetryTwiceAttribute.FirstRunResultCount}",
+                $"FirstRunOutcome={RetryTwiceAttribute.FirstRunOutcome}",
+            });
+    }
+}
 """;
     }
 

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -91,6 +91,47 @@ public sealed class UnitTestRunnerTests : TestContainer
         UnitTestRunner unitTestRunner = CreateUnitTestRunner([unitTestElement]);
         Func<Task> func = () => unitTestRunner.RunSingleTestAsync(unitTestElement, null!, null!);
         await func.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    public void CombineRetryAttempts_WhenRetriesProduceResults_FlattensAndTagsAttempts()
+    {
+        var initialFailure = new TestResult { Outcome = UnitTestOutcome.Failed };
+        var firstRetryFailure = new TestResult { Outcome = UnitTestOutcome.Timeout };
+        var finalSuccess = new TestResult { Outcome = UnitTestOutcome.Passed };
+        var retryResult = new RetryResult();
+        retryResult.AddResult([firstRetryFailure]);
+        retryResult.AddResult([finalSuccess]);
+
+        TestResult[] combined = UnitTestRunner.CombineRetryAttempts([initialFailure], retryResult);
+
+        combined.Should().Equal(initialFailure, firstRetryFailure, finalSuccess);
+        combined.Select(result => result.RetryAttemptNumber).Should().Equal(1, 2, 3);
+        combined.Select(result => result.IsSupersededRetryAttempt).Should().Equal(true, true, false);
+    }
+
+    public void CombineRetryAttempts_WhenLastRetryProducesNoResults_ReturnsEmptyResult()
+    {
+        var initialFailure = new TestResult { Outcome = UnitTestOutcome.Failed };
+        var retryFailure = new TestResult { Outcome = UnitTestOutcome.Failed };
+        var retryResult = new RetryResult();
+        retryResult.AddResult([retryFailure]);
+        retryResult.AddResult([]);
+
+        TestResult[] combined = UnitTestRunner.CombineRetryAttempts([initialFailure], retryResult);
+
+        combined.Should().BeEmpty();
+        initialFailure.IsSupersededRetryAttempt.Should().BeFalse();
+        retryFailure.IsSupersededRetryAttempt.Should().BeFalse();
+    }
+
+    public void CombineRetryAttempts_WhenRetryProducesNoAttempts_ThrowsUnreachableException()
+    {
+        Action act = () => UnitTestRunner.CombineRetryAttempts(
+            [new TestResult { Outcome = UnitTestOutcome.Failed }],
+            new RetryResult());
+
+        Exception exception = act.Should().Throw<Exception>().Which;
+        exception.GetType().FullName.Should().Be(typeof(global::System.Diagnostics.UnreachableException).FullName);
     }
 
     public async Task RunSingleTestShouldReturnTestResultIndicateATestNotFoundIfTestMethodCannotBeFound()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -132,7 +132,9 @@ public sealed class UnitTestRunnerTests : TestContainer
             new RetryResult());
 
         Exception exception = act.Should().Throw<Exception>().Which;
-        exception.GetType().FullName.Should().Be(typeof(global::System.Diagnostics.UnreachableException).FullName);
+        // UnreachableException is an internal, per-assembly polyfill on non-NETCOREAPP TFMs, so a generic type
+        // assertion would compare the adapter's copy with this test assembly's copy and fail on type identity.
+        exception.GetType().FullName.Should().Be("System.Diagnostics.UnreachableException");
     }
 
     public async Task RunSingleTestShouldReturnTestResultIndicateATestNotFoundIfTestMethodCannotBeFound()

--- a/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
+++ b/test/UnitTests/MSTestAdapter.PlatformServices.UnitTests/Execution/UnitTestRunnerTests.cs
@@ -120,6 +120,7 @@ public sealed class UnitTestRunnerTests : TestContainer
         TestResult[] combined = UnitTestRunner.CombineRetryAttempts([initialFailure], retryResult);
 
         combined.Should().BeEmpty();
+        // The empty final attempt returns before tagging, so the supplied results must remain unchanged.
         initialFailure.IsSupersededRetryAttempt.Should().BeFalse();
         retryFailure.IsSupersededRetryAttempt.Should().BeFalse();
     }


### PR DESCRIPTION
`RetryBaseAttribute` is a shipped extensibility point, but custom retry policies were not discoverable in the glossary and lacked coverage through a real test host.

This change documents the in-process retry APIs and distinguishes them from the process-level `Microsoft.Testing.Extensions.Retry` orchestrator, including the multiplicative attempt-count behavior when both are enabled. It also adds an acceptance scenario using a genuine custom attribute and focused adapter tests for combining retry attempts, including empty-result handling.

Validation:
- 3 focused `CombineRetryAttempts` unit tests passed
- 1 custom `RetryBaseAttribute` acceptance test passed

Closes #10666