### PR TITLE
Enable multithreaded MSBuild for local and PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,7 +172,6 @@ stages:
           "-NoProfile",
           "-File", "./eng/common/msbuild.ps1",
           "-prepareMachine",
-          "-msbuildMultiThreaded:`$true",
           "-warnAsError:`$false",
           "./TestFx.slnx",
           "/restore",
@@ -257,6 +256,8 @@ stages:
       displayName: Preserve cache diagnostics and clean failed seed outputs
       condition: and(always(), ne(variables['MSBuildCacheBuildSucceeded'], 'true'))
 
+    # Keep the cache support packages out of the multithreaded fallback. Their unannotated
+    # ResolveFileAccesses task currently fails in MSBuild's sidecar task host under -mt.
     - script: eng\common\CIBuild.cmd
         -configuration $(_BuildConfig)
         -msbuildMultiThreaded 1
@@ -264,7 +265,7 @@ stages:
         /p:Publish=false
         /p:Test=false
         /p:FastAcceptanceTest=true
-        /p:MSBuildCachePackageEnabled=true
+        /p:MSBuildCachePackageEnabled=false
         /p:MSBuildCacheEnabled=false
       name: Build
       displayName: Build
@@ -278,7 +279,6 @@ stages:
             -ci `
             -disablePipelineSetResult `
             -configuration $(_BuildConfig) `
-            -msbuildMultiThreaded $true `
             -binaryLogName "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog" `
             -restore `
             -sign `
@@ -457,7 +457,6 @@ stages:
               "-NoProfile",
               "-File", "./eng/common/msbuild.ps1",
               "-prepareMachine",
-              "-msbuildMultiThreaded:`$true",
               "-warnAsError:`$false",
               "./TestFx.slnx",
               "/restore",
@@ -601,7 +600,6 @@ stages:
               "-ci",
               "-disablePipelineSetResult",
               "-configuration", "$(_BuildConfig)",
-              "-msbuildMultiThreaded:`$true",
               "-binaryLogName", "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog",
               "-restore",
               "-sign",
@@ -710,6 +708,8 @@ stages:
 
         # Fallback build. Skipped when the MSBuildCache steps above already produced, signed and packed the
         # outputs; also skipped when they failed with build errors, because this step would only reproduce them.
+        # Keep the cache support packages out of this multithreaded build because their unannotated
+        # ResolveFileAccesses task currently fails in MSBuild's sidecar task host under -mt.
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
             -msbuildMultiThreaded 1
@@ -717,7 +717,7 @@ stages:
             /p:Publish=false
             /p:Test=false
             /p:FastAcceptanceTest=true
-            /p:MSBuildCachePackageEnabled=true
+            /p:MSBuildCachePackageEnabled=false
             /p:MSBuildCacheEnabled=false
           name: Build
           displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,6 +172,7 @@ stages:
           "-NoProfile",
           "-File", "./eng/common/msbuild.ps1",
           "-prepareMachine",
+          "-msbuildMultiThreaded:`$true",
           "-warnAsError:`$false",
           "./TestFx.slnx",
           "/restore",
@@ -258,6 +259,7 @@ stages:
 
     - script: eng\common\CIBuild.cmd
         -configuration $(_BuildConfig)
+        -msbuildMultiThreaded 1
         -prepareMachine
         /p:Publish=false
         /p:Test=false
@@ -276,6 +278,7 @@ stages:
             -ci `
             -disablePipelineSetResult `
             -configuration $(_BuildConfig) `
+            -msbuildMultiThreaded $true `
             -binaryLogName "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog" `
             -restore `
             -sign `
@@ -454,6 +457,7 @@ stages:
               "-NoProfile",
               "-File", "./eng/common/msbuild.ps1",
               "-prepareMachine",
+              "-msbuildMultiThreaded:`$true",
               "-warnAsError:`$false",
               "./TestFx.slnx",
               "/restore",
@@ -597,6 +601,7 @@ stages:
               "-ci",
               "-disablePipelineSetResult",
               "-configuration", "$(_BuildConfig)",
+              "-msbuildMultiThreaded:`$true",
               "-binaryLogName", "$(Build.SourcesDirectory)\artifacts\log\$(_BuildConfig)\SignPack.binlog",
               "-restore",
               "-sign",
@@ -707,6 +712,7 @@ stages:
         # outputs; also skipped when they failed with build errors, because this step would only reproduce them.
         - script: eng\common\CIBuild.cmd
             -configuration $(_BuildConfig)
+            -msbuildMultiThreaded 1
             -prepareMachine
             /p:Publish=false
             /p:Test=false
@@ -850,6 +856,7 @@ stages:
         steps:
         - script: eng/common/cibuild.sh
             -configuration $(_BuildConfig)
