### PR TITLE
Improve NuGet package README onboarding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ For technical reasoning and implementation details, you can refer to the list of
 ## Guides
 
 - [Affected-test selection rollout](affected-test-selection.md): disabled adoption layout and activation prerequisites.
+- [Package README guidelines](package-readme-guidelines.md): required content and review checklist for NuGet package pages.
 - [Testing WinUI apps](winui-testing.md): packaged (MSIX) vs unpackaged WinUI, and how the test host is started for each.
 
 ## Design notes

--- a/docs/package-readme-guidelines.md
+++ b/docs/package-readme-guidelines.md
@@ -1,0 +1,22 @@
+# Package README guidelines
+
+Every packable project must include a `PACKAGE.md` next to its project file. The repository packs this file as the NuGet package README, and nuget.org renders it on the package page.
+
+Use this checklist when adding or updating a package:
+
+- Start with an H1 containing the exact package ID and a short package-specific description.
+- Show the installation command unless the package is not directly consumable.
+- Include a compact `Getting started` or `Usage` section. Prefer a runnable API example, the CLI option that enables the extension, or the MSBuild configuration that activates the package. For abstraction-only packages, explain who should reference the package and identify its main extension point.
+- Link to the package's dedicated documentation. Also link to the product overview when it provides useful additional context.
+- State supported platforms or important runtime limitations when they differ from the product defaults.
+- Provide a feedback or contributing link for packages whose README uses the standard product template.
+
+Keep examples short and verify every API name, command-line option, environment variable, and documentation URL against the current implementation. Use absolute URLs because NuGet renders the file outside this repository.
+
+The project must also define `PackageDescription`. Lead with what the package does and close with `$(CommonProductDescription)`. Wrap multiline values in CDATA without indenting continuation lines so project-file whitespace does not leak into the published description:
+
+```xml
+<PackageDescription><![CDATA[Explains what this package does. $(CommonProductDescription)]]></PackageDescription>
+```
+
+`Directory.Build.targets` automatically sets `PackageReadmeFile` to `PACKAGE.md`, packs it at the package root, and rejects packable projects that omit either the README or an authored package description.

--- a/src/Adapter/MSTest.TestAdapter/PACKAGE.md
+++ b/src/Adapter/MSTest.TestAdapter/PACKAGE.md
@@ -4,6 +4,22 @@ MSTest is Microsoft supported Test Framework.
 
 This package includes the adapter logic to discover and run tests. For access to the testing framework, install the MSTest.TestFramework package.
 
+## Getting started
+
+After referencing both `MSTest.TestAdapter` and `MSTest.TestFramework`, define tests with `[TestClass]` and `[TestMethod]`:
+
+```csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class CalculatorTests
+{
+    [TestMethod]
+    public void AddReturnsExpectedResult()
+        => Assert.AreEqual(4, 2 + 2);
+}
+```
+
 Supported platforms:
 
 - .NET 4.6.2+
@@ -11,3 +27,9 @@ Supported platforms:
 - .NET 8.0 Windows.18362+ (WinUI)
 - UWP 10.0.16299
 - UWP 10.0.17763 with .NET 9+
+
+## Documentation
+
+For installation and configuration guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started>.
+
+For information about running tests, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-running-tests>.

--- a/src/Package/MSTest.Sdk/PACKAGE.md
+++ b/src/Package/MSTest.Sdk/PACKAGE.md
@@ -4,6 +4,18 @@ MSTest is Microsoft supported Test Framework.
 
 This package includes a custom test SDK for writing tests with MSTest.
 
+## Getting started
+
+Create a test project by using `MSTest.Sdk` as the project SDK. Replace the example version with the version you want to use.
+
+```xml
+<Project Sdk="MSTest.Sdk/4.1.0">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+```
+
 Supported platforms:
 
 - .NET 4.6.2+
@@ -11,3 +23,9 @@ Supported platforms:
 - .NET 8.0 Windows.18362+ (WinUI)
 - UWP 10.0.16299
 - UWP 10.0.17763 with .NET 9+
+
+## Documentation
+
+For setup guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started>.
+
+For SDK configuration options, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk>.

--- a/src/Package/MSTest/PACKAGE.md
+++ b/src/Package/MSTest/PACKAGE.md
@@ -4,6 +4,20 @@ MSTest is Microsoft supported Test Framework.
 
 This package is a meta package that simplifies referencing all recommended MSTest packages.
 
