### PR TITLE
Fix Azure DevOps retry sub-result publishing

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
@@ -100,9 +100,9 @@ internal sealed record AzureDevOpsTestCaseResult(
     /// <remarks>
     /// Declared as properties rather than positional parameters so that adding them does not change the
     /// record's constructor and deconstructor signatures. <see cref="Id"/> is populated only when updating
-    /// an existing result. <see cref="ResultGroupType"/> and <see cref="SubResults"/> are also populated on
-    /// a freshly created, attachment-bearing result when retry tracking is enabled, so its attachments can
-    /// target the first attempt.
+    /// an existing result. <see cref="ResultGroupType"/> and <see cref="SubResults"/> are populated when
+    /// appending attempts to that result, including the follow-up update that gives a newly created result's
+    /// first attachment a sub-result to target.
     /// </remarks>
     [JsonPropertyName("id")]
     public int? Id { get; init; }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -125,6 +125,19 @@ internal sealed class AzureDevOpsResultIdStore
         _hasUnsavedChanges = true;
     }
 
+    /// <summary>
+    /// Records the highest attempt sequence Azure DevOps has accepted as a sub-result for a newly created result.
+    /// </summary>
+    public void RecordPublishedSubResults(AzureDevOpsTestCaseResult result, int resultId, int lastPublishedSubResultSequenceId)
+    {
+        string key = CreateKey(result.AutomatedTestStorage, result.AutomatedTestName, result.TestCaseTitle);
+        if (_results.TryGetValue(key, out AzureDevOpsPublishedResult? published) && published.Id == resultId)
+        {
+            _results[key] = published with { LastPublishedSubResultSequenceId = lastPublishedSubResultSequenceId };
+            _hasUnsavedChanges = true;
+        }
+    }
+
     public static AzureDevOpsTestSubResult CreateFirstAttempt(AzureDevOpsTestCaseResult result)
         => ToSubResult(result, sequenceId: 1);
 
@@ -165,6 +178,7 @@ internal sealed class AzureDevOpsResultIdStore
     public void RecordAttempts(
         AzureDevOpsPublishedResult published,
         IReadOnlyList<AzureDevOpsTestSubResult> attempts,
+        int lastPublishedSubResultSequenceId,
         long? totalDurationInMs,
         DateTimeOffset? startedDate,
         DateTimeOffset? completedDate)
