### PR TITLE
Label Azure DevOps retry attempt results

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -294,7 +294,7 @@ internal sealed class AzureDevOpsResultIdStore
     private static AzureDevOpsTestSubResult ToSubResult(AzureDevOpsTestCaseResult result, int sequenceId)
         => new(
             sequenceId,
-            result.TestCaseTitle,
+            $"Attempt# {(sequenceId - 1).ToString(CultureInfo.InvariantCulture)} - {result.TestCaseTitle}",
             result.Outcome,
             result.DurationInMs,
             result.ErrorMessage,

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -291,6 +291,7 @@ internal sealed class AzureDevOpsResultIdStore
         }
     }
 
+    // Match PublishTestResults@2: the original execution is Attempt# 0, while sequence ids are 1-based.
     private static AzureDevOpsTestSubResult ToSubResult(AzureDevOpsTestCaseResult result, int sequenceId)
         => new(
             sequenceId,

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -1969,9 +1969,11 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.IsNotNull(parent.SubResults);
         Assert.HasCount(2, parent.SubResults);
         Assert.AreEqual(1, parent.SubResults[0].SequenceId);
+        Assert.AreEqual("Attempt# 0 - MyTest", parent.SubResults[0].DisplayName);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, parent.SubResults[0].Outcome);
         Assert.AreEqual("boom", parent.SubResults[0].ErrorMessage);
         Assert.AreEqual(2, parent.SubResults[1].SequenceId);
+        Assert.AreEqual("Attempt# 1 - MyTest", parent.SubResults[1].DisplayName);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, parent.SubResults[1].Outcome);
     }
 


### PR DESCRIPTION
Azure DevOps live publishing currently gives every retry sub-result the bare test name, making attempts indistinguishable in the Tests tab. This change matches the `PublishTestResults@2` convention by formatting the 1-based sequence IDs as 0-based labels such as `Attempt# 0 - MyTest` and `Attempt# 1 - MyTest`.

Regression coverage verifies the labels for both the initial execution and its retry.

Closes #10556