### PR TITLE
Declare PlatformServices as non-packable

### DIFF
--- a/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
+++ b/src/Adapter/MSTestAdapter.PlatformServices/MSTestAdapter.PlatformServices.csproj
@@ -13,6 +13,8 @@
     <RootNamespace>Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices</RootNamespace>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 
+    <!-- MSTest.TestAdapter bundles this assembly into its buildTransitive folder, so this project is never packed on its own. -->
+    <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);EXCLUDE_OS_POLYFILL</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
`MSTestAdapter.PlatformServices` is bundled into `MSTest.TestAdapter` rather than published as a standalone package, but its project relied on the SDK's implicit `IsPackable=true` default.

Explicitly set `IsPackable=false` and document the embedding relationship so the project's packaging intent is clear and direct pack invocations do not attempt to produce a package.

Fixes #10709