@@ -172,6 +186,7 @@ internal sealed class AzureDevOpsResultIdStore
         _results[CreateKey(published.Storage, published.Name, published.Title)] = published with
         {
             Attempts = attempts,
+            LastPublishedSubResultSequenceId = lastPublishedSubResultSequenceId,
             TotalDurationInMs = totalDurationInMs,
             StartedDate = startedDate,
             CompletedDate = completedDate,
@@ -253,6 +268,7 @@ internal sealed class AzureDevOpsResultIdStore
             {
                 entries[index++] = new AzureDevOpsResultMapEntry(published.Storage, published.Name, published.Title, published.Id, published.Attempts)
                 {
+                    LastPublishedSubResultSequenceId = published.LastPublishedSubResultSequenceId,
                     TotalDurationInMs = published.TotalDurationInMs,
                     StartedDate = published.StartedDate,
                     CompletedDate = published.CompletedDate,
@@ -363,6 +379,12 @@ internal sealed class AzureDevOpsResultIdStore
                         continue;
                     }
 
+                    if (entry.LastPublishedSubResultSequenceId is < 0
+                        || entry.LastPublishedSubResultSequenceId > entry.Attempts[^1].SequenceId)
+                    {
+                        continue;
+                    }
+
                     long? retainedDuration = SumDurations(entry.Attempts);
                     if (entry.TotalDurationInMs is < 0
                         || (entry.TotalDurationInMs is { } totalDuration && retainedDuration is { } retained && totalDuration < retained))
@@ -384,6 +406,7 @@ internal sealed class AzureDevOpsResultIdStore
 
                 _results[key] = new AzureDevOpsPublishedResult(entry.Storage!, entry.Name!, entry.Title!, entry.Id, entry.Attempts!)
                 {
+                    LastPublishedSubResultSequenceId = entry.LastPublishedSubResultSequenceId ?? 0,
                     TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
                     StartedDate = entry.StartedDate ?? GetEarliestStartedDate(entry.Attempts!),
                     CompletedDate = entry.CompletedDate ?? GetLatestCompletedDate(entry.Attempts!),
@@ -507,6 +530,8 @@ internal sealed record AzureDevOpsPublishedResult(
     int Id,
     IReadOnlyList<AzureDevOpsTestSubResult> Attempts)
 {
+    public int LastPublishedSubResultSequenceId { get; init; }
+
     public long? TotalDurationInMs { get; init; }
 
     public DateTimeOffset? StartedDate { get; init; }
@@ -529,6 +554,9 @@ internal sealed record AzureDevOpsResultMapEntry(
     [property: JsonPropertyName("id")] int Id,
     [property: JsonPropertyName("attempts")] IReadOnlyList<AzureDevOpsTestSubResult>? Attempts)
 {
+    [JsonPropertyName("lastPublishedSubResultSequenceId")]
+    public int? LastPublishedSubResultSequenceId { get; init; }
+
     [JsonPropertyName("totalDurationInMs")]
     public long? TotalDurationInMs { get; init; }
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsResultIdStore.cs
@@ -379,8 +379,11 @@ internal sealed class AzureDevOpsResultIdStore
                         continue;
                     }
 
-                    if (entry.LastPublishedSubResultSequenceId is < 0
-                        || entry.LastPublishedSubResultSequenceId > entry.Attempts[^1].SequenceId)
+                    bool hasUnpublishedFirstAttempt = entry.LastPublishedSubResultSequenceId == 0
+                        && entry.Attempts.Count == 1
+                        && entry.Attempts[0].SequenceId == 1;
+                    bool hasFullyPublishedHistory = entry.LastPublishedSubResultSequenceId == entry.Attempts[^1].SequenceId;
+                    if (!hasUnpublishedFirstAttempt && !hasFullyPublishedHistory)
                     {
                         continue;
                     }
@@ -406,7 +409,7 @@ internal sealed class AzureDevOpsResultIdStore
 
                 _results[key] = new AzureDevOpsPublishedResult(entry.Storage!, entry.Name!, entry.Title!, entry.Id, entry.Attempts!)
                 {
-                    LastPublishedSubResultSequenceId = entry.LastPublishedSubResultSequenceId ?? 0,
+                    LastPublishedSubResultSequenceId = entry.LastPublishedSubResultSequenceId!.Value,
                     TotalDurationInMs = entry.TotalDurationInMs ?? retainedDuration,
                     StartedDate = entry.StartedDate ?? GetEarliestStartedDate(entry.Attempts!),
                     CompletedDate = entry.CompletedDate ?? GetLatestCompletedDate(entry.Attempts!),

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Payloads.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Payloads.cs
@@ -80,22 +80,46 @@ internal sealed partial class AzureDevOpsTestResultsClient
 
                 if (submittedSequenceIds.Count == submittedSubResults.Count)
                 {
-                    for (int j = 0; j < publishedSubResults.Length; j++)
+                    bool sequenceIdsOmitted = publishedSubResults.Length == submittedSubResults.Count;
+                    for (int j = 0; sequenceIdsOmitted && j < publishedSubResults.Length; j++)
                     {
-                        PublishedTestSubResult publishedSubResult = publishedSubResults[j];
-                        if (!submittedSequenceIds.Contains(publishedSubResult.SequenceId))
-                        {
-                            continue;
-                        }
+                        sequenceIdsOmitted = publishedSubResults[j].SequenceId == 0;
+                    }
 
-                        if (publishedSubResult.Id <= 0
-                            || subResultIdsBySequenceId.ContainsKey(publishedSubResult.SequenceId))
+                    if (sequenceIdsOmitted)
+                    {
+                        // Azure DevOps' PATCH response returns only the appended sub-results, in request
+                        // order, but omits sequenceId. Correlate by position only for that exact-count shape.
+                        for (int j = 0; j < publishedSubResults.Length; j++)
                         {
-                            subResultIdsBySequenceId.Clear();
-                            break;
-                        }
+                            if (publishedSubResults[j].Id <= 0)
+                            {
+                                subResultIdsBySequenceId.Clear();
+                                break;
+                            }
 
-                        subResultIdsBySequenceId.Add(publishedSubResult.SequenceId, publishedSubResult.Id);
+                            subResultIdsBySequenceId.Add(submittedSubResults[j].SequenceId, publishedSubResults[j].Id);
+                        }
+                    }
+                    else
+                    {
+                        for (int j = 0; j < publishedSubResults.Length; j++)
+                        {
+                            PublishedTestSubResult publishedSubResult = publishedSubResults[j];
+                            if (!submittedSequenceIds.Contains(publishedSubResult.SequenceId))
+                            {
+                                continue;
+                            }
+
+                            if (publishedSubResult.Id <= 0
+                                || subResultIdsBySequenceId.ContainsKey(publishedSubResult.SequenceId))
+                            {
+                                subResultIdsBySequenceId.Clear();
+                                break;
+                            }
+
+                            subResultIdsBySequenceId.Add(publishedSubResult.SequenceId, publishedSubResult.Id);
+                        }
                     }
 
                     if (subResultIdsBySequenceId.Count != submittedSubResults.Count)

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Payloads.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Payloads.cs
@@ -67,8 +67,7 @@ internal sealed partial class AzureDevOpsTestResultsClient
             IReadOnlyList<AzureDevOpsTestSubResult>? submittedSubResults = submitted.SubResults;
             Dictionary<int, int> subResultIdsBySequenceId = [];
             if (submittedSubResults is { Count: > 0 }
-                && published.SubResults is { } publishedSubResults
-                && publishedSubResults.Length == submittedSubResults.Count)
+                && published.SubResults is { } publishedSubResults)
             {
                 var submittedSequenceIds = new HashSet<int>();
                 for (int j = 0; j < submittedSubResults.Count; j++)
@@ -84,13 +83,24 @@ internal sealed partial class AzureDevOpsTestResultsClient
                     for (int j = 0; j < publishedSubResults.Length; j++)
                     {
                         PublishedTestSubResult publishedSubResult = publishedSubResults[j];
-                        if (publishedSubResult.Id <= 0 || !submittedSequenceIds.Remove(publishedSubResult.SequenceId))
+                        if (!submittedSequenceIds.Contains(publishedSubResult.SequenceId))
+                        {
+                            continue;
+                        }
+
+                        if (publishedSubResult.Id <= 0
+                            || subResultIdsBySequenceId.ContainsKey(publishedSubResult.SequenceId))
                         {
                             subResultIdsBySequenceId.Clear();
                             break;
                         }
 
                         subResultIdsBySequenceId.Add(publishedSubResult.SequenceId, publishedSubResult.Id);
+                    }
+
+                    if (subResultIdsBySequenceId.Count != submittedSubResults.Count)
+                    {
+                        subResultIdsBySequenceId.Clear();
                     }
                 }
             }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -245,13 +245,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             var resultsOnly = new AzureDevOpsTestCaseResult[batch.Count];
             for (int i = 0; i < batch.Count; i++)
             {
-                resultsOnly[i] = _resultIdStore is not null && batch[i].Attachments.Count > 0
-                    ? batch[i].Result with
-                    {
-                        ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
-                        SubResults = [AzureDevOpsResultIdStore.CreateFirstAttempt(batch[i].Result)],
-                    }
-                    : batch[i].Result;
+                resultsOnly[i] = batch[i].Result;
             }
 
             publishedResults = await _client.PublishTestResultsWithSubResultsAsync(_publishConfiguration!, CurrentRunId!.Value, resultsOnly, cancellationToken).ConfigureAwait(false);
@@ -283,7 +277,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
         // Record the whole accepted batch before any cancellable attachment upload. Azure DevOps accepted
         // every result in one operation, so the map must describe all of them even if cancellation
         // interrupts the best-effort attachment phase.
-        bool failedToResolveSubResultId = false;
+        List<(int ResultId, AzureDevOpsTestCaseResultWithAttachments Attempt)> firstAttemptSeeds = [];
         for (int i = 0; i < batch.Count; i++)
         {
             // Folded data-driven rows share one uid. A failure in any row retries the whole uid, including
@@ -296,32 +290,112 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
             if (batch[i].Attachments.Count > 0)
             {
-                int? testSubResultId = null;
                 if (_resultIdStore is not null)
                 {
-                    if (!publishedResults[i].TryGetSubResultId(sequenceId: 1, out int resolvedSubResultId))
-                    {
-                        Interlocked.Add(ref _failedAttachmentCount, batch[i].Attachments.Count);
-                        failedToResolveSubResultId = true;
-                        continue;
-                    }
-
-                    testSubResultId = resolvedSubResultId;
+                    firstAttemptSeeds.Add((publishedResults[i].Id, batch[i]));
                 }
-
-                deferredAttachments.Add((
-                    publishedResults[i].Id,
-                    testSubResultId,
-                    batch[i].Attachments));
+                else
+                {
+                    deferredAttachments.Add((
+                        publishedResults[i].Id,
+                        TestSubResultId: null,
+                        batch[i].Attachments));
+                }
             }
         }
 
-        if (failedToResolveSubResultId)
+        if (firstAttemptSeeds.Count > 0)
         {
-            TryLogWarning(AzureDevOpsResources.AzureDevOpsLivePublishingResultIdParseFailedWarning);
+            await SeedFirstAttemptsAsync(firstAttemptSeeds, deferredAttachments, cancellationToken).ConfigureAwait(false);
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Appends the first attempt after its parent has been created, then targets that stable sub-result with
+    /// the attempt's attachments.
+    /// </summary>
+    /// <remarks>
+    /// Azure DevOps appends sub-results supplied by PATCH. Sending the first attempt in the create request and
+    /// replaying the full history in a later PATCH therefore duplicates sequence 1. Keeping creation flat and
+    /// appending each attempt exactly once also prevents a later PATCH from replacing the sub-result that owns
+    /// the attachment.
+    /// </remarks>
+    private async Task SeedFirstAttemptsAsync(
+        List<(int ResultId, AzureDevOpsTestCaseResultWithAttachments Attempt)> seeds,
+        List<(int ResultId, int? TestSubResultId, IReadOnlyList<AzureDevOpsTestResultAttachment> Attachments)> deferredAttachments,
+        CancellationToken cancellationToken)
+    {
+        var parents = new AzureDevOpsTestCaseResult[seeds.Count];
+        for (int i = 0; i < seeds.Count; i++)
+        {
+            parents[i] = seeds[i].Attempt.Result with
+            {
+                Id = seeds[i].ResultId,
+                ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
+                SubResults = [AzureDevOpsResultIdStore.CreateFirstAttempt(seeds[i].Attempt.Result)],
+            };
+        }
+
+        IReadOnlyList<AzureDevOpsPublishedTestResult>? publishedResults;
+        try
+        {
+            if (_coordinatedRun is not null && _runIdCoordinator is not null)
+            {
+                await _runIdCoordinator.RenewLeaseAsync(_coordinatedRun, cancellationToken).ConfigureAwait(false);
+            }
+
+            publishedResults = await _client.UpdateTestResultsWithSubResultsAsync(
+                _publishConfiguration!,
+                CurrentRunId!.Value,
+                parents,
+                cancellationToken).ConfigureAwait(false);
+            _lastFlushTime = _clock.UtcNow;
+        }
+        catch (Exception ex)
+        {
+            // The parent POST already succeeded, but the PATCH may have reached Azure DevOps. Forget the
+            // mapping before propagating cancellation or falling back so a later attempt cannot replay an
+            // uncertain first sub-result and duplicate sequence 1.
+            foreach ((int resultId, AzureDevOpsTestCaseResultWithAttachments attempt) in seeds)
+            {
+                if (_resultIdStore!.TryGet(attempt.Result) is { } published)
+                {
+                    _resultIdStore.Forget(published);
+                }
+            }
+
+            if (ex is OperationCanceledException)
+            {
+                throw;
+            }
+
+            foreach ((int resultId, AzureDevOpsTestCaseResultWithAttachments attempt) in seeds)
+            {
+                deferredAttachments.Add((resultId, TestSubResultId: null, attempt.Attachments));
+            }
+
+            TryLogWarning($"{AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed} {ex.Message}");
+            return;
+        }
+
+        for (int i = 0; i < seeds.Count; i++)
+        {
+            _resultIdStore!.RecordPublishedSubResults(
+                seeds[i].Attempt.Result,
+                seeds[i].ResultId,
+                lastPublishedSubResultSequenceId: 1);
+
+            int? testSubResultId = publishedResults is not null
+                && publishedResults[i].TryGetSubResultId(sequenceId: 1, out int resolvedSubResultId)
+                    ? resolvedSubResultId
+                    : null;
+            deferredAttachments.Add((
+                seeds[i].ResultId,
+                testSubResultId,
+                seeds[i].Attempt.Attachments));
+        }
     }
 
     /// <summary>
@@ -342,6 +416,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
     {
         var parents = new AzureDevOpsTestCaseResult[updates.Count];
         var attemptHistories = new IReadOnlyList<AzureDevOpsTestSubResult>[updates.Count];
+        var appendedAttempts = new IReadOnlyList<AzureDevOpsTestSubResult>[updates.Count];
         long?[] totalDurations = new long?[updates.Count];
         var startedDates = new DateTimeOffset?[updates.Count];
         var completedDates = new DateTimeOffset?[updates.Count];
@@ -350,6 +425,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             // Built but not recorded yet: the map may only advance once Azure DevOps has accepted the
             // update, otherwise retrying a failed update would list the same execution twice.
             attemptHistories[i] = AzureDevOpsResultIdStore.BuildNextAttempts(updates[i].Published, updates[i].Attempt.Result);
+            appendedAttempts[i] = [.. attemptHistories[i].Where(attempt => attempt.SequenceId > updates[i].Published.LastPublishedSubResultSequenceId)];
             totalDurations[i] = AzureDevOpsResultIdStore.BuildNextTotalDuration(updates[i].Published, updates[i].Attempt.Result);
             startedDates[i] = Min(updates[i].Published.StartedDate, updates[i].Attempt.Result.StartedDate);
             completedDates[i] = Max(updates[i].Published.CompletedDate, updates[i].Attempt.Result.CompletedDate);
@@ -357,7 +433,7 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             {
                 Id = updates[i].Published.Id,
                 ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
-                SubResults = attemptHistories[i],
+                SubResults = appendedAttempts[i],
                 DurationInMs = totalDurations[i],
                 StartedDate = startedDates[i],
                 CompletedDate = completedDates[i],
@@ -399,12 +475,12 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
             _resultIdStore!.RecordAttempts(
                 updates[i].Published,
                 attemptHistories[i],
+                attemptHistories[i][^1].SequenceId,
                 totalDurations[i],
                 startedDates[i],
                 completedDates[i]);
         }
 
-        bool failedToResolveSubResultId = false;
         for (int i = 0; i < updates.Count; i++)
         {
             if (updates[i].Attempt.Attachments.Count > 0)
@@ -413,8 +489,10 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                 if (publishedResults is null
                     || !publishedResults[i].TryGetSubResultId(sequenceId, out int testSubResultId))
                 {
-                    Interlocked.Add(ref _failedAttachmentCount, updates[i].Attempt.Attachments.Count);
-                    failedToResolveSubResultId = true;
+                    deferredAttachments.Add((
+                        updates[i].Published.Id,
+                        TestSubResultId: null,
+                        updates[i].Attempt.Attachments));
                     continue;
                 }
 
@@ -423,11 +501,6 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     testSubResultId,
                     updates[i].Attempt.Attachments));
             }
-        }
-
-        if (failedToResolveSubResultId)
-        {
-            TryLogWarning(AzureDevOpsResources.AzureDevOpsLivePublishingResultIdParseFailedWarning);
         }
 
         return true;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsPublisher.Flush.cs
@@ -163,7 +163,29 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
                     }
                 }
 
