### PR TITLE
Fix executable condition localization locks

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -256,7 +256,7 @@
   </data>
   <data name="UseExecutableConditionAttributeInsteadOfProcessCheckFix" xml:space="preserve">
     <value>Use '[ExecutableCondition]' attribute</value>
-    <comment>{Locked="'[ExecutableCondition]'"}</comment>
+    <comment>{Locked="[ExecutableCondition]"}</comment>
   </data>
   <data name="AvoidOutRefTestMethodParametersFix" xml:space="preserve">
     <value>Remove 'out' and 'ref' modifiers</value>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">Použít atribut '[ExecutableCondition]'</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Použít atribut '[ExecutableCondition]'</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
         <target state="new">Use '[ExecutableCondition]' attribute</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
         <target state="new">Use '[ExecutableCondition]' attribute</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
         <target state="new">Use '[ExecutableCondition]' attribute</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">Usa l'attributo '[ExecutableCondition]'</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Usa l'attributo '[ExecutableCondition]'</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">'[ExecutableCondition]' 属性を使用する</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">'[ExecutableCondition]' 属性を使用する</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">'[ExecutableCondition]' 특성 사용</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">'[ExecutableCondition]' 특성 사용</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
         <target state="new">Use '[ExecutableCondition]' attribute</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">Use o atributo '[ExecutableCondition]'</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Use o atributo '[ExecutableCondition]'</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -215,7 +215,7 @@
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
         <target state="new">Use '[ExecutableCondition]' attribute</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">'[ExecutableCondition]' özniteliğini kullanın</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">'[ExecutableCondition]' özniteliğini kullanın</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">使用 '[ExecutableCondition]' 属性</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">使用 '[ExecutableCondition]' 属性</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -214,8 +214,8 @@
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckFix">
         <source>Use '[ExecutableCondition]' attribute</source>
