### PR TITLE
Skip the artifact publish steps when the folder does not exist

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -205,12 +205,29 @@ extends:
                   Remove-Item -Path $(Build.SourcesDirectory)/artifacts/tmp -Recurse -Force
                 displayName: Remove artifacts/tmp
 
+              # artifacts/TestResults/$(_BuildConfig) only exists once a test step has written into it, and
+              # 1ES.PublishBuildArtifacts@1 hard-fails when PathtoPublish does not exist. A job that dies
+              # before the tests run therefore reported one real problem as two failed steps: an Azure
+              # Artifacts outage broke Install MicroBuild plugin, which skipped Build and Test, and this step
+              # then failed with "Not found PathtoPublish" in
+              # https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151. Probe for the folder so
+              # the publish skips when there is nothing to publish. When the tests did write results they are
+              # published exactly as before, including on a failed run, which is why this uses always().
+              - pwsh: |
+                  $testResults = Join-Path '$(Build.SourcesDirectory)' 'artifacts/TestResults/$(_BuildConfig)'
+                  $hasTestResults = 'false'
+                  if (Test-Path -LiteralPath $testResults -PathType Container) { $hasTestResults = 'true' }
+                  Write-Host "Test results under '$testResults': $hasTestResults"
+                  Write-Host "##vso[task.setvariable variable=HasTestResults]$hasTestResults"
+                displayName: 'Check for Test Results folders'
+                condition: always()
+
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish Test Results folders'
                 inputs:
                   PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
                   ArtifactName: TestResults_Windows_Attempt$(System.JobAttempt)
-                condition: always()
+                condition: and(always(), eq(variables.HasTestResults, 'true'))
 
             - task: NuGetAuthenticate@1
               displayName: 'NuGet Authenticate to test-tools feed'
@@ -283,12 +300,28 @@ extends:
                   # mapping is required; the history service no-ops if the token or endpoints are unavailable.
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+              # artifacts/TestResults/$(_BuildConfig) only exists once a test step has written into it, and
+              # 1ES.PublishBuildArtifacts@1 hard-fails when PathtoPublish does not exist. A job that dies
+              # before the tests run therefore reported one real problem as two failed steps, the way the
+              # Windows job did in
+              # https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151. Probe for the folder so
+              # the publish skips when there is nothing to publish. When the tests did write results they are
+              # published exactly as before, including on a failed run, which is why this uses always().
+              - pwsh: |
+                  $testResults = Join-Path '$(Build.SourcesDirectory)' 'artifacts/TestResults/$(_BuildConfig)'
+                  $hasTestResults = 'false'
+                  if (Test-Path -LiteralPath $testResults -PathType Container) { $hasTestResults = 'true' }
+                  Write-Host "Test results under '$testResults': $hasTestResults"
+                  Write-Host "##vso[task.setvariable variable=HasTestResults]$hasTestResults"
+                displayName: 'Check for Test Results folders'
+                condition: always()
+
               - task: 1ES.PublishBuildArtifacts@1
                 displayName: 'Publish Test Results folders'
                 inputs:
                   PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
                   ArtifactName: TestResults_Linux_Attempt$(System.JobAttempt)
-                condition: always()
+                condition: and(always(), eq(variables.HasTestResults, 'true'))
 
     # Localization runs in its own stage rather than as a job of `build`.
     # OneLocBuild hands the resource strings off to the loc service and then opens a PR back into

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -815,13 +815,11 @@ stages:
               ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
             condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
-          # artifacts/CrashDumps only exists when a test host actually crashed, and PublishBuildArtifacts@1
-          # hard-fails when PathtoPublish does not exist. Every failed run that produced no dump therefore
-          # added a red step of its own on top of the real failure, the same way the missing TestResults
-          # folder did in https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151. Probe for the
-          # folder so the publish skips when there are no dumps. The probe runs on every outcome so the
-          # variable is set whichever way the job goes; the publish still only runs on a failed run, and when
-          # there are dumps it publishes them exactly as before.
+          # "Enable local dumps" creates artifacts/CrashDumps before the build, but an earlier failure can skip
+          # that setup step. PublishBuildArtifacts@1 then hard-fails because PathtoPublish does not exist, adding
+          # another red step on top of the real failure. Probe for the folder so the publish skips when the setup
+          # step did not create it. The probe runs on every outcome so the variable is set whichever way the job
+          # goes; the publish still only runs on a failed run and publishes the folder exactly as before.
           - pwsh: |
               $crashDumps = Join-Path '$(Build.SourcesDirectory)' 'artifacts/CrashDumps'
               $hasCrashDumps = 'false'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -757,12 +757,28 @@ stages:
               # branch builds exercise it end-to-end.
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+          # artifacts/TestResults/$(_BuildConfig) only exists once a test step has written into it, and
+          # PublishBuildArtifacts@1 hard-fails when PathtoPublish does not exist. A job that dies before the
+          # tests run therefore reported one real problem as two failed steps, the way the official build did
+          # in https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151, where an Azure Artifacts
+          # outage skipped Build and Test and this step then failed with "Not found PathtoPublish". Probe for
+          # the folder so the publish skips when there is nothing to publish. When the tests did write results
+          # they are published exactly as before, including on a failed run, which is why this uses always().
+          - pwsh: |
+              $testResults = Join-Path '$(Build.SourcesDirectory)' 'artifacts/TestResults/$(_BuildConfig)'
+              $hasTestResults = 'false'
+              if (Test-Path -LiteralPath $testResults -PathType Container) { $hasTestResults = 'true' }
+              Write-Host "Test results under '$testResults': $hasTestResults"
+              Write-Host "##vso[task.setvariable variable=HasTestResults]$hasTestResults"
+            displayName: 'Check for Test Results folders'
+            condition: always()
+
           - task: PublishBuildArtifacts@1
             displayName: 'Publish Test Results folders'
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
               ArtifactName: TestResults_Windows_$(_BuildConfig)_Attempt$(System.JobAttempt)