-                if (creations.Count > 0 && !await TryCreateResultsAsync(creations, deferredAttachments, cancellationToken).ConfigureAwait(false))
+                bool creationsAccepted = true;
+                if (creations.Count > 0)
+                {
+                    try
+                    {
+                        creationsAccepted = await TryCreateResultsAsync(creations, deferredAttachments, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (FirstAttemptSeedCanceledException)
+                    {
+                        // Creation already reached Azure DevOps, but its follow-up seed was canceled before
+                        // these updates were attempted. Release their claims and put them back so session
+                        // finalization can retry them or include them in the unpublished-result warning.
+                        foreach ((AzureDevOpsPublishedResult published, AzureDevOpsTestCaseResultWithAttachments _) in updates)
+                        {
+                            _claimedResultIds.Remove(published.Id);
+                        }
+
+                        RequeueUnsafe([.. updates.Select(update => update.Attempt)]);
+                        throw;
+                    }
+                }
+
+                if (!creationsAccepted)
                 {
                     // Nothing in this batch reached Azure DevOps: the creations failed, and the updates were
                     // not attempted. Release every parent claimed while classifying this untouched batch,
@@ -306,7 +328,14 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         if (firstAttemptSeeds.Count > 0)
         {
-            await SeedFirstAttemptsAsync(firstAttemptSeeds, deferredAttachments, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await SeedFirstAttemptsAsync(firstAttemptSeeds, deferredAttachments, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException ex)
+            {
+                throw new FirstAttemptSeedCanceledException(ex);
+            }
         }
 
         return true;
@@ -589,6 +618,9 @@ internal sealed partial class AzureDevOpsTestResultsPublisher
 
         return count;
     }
+
+    private sealed class FirstAttemptSeedCanceledException(OperationCanceledException innerException)
+        : OperationCanceledException(innerException.Message, innerException, innerException.CancellationToken);
 
     private bool ShouldFlushUnsafe(bool force)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -81,6 +81,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Decons
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult? other) -> bool
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.get -> int
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Id.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.LastPublishedSubResultSequenceId.get -> int
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.LastPublishedSubResultSequenceId.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult.Storage.get -> string!
@@ -113,6 +115,8 @@ Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Deconst
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Equals(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry? other) -> bool
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.get -> int
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Id.init -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.LastPublishedSubResultSequenceId.get -> int?
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.LastPublishedSubResultSequenceId.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.get -> string?
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Name.init -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapEntry.Storage.get -> string?
@@ -195,7 +199,8 @@ static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.o
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultMapFile? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator !=(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult.operator ==(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? left, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult? right) -> bool
-Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts, long? totalDurationInMs, System.DateTimeOffset? startedDate, System.DateTimeOffset? completedDate) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>! attempts, int lastPublishedSubResultSequenceId, long? totalDurationInMs, System.DateTimeOffset? startedDate, System.DateTimeOffset? completedDate) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.RecordPublishedSubResults(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result, int resultId, int lastPublishedSubResultSequenceId) -> void
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextAttempts(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestSubResult!>!
 static Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsResultIdStore.BuildNextTotalDuration(Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsPublishedResult! published, Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult! result) -> long?
 Microsoft.Testing.Extensions.TestFailureDetails

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -3435,6 +3435,38 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_UpdateTestResults_MapsPatchResponseThatOmitsSequenceIds()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"count\":1,\"value\":[{\"id\":777,\"subResults\":[{\"id\":1002}]}]}"),
+        };
+        QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock());
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 123, "run", "tests.dll", "results");
+        AzureDevOpsTestCaseResult parent = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "second", null, null, null)
+        {
+            Id = 777,
+            ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
+            SubResults =
+            [
+                new AzureDevOpsTestSubResult(2, "Attempt# 1 - MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "second", null, null, null),
+            ],
+        };
+
+        IReadOnlyList<AzureDevOpsPublishedTestResult>? publishedResults =
+            await client.UpdateTestResultsWithSubResultsAsync(configuration, runId: 42, [parent], CancellationToken.None);
+
+        Assert.IsNotNull(publishedResults);
+        Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 2, out int secondSubResultId));
+        Assert.AreEqual(1002, secondSubResultId);
+    }
+
+    [TestMethod]
     public async Task AzureDevOpsTestResultsClient_UploadTestResultAttachment_TargetsTheSubResult()
     {
         FakeTask task = new();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2505,6 +2505,28 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task MapEntryWithMissingOrStalePublishedSubResultSequence_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        File.WriteAllText(
+            mapPath,
+            """
+            {"buildId":123,"runId":42,"results":[
+              {"storage":"tests","name":"Missing","title":"Missing","id":453,"attempts":[{"sequenceId":1,"displayName":"Missing","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"Stale","title":"Stale","id":454,"attempts":[{"sequenceId":1,"displayName":"Stale 1","outcome":"Failed","durationInMs":1},{"sequenceId":2,"displayName":"Stale 2","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":1}
+            ]}
+            """);
+
+        AzureDevOpsResultIdStore store = await AzureDevOpsResultIdStore.OpenAsync(new SystemFileSystem(), new CollectingLogger(), mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult missing = new("Missing", "tests", "Missing", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        AzureDevOpsTestCaseResult stale = new("Stale", "tests", "Stale", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+
+        Assert.IsNull(store.TryGet(missing));
+        Assert.IsNull(store.TryGet(stale));
+    }
+
+    [TestMethod]
     public async Task SameTestNameInTwoAssemblies_IsNotTreatedAsARerun()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -3074,6 +3096,54 @@ public sealed class AzureDevOpsLivePublishingTests
         string map = File.ReadAllText(mapPath);
         Assert.DoesNotContain("\"id\":111", map);
         Assert.DoesNotContain("MyTest", map);
+    }
+
+    [TestMethod]
+    public async Task FirstAttemptSeedCancellationInMixedBatch_RequeuesTheUntouchedUpdate()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        await PublishSingleResultAsync(
+            directory.Path,
+            environment,
+            "ExistingTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            resultId: 211);
+
+        AzureDevOpsTestResultsPublisherOptions options = new(2, TimeSpan.FromMinutes(1), 40, TimeSpan.FromMilliseconds(250));
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(directory.Path, options, out FakeAzureDevOpsTestResultsClient client, out _, out _, environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([212]);
+        client.UpdateTestResultsWithSubResultsAsyncFunc = (_, _, results, _) =>
+        {
+            AzureDevOpsTestCaseResult result = results.Single();
+            if (result.AutomatedTestName == "NewTest")
+            {
+                return Task.FromException<IReadOnlyList<AzureDevOpsPublishedTestResult>?>(new OperationCanceledException());
+            }
+
+            var subResultIds = result.SubResults!.ToDictionary(attempt => attempt.SequenceId, attempt => attempt.SequenceId);
+            return Task.FromResult<IReadOnlyList<AzureDevOpsPublishedTestResult>?>([
+                new AzureDevOpsPublishedTestResult(result.Id!.Value, subResultIds),
+            ]);
+        };
+        await StartPublisherAsync(publisher);
+
+        TestNode newTest = CreateNode("NewTest", new FailedTestNodeStateProperty(new InvalidOperationException("new")), RetryTestStartTime);
+        newTest.Properties.Add(new StandardOutputProperty("new output"));
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(newTest), CancellationToken.None);
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => publisher.ConsumeAsync(
+                Mock.Of<IDataProducer>(),
+                CreateMessage(CreateNode("ExistingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
+                CancellationToken.None));
+
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(2, client.UpdateTestResultsCalls);
+        Assert.AreEqual("NewTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
+        Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[1].Results.Single().AutomatedTestName);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2098,10 +2098,18 @@ public sealed class AzureDevOpsLivePublishingTests
             out _,
             out _,
             environment);
-        AzureDevOpsTestCaseResult? publishedResult = null;
+        AzureDevOpsTestCaseResult? createdResult = null;
+        AzureDevOpsTestCaseResult? seededResult = null;
         client.PublishTestResultsWithSubResultsAsyncFunc = (_, _, results, _) =>
         {
-            publishedResult = results.Single();
+            createdResult = results.Single();
+            return Task.FromResult<IReadOnlyList<AzureDevOpsPublishedTestResult>?>([
+                new AzureDevOpsPublishedTestResult(1, new Dictionary<int, int>()),
+            ]);
+        };
+        client.UpdateTestResultsWithSubResultsAsyncFunc = (_, _, results, _) =>
+        {
+            seededResult = results.Single();
             IReadOnlyDictionary<int, int> subResultIds = new Dictionary<int, int> { [1] = 101 };
             return Task.FromResult<IReadOnlyList<AzureDevOpsPublishedTestResult>?>([new AzureDevOpsPublishedTestResult(1, subResultIds)]);
         };
@@ -2116,13 +2124,81 @@ public sealed class AzureDevOpsLivePublishingTests
         await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
 
         Assert.HasCount(1, client.UploadTestResultAttachmentCalls);
-        Assert.IsNotNull(publishedResult);
-        Assert.AreEqual(AzureDevOpsLivePublishingConstants.RerunResultGroupType, publishedResult.ResultGroupType);
-        Assert.IsNotNull(publishedResult.SubResults);
-        Assert.ContainsSingle(publishedResult.SubResults);
-        Assert.AreEqual(1, publishedResult.SubResults[0].SequenceId);
+        Assert.IsNotNull(createdResult);
+        Assert.IsNull(createdResult.ResultGroupType);
+        Assert.IsNull(createdResult.SubResults);
+        Assert.IsNotNull(seededResult);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.RerunResultGroupType, seededResult.ResultGroupType);
+        Assert.IsNotNull(seededResult.SubResults);
+        Assert.ContainsSingle(seededResult.SubResults);
+        Assert.AreEqual(1, seededResult.SubResults[0].SequenceId);
         Assert.AreEqual(101, client.UploadTestResultAttachmentCalls[0].TestSubResultId);
         Assert.AreEqual("stdout.log", client.UploadTestResultAttachmentCalls[0].Attachment.FileName);
+    }
+
+    [TestMethod]
+    public async Task RetryAttempt_AgainstAppendingAzureDevOps_DoesNotReplayFirstAttemptOrLoseItsAttachment()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+        AppendingAzureDevOpsService service = new();
+
+        AzureDevOpsTestResultsPublisher firstAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient firstClient,
+            out _,
+            out _,
+            environment);
+        service.Connect(firstClient);
+        TestNode failedNode = CreateNode(
+            "MyTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("first")),
+            RetryTestStartTime);
+        failedNode.Properties.Add(new StandardOutputProperty("first output"));
+
+        await StartPublisherAsync(firstAttempt);
+        await firstAttempt.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(failedNode), CancellationToken.None);
+        await firstAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        AzureDevOpsTestResultsPublisher secondAttempt = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient secondClient,
+            out _,
+            out _,
+            environment);
+        service.Connect(secondClient);
+        TestNode secondFailedNode = CreateNode(
+            "MyTest",
+            new FailedTestNodeStateProperty(new InvalidOperationException("second")),
+            RetryTestStartTime);
+        secondFailedNode.Properties.Add(new StandardOutputProperty("second output"));
+
+        await StartPublisherAsync(secondAttempt);
+        await secondAttempt.ConsumeAsync(
+            Mock.Of<IDataProducer>(),
+            CreateMessage(secondFailedNode),
+            CancellationToken.None);
+        await secondAttempt.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(2, service.SubResults);
+        Assert.AreEqual(1, service.SubResults[0].SequenceId);
+        Assert.AreEqual("Attempt# 0 - MyTest", service.SubResults[0].DisplayName);
+        Assert.AreEqual(2, service.SubResults[1].SequenceId);
+        Assert.AreEqual("Attempt# 1 - MyTest", service.SubResults[1].DisplayName);
+        Assert.HasCount(1, service.SubResults[0].Attachments);
+        Assert.AreEqual("stdout.log", service.SubResults[0].Attachments[0].FileName);
+        Assert.HasCount(1, service.SubResults[1].Attachments);
+        Assert.AreEqual("stdout.log", service.SubResults[1].Attachments[0].FileName);
+        Assert.IsEmpty(service.ParentAttachments);
+
+        Assert.HasCount(1, secondClient.UpdateTestResultsCalls);
+        IReadOnlyList<AzureDevOpsTestSubResult> appended = secondClient.UpdateTestResultsCalls[0].Results.Single().SubResults!;
+        Assert.ContainsSingle(appended);
+        Assert.AreEqual(2, appended[0].SequenceId);
     }
 
     [TestMethod]
