### PR TITLE
Deduplicate published-results parsing in Azure DevOps client

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
@@ -117,19 +117,7 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
 
         // From this point on the AzDO server has accepted the results. Failing to parse the response
         // must not cause the caller to retry the publish (that would duplicate result rows).
-        try
-        {
-            string payload = await ReadAsStringAsync(response.Content, requestTimeoutSource.Token).ConfigureAwait(false);
-            return ParsePublishedResults(payload, results, validateAutomatedTestName: true);
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
-        {
-            return null;
-        }
-        catch (Exception ex) when (ex is JsonException or HttpRequestException or IOException or InvalidOperationException or ArgumentException)
-        {
-            return null;
-        }
+        return await TryReadAndParsePublishedResultsAsync(response, requestTimeoutSource.Token, cancellationToken, results, validateAutomatedTestName: true).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -154,12 +142,28 @@ internal sealed class AzureDevOpsTestResultsClient : IAzureDevOpsTestResultsClie
         requestTimeoutSource.CancelAfter(RequestTimeout);
         using HttpResponseMessage response = await SendCoreAsync(request, requestTimeoutSource.Token, cancellationToken, AttemptTimeout).ConfigureAwait(false);
 
+        return await TryReadAndParsePublishedResultsAsync(response, requestTimeoutSource.Token, cancellationToken, results, validateAutomatedTestName: false).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the response body and parses it into published results, swallowing parse/transport failures
+    /// that must not cause the caller to retry (the server has already accepted the write).
+    /// </summary>
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = "Response types are internal, fixed, and controlled by this extension.")]
+    [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Response types are internal, fixed, and controlled by this extension.")]
+    private static async Task<IReadOnlyList<AzureDevOpsPublishedTestResult>?> TryReadAndParsePublishedResultsAsync(
+        HttpResponseMessage response,
+        CancellationToken readTimeoutToken,
+        CancellationToken userCancellationToken,
+        IReadOnlyList<AzureDevOpsTestCaseResult> results,
+        bool validateAutomatedTestName)
+    {
         try
         {
-            string payload = await ReadAsStringAsync(response.Content, requestTimeoutSource.Token).ConfigureAwait(false);
-            return ParsePublishedResults(payload, results, validateAutomatedTestName: false);
+            string payload = await ReadAsStringAsync(response.Content, readTimeoutToken).ConfigureAwait(false);
+            return ParsePublishedResults(payload, results, validateAutomatedTestName);
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (!userCancellationToken.IsCancellationRequested)
         {
             return null;
         }


### PR DESCRIPTION
Publishing and updating Azure DevOps test results duplicated the same response parsing and non-retry exception handling, making the two paths easier to drift apart.

Extract the shared behavior into `TryReadAndParsePublishedResultsAsync` and use it from both paths while preserving their distinct result validation and user-cancellation semantics.

Tests: `AzureDevOpsLivePublishingTests` (128 passed).

Fixes #10732