### PR TITLE
Update Microsoft.TestPlatform.Filter.Source versioning

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,7 +97,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="$(MicrosoftTestingExtensionsCodeCoverageVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.TestPlatform.TranslationLayer" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="18.8.0-release-26326-101" />
+    <PackageVersion Include="Microsoft.TestPlatform.Filter.Source" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.251003001" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />


### PR DESCRIPTION
Replaced hardcoded version for Microsoft.TestPlatform.Filter.Source with a variable reference.

<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->