@@ -2404,6 +2480,28 @@ public sealed class AzureDevOpsLivePublishingTests
         AzureDevOpsTestCaseResult result = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
 
         Assert.IsNull(store.TryGet(result));
+    }
+
+    [TestMethod]
+    public async Task MapEntryWithInvalidPublishedSubResultSequence_IsIgnored()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        string mapPath = Path.Combine(directory.Path, "azdo-results.json");
+        File.WriteAllText(
+            mapPath,
+            """
+            {"buildId":123,"runId":42,"results":[
+              {"storage":"tests","name":"Negative","title":"Negative","id":451,"attempts":[{"sequenceId":1,"displayName":"Negative","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":-1},
+              {"storage":"tests","name":"PastHistory","title":"PastHistory","id":452,"attempts":[{"sequenceId":1,"displayName":"PastHistory","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":2}
+            ]}
+            """);
+
+        AzureDevOpsResultIdStore store = await AzureDevOpsResultIdStore.OpenAsync(new SystemFileSystem(), new CollectingLogger(), mapPath, buildId: 123, runId: 42);
+        AzureDevOpsTestCaseResult negative = new("Negative", "tests", "Negative", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+        AzureDevOpsTestCaseResult pastHistory = new("PastHistory", "tests", "PastHistory", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 1, null, null, null, null);
+
+        Assert.IsNull(store.TryGet(negative));
+        Assert.IsNull(store.TryGet(pastHistory));
     }
 
     [TestMethod]
