### PR TITLE
Avoid restoring SDK dependency anchors in CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -156,7 +156,7 @@
     templates) and are not otherwise consumed by a restored project, so that Dependabot can
     discover and update them. They are referenced only inside the SDK feature targets
     (Sdk/Features/*.targets, which Dependabot doesn't restore); their only Dependabot-visible
-    reference from a repo project is the inert anchor described in condition 2 below.
+    reference from a repo project is the restore-isolated anchor described in condition 2 below.
 
     Two conditions must BOTH hold for Dependabot to bump one of these, and missing either one
     silently stops the updates:
@@ -170,8 +170,8 @@
          Dependabot only updates a CPM PackageVersion that is actually referenced by a project;
          an "orphan" PackageVersion (declared here but referenced nowhere) is ignored. Because
          these packages are only baked into the shipped SDK templates (Sdk/Features/*.targets)
-         and never referenced by a built project, we add inert anchor references in
-         test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj.
+         and never referenced by a built project, we add restore-isolated anchor references in
+         eng/Dependabot.Dependencies/Dependabot.Dependencies.csproj.
          The anchor MUST be a PackageReference (ExcludeAssets="all" is fine - it only stops the
          package's assets from flowing into the project; it does NOT hide the reference from
          Dependabot, which reads the PackageReference XML node, not the asset-flow rules). It must

--- a/TestFx.slnx
+++ b/TestFx.slnx
@@ -21,6 +21,7 @@
     <File Path="eng/Analyzers.props" />
     <File Path="eng/Build.props" />
     <File Path="eng/coverage.config" />
+    <Project Path="eng/Dependabot.Dependencies/Dependabot.Dependencies.csproj" Build="false" />
     <File Path="eng/install-windows-sdk.ps1" />
     <File Path="eng/verify-nupkgs.ps1" />
     <File Path="eng/Version.Details.xml" />

--- a/eng/Dependabot.Dependencies/Dependabot.Dependencies.csproj
+++ b/eng/Dependabot.Dependencies/Dependabot.Dependencies.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!--
+    Dependabot anchors for the packages bundled by MSTest.Sdk (Microsoft.Playwright.MSTest.v4
+    and Aspire.Hosting.Testing). Dependabot expands TestFx.slnx and restores each project
+    independently, so these references make the matching Central Package Management versions
+    discoverable.
+
+    TestFx.slnx marks this project Build="false", and SolutionPath keeps the references out of
+    solution restores even though MSBuild evaluates projects excluded from the build. Dependabot
+    invokes project discovery directly (it only supplies a synthetic SolutionDir), so SolutionPath
+    remains empty and the anchors are restored there. This is important:
+    ExcludeAssets="all" prevents package assets from flowing into a project, but NuGet would still
+    download the packages and their transitive dependencies, including the large Playwright payload.
+
+    A PackageDownload does not work as the anchor because Dependabot does not read PackageDownload
+    items (dependabot/dependabot-core#2502). See #9362 and #9452.
+  -->
+  <ItemGroup Condition="'$(SolutionPath)' == ''">
+    <PackageReference Include="Aspire.Hosting.Testing" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Playwright.MSTest.v4" ExcludeAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSTest.Acceptance.IntegrationTests.csproj
@@ -52,31 +52,6 @@
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform.ServerMode.Client.Sources\Microsoft.Testing.Platform.ServerMode.Client.Sources.csproj" Aliases="serverclient" />
   </ItemGroup>
 
-  <!--
-    Dependabot anchors for the packages bundled by MSTest.Sdk (Microsoft.Playwright.MSTest.v4,
-    Aspire.Hosting.Testing). These are baked into the shipped SDK templates (Sdk/Features/*.targets)
-    and are otherwise referenced only there (which Dependabot doesn't restore), so their Central
-    Package Management PackageVersion entries in Directory.Packages.props are "orphans" that
-    Dependabot ignores unless a project references them.
-
-    The PackageReference (with ExcludeAssets="all") is the Dependabot ANCHOR: Dependabot reads the
-    PackageReference XML node to discover the dependency and bump its CPM PackageVersion.
-    ExcludeAssets="all" only stops the package's assets (compile/runtime/build, e.g. Playwright's
-    browser install) from flowing into this test project - it does NOT hide the reference from
-    Dependabot. A PackageDownload does NOT work as the anchor: Dependabot does not read
-    PackageDownload items at all (dependabot/dependabot-core#2502). Using PackageDownload as the
-    anchor is exactly why Playwright silently stopped updating - see #9362 / #9452.
-
-    Dependabot only bumps the literal PackageVersion in Directory.Packages.props, not the matching
-    *Version property the build consumes; the _ValidateBundledSdkFeatureVersions target in
-    Directory.Build.targets fails the build if the two drift apart, so a maintainer reconciles the
-    property in the Dependabot PR.
-  -->
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.Playwright.MSTest.v4" ExcludeAssets="all" />
-  </ItemGroup>
-
   <!-- Packages needed to stage nupkgs for the generated test assets (see
        CopyNuGetPackagesForTestAssets below) but that we don't want to reference. -->
   <ItemGroup>


### PR DESCRIPTION
## Summary

- move the Dependabot-only `Microsoft.Playwright.MSTest.v4` and `Aspire.Hosting.Testing` references into a dedicated non-building project
- omit those references when restoring `TestFx.slnx`, while preserving them for Dependabot's direct project discovery
- remove the anchors from the MSTest acceptance-test restore graph

This avoids downloading Playwright's roughly 772 MB payload on every solution restore without disabling its dependency updates.

## Validation

- generated solution and direct-project restore graphs: `TestFx.slnx` has zero anchor dependencies, while the Dependabot project has both
- completed a cold full-solution restore into an isolated package directory: 216 packages / 6.17 GB extracted, with zero `Microsoft.Playwright*` packages