-            condition: always()
+            condition: and(always(), eq(variables.HasTestResults, 'true'))
 
           # The integration suite only creates artifacts/tmp/$(_BuildConfig)/testsuite once it runs, and
           # CopyFiles@2 hard-fails when SourceFolder does not exist. A Test failure early enough to skip the
@@ -799,12 +815,28 @@ stages:
               ArtifactName: Integration_Tests_Windows_Binlogs_$(_BuildConfig)
             condition: and(always(), eq(variables._BuildConfig, 'Debug'), eq(variables.HasIntegrationTestBinlogs, 'true'))
 
+          # artifacts/CrashDumps only exists when a test host actually crashed, and PublishBuildArtifacts@1
+          # hard-fails when PathtoPublish does not exist. Every failed run that produced no dump therefore
+          # added a red step of its own on top of the real failure, the same way the missing TestResults
+          # folder did in https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151. Probe for the
+          # folder so the publish skips when there are no dumps. The probe runs on every outcome so the
+          # variable is set whichever way the job goes; the publish still only runs on a failed run, and when
+          # there are dumps it publishes them exactly as before.
+          - pwsh: |
+              $crashDumps = Join-Path '$(Build.SourcesDirectory)' 'artifacts/CrashDumps'
+              $hasCrashDumps = 'false'
+              if (Test-Path -LiteralPath $crashDumps -PathType Container) { $hasCrashDumps = 'true' }
+              Write-Host "Crash dumps under '$crashDumps': $hasCrashDumps"
+              Write-Host "##vso[task.setvariable variable=HasCrashDumps]$hasCrashDumps"
+            displayName: 'Check for local dumps'
+            condition: always()
+
           - task: PublishBuildArtifacts@1
             displayName: 'Publish local dumps'
             inputs:
               PathtoPublish: '$(Build.SourcesDirectory)/artifacts/CrashDumps'
               ArtifactName: TestResults_Windows_$(_BuildConfig)
-            condition: failed()
+            condition: and(failed(), eq(variables.HasCrashDumps, 'true'))
 
       # Real UWP and packaged WinUI activation require more than a Windows image label. Keep this as a
       # separate blocking job: its strict preflight verifies the VS/UWP SDKs and interactive machine state

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -72,12 +72,27 @@ steps:
     # secret, so the history service simply no-ops there; trusted branch builds run it end-to-end.
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
+# artifacts/TestResults/$(_BuildConfig) only exists once a test step has written into it, and
+# PublishBuildArtifacts@1 hard-fails when PathtoPublish does not exist. A job that dies before the tests run
+# therefore reported one real problem as two failed steps, the way the official build did in
+# https://dev.azure.com/dnceng/internal/_build/results?buildId=3057151. This template is shared by the Linux
+# and MacOS jobs, so the probe covers both. When the tests did write results they are published exactly as
+# before, including on a failed run, which is why this uses always().
+- pwsh: |
+    $testResults = Join-Path '$(Build.SourcesDirectory)' 'artifacts/TestResults/$(_BuildConfig)'
+    $hasTestResults = 'false'
+    if (Test-Path -LiteralPath $testResults -PathType Container) { $hasTestResults = 'true' }
+    Write-Host "Test results under '$testResults': $hasTestResults"
+    Write-Host "##vso[task.setvariable variable=HasTestResults]$hasTestResults"
+  displayName: 'Check for Test Results folders'
+  condition: always()
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Test Results folders'
   inputs:
     PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
     ArtifactName: TestResults_${{ parameters.osName }}_$(_BuildConfig)_Attempt$(System.JobAttempt)
-  condition: always()
+  condition: and(always(), eq(variables.HasTestResults, 'true'))
 
 # The integration suite only creates artifacts/tmp/$(_BuildConfig)/testsuite once it runs, and CopyFiles@2
 # hard-fails when SourceFolder does not exist. A Test failure early enough to skip the suite therefore


### PR DESCRIPTION
`PublishBuildArtifacts@1` hard-fails when `PathtoPublish` is missing, and `artifacts/TestResults` and `artifacts/CrashDumps` only exist once the tests have run. Any job that dies before that reported one real problem as several red steps. [Build 1566786](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1566786) had 13 failed tasks, 6 of them this cascade, on top of a single restore error. It happens in 11 of the last 25 failed public PR builds.

Probe for the folder first and gate the publish on it, the same way #10613 did for the integration binlogs. A probe rather than `continueOnError`, so the step comes out skipped instead of orange and `SucceededWithIssues`. The probe only checks that the directory exists, so everything that publishes today still publishes, including on failed runs.

## Testing

Parsed all three files with PyYAML and walked the parsed step lists to confirm each publish step is preceded by its probe. Read the diff line by line: the only changes are the five added probe steps and the widened conditions, and no `ArtifactName`, `PathtoPublish`, or `displayName` value changed.

🤖