@@ -2825,7 +2923,7 @@ public sealed class AzureDevOpsLivePublishingTests
         IReadOnlyList<AzureDevOpsTestSubResult> attempts = AzureDevOpsResultIdStore.BuildNextAttempts(
             published,
             first with { ErrorMessage = "second" });
-        updated.RecordAttempts(published, attempts, totalDurationInMs: 2, startedDate: null, completedDate: null);
+        updated.RecordAttempts(published, attempts, lastPublishedSubResultSequenceId: 2, totalDurationInMs: 2, startedDate: null, completedDate: null);
         await updated.SaveAsync(CancellationToken.None);
 
         Assert.IsFalse(File.Exists(mapPath), "A stale map would let the next attempt erase accepted server history.");
@@ -2948,6 +3046,37 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task FirstAttemptSeedCancellation_ForgetsTheUncertainSubResultState()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient client,
+            out _,
+            out _,
+            environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([111]);
+        client.UpdateTestResultsWithSubResultsAsyncFunc = (_, _, _, _) =>
+            Task.FromException<IReadOnlyList<AzureDevOpsPublishedTestResult>?>(new OperationCanceledException());
+        TestNode node = CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("first")), RetryTestStartTime);
+        node.Properties.Add(new StandardOutputProperty("first output"));
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(node), CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        string map = File.ReadAllText(mapPath);
+        Assert.DoesNotContain("\"id\":111", map);
+        Assert.DoesNotContain("MyTest", map);
+    }
+
+    [TestMethod]
     public async Task AttachmentCancellationInMixedBatch_DoesNotSkipUpdates()
     {
         using TestDirectory directory = CreateTestDirectory();
@@ -2982,8 +3111,9 @@ public sealed class AzureDevOpsLivePublishingTests
                 CreateMessage(CreateNode("ExistingTest", new PassedTestNodeStateProperty(), RetryTestStartTime)),
                 CancellationToken.None));
 
