### PR TITLE
Fix Azure DevOps published test identity

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsPublishConfigurationFactory.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsPublishConfigurationFactory.cs
@@ -59,7 +59,7 @@ internal static class AzureDevOpsPublishConfigurationFactory
 
         string currentTestApplicationPath = testApplicationModuleInfo.GetCurrentTestApplicationFullPath();
         string assemblyName = testApplicationModuleInfo.TryGetAssemblyName() ?? Path.GetFileNameWithoutExtension(currentTestApplicationPath);
-        string automatedTestStorage = Path.GetFileNameWithoutExtension(currentTestApplicationPath);
+        string automatedTestStorage = Path.GetFileName(currentTestApplicationPath).ToLowerInvariant();
         string targetFrameworkMoniker = TargetFrameworkMonikerHelper.GetTargetFrameworkMonikerIncludingPlatform();
         string agentName = environment.GetEnvironmentVariable("AGENT_NAME") ?? environment.MachineName;
         string? stageName = environment.GetEnvironmentVariable("SYSTEM_STAGENAME");

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -54,8 +54,8 @@ internal sealed class AzureDevOpsResultIdStore
     private readonly int _buildId;
     private readonly int _runId;
 
-    // Keyed by (storage, name, title): automatedTestName is TestNode.Uid.Value, which can be shared by
-    // several folded data-driven rows. The title carries the row identity within that test application.
+    // Keyed by (storage, name, title): the fully-qualified automated test name can be shared by several
+    // folded data-driven rows. The title carries the row identity within that test application.
     private readonly Dictionary<string, AzureDevOpsPublishedResult> _results = [];
     private readonly HashSet<string> _ambiguousKeys = [];
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.ResultFactory.cs
@@ -20,7 +20,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         }
 
         TimingProperty? timing = testNode.Properties.SingleOrDefault<TimingProperty>();
-        string automatedTestName = testNode.Uid.Value;
+        string automatedTestName = TestNodeIdentity.GetTestName(testNode);
 
         AzureDevOpsTestCaseResult? result = state switch
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -354,7 +354,26 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
-    public async Task CreatePublisher_UsesSanitizedRunNameAndStorageWithoutExtension()
+    public void CreateTestCaseResult_UsesFullyQualifiedNameAsAutomatedTestName()
+    {
+        TestNode testNode = new()
+        {
+            Uid = new TestNodeUid("opaque-test-node-uid"),
+            DisplayName = "MyMethod",
+            Properties = new PropertyBag(
+                new PassedTestNodeStateProperty(),
+                new TestMethodIdentifierProperty("tests.dll", "My.Namespace", "MyType", "MyMethod", 0, [], "System.Void")),
+        };
+
+        AzureDevOpsTestCaseResult? result = AzureDevOpsTestResultsPublisher.CreateTestCaseResult(testNode, "tests.dll")?.Result;
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("My.Namespace.MyType.MyMethod", result.AutomatedTestName);
+        Assert.AreEqual("MyMethod", result.TestCaseTitle);
+    }
+
+    [TestMethod]
+    public async Task CreatePublisher_UsesSanitizedRunNameAndStorageFileName()
     {
         using TestDirectory directory = CreateTestDirectory();
         Mock<IEnvironment> environment = CreateEnvironmentMock(processId: GetAliveProcessId(), stageName: new string('s', 240) + "/stage", jobName: "job\r\nline\u0001");
@@ -370,7 +389,7 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.IsNotNull(capturedConfiguration);
         AzureDevOpsPublishConfiguration configuration = capturedConfiguration!;
-        Assert.AreEqual("MyTests", configuration.AutomatedTestStorage);
+        Assert.AreEqual("mytests.dll", configuration.AutomatedTestStorage);
         Assert.DoesNotContain("/", configuration.RunName);
         Assert.DoesNotContain("\r", configuration.RunName);
         Assert.DoesNotContain("\n", configuration.RunName);
@@ -2388,7 +2407,7 @@ public sealed class AzureDevOpsLivePublishingTests
         await otherPublisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.HasCount(1, created);
-        Assert.AreEqual("OtherTests", created[0].AutomatedTestStorage);
+        Assert.AreEqual("othertests.dll", created[0].AutomatedTestStorage);
         Assert.AreEqual("MyTest", created[0].AutomatedTestName);
         Assert.IsEmpty(client.UpdateTestResultsCalls, "A different assembly is a different test, not another attempt.");
     }
@@ -3445,7 +3464,9 @@ public sealed class AzureDevOpsLivePublishingTests
 
     private static TestNode CreateNode(string uid, IProperty state, DateTimeOffset startTime, TimingProperty? timing = null, string? displayName = null)
     {
-        PropertyBag properties = timing is null ? new PropertyBag(state) : new PropertyBag(state, timing);
+        PropertyBag properties = timing is null
+            ? new PropertyBag(state, new SerializableKeyValuePairStringProperty("vstest.TestCase.FullyQualifiedName", uid))
+            : new PropertyBag(state, timing, new SerializableKeyValuePairStringProperty("vstest.TestCase.FullyQualifiedName", uid));
         return new TestNode
         {
             Uid = new TestNodeUid(uid),

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -368,8 +368,9 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestCaseResult? result = AzureDevOpsTestResultsPublisher.CreateTestCaseResult(testNode, "tests.dll")?.Result;
 
         Assert.IsNotNull(result);
-        Assert.AreEqual("My.Namespace.MyType.MyMethod", result.AutomatedTestName);
-        Assert.AreEqual("MyMethod", result.TestCaseTitle);
+        AzureDevOpsTestCaseResult publishedResult = result!;
+        Assert.AreEqual("My.Namespace.MyType.MyMethod", publishedResult.AutomatedTestName);
+        Assert.AreEqual("MyMethod", publishedResult.TestCaseTitle);
     }
 
     [TestMethod]


### PR DESCRIPTION
Azure DevOps live publishing currently sends the opaque `TestNode` UID as `automatedTestName`, which disconnects results from history created by `PublishTestResults@2` and prevents the extension's history-based reporting from matching tests.

Use the shared canonical identity resolver to publish the fully-qualified test name. Also align `automatedTestStorage` with TRX publication by using the lowercase assembly filename with its extension. Regression coverage verifies that an opaque node UID does not leak into the published result while rerun and data-driven result identity remains stable.

Fixes #10557