### PR TITLE
Deduplicate report post-processing helpers

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
@@ -50,9 +50,7 @@ internal sealed class CtrfArtifactPostProcessor : IArtifactPostProcessor
             ? [.. inputs]
             :
             [
-                .. inputs
-                    .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-                    .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
+                .. ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: false),
             ];
         string[] inputPaths = [.. orderedInputs.Select(input => input.Path)];
         string[] identityInputs =

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -34,3 +34,4 @@ static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAli
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.ArtifactPostProcessingHelper
 static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.IsReparsePoint(string! path) -> bool
+static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.OrderInputs(System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, bool includeModuleMetadata) -> System.Linq.IOrderedEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>!

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlArtifactPostProcessor.cs
@@ -48,7 +48,7 @@ internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
 
         InputArtifact[] orderedInputs =
         [
-            .. OrderInputs(inputs),
+            .. ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: true),
         ];
 
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
@@ -81,7 +81,8 @@ internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
     }
 
     internal static string CreateMergeId(IReadOnlyList<InputArtifact> inputs)
-        => CreateMergeIdFromOrderedInputs(OrderInputs(inputs));
+        => CreateMergeIdFromOrderedInputs(
+            ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: true));
 
     private static string CreateMergeIdFromOrderedInputs(IEnumerable<InputArtifact> orderedInputs)
     {
@@ -105,11 +106,4 @@ internal sealed class HtmlArtifactPostProcessor : IArtifactPostProcessor
 
         return result.ToString();
     }
-
-    private static IOrderedEnumerable<InputArtifact> OrderInputs(IEnumerable<InputArtifact> inputs)
-        => inputs.OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
-            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
-            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
-            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -24,6 +24,7 @@ static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAli
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.ArtifactPostProcessingHelper
 static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.IsReparsePoint(string! path) -> bool
+static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.OrderInputs(System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, bool includeModuleMetadata) -> System.Linq.IOrderedEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>!
 virtual Microsoft.Testing.Extensions.ReportGeneratorBase<TGenerator, TCapturedTestResult>.ArtifactKind.get -> string?
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectoryNotWritableErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -32,4 +32,5 @@ static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAli
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.ArtifactPostProcessingHelper
 static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.IsReparsePoint(string! path) -> bool
+static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.OrderInputs(System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, bool includeModuleMetadata) -> System.Linq.IOrderedEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>!
 static Microsoft.Testing.Extensions.JUnitReport.JUnitXmlWriter.BuildFailureBody(Microsoft.Testing.Extensions.JUnitReport.CapturedTestResult! result) -> string?

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitArtifactPostProcessor.cs
@@ -49,7 +49,7 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
 
         InputArtifact[] orderedInputs = context.Mode == ArtifactPostProcessingMode.RetryAttempts
             ? [.. inputs]
-            : [.. OrderInputs(inputs)];
+            : [.. ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: true)];
 
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
         try
@@ -86,7 +86,9 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
     }
 
     internal static string CreateMergeId(IReadOnlyList<InputArtifact> inputs)
-        => CreateMergeIdFromOrderedInputs(OrderInputs(inputs), ArtifactPostProcessingMode.TestModules);
+        => CreateMergeIdFromOrderedInputs(
+            ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: true),
+            ArtifactPostProcessingMode.TestModules);
 
     private static string CreateMergeIdFromOrderedInputs(
         IEnumerable<InputArtifact> orderedInputs,
@@ -112,11 +114,4 @@ internal sealed class JUnitArtifactPostProcessor : IArtifactPostProcessor
 
         return result.ToString();
     }
-
-    private static IOrderedEnumerable<InputArtifact> OrderInputs(IEnumerable<InputArtifact> inputs)
-        => inputs.OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-            .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
-            .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
-            .ThenBy(input => input.Architecture, StringComparer.Ordinal)
-            .ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
 }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -76,6 +76,7 @@ static Microsoft.Testing.Extensions.MergeOutputFileHelper.EnsureOutputDoesNotAli
 static Microsoft.Testing.Extensions.MergeOutputFileHelper.WriteViaTemporarySiblingAsync(string! outputPath, System.Func<string!, System.Threading.Tasks.Task!>! writeToTempAsync) -> System.Threading.Tasks.Task!
 Microsoft.Testing.Extensions.ArtifactPostProcessingHelper
 static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.IsReparsePoint(string! path) -> bool