-        Assert.HasCount(1, client.UpdateTestResultsCalls, "The update must reach Azure DevOps before creation attachments are uploaded.");
-        Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
+        Assert.HasCount(2, client.UpdateTestResultsCalls, "Both the creation seed and existing update must reach Azure DevOps before attachments are uploaded.");
+        Assert.AreEqual("NewTest", client.UpdateTestResultsCalls[0].Results.Single().AutomatedTestName);
+        Assert.AreEqual("ExistingTest", client.UpdateTestResultsCalls[1].Results.Single().AutomatedTestName);
         Assert.HasCount(1, created);
         Assert.AreEqual("NewTest", created[0].AutomatedTestName);
     }
@@ -3267,6 +3397,40 @@ public sealed class AzureDevOpsLivePublishingTests
         Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 1, out int firstSubResultId));
         Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 2, out int secondSubResultId));
         Assert.AreEqual(1001, firstSubResultId);
+        Assert.AreEqual(1002, secondSubResultId);
+    }
+
+    [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_UpdateTestResults_MapsAppendedSubResultFromFullHistoryResponse()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                "{\"count\":1,\"value\":[{\"id\":777,\"subResults\":[{\"id\":1001,\"sequenceId\":1},{\"id\":1002,\"sequenceId\":2}]}]}"),
+        };
+        QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock());
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 123, "run", "tests.dll", "results");
+        AzureDevOpsTestCaseResult parent = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "second", null, null, null)
+        {
+            Id = 777,
+            ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
+            SubResults =
+            [
+                new AzureDevOpsTestSubResult(2, "Attempt# 1 - MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "second", null, null, null),
+            ],
+        };
+
+        IReadOnlyList<AzureDevOpsPublishedTestResult>? publishedResults =
+            await client.UpdateTestResultsWithSubResultsAsync(configuration, runId: 42, [parent], CancellationToken.None);
+
+        Assert.IsNotNull(publishedResults);
+        Assert.IsFalse(publishedResults[0].TryGetSubResultId(sequenceId: 1, out _));
+        Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 2, out int secondSubResultId));
         Assert.AreEqual(1002, secondSubResultId);
     }
 