-        <target state="translated">使用 '[ExecutableCondition]' 屬性</target>
-        <note>{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">使用 '[ExecutableCondition]' 屬性</target>
+        <note>{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseMSTestDescriptionAttributeInsteadFix">
         <source>Use MSTest 'Description' attribute instead</source>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -978,15 +978,15 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="UseExecutableConditionAttributeInsteadOfProcessCheckTitle" xml:space="preserve">
     <value>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</value>
-    <comment>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</comment>
+    <comment>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</comment>
   </data>
   <data name="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat" xml:space="preserve">
     <value>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</value>
-    <comment>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</comment>
+    <comment>{0} is the executable path. {Locked="[ExecutableCondition]"}</comment>
   </data>
   <data name="UseExecutableConditionAttributeInsteadOfProcessCheckDescription" xml:space="preserve">
     <value>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</value>
-    <comment>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</comment>
+    <comment>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</comment>
   </data>
   <data name="DuplicateTestMethodAttributeTitle" xml:space="preserve">
     <value>Avoid duplicate test method attributes</value>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -1379,18 +1379,18 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">Testovací metody, které používají 'File.Exists' k přeskočení testu před spuštěním stejného spustitelného souboru s 'Process.Start', by místo toho měly používat atribut '[ExecutableCondition]'. Tento atribut poskytuje deklarativní a snadno zjistitelný požadavek na nástroj a hlásí předčasný návrat jako přeskočený test, nikoli jako úspěšný test.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Testovací metody, které používají 'File.Exists' k přeskočení testu před spuštěním stejného spustitelného souboru s 'Process.Start', by místo toho měly používat atribut '[ExecutableCondition]'. Tento atribut poskytuje deklarativní a snadno zjistitelný požadavek na nástroj a hlásí předčasný návrat jako přeskočený test, nikoli jako úspěšný test.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">Před spuštěním použijte atribut '[ExecutableCondition]' namísto kontroly spustitelného souboru {0}</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Před spuštěním použijte atribut '[ExecutableCondition]' namísto kontroly spustitelného souboru {0}</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">Použít atribut '[ExecutableCondition]' namísto kontrol 'File.Exists' před 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">Použít atribut '[ExecutableCondition]' namísto kontrol 'File.Exists' před 'Process.Start'</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -1380,17 +1380,17 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
         <target state="new">Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -1380,17 +1380,17 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
         <target state="new">Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -1379,18 +1379,18 @@ Le type doit être une classe
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">Les méthodes de test qui utilisent 'File.Exists' pour ignorer un test avant de démarrer le même exécutable avec 'Process.Start' doivent utiliser l’attribut '[ExecutableCondition]' à la place. Cet attribut fournit une exigence d’outil déclarative et facile à repérer, et signale un retour anticipé comme un test ignoré plutôt que réussi.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Les méthodes de test qui utilisent 'File.Exists' pour ignorer un test avant de démarrer le même exécutable avec 'Process.Start' doivent utiliser l’attribut '[ExecutableCondition]' à la place. Cet attribut fournit une exigence d’outil déclarative et facile à repérer, et signale un retour anticipé comme un test ignoré plutôt que réussi.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">Utilisez l’attribut '[ExecutableCondition]' au lieu de vérifier l’exécutable '{0}' avant de le démarrer</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Utilisez l’attribut '[ExecutableCondition]' au lieu de vérifier l’exécutable '{0}' avant de le démarrer</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">Utilisez l’attribut '[ExecutableCondition]' au lieu de vérifier l’existence de 'File.Exists' avant 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">Utilisez l’attribut '[ExecutableCondition]' au lieu de vérifier l’existence de 'File.Exists' avant 'Process.Start'</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -1379,18 +1379,18 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">I metodi di test che usano 'File.Exists' per ignorare un test prima di avviare lo stesso eseguibile con 'Process.Start' devono usare l'attributo '[ExecutableCondition]'. Questo attributo fornisce un requisito dichiarativo e individuabile dello strumento e segnala un ritorno anticipato come test ignorato anziché come test superato.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">I metodi di test che usano 'File.Exists' per ignorare un test prima di avviare lo stesso eseguibile con 'Process.Start' devono usare l'attributo '[ExecutableCondition]'. Questo attributo fornisce un requisito dichiarativo e individuabile dello strumento e segnala un ritorno anticipato come test ignorato anziché come test superato.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">Usare l'attributo '[ExecutableCondition]' invece di cercare l'eseguibile '{0}' prima di avviarlo</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Usare l'attributo '[ExecutableCondition]' invece di cercare l'eseguibile '{0}' prima di avviarlo</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">Usare l'attributo '[ExecutableCondition]' anziché i controlli 'File.Exists' prima di 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">Usare l'attributo '[ExecutableCondition]' anziché i controlli 'File.Exists' prima di 'Process.Start'</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -1379,18 +1379,18 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">'Process.Start' で同じ実行可能ファイルの開始前にテストをスキップするために 'File.Exists' を使用するテスト メソッドでは、代わりに '[ExecutableCondition]' 属性を使用する必要があります。この属性は、宣言的で検出可能なツール要件を提供し、早期リターンを、成功したテストではなくスキップされたテストとして報告します。</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">'Process.Start' で同じ実行可能ファイルの開始前にテストをスキップするために 'File.Exists' を使用するテスト メソッドでは、代わりに '[ExecutableCondition]' 属性を使用する必要があります。この属性は、宣言的で検出可能なツール要件を提供し、早期リターンを、成功したテストではなくスキップされたテストとして報告します。</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">実行可能ファイル '{0}' を開始する前にそれをチェックする代わりに、'[ExecutableCondition]' 属性を使用してください</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">実行可能ファイル '{0}' を開始する前にそれをチェックする代わりに、'[ExecutableCondition]' 属性を使用してください</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">'Process.Start' の前に、'File.Exists' チェックの代わりに '[ExecutableCondition]' 属性を使用してください</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">'Process.Start' の前に、'File.Exists' チェックの代わりに '[ExecutableCondition]' 属性を使用してください</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -1379,18 +1379,18 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">'File.Exists'를 사용하여 테스트를 건너뛴 뒤 'Process.Start'로 동일한 실행 파일을 시작하는 테스트 메서드는 대신 '[ExecutableCondition]' 특성을 사용해야 합니다. 이 특성은 선언적이고 검색 가능한 도구 요구 사항을 제공하며, 조기 반환을 통과한 테스트가 아니라 건너뛴 테스트로 보고합니다.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">'File.Exists'를 사용하여 테스트를 건너뛴 뒤 'Process.Start'로 동일한 실행 파일을 시작하는 테스트 메서드는 대신 '[ExecutableCondition]' 특성을 사용해야 합니다. 이 특성은 선언적이고 검색 가능한 도구 요구 사항을 제공하며, 조기 반환을 통과한 테스트가 아니라 건너뛴 테스트로 보고합니다.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">실행 파일 '{0}'을(를) 시작하기 전에 검사하는 대신 '[ExecutableCondition]' 특성 사용</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">실행 파일 '{0}'을(를) 시작하기 전에 검사하는 대신 '[ExecutableCondition]' 특성 사용</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">'Process.Start' 전에 'File.Exists' 검사 대신 '[ExecutableCondition]' 특성 사용</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">'Process.Start' 전에 'File.Exists' 검사 대신 '[ExecutableCondition]' 특성 사용</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -1380,17 +1380,17 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
         <target state="new">Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -1379,18 +1379,18 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">Os métodos de teste que usam 'File.Exists' para ignorar um teste antes de iniciar o mesmo executável com 'Process.Start' devem usar o atributo '[ExecutableCondition]' em vez disso. Este atributo fornece um requisito de ferramenta declarativo e detectável e informa um retorno antecipado como um teste ignorado, em vez de um teste aprovado.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Os métodos de teste que usam 'File.Exists' para ignorar um teste antes de iniciar o mesmo executável com 'Process.Start' devem usar o atributo '[ExecutableCondition]' em vez disso. Este atributo fornece um requisito de ferramenta declarativo e detectável e informa um retorno antecipado como um teste ignorado, em vez de um teste aprovado.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">Use o atributo '[ExecutableCondition]' em vez de verificar o executável '{0}' antes de iniciá-lo</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Use o atributo '[ExecutableCondition]' em vez de verificar o executável '{0}' antes de iniciá-lo</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">Use o atributo '[ExecutableCondition]' em vez de verificações de 'File.Exists' antes de 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">Use o atributo '[ExecutableCondition]' em vez de verificações de 'File.Exists' antes de 'Process.Start'</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -1380,17 +1380,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
         <target state="new">Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
         <target state="new">Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -1379,18 +1379,18 @@ Bu yöntemleri bildiren tipin ayrıca aşağıdaki kurallara uyması gerekir:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">Aynı yürütülebilir dosyayı 'Process.Start' ile başlatmadan önce testi atlamak için 'File.Exists' kullanan test yöntemleri, bunun yerine '[ExecutableCondition]' özniteliğini kullanmalıdır. Bu öznitelik, bildirime dayalı ve kolayca bulunabilir bir araç gereksinimi sağlar ve erken dönüş olursa başarılı bir test yerine atlanmış bir test olarak bildirir.</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Aynı yürütülebilir dosyayı 'Process.Start' ile başlatmadan önce testi atlamak için 'File.Exists' kullanan test yöntemleri, bunun yerine '[ExecutableCondition]' özniteliğini kullanmalıdır. Bu öznitelik, bildirime dayalı ve kolayca bulunabilir bir araç gereksinimi sağlar ve erken dönüş olursa başarılı bir test yerine atlanmış bir test olarak bildirir.</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">Başlatmadan önce yürütülebilir '{0}' yolunu denetlemek yerine '[ExecutableCondition]' özniteliğini kullanın</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">Başlatmadan önce yürütülebilir '{0}' yolunu denetlemek yerine '[ExecutableCondition]' özniteliğini kullanın</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">'Process.Start' öncesinde 'File.Exists' denetimleri yerine '[ExecutableCondition]' özniteliğini kullanın</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">'Process.Start' öncesinde 'File.Exists' denetimleri yerine '[ExecutableCondition]' özniteliğini kullanın</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -1379,18 +1379,18 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">在使用 'Process.Start' 启动同一可执行文件之前使用 'File.Exists' 跳过测试的测试方法应改用 '[ExecutableCondition]' 属性。此属性提供声明性且可发现的工具要求，并将提前返回报告为跳过测试，而不是通过测试。</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">在使用 'Process.Start' 启动同一可执行文件之前使用 'File.Exists' 跳过测试的测试方法应改用 '[ExecutableCondition]' 属性。此属性提供声明性且可发现的工具要求，并将提前返回报告为跳过测试，而不是通过测试。</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">在启动可执行文件“{0}”之前使用 '[ExecutableCondition]' 属性，而不是检查该文件</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">在启动可执行文件“{0}”之前使用 '[ExecutableCondition]' 属性，而不是检查该文件</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">在 'Process.Start' 之前使用 '[ExecutableCondition]' 属性而不是 'File.Exists' 检查</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">在 'Process.Start' 之前使用 '[ExecutableCondition]' 属性而不是 'File.Exists' 检查</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -1379,18 +1379,18 @@ The type declaring these methods should also respect the following rules:
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckDescription">
         <source>Test methods that use 'File.Exists' to skip a test before starting the same executable with 'Process.Start' should use the '[ExecutableCondition]' attribute instead. This attribute provides a declarative and discoverable tool requirement and reports an early return as a skipped test rather than a passed test.</source>
-        <target state="translated">在使用 'Process.Start' 啟動相同的可執行檔之前，使用 'File.Exists' 來略過測試的測試方法，應改為使用 '[ExecutableCondition]' 屬性。此屬性提供宣告式且可供探索的工具需求，並會將提早傳回回報為略過的測試，而不是通過的測試。</target>
-        <note>{Locked="'File.Exists'"}{Locked="'Process.Start'"}{Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">在使用 'Process.Start' 啟動相同的可執行檔之前，使用 'File.Exists' 來略過測試的測試方法，應改為使用 '[ExecutableCondition]' 屬性。此屬性提供宣告式且可供探索的工具需求，並會將提早傳回回報為略過的測試，而不是通過的測試。</target>
+        <note>{Locked="File.Exists"}{Locked="Process.Start"}{Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckMessageFormat">
         <source>Use '[ExecutableCondition]' attribute instead of checking for executable '{0}' before starting it</source>
-        <target state="translated">在啟動之前使用 '[ExecutableCondition]' 屬性，而不是檢查可執行檔 '{0}'</target>
-        <note>{0} is the executable path. {Locked="'[ExecutableCondition]'"}</note>
+        <target state="needs-review-translation">在啟動之前使用 '[ExecutableCondition]' 屬性，而不是檢查可執行檔 '{0}'</target>
+        <note>{0} is the executable path. {Locked="[ExecutableCondition]"}</note>
       </trans-unit>
       <trans-unit id="UseExecutableConditionAttributeInsteadOfProcessCheckTitle">
         <source>Use '[ExecutableCondition]' attribute instead of 'File.Exists' checks before 'Process.Start'</source>
-        <target state="translated">在 'Process.Start' 之前使用 '[ExecutableCondition]' 屬性，而不是 'File.Exists' 檢查</target>
-        <note>{Locked="'[ExecutableCondition]'"}{Locked="'File.Exists'"}{Locked="'Process.Start'"}</note>
+        <target state="needs-review-translation">在 'Process.Start' 之前使用 '[ExecutableCondition]' 屬性，而不是 'File.Exists' 檢查</target>
+        <note>{Locked="[ExecutableCondition]"}{Locked="File.Exists"}{Locked="Process.Start"}</note>
       </trans-unit>
       <trans-unit id="UseParallelizeAttributeAnalyzerDescription">
         <source>By default, MSTest runs tests within the same assembly sequentially, which can lead to severe performance limitations. It is recommended to enable assembly attribute '[Parallelize]' to run tests in parallel, or if the assembly is known to not be parallelizable, to use explicitly the assembly level attribute '[DoNotParallelize]'.</source>


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->
Localization needs to adapt the apostrophes surrounding `[ExecutableCondition]`, `File.Exists`, and `Process.Start` for languages with different quotation rules. The existing Dev rules incorrectly lock the apostrophes together with those technical terms.

This updates the four affected analyzer and code-fix resources to lock only the terms, then regenerates the XLF files so existing translations can be reviewed and localized appropriately.