+static Microsoft.Testing.Extensions.ArtifactPostProcessingHelper.OrderInputs(System.Collections.Generic.IEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>! inputs, bool includeModuleMetadata) -> System.Linq.IOrderedEnumerable<Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing.InputArtifact!>!
 Microsoft.Testing.Platform.IPC.NamedPipeConnectionBase.ReadNextMessageAsync(System.IO.Stream! stream, System.Threading.CancellationToken cancellationToken, int maximumFrameSize = 2147483647) -> System.Threading.Tasks.Task<object?>!
 Microsoft.Testing.Platform.IPC.NamedPipeConnectionBase.WriteMessageAsync(System.IO.Stream! stream, Microsoft.Testing.Platform.IPC.INamedPipeSerializer! serializer, object! message, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 *REMOVED*Microsoft.Testing.Platform.IPC.NamedPipeConnectionBase.ReadNextMessageAsync(System.IO.Pipes.PipeStream! stream, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<object?>!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxArtifactPostProcessor.cs
@@ -49,9 +49,7 @@ internal sealed class TrxArtifactPostProcessor : IArtifactPostProcessor
 
         InputArtifact[] orderedInputs =
         [
-            .. inputs
-                .OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal)
-                .ThenBy(input => input.ExecutionId, StringComparer.Ordinal),
+            .. ArtifactPostProcessingHelper.OrderInputs(inputs, includeModuleMetadata: false),
         ];
         string[] inputPaths = [.. orderedInputs.Select(input => input.Path)];
         Guid runId = TrxReportEngine.CreateMergeRunId(inputPaths, [.. orderedInputs.Select(input => input.ExecutionId)]);

--- a/src/Platform/SharedExtensionHelpers/ArtifactPostProcessingHelper.cs
+++ b/src/Platform/SharedExtensionHelpers/ArtifactPostProcessingHelper.cs
@@ -1,10 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
+
 namespace Microsoft.Testing.Extensions;
 
 internal static class ArtifactPostProcessingHelper
 {
+    internal static IOrderedEnumerable<InputArtifact> OrderInputs(
+        IEnumerable<InputArtifact> inputs,
+        bool includeModuleMetadata)
+    {
+        IOrderedEnumerable<InputArtifact> orderedInputs =
+            inputs.OrderBy(input => Path.GetFullPath(input.Path), StringComparer.Ordinal);
+
+        return includeModuleMetadata
+            ? orderedInputs
+                .ThenBy(input => input.ProducingTestModule, StringComparer.Ordinal)
+                .ThenBy(input => input.TargetFramework, StringComparer.Ordinal)
+                .ThenBy(input => input.Architecture, StringComparer.Ordinal)
+                .ThenBy(input => input.ExecutionId, StringComparer.Ordinal)
+            : orderedInputs.ThenBy(input => input.ExecutionId, StringComparer.Ordinal);
+    }
+
     /// <summary>
     /// Returns <see langword="true"/> when <paramref name="path"/> is a symlink/junction, or when its
     /// attributes cannot be read. An unreadable directory is treated as unsafe because artifact


### PR DESCRIPTION
Consolidates the shared artifact post-processing safeguards so report processors do not maintain parallel copies of ordering and filesystem safety logic.

- Moves both input ordering variants into `ArtifactPostProcessingHelper` while preserving the existing JUnit/HTML and CTRF/TRX sort keys.
- Keeps all four processors on the shared reparse-point check.
- Updates each extension's internal API baseline for the linked helper source.

Tests: 41 targeted artifact post-processor tests passed on `net8.0`.

Fixes #10568
Fixes #10567