### PR TITLE
Add tests for artifact reparse point detection

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ArtifactPostProcessingHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ArtifactPostProcessingHelperTests.cs
@@ -27,13 +27,27 @@ public sealed class ArtifactPostProcessingHelperTests
     [TestCleanup]
     public void Cleanup()
     {
+        IOException? cleanupException = null;
+
         for (int i = _trackedDirectories.Count - 1; i >= 0; i--)
         {
             string directory = _trackedDirectories[i];
-            if (Directory.Exists(directory))
+            try
             {
-                Directory.Delete(directory, recursive: true);
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
             }
+            catch (IOException ex)
+            {
+                cleanupException ??= ex;
+            }
+        }
+
+        if (cleanupException is not null)
+        {
+            throw cleanupException;
         }
     }
 
@@ -52,6 +66,7 @@ public sealed class ArtifactPostProcessingHelperTests
     {
         string path = Path.Combine(Path.GetTempPath(), nameof(ArtifactPostProcessingHelperTests), Guid.NewGuid().ToString("N"));
 
+        // A non-existent path cannot be inspected, so the method conservatively returns true.
         bool result = Invoke(path);
 
         Assert.IsTrue(result);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ArtifactPostProcessingHelperTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ArtifactPostProcessingHelperTests.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+#if NETFRAMEWORK
+using System.Diagnostics;
+#endif
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class ArtifactPostProcessingHelperTests
+{
+    // ArtifactPostProcessingHelper is linked into each report-engine assembly, so resolve the
+    // TrxReport copy through reflection to avoid an ambiguous type reference.
+    private static readonly MethodInfo IsReparsePointMethod =
+        (typeof(TrxReportEngine).Assembly.GetType("Microsoft.Testing.Extensions.ArtifactPostProcessingHelper")
+            ?? throw new InvalidOperationException("Could not find type ArtifactPostProcessingHelper in the Trx report engine assembly."))
+        .GetMethod("IsReparsePoint", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Could not resolve ArtifactPostProcessingHelper.IsReparsePoint.");
+
+    private readonly List<string> _trackedDirectories = [];
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        for (int i = _trackedDirectories.Count - 1; i >= 0; i--)
+        {
+            string directory = _trackedDirectories[i];
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void IsReparsePoint_RegularDirectory_ReturnsFalse()
+    {
+        string directory = CreateTrackedDirectory();
+
+        bool result = Invoke(directory);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsReparsePoint_NonExistentPath_ReturnsTrue()
+    {
+        string path = Path.Combine(Path.GetTempPath(), nameof(ArtifactPostProcessingHelperTests), Guid.NewGuid().ToString("N"));
+
+        bool result = Invoke(path);
+
+        Assert.IsTrue(result);
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public void IsReparsePoint_SymbolicLinkToDirectory_ReturnsTrue()
+    {
+        string target = CreateTrackedDirectory();
+        string linkPath = Path.Combine(Path.GetTempPath(), nameof(ArtifactPostProcessingHelperTests), Guid.NewGuid().ToString("N"));
+        _trackedDirectories.Add(linkPath);
+
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, target);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            Assert.Inconclusive($"Symbolic link creation is not supported or permitted in this environment: {ex.Message}");
+            return;
+        }
+
+        bool result = Invoke(linkPath);
+
+        Assert.IsTrue(result);
+    }
+#endif
+
+#if NETFRAMEWORK
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public async Task IsReparsePoint_JunctionToDirectory_ReturnsTrue()
+    {
+        string target = CreateTrackedDirectory();
+        string junctionPath = Path.Combine(Path.GetTempPath(), nameof(ArtifactPostProcessingHelperTests), Guid.NewGuid().ToString("N"));
+        _trackedDirectories.Add(junctionPath);
+
+        using Process process = Process.Start(new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+            Arguments = $"/d /c mklink /J \"{junctionPath}\" \"{target}\"",
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        })!;
+        Task<string> standardOutputTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> standardErrorTask = process.StandardError.ReadToEndAsync();
+        process.WaitForExit();
+        string standardOutput = await standardOutputTask;
+        string standardError = await standardErrorTask;
+
+        if (process.ExitCode != 0)
+        {
+            Assert.Inconclusive(
+                $"Junction creation failed with exit code {process.ExitCode}: "
+                + $"{standardOutput}{standardError}");
+            return;
+        }
+
+        bool result = Invoke(junctionPath);
+
+        Assert.IsTrue(result);
+    }
+#endif
+
+    [TestMethod]
+    public void IsReparsePoint_File_ReturnsFalse()
+    {
+        string directory = CreateTrackedDirectory();
+        string filePath = Path.Combine(directory, "file.txt");
+        File.WriteAllText(filePath, "content");
+
+        bool result = Invoke(filePath);
+
+        Assert.IsFalse(result);
+    }
+
+    private string CreateTrackedDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), nameof(ArtifactPostProcessingHelperTests), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        _trackedDirectories.Add(path);
+        return path;
+    }
+
+    private static bool Invoke(string path)
+        => (bool)IsReparsePointMethod.Invoke(null, [path])!;
+}


### PR DESCRIPTION
## Summary
- add direct tests for regular directories, missing paths, plain files, and reparse-point directories
- exercise symbolic links on modern .NET and Windows junctions on .NET Framework
- resolve the linked internal helper through the Trx report assembly to avoid ambiguous type references

## Testing
- targeted project build for net8.0, net9.0, net462, and net472
- `ArtifactPostProcessingHelperTests` on all four target frameworks
- full `Microsoft.Testing.Extensions.UnitTests` net9.0 suite (1,163 tests, 0 failures)

Fixes #10710