### PR TITLE
Decouple per-TFM summary assertions from interleaved dotnet test output

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -75,15 +75,27 @@ namespace MSTestSdkTest
         DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"test -c {buildConfiguration} {testAsset.TargetAssetPath}", workingDirectory: testAsset.TargetAssetPath, cancellationToken: TestContext.CancellationToken);
         compilationResult.AssertExitCodeIs(0);
 
-        compilationResult.AssertOutputMatchesRegex(@"Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: .* [m]?s - MSTestSdk.dll \(net10\.0\)");
+        // 'dotnet test' runs the target frameworks in parallel and writes each framework's summary as two separate
+        // writes: the 'Passed!  - Failed: ...' counts, then the ' - MSTestSdk.dll (<tfm>)' suffix. Those writes
+        // interleave, so the two halves of one framework's summary are not guaranteed to share an output line. Assert
+        // the two independent facts instead: every expected framework ran, and every framework reported a clean result.
+        List<string> expectedTargetFrameworks = ["net10.0"];
 #if !SKIP_INTERMEDIATE_TARGET_FRAMEWORKS
-        compilationResult.AssertOutputMatchesRegex(@"Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: .* [m]?s - MSTestSdk.dll \(net8\.0\)");
+        expectedTargetFrameworks.Add("net8.0");
 #endif
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            compilationResult.AssertOutputMatchesRegex(@"Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: .* [m]?s - MSTestSdk.dll \(net462\)");
+            expectedTargetFrameworks.Add("net462");
         }
+
+        foreach (string targetFramework in expectedTargetFrameworks)
+        {
+            compilationResult.AssertOutputContains($" - MSTestSdk.dll ({targetFramework})");
+        }
+
+        compilationResult.AssertOutputMatchesRegexTimes("Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1", expectedTargetFrameworks.Count);
+        compilationResult.AssertOutputDoesNotContain("Failed!");
     }
 
     [TestMethod]

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceAssert.cs
@@ -130,6 +130,18 @@ internal static class AcceptanceAssert
     public static void AssertOutputMatchesRegex(this DotnetMuxerResult dotnetMuxerResult, [StringSyntax("Regex")] string pattern, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.IsTrue(Regex.IsMatch(dotnetMuxerResult.StandardOutput, pattern), GenerateFailedAssertionMessage(dotnetMuxerResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 
+    /// <summary>
+    /// Ensure the output contains exactly <paramref name="expectedMatchCount"/> matches of <paramref name="pattern"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this when several test hosts write to the same output concurrently. Their writes interleave, so a given
+    /// occurrence cannot be tied to the host that produced it, and a regex spanning two of a host's writes matches
+    /// whatever happened to be written in between. Counting occurrences still verifies that every host reported the
+    /// expected result, without depending on where the line breaks fall.
+    /// </remarks>
+    public static void AssertOutputMatchesRegexTimes(this DotnetMuxerResult dotnetMuxerResult, [StringSyntax("Regex")] string pattern, int expectedMatchCount, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
+        => Assert.HasCount(expectedMatchCount, Regex.Matches(dotnetMuxerResult.StandardOutput, pattern), GenerateFailedAssertionMessage(dotnetMuxerResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
+
     public static void AssertOutputDoesNotContain(this TestHostResult testHostResult, string value, [CallerMemberName] string? callerMemberName = null, [CallerFilePath] string? callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0)
         => Assert.IsFalse(testHostResult.StandardOutput.Contains(value, StringComparison.Ordinal), GenerateFailedAssertionMessage(testHostResult, callerMemberName: callerMemberName, callerFilePath: callerFilePath, callerLineNumber: callerLineNumber));
 


### PR DESCRIPTION
`dotnet test` runs the target frameworks in parallel and writes each framework's summary as two separate writes, the `Passed!  - Failed: ...` counts and the ` - MSTestSdk.dll (<tfm>)` suffix. When those writes interleave the suffix ends up on a line of its own, and the single-line regex in `RunTests_With_VSTest` cannot match it. This is what build 20260825.7 captured on the Linux leg:

```
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 40 msPassed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 75 ms - MSTestSdk.dll (net10.0)
 - MSTestSdk.dll (net8.0)
```

`AssertOutputMatchesRegex` uses default `RegexOptions`, so `.` does not match a newline and the net8.0 pattern has nothing to match. The net10.0 pattern had the opposite problem, its greedy `.*` swallowed `40 msPassed!  - Failed: ... Duration: 75`, so a mangled line was reported as a pass.

The two halves are separate writes, so nothing can assert they share a line. Assert the two independent facts instead: every expected framework produced its ` - MSTestSdk.dll (<tfm>)` marker, and the number of clean summaries equals the number of expected frameworks with no `Failed!` summary anywhere. Adding `RegexOptions.Singleline` would be worse, one framework's pattern would then match across a newline into another framework's summary and pass even when the named framework never ran.

Verified: replayed the new assertions over the captured interleaved output, over normal non-interleaved output, and over samples where one framework reports `Failed!  - Failed:     1, ...` or never runs at all. The first two pass, the last two fail on both the count and the missing marker. `RunTests_With_VSTest` passes locally for Debug and Release with net10.0, net8.0 and net462.

🤖