@@ -3955,6 +4119,89 @@ public sealed class AzureDevOpsLivePublishingTests
             }
 
             return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Minimal stateful Azure DevOps substitute that models the service's append-only PATCH behavior for
+    /// sub-results and keeps attachments on the concrete sub-result id they target.
+    /// </summary>
+    private sealed class AppendingAzureDevOpsService
+    {
+        private const int ParentResultId = 100_000;
+        private int _nextSubResultId = 1;
+
+        public List<ServiceSubResult> SubResults { get; } = [];
+
+        public List<AzureDevOpsTestResultAttachment> ParentAttachments { get; } = [];
+
+        public void Connect(FakeAzureDevOpsTestResultsClient client)
+        {
+            client.PublishTestResultsWithSubResultsAsyncFunc = (_, _, results, _) =>
+            {
+                Append(results);
+                return Task.FromResult<IReadOnlyList<AzureDevOpsPublishedTestResult>?>([CreatePublishedResult()]);
+            };
+            client.UpdateTestResultsWithSubResultsAsyncFunc = (_, _, results, _) =>
+            {
+                Append(results);
+                return Task.FromResult<IReadOnlyList<AzureDevOpsPublishedTestResult>?>([CreatePublishedResult()]);
+            };
+            client.UploadTestResultAttachmentAsyncFunc = (_, _, testCaseResultId, testSubResultId, attachment, _) =>
+            {
+                Assert.AreEqual(ParentResultId, testCaseResultId);
+                if (testSubResultId is null)
+                {
+                    ParentAttachments.Add(attachment);
+                }
+                else
+                {
+                    ServiceSubResult subResult = SubResults.Single(result => result.Id == testSubResultId);
+                    subResult.Attachments.Add(attachment);
+                }
+
+                return Task.CompletedTask;
+            };
+        }
+
+        private void Append(IReadOnlyList<AzureDevOpsTestCaseResult> results)
+        {
+            AzureDevOpsTestCaseResult parent = results.Single();
+            if (parent.SubResults is null)
+            {
+                return;
+            }
+
+            foreach (AzureDevOpsTestSubResult subResult in parent.SubResults)
+            {
+                SubResults.Add(new ServiceSubResult(
+                    _nextSubResultId++,
+                    subResult.SequenceId,
+                    subResult.DisplayName));
+            }
+        }
+
+        private AzureDevOpsPublishedTestResult CreatePublishedResult()
+        {
+            Dictionary<int, int> subResultIds = [];
+            foreach (ServiceSubResult subResult in SubResults)
+            {
+                // Azure DevOps can contain duplicate sequence ids; its latest row is the one consumers resolve.
+                subResultIds[subResult.SequenceId] = subResult.Id;
+            }
+
+            return new AzureDevOpsPublishedTestResult(ParentResultId, subResultIds);
+        }
+
+        internal sealed class ServiceSubResult(int id, int sequenceId, string displayName)
+        {
+            public int Id { get; } = id;
+
+            public int SequenceId { get; } = sequenceId;
+
+            public string DisplayName { get; } = displayName;
+
+            public List<AzureDevOpsTestResultAttachment> Attachments { get; } = [];
         }
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -2440,14 +2440,14 @@ public sealed class AzureDevOpsLivePublishingTests
             mapPath,
             """
             {"buildId":123,"runId":42,"results":[
-              {"storage":"tests","name":"First","title":"First","id":431,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"First","title":"First","id":432,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"First","title":"First","id":433,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}]},
+              {"storage":"tests","name":"First","title":"First","id":431,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
+              {"storage":"tests","name":"First","title":"First","id":432,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
+              {"storage":"tests","name":"First","title":"First","id":433,"attempts":[{"sequenceId":1,"displayName":"First","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
+              {"storage":"tests","name":"Second","title":"Second","id":433,"attempts":[{"sequenceId":1,"displayName":"Second","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
               {"storage":"tests","name":"Malformed","title":"Malformed","id":434,"attempts":null},
-              {"storage":"tests","name":"Third","title":"Third","id":434,"attempts":[{"sequenceId":1,"displayName":"Third","outcome":"Failed","durationInMs":1}]},
-              {"storage":null,"name":"MalformedKey","title":"MalformedKey","id":435,"attempts":[{"sequenceId":1,"displayName":"MalformedKey","outcome":"Failed","durationInMs":1}]},
-              {"storage":"tests","name":"Fourth","title":"Fourth","id":435,"attempts":[{"sequenceId":1,"displayName":"Fourth","outcome":"Failed","durationInMs":1}]}
+              {"storage":"tests","name":"Third","title":"Third","id":434,"attempts":[{"sequenceId":1,"displayName":"Third","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
+              {"storage":null,"name":"MalformedKey","title":"MalformedKey","id":435,"attempts":[{"sequenceId":1,"displayName":"MalformedKey","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0},
+              {"storage":"tests","name":"Fourth","title":"Fourth","id":435,"attempts":[{"sequenceId":1,"displayName":"Fourth","outcome":"Failed","durationInMs":1}],"lastPublishedSubResultSequenceId":0}
             ]}
             """);
 