+## Getting started
+
+```csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class CalculatorTests
+{
+    [TestMethod]
+    public void AddReturnsExpectedResult()
+        => Assert.AreEqual(4, 2 + 2);
+}
+```
+
 Supported platforms:
 
 - .NET 4.6.2+
@@ -11,3 +25,9 @@ Supported platforms:
 - .NET 8.0 Windows.18362+ (WinUI)
 - UWP 10.0.16299
 - UWP 10.0.17763 with .NET 9+
+
+## Documentation
+
+For installation and configuration guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started>.
+
+For test authoring guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-writing-tests>.

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/PACKAGE.md
@@ -21,6 +21,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Automatic attachments**: for failed tests, attaches stdout/stderr and any `FileArtifactProperty` data (dumps, screenshots) to the matching result in the Tests tab; uploads `*.coverage`, `*.cobertura.xml`, and `*.opencover.xml` artifacts as run-level attachments
 - **Extensions-tab summary**: `--report-azdo-summary` writes and uploads Markdown through `##vso[task.uploadsummary]`. With an SDK that supports required artifact post-processing, a multi-module `dotnet test` invocation uploads one authoritative overall summary with per-assembly details. Older SDKs preserve the existing per-assembly summaries. This does not change live publishing to the Azure DevOps Tests tab.
 
+## Usage
+
 Enable Azure DevOps reporting with the `--report-azdo` command line option.
 
 ## Related packages

--- a/src/Platform/Microsoft.Testing.Extensions.CrashDump/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.CrashDump/PACKAGE.md
@@ -20,6 +20,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Cross-platform**: crash dumps are supported on Windows, Linux, and macOS (dumps collected on macOS can only be analyzed on macOS). Crash reports are currently only supported on Linux and macOS.
 - **Runtime behavior**: supported for .NET 6+; on .NET Framework this extension is ignored
 