+            -msbuildMultiThreaded true
             -prepareMachine
             /p:Test=false
             /p:Publish=false
@@ -889,6 +896,7 @@ stages:
         steps:
         - script: eng/common/cibuild.sh
             -configuration $(_BuildConfig)
+            -msbuildMultiThreaded true
             -prepareMachine
             /p:Test=false
             /p:Publish=false

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -7,6 +7,7 @@ Param(
   [string] $msbuildEngine = $null,
   [bool] $warnAsError = $true,
   [bool] $nodeReuse = $true,
+  [bool][Alias('mt')]$msbuildMultiThreaded = $false,
   [switch][Alias('r')]$restore,
   [switch] $deployDeps,
   [switch][Alias('b')]$build,
@@ -81,5 +82,9 @@ if ($installWindowsSdk) {
 # Remove extra parameters that are not used by the common build script
 $null = $PSBoundParameters.Remove("vs")
 $null = $PSBoundParameters.Remove("installWindowsSdk")
+
+if (-not $PSBoundParameters.ContainsKey("msbuildMultiThreaded")) {
+    $PSBoundParameters["msbuildMultiThreaded"] = -not $ci
+}
 
 & $PSScriptRoot\common\Build.ps1 @PSBoundParameters


### PR DESCRIPTION
## Summary

- enable MSBuild's experimental multithreaded mode by default for local builds
- enable multithreaded MSBuild explicitly in ordinary public/PR Azure Pipelines builds on Windows, Linux, and macOS
- keep MSBuildCache graph/cache follow-up builds process-based
- keep the official build pipeline unchanged

## Local benchmark

Measured five clean-output restore+build runs per mode after warming the SDK, workload, and NuGet caches on an 8-core/16-logical-processor Windows machine.

| Mode | Runs | Average | Median | Range |
| --- | ---: | ---: | ---: | ---: |
| Existing process-based MSBuild | 5 | 167.1s | 166.6s | 154.1–181.9s |
| Multithreaded MSBuild | 5 | 159.0s | 160.7s | 144.2–168.3s |

Local average improved by **8.1 seconds (4.8%)** and median by **5.9 seconds (3.6%)**. The ranges overlap, so this is directional rather than statistically conclusive.

## CI benchmark

[Azure Pipelines build 1566758](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1566758) succeeded in every configuration. The baseline is the average build-step duration from the four most recent successful fork PR builds (1566681, 1564881, 1564777, and 1564593), which use the same cache-disabled fallback path and are therefore more comparable than trusted-branch cache builds.

| Build step | Multithreaded | Fork PR baseline | Change |
| --- | ---: | ---: | ---: |
| Windows Debug | 666.1s | 715.0s | -6.8% |
| Windows Release | 685.5s | 692.4s | -1.0% |
| Linux Debug | 367.1s | 367.1s | 0.0% |
| Linux Release | 352.1s | 369.5s | -4.7% |
| macOS Debug | 663.0s | 702.8s | -5.7% |
| macOS Release | 513.3s | 850.6s | -39.7% |

The two Windows configurations improved from **703.7s to 675.8s combined (-4.0%)**, closely matching the **4.8% local average improvement**. Linux is neutral-to-modestly faster. macOS is highly variable—the baseline samples range from 533.7s to 1,015.6s for Debug and 723.9s to 1,021.9s for Release—so the apparent Release gain should not be treated as a reliable estimate.

## MSBuildCache compatibility finding

The first experiment, [build 1566674](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1566674), failed because the cache-disabled Windows fallback still imported `Microsoft.MSBuildCache.SharedCompilation`. Its unannotated `ResolveFileAccesses` task was routed to a sidecar TaskHost under `-mt`. MSBuild then corrupted the returned `FileAccessData` structs during TaskHost packet deserialization through interface boxing and crashed in `FileAccessManager.ReportFileAccess` when replaying a null path.

The ProjectCachePlugin itself was inactive, so this was not a cache lookup or materialization race. The engine defect is tracked by [dotnet/msbuild#14824](https://github.com/dotnet/msbuild/issues/14824).

This PR therefore keeps cache graph and cache-specific sign/pack operations process-based. Ordinary Windows fallback builds use `-mt` without importing cache support packages; Linux and macOS ordinary builds also use `-mt`.

## Conclusion

Multithreaded MSBuild provides a modest end-to-end improvement on Windows: **4.8% locally and 4.0% in comparable PR CI**, with no corrected-run failures. Linux results are consistent with a smaller improvement, while current macOS variance is too high for a precise estimate. Cache population and multithreaded execution should remain separate experiments until the TaskHost file-access serialization defect is fixed and their combined topology can be evaluated independently.