### PR TITLE
Test that the HTML post-processor refuses to merge through a symlink

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlArtifactPostProcessorTests.cs
@@ -427,6 +427,92 @@ public sealed class HtmlArtifactPostProcessorTests
         }
     }
 
+#if NETCOREAPP
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
+    {
+        // 'merged' is a fixed, predictable child name under the orchestrator-supplied output directory.
+        // A symlink or junction planted at that name becomes the base the merge writes into, redirecting
+        // the merged report to wherever the link points and letting the run write outside the directory it
+        // was given, so the processor must refuse rather than write through it.
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string outsideDirectory = Path.Combine(root, "outside");
+        Directory.CreateDirectory(resultsDirectory);
+        Directory.CreateDirectory(outsideDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), outsideDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                // Creating a directory symlink needs elevation or Developer Mode on Windows.
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = Path.Combine(resultsDirectory, "first.html");
+            string secondPath = Path.Combine(resultsDirectory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("first.dll", "MSTest", Epoch, Epoch, Test("a", "A", "passed", 1)));
+            File.WriteAllText(secondPath, CreateReport("second.dll", "MSTest", Epoch, Epoch, Test("b", "B", "passed", 2)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath)],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsADanglingReparsePoint_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string missingDirectory = Path.Combine(root, "missing");
+        Directory.CreateDirectory(resultsDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), missingDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = Path.Combine(resultsDirectory, "first.html");
+            string secondPath = Path.Combine(resultsDirectory, "second.html");
+            File.WriteAllText(firstPath, CreateReport("first.dll", "MSTest", Epoch, Epoch, Test("a", "A", "passed", 1)));
+            File.WriteAllText(secondPath, CreateReport("second.dll", "MSTest", Epoch, Epoch, Test("b", "B", "passed", 2)));
+
+            ProcessedArtifact? output = await new HtmlArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath), CreateInput(secondPath)],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsFalse(Directory.Exists(missingDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+#endif
+
     [TestMethod]
     public void CreateMergeId_IncludesExecutionProvenance()
     {


### PR DESCRIPTION
HtmlArtifactPostProcessor calls `ArtifactPostProcessingHelper.IsReparsePoint` before it merges, so a symlink or junction planted at the fixed `merged` name cannot redirect the merged report outside the output directory the orchestrator gave it. Trx, JUnit and Ctrf all have a test at the call site proving they act on that check, the HTML one did not, so deleting the guard from `HtmlArtifactPostProcessor.cs` made nothing in the repository fail.

Adds the symlink case and the dangling symlink case to `HtmlArtifactPostProcessorTests`, copying the shape of the existing ones.

Verified by removing the guard and rerunning: the symlink test fails on `Assert.IsNull(output)` because the merge writes through the link, and the dangling one fails by throwing. Both pass again with the guard restored. Full `Microsoft.Testing.Extensions.UnitTests` run on net9.0 is 1202 tests, 0 failed, and the project still builds for net462, net472, net8.0 and net9.0.

The dangling variant is not added to the Trx and Ctrf files. Those two call `Directory.CreateDirectory(mergedDirectory)` without the try/catch that the HTML and JUnit processors have, and on Linux that call throws `IOException` on a dangling directory symlink instead of returning, so the test would pass on Windows and fail on Linux CI. It looks like those two do not hold the never-fail-the-run invariant that the comment in `TrxArtifactPostProcessor.cs` describes, but that is a behavior change rather than a test, so I left it out of this PR.

Related: #10710

🤖
