### PR TITLE
Document IDataConsumer UID filtering

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IDataConsumer.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Testing.Platform.Extensions;
 /// <summary>
 /// Represents a data consumer that can consume data produced by a data producer.
 /// </summary>
+/// <remarks>
+/// The message bus does not dispatch data to a consumer when the consumer and producer have the same
+/// <see cref="IExtension.Uid"/>. Producer and consumer registrations that communicate through the message bus
+/// must use different UIDs. An extension that processes its own data should invoke that processing directly.
+/// </remarks>
 public interface IDataConsumer : IExtension
 {
     /// <summary>

--- a/src/Platform/Microsoft.Testing.Platform/Messages/IMessageBus.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/IMessageBus.cs
@@ -16,5 +16,9 @@ public interface IMessageBus
     /// <param name="dataProducer">The data producer.</param>
     /// <param name="data">The data to be published.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// The data is not dispatched to consumers whose <see cref="Microsoft.Testing.Platform.Extensions.IExtension.Uid"/> matches the
+    /// <paramref name="dataProducer"/>'s UID.
+    /// </remarks>
     Task PublishAsync(IDataProducer dataProducer, IData data);
 }


### PR DESCRIPTION
Clarifies that the Microsoft.Testing.Platform message bus does not dispatch data to an `IDataConsumer` when the producer and consumer share the same `IExtension.Uid`.

The API documentation now explains that producer and consumer registrations communicating through the message bus need distinct UIDs, while self-produced data should be processed directly.

Fixes #4588