### PR TITLE
Update Aspire.Hosting.Testing to 13.5.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -190,7 +190,7 @@
     bumps only the PackageVersion), so the duplication can never ship out of sync.
     -->
   <ItemGroup Label="Declared by MSTest.Sdk but not used directly">
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.5.2" />
     <PackageVersion Include="Microsoft.Playwright.MSTest.v4" Version="1.62.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
          declared near the bottom of this file (the one Dependabot updates). The
          _ValidateBundledSdkFeatureVersions target (in Directory.Build.targets) fails the build if
          the two drift apart. -->
-    <AspireHostingTestingVersion>13.4.6</AspireHostingTestingVersion>
+    <AspireHostingTestingVersion>13.5.2</AspireHostingTestingVersion>
     <MicrosoftBuildVersion>17.11.48</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisVersion>3.11.0</MicrosoftCodeAnalysisVersion>
     <MicrosoftCodeAnalysisVersionForTests>4.10.0</MicrosoftCodeAnalysisVersionForTests>


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Updates `Aspire.Hosting.Testing` to 13.5.2 and keeps the `AspireHostingTestingVersion` property synchronized so the bundled MSTest.Sdk template uses the same version.

The previous one-sided package bump triggered `_ValidateBundledSdkFeatureVersions` across every CI build leg. This change updates both version declarations together.