@@ -3095,6 +3095,43 @@ public sealed class AzureDevOpsLivePublishingTests
         string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
         string map = File.ReadAllText(mapPath);
         Assert.DoesNotContain("\"id\":111", map);
+        Assert.DoesNotContain("MyTest", map);
+    }
+
+    [TestMethod]
+    public async Task FirstAttemptSeedFailure_UploadsAttachmentToParentAndForgetsMapping()
+    {
+        using TestDirectory directory = CreateTestDirectory();
+        Mock<IEnvironment> environment = CreateEnvironmentMockWithSettableRunId();
+        AzureDevOpsTestRunOrchestratorLifetime lifetime = CreateOrchestratorLifetime(directory.Path, out _, out _, environment);
+        await lifetime.BeforeRunAsync(CancellationToken.None);
+
+        using AzureDevOpsTestResultsPublisher publisher = CreatePublisher(
+            directory.Path,
+            AzureDevOpsTestResultsPublisherOptions.Default,
+            out FakeAzureDevOpsTestResultsClient client,
+            out _,
+            out CollectingLogger logger,
+            environment);
+        client.PublishTestResultsAsyncFunc = (_, _, _, _) => Task.FromResult<IReadOnlyList<int>?>([121]);
+        client.UpdateTestResultsWithSubResultsAsyncFunc = (_, _, _, _) =>
+            Task.FromException<IReadOnlyList<AzureDevOpsPublishedTestResult>?>(new HttpRequestException("seed failed"));
+        TestNode node = CreateNode("MyTest", new FailedTestNodeStateProperty(new InvalidOperationException("first")), RetryTestStartTime);
+        node.Properties.Add(new StandardOutputProperty("first output"));
+
+        await StartPublisherAsync(publisher);
+        await publisher.ConsumeAsync(Mock.Of<IDataProducer>(), CreateMessage(node), CancellationToken.None);
+        await publisher.OnTestSessionFinishingAsync(new Microsoft.Testing.Platform.Services.TestSessionContext(CancellationToken.None));
+
+        Assert.HasCount(1, client.UploadTestResultAttachmentCalls);
+        Assert.AreEqual(121, client.UploadTestResultAttachmentCalls[0].TestCaseResultId);
+        Assert.IsNull(client.UploadTestResultAttachmentCalls[0].TestSubResultId);
+        Assert.AreEqual("stdout.log", client.UploadTestResultAttachmentCalls[0].Attachment.FileName);
+        Assert.Contains(AzureDevOpsResources.AzureDevOpsLivePublishingPublishResultsFailed, string.Join(Environment.NewLine, logger.Logs));
+
+        string mapPath = AzureDevOpsConstants.TryGetInheritedResultMapPath(environment.Object, buildId: 123)!;
+        string map = File.ReadAllText(mapPath);
+        Assert.DoesNotContain("\"id\":121", map);
         Assert.DoesNotContain("MyTest", map);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -3509,7 +3509,7 @@ public sealed class AzureDevOpsLivePublishingTests
     {
         using HttpResponseMessage response = new(HttpStatusCode.OK)
         {
-            Content = new StringContent("{\"count\":1,\"value\":[{\"id\":777,\"subResults\":[{\"id\":1002}]}]}"),
+            Content = new StringContent("{\"count\":1,\"value\":[{\"id\":777,\"subResults\":[{\"id\":1001},{\"id\":1002}]}]}"),
         };
         QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
         using HttpClient httpClient = new(handler)
@@ -3524,6 +3524,7 @@ public sealed class AzureDevOpsLivePublishingTests
             ResultGroupType = AzureDevOpsLivePublishingConstants.RerunResultGroupType,
             SubResults =
             [
+                new AzureDevOpsTestSubResult(1, "Attempt# 0 - MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "first", null, null, null),
                 new AzureDevOpsTestSubResult(2, "Attempt# 1 - MyTest", AzureDevOpsLivePublishingConstants.FailedTestOutcome, 5, "second", null, null, null),
             ],
         };
@@ -3532,7 +3533,9 @@ public sealed class AzureDevOpsLivePublishingTests
             await client.UpdateTestResultsWithSubResultsAsync(configuration, runId: 42, [parent], CancellationToken.None);
 
         Assert.IsNotNull(publishedResults);
+        Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 1, out int firstSubResultId));
         Assert.IsTrue(publishedResults[0].TryGetSubResultId(sequenceId: 2, out int secondSubResultId));
+        Assert.AreEqual(1001, firstSubResultId);
         Assert.AreEqual(1002, secondSubResultId);
     }
 


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->
Azure DevOps appends rerun sub-results on PATCH. Seeding `Attempt# 0` during result creation and later replaying the full attempt history therefore duplicated sequence 1 and left attachments without a stable sub-result target.

This change creates the parent result without sub-results, appends each attempt exactly once, and persists the highest published sequence across retry processes. It also handles Azure DevOps PATCH responses that return assigned sub-result IDs in request order but omit `sequenceId`.

Validation includes the complete extensions unit-test project and a real Azure DevOps publication: [run 43227682](https://dev.azure.com/dnceng-public/public/_TestManagement/Runs?runId=43227682&_a=resultQuery) contains exactly attempts 1 and 2, no parent attachments, and the failed attempt's file on sub-result 1.

Fixes: #10776