### PR TITLE
Handle report merge directory creation failures

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfArtifactPostProcessor.cs
@@ -60,7 +60,15 @@ internal sealed class CtrfArtifactPostProcessor : IArtifactPostProcessor
         ];
         Guid artifactId = CtrfReportMerger.CreateDeterministicId(identityInputs);
         string mergedDirectory = Path.Combine(outputDirectory, MergedReportDirectoryName);
-        Directory.CreateDirectory(mergedDirectory);
+        try
+        {
+            Directory.CreateDirectory(mergedDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
         if (ArtifactPostProcessingHelper.IsReparsePoint(mergedDirectory))
         {
             return null;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxArtifactPostProcessor.cs
@@ -69,7 +69,15 @@ internal sealed class TrxArtifactPostProcessor : IArtifactPostProcessor
         // outside the supplied output directory (Directory.CreateDirectory succeeds on an existing link).
         // Materialize the directory here and refuse to merge through a reparse point instead. Returning
         // null leaves the per-module reports untouched, matching the never-fail-the-run invariant.
-        Directory.CreateDirectory(mergedDirectory);
+        try
+        {
+            Directory.CreateDirectory(mergedDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
         if (ArtifactPostProcessingHelper.IsReparsePoint(mergedDirectory))
         {
             return null;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfArtifactPostProcessorTests.cs
@@ -223,6 +223,34 @@ public sealed class CtrfArtifactPostProcessorTests
         }
     }
 
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedPathIsAFile_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        Directory.CreateDirectory(resultsDirectory);
+        File.WriteAllText(Path.Combine(resultsDirectory, "merged"), string.Empty);
+        try
+        {
+            string firstPath = WriteReport(resultsDirectory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(resultsDirectory, "second.ctrf.json", "second");
+
+            ProcessedArtifact? output = await new CtrfArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath, "execution-1"), CreateInput(secondPath, "execution-2")],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsTrue(File.Exists(firstPath));
+            Assert.IsTrue(File.Exists(secondPath));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
 #if NETCOREAPP
     [TestMethod]
     public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
@@ -256,6 +284,45 @@ public sealed class CtrfArtifactPostProcessorTests
 
             Assert.IsNull(output);
             Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsADanglingReparsePoint_DoesNotMerge()
+    {
+        string root = CreateTemporaryDirectory();
+        string resultsDirectory = Path.Combine(root, "results");
+        string missingDirectory = Path.Combine(root, "missing");
+        Directory.CreateDirectory(resultsDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), missingDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = WriteReport(resultsDirectory, "first.ctrf.json", "first");
+            string secondPath = WriteReport(resultsDirectory, "second.ctrf.json", "second");
+
+            ProcessedArtifact? output = await new CtrfArtifactPostProcessor().ProcessAsync(
+                [CreateInput(firstPath, "execution-1"), CreateInput(secondPath, "execution-2")],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsTrue(File.Exists(firstPath));
+            Assert.IsTrue(File.Exists(secondPath));
+            Assert.IsFalse(Directory.Exists(missingDirectory));
         }
         finally
         {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxArtifactPostProcessorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxArtifactPostProcessorTests.cs
@@ -177,6 +177,39 @@ public sealed class TrxArtifactPostProcessorTests
         }
     }
 
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedPathIsAFile_DoesNotMerge()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"trx-post-processor-{Guid.NewGuid():N}");
+        string resultsDirectory = Path.Combine(root, "results");
+        Directory.CreateDirectory(resultsDirectory);
+        File.WriteAllText(Path.Combine(resultsDirectory, "merged"), string.Empty);
+        try
+        {
+            string firstPath = Path.Combine(resultsDirectory, "first.trx");
+            string secondPath = Path.Combine(resultsDirectory, "second.trx");
+            WriteMinimalReport(firstPath, "first");
+            WriteMinimalReport(secondPath, "second");
+
+            ProcessedArtifact? output = await new TrxArtifactPostProcessor().ProcessAsync(
+                [
+                    new InputArtifact(firstPath, TrxReportEngine.TrxArtifactKind, null, null, null, "execution-1"),
+                    new InputArtifact(secondPath, TrxReportEngine.TrxArtifactKind, null, null, null, "execution-2"),
+                ],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsTrue(File.Exists(firstPath));
+            Assert.IsTrue(File.Exists(secondPath));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
 #if NETCOREAPP
     [TestMethod]
     public async Task ProcessAsync_WhenMergedDirectoryIsAReparsePoint_DoesNotMerge()
@@ -220,6 +253,50 @@ public sealed class TrxArtifactPostProcessorTests
 
             Assert.IsNull(output);
             Assert.IsEmpty(Directory.GetFileSystemEntries(outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_WhenMergedDirectoryIsADanglingReparsePoint_DoesNotMerge()
+    {
+        string root = Path.Combine(Path.GetTempPath(), $"trx-post-processor-{Guid.NewGuid():N}");
+        string resultsDirectory = Path.Combine(root, "results");
+        string missingDirectory = Path.Combine(root, "missing");
+        Directory.CreateDirectory(resultsDirectory);
+        try
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(Path.Combine(resultsDirectory, "merged"), missingDirectory);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+            {
+                Assert.Inconclusive("Host cannot create directory symbolic links.");
+                return;
+            }
+
+            string firstPath = Path.Combine(resultsDirectory, "first.trx");
+            string secondPath = Path.Combine(resultsDirectory, "second.trx");
+            WriteMinimalReport(firstPath, "first");
+            WriteMinimalReport(secondPath, "second");
+
+            ProcessedArtifact? output = await new TrxArtifactPostProcessor().ProcessAsync(
+                [
+                    new InputArtifact(firstPath, TrxReportEngine.TrxArtifactKind, null, null, null, "execution-1"),
+                    new InputArtifact(secondPath, TrxReportEngine.TrxArtifactKind, null, null, null, "execution-2"),
+                ],
+                resultsDirectory,
+                new ArtifactPostProcessingContext(ArtifactPostProcessingTruncationReason.None),
+                CancellationToken.None);
+
+            Assert.IsNull(output);
+            Assert.IsTrue(File.Exists(firstPath));
+            Assert.IsTrue(File.Exists(secondPath));
+            Assert.IsFalse(Directory.Exists(missingDirectory));
         }
         finally
         {


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Trx and Ctrf artifact post-processors could throw when their fixed `merged` output directory could not be created, allowing a filesystem condition during post-processing to fail the test run contrary to RFC 018.

This change handles `IOException` and `UnauthorizedAccessException` consistently with the HTML and JUnit processors by returning no merged artifact and preserving the inputs. It adds portable file-collision coverage plus dangling directory symlink regressions for both processors.

The targeted project builds for net462, net472, net8.0, and net9.0, and all 21 Trx/Ctrf processor tests pass on net9.0.

Fixes #10733