+## Usage
+
 Enable crash dump collection via the `--crashdump` command line option.
 Add `--crash-report` (Linux/macOS only; requires .NET 7+ when used alone or .NET 6+ with `--crashdump`) to generate a JSON crash report; combine `--crashdump --crash-report` to produce both a dump and a report.
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/PACKAGE.md
@@ -19,6 +19,8 @@ This package extends Microsoft.Testing.Platform with:
 - **CTRF (Common Test Report Format) report**: a single JSON file conforming to the [CTRF schema](https://github.com/ctrf-io/ctrf/blob/main/schema/ctrf.schema.json) that can be consumed by any tool that understands CTRF (dashboards, CI integrations, AI agents, etc.) without requiring a TRX or JUnit XML parser.
 - **Cross-tool interoperability**: same shape as outputs produced by other testing frameworks that adopt CTRF, so results from multiple test runs can be aggregated by a single consumer.
 
+## Usage
+
 Enable the report via the `--report-ctrf` command line option. The report file name can be overridden with `--report-ctrf-filename <name>.json`.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/PACKAGE.md
@@ -20,6 +20,8 @@ This package extends Microsoft.Testing.Platform with:
 
 The timeout defaults to `30m` and can be configured in values such as `90s`, `5m`, or `1.5h`.
 
+## Usage
+
 Enable hang dump collection via the `--hangdump` command line option, and configure the timeout with `--hangdump-timeout`.
 
 ## Related packages

--- a/src/Platform/Microsoft.Testing.Extensions.HotReload/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HotReload/PACKAGE.md
@@ -18,6 +18,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Faster inner loop**: reduces the time between making a change and seeing the test results
 - **Console-mode support**: currently supported in console mode (not in Visual Studio/VS Code Test Explorer)
 
+## Usage
+
 Enable Hot Reload support by setting `TESTINGPLATFORM_HOTRELOAD_ENABLED=1`.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/PACKAGE.md
@@ -22,6 +22,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Performance**: pagination keeps the report usable even for very large runs
 - **Automatic consolidation**: reports from multi-process, multi-target-framework and retry runs are merged into one HTML summary while the original per-process reports remain available
 
+## Usage
+
 Enable the report via the `--report-html` command line option. The report file name can be overridden with `--report-html-filename <name>.html`.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/PACKAGE.md
@@ -20,6 +20,8 @@ This package extends Microsoft.Testing.Platform with:
 - **CI-friendly**: directly consumable by Jenkins (`junit` step), GitLab (`junit:` artifact reports), Azure DevOps (`PublishTestResults@2` with `testResultsFormat: 'JUnit'`), CircleCI, GitHub Actions test reporters and any other tool that understands the JUnit XML schema
 - **Tree-of-tests preserved**: MTP exposes a tree of tests, not a flat list. The JUnit XML schema only defines a flat list of test suites, so the full parent chain of each test is preserved as a `<property name="testpath" value="A/B/C"/>` element inside `<testcase>` for tools that wish to reconstruct the hierarchy
 
+## Usage
+
 Enable the report via the `--report-junit` command line option. The report file name can be overridden with `--report-junit-filename <name>.xml`.
 
 ## Documentation

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PACKAGE.md
@@ -68,6 +68,12 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Exten
 dotnet add package Microsoft.Testing.Extensions.PackagedApp
 ```
 
+## Usage
+
+Referencing this package automatically registers its test-host launcher. Packaged layouts are detected automatically; set `TESTINGPLATFORM_PACKAGEDAPP_LAUNCHER=always` to opt a non-packaged loose layout into deployment, or `never` to disable the launcher.
+
+For a `windowsApp`/UWP host, restore the launch activation arguments with `PackagedAppExtensions.GetTestApplicationArguments` before creating the test application builder, as shown in [Launch-activation bootstrap](#launch-activation-bootstrap).
+
 ## About
 
 This package extends Microsoft.Testing.Platform with:

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/PACKAGE.md
@@ -19,6 +19,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Retry delay**: optionally wait between retry attempts (`--retry-failed-tests-delay`)
 - **Integration-test focus**: intended for scenarios where transient environment issues can cause intermittent failures
 
+## Usage
+
 Configure retry using `--retry-failed-tests <retries>`, and optionally limit retries with `--retry-failed-tests-max-percentage` or `--retry-failed-tests-max-tests`, or add a delay between retries with `--retry-failed-tests-delay` (e.g. `1s`, `2.5m`, `1h`).
 
 This extension restarts the test host for each retry. It is independent from MSTest's in-process `RetryAttribute` and custom `RetryBaseAttribute` implementations. When both mechanisms are enabled, their attempt counts multiply: a test using `[Retry(n)]` can run up to `(n + 1) * (--retry-failed-tests + 1)` times.

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PACKAGE.md
@@ -10,6 +10,10 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Exten
 dotnet add package Microsoft.Testing.Extensions.TrxReport.Abstractions
 ```
 
+## Usage
+
+Reference this package from a testing-platform extension that needs to contribute TRX-specific properties or inspect `ITrxReportCapability`. Test projects that only need to generate a TRX report should use `Microsoft.Testing.Extensions.TrxReport` instead.
+
 ## About
 
 This package provides:

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/PACKAGE.md
@@ -18,6 +18,8 @@ This package extends Microsoft.Testing.Platform with:
 - **Standardized format**: TRX is a widely supported XML-based test results format
 - **CI integration**: TRX files can be published to Azure DevOps, GitHub Actions and other CI systems for rich test result visualization
 
+## Usage
+
 Enable TRX report generation via the `--report-trx` command line option.
 
 ## Related packages

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/PACKAGE.md
@@ -12,6 +12,10 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Exten
 dotnet add package Microsoft.Testing.Extensions.VSTestBridge
 ```
 
+## Usage
+
+Framework and adapter authors derive their Microsoft.Testing.Platform framework implementation from `VSTestBridgedTestFrameworkBase`, or from `SynchronizedSingleSessionVSTestBridgedTestFramework` when discovery and execution must share one synchronized VSTest session. Register the derived implementation as the test framework for the application.
+
 ## About
 
 This package provides:

--- a/src/Platform/Microsoft.Testing.Platform.AI/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.AI/PACKAGE.md
@@ -10,6 +10,16 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platf
 dotnet add package Microsoft.Testing.Platform.AI
 ```
 
+## Usage
+
+Implement `IChatClientProvider`, then register the provider while building the test application:
+
+```csharp
+builder.AddChatClientProvider(_ => new CustomChatClientProvider());
+```
+
+Extensions can call `GetChatClientAsync` on their service provider to obtain the configured `IChatClient`. Use a provider package such as `Microsoft.Testing.Extensions.AzureFoundry` if you do not need a custom implementation.
+
 ## About
 
 This package provides:

--- a/src/Platform/Microsoft.Testing.Platform.MSBuild/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.MSBuild/PACKAGE.md
@@ -10,6 +10,10 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platf
 dotnet add package Microsoft.Testing.Platform.MSBuild
 ```
 
+## Usage
+
+No manual API call is required. Referencing the package imports its MSBuild integration, which generates the test application entry point and copies `testconfig.json` to the output directory. Test framework packages normally reference this package transitively.
+
 ## About
 
 This package provides:

--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/PACKAGE.md
@@ -19,6 +19,28 @@ compiled (as `internal` types) into your own assembly. That means:
 - The launch/transport layer (loopback TCP listener the app dials back to, LSP-style
   `Content-Length` framing) and the strongly-typed protocol records.
 
+## Install the package
+
+```dotnetcli
+dotnet add package Microsoft.Testing.Platform.ServerMode.Client.Sources
+```
+
+## Usage
+
+The injected client types use the `Microsoft.Testing.Platform.ServerMode.Client` namespace:
+
+```csharp
+using Microsoft.Testing.Platform.ServerMode.Client;
+
+using IMtpServerClient client = await MtpServerClient.LaunchAsync(testApplicationPath);
+client.TestNodesUpdated += (_, update) => Console.WriteLine(update.RunId);
+
+await client.InitializeAsync();
+await client.DiscoverTestsAsync();
+MtpRunResult result = await client.RunTestsAsync();
+await client.ExitAsync();
+```
+
 ## Consumer requirements
 
 Because the source is compiled into your assembly, your project must provide the ambient pieces the
@@ -44,3 +66,9 @@ do):
 
 The injected types are `internal`; delete any previous hand-written MTP client in your repo when you
 adopt this package to avoid duplicate symbols.
+
+## Documentation
+
+For the server-mode JSON-RPC protocol, see <https://github.com/microsoft/testfx/blob/main/docs/mstest-runner-protocol/001-protocol-intro.md>.
+
+For comprehensive Microsoft.Testing.Platform documentation, see <https://aka.ms/testingplatform>.

--- a/src/Platform/Microsoft.Testing.Platform/PACKAGE.md
+++ b/src/Platform/Microsoft.Testing.Platform/PACKAGE.md
@@ -10,6 +10,19 @@ Microsoft.Testing.Platform is open source. You can find `Microsoft.Testing.Platf
 dotnet add package Microsoft.Testing.Platform
 ```
 
+## Usage
+
+Framework authors can create and run a test application directly:
+
+```csharp
+using Microsoft.Testing.Platform.Builder;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+// Register the test framework and extensions with builder.
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();
+```
+
 ## About
 
 This package provides the core platform and the .NET implementation of the testing protocol. It includes:

--- a/src/TestFramework/TestFramework.Extensions/PACKAGE.md
+++ b/src/TestFramework/TestFramework.Extensions/PACKAGE.md
@@ -4,6 +4,20 @@ MSTest is Microsoft supported Test Framework.
 
 This package includes the libraries for writing tests with MSTest. To ensure discovery and execution of your tests, install the MSTest.TestAdapter package.
 
+## Getting started
+
+```csharp
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class CalculatorTests
+{
+    [TestMethod]
+    public void AddReturnsExpectedResult()
+        => Assert.AreEqual(4, 2 + 2);
+}
+```
+
 Supported platforms:
 
 - .NET 4.6.2+
@@ -11,3 +25,9 @@ Supported platforms:
 - .NET 6.0 Windows.18362+
 - UWP 10.0.16299
 - UWP 10.0.17763 with .NET 9
+
+## Documentation
+
+For installation and configuration guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started>.
+
+For test authoring guidance, see <https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-writing-tests>.


### PR DESCRIPTION
NuGet package pages currently provide uneven onboarding, with the flagship MSTest packages and several Microsoft.Testing.Platform packages offering little or no usage guidance.

This change adds compact getting-started examples and documentation links to the flagship packages, gives each identified platform package an explicit usage section based on its actual CLI, API, or MSBuild activation model, and documents the source-only server-mode client. It also adds a contributor checklist to keep future package readmes consistent.

Fixes: #10745