### PR TITLE
Add video recorder logic coverage

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/FfmpegVideoRecorder.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/FfmpegVideoRecorder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.VideoRecorder.Resources;
@@ -22,7 +22,7 @@ namespace Microsoft.Testing.Extensions.VideoRecorder;
 [UnsupportedOSPlatform("ios")]
 [UnsupportedOSPlatform("tvos")]
 [UnsupportedOSPlatform("wasi")]
-internal sealed partial class FfmpegVideoRecorder
+internal sealed partial class FfmpegVideoRecorder : IVideoRecorder
 {
     private static readonly TimeSpan StopTimeout = TimeSpan.FromSeconds(15);
 

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/IVideoRecorder.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/IVideoRecorder.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Extensions.VideoRecorder;
+
+internal interface IVideoRecorder
+{
+    bool IsAvailable { get; }
+
+    string? FfmpegPath { get; }
+
+    DateTimeOffset? RecordingStartUtc { get; }
+
+    string? SegmentDirectory { get; }
+
+    string SegmentExtension { get; }
+
+    void Start();
+
+    Task StopAsync(CancellationToken cancellationToken = default);
+
+    IReadOnlyList<VideoSegment> ReadSegments();
+
+    string DescribeLastFfmpegError();
+
+    Task<string?> ConcatAsync(
+        IReadOnlyList<VideoSegment> segments,
+        string outputFileName,
+        string? ffmetadataPath,
+        CancellationToken cancellationToken);
+}

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,4 +1,16 @@
 #nullable enable
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.ConcatAsync(System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.VideoRecorder.VideoSegment>! segments, string! outputFileName, string? ffmetadataPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string?>!
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.DescribeLastFfmpegError() -> string!
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.FfmpegPath.get -> string?
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.IsAvailable.get -> bool
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.ReadSegments() -> System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Extensions.VideoRecorder.VideoSegment>!
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.RecordingStartUtc.get -> System.DateTimeOffset?
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.SegmentDirectory.get -> string?
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.SegmentExtension.get -> string!
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.Start() -> void
+Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder.StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.Testing.Extensions.VideoRecorder.VideoRecorderSessionHandler.VideoRecorderSessionHandler(Microsoft.Testing.Extensions.VideoRecorder.VideoRecorderOptions! options, Microsoft.Testing.Platform.Configurations.IConfiguration! configuration, Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions, Microsoft.Testing.Platform.Messages.IMessageBus! messageBus, Microsoft.Testing.Platform.OutputDevice.IOutputDevice! outputDevice, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Logging.ILogger<Microsoft.Testing.Extensions.VideoRecorder.VideoRecorderSessionHandler!>! logger, Microsoft.Testing.Extensions.VideoRecorder.IVideoRecorder? recorder) -> void
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipeDirectoryNotWritableErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Resources.PlatformResources.NamedPipePathTooLongErrorMessage.get -> string!
 static Microsoft.Testing.Platform.Services.ArtifactNamingHelper.ResolveAndSanitize(string! template, string! processName, string! processId, System.DateTimeOffset timestamp, System.Func<string!, string!>! sanitizeLeafFileName) -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.VideoRecorder.Resources;
@@ -38,7 +38,7 @@ internal sealed partial class VideoRecorderSessionHandler :
     private static readonly char[] InvalidFileNameChars = Path.GetInvalidFileNameChars();
 
     private readonly bool _enabled;
-    private readonly FfmpegVideoRecorder? _recorder;
+    private readonly IVideoRecorder? _recorder;
     private readonly VideoRecorderOptions _options;
     private readonly VideoRecorderPersistenceMode _persistMode;
     private readonly VideoCaptureGranularity _granularity;
@@ -67,6 +67,19 @@ internal sealed partial class VideoRecorderSessionHandler :
         IOutputDevice outputDevice,
         IClock clock,
         ILogger<VideoRecorderSessionHandler> logger)
+        : this(options, configuration, commandLineOptions, messageBus, outputDevice, clock, logger, recorder: null)
+    {
+    }
+
+    internal VideoRecorderSessionHandler(
+        VideoRecorderOptions options,
+        IConfiguration configuration,
+        ICommandLineOptions commandLineOptions,
+        IMessageBus messageBus,
+        IOutputDevice outputDevice,
+        IClock clock,
+        ILogger<VideoRecorderSessionHandler> logger,
+        IVideoRecorder? recorder)
     {
         _messageBus = messageBus;
         _outputDevice = outputDevice;
@@ -91,7 +104,7 @@ internal sealed partial class VideoRecorderSessionHandler :
         string outputDirectory = options.OutputDirectory
             ?? Path.Combine(configuration.GetTestResultDirectory(), "VideoRecordings");
 
-        _recorder = new FfmpegVideoRecorder(
+        _recorder = recorder ?? new FfmpegVideoRecorder(
             options,
             outputDirectory,
             clock,

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/FfmpegVideoRecorderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/FfmpegVideoRecorderTests.cs
@@ -206,7 +206,7 @@ public sealed class FfmpegVideoRecorderTests
 
     private static string CreateTemporaryDirectory()
     {
-        string directory = Path.Combine(Path.GetTempPath(), "FfmpegVideoRecorderTests_" + Guid.NewGuid().ToString("N"));
+        string directory = Path.Combine(Path.GetTempPath(), $"{nameof(FfmpegVideoRecorderTests)}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         return directory;
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/FfmpegVideoRecorderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/FfmpegVideoRecorderTests.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Globalization;
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.VideoRecorder;
+using Microsoft.Testing.Platform.Helpers;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class FfmpegVideoRecorderTests
+{
+    private static readonly FieldInfo SegmentListPathField =
+        typeof(FfmpegVideoRecorder).GetField("_segmentListPath", BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not resolve FfmpegVideoRecorder._segmentListPath.");
+
+    private static readonly PropertyInfo SegmentDirectoryProperty =
+        typeof(FfmpegVideoRecorder).GetProperty(nameof(FfmpegVideoRecorder.SegmentDirectory))
+        ?? throw new InvalidOperationException("Could not resolve FfmpegVideoRecorder.SegmentDirectory.");
+
+    [TestMethod]
+    public void ReadSegments_DefaultState_ReturnsEmpty()
+    {
+        FfmpegVideoRecorder recorder = CreateRecorder(Path.GetTempPath());
+
+        IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+        Assert.IsEmpty(segments);
+    }
+
+    [TestMethod]
+    public void ReadSegments_MissingListFile_ReturnsEmpty()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, Path.Combine(directory, "missing.csv"));
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.IsEmpty(segments);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void ReadSegments_RelativeEntry_CombinesDirectoryAndParsesInvariantNumbers()
+    {
+        string directory = CreateTemporaryDirectory();
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            string segmentPath = Path.Combine(directory, "relative.mp4");
+            string listPath = Path.Combine(directory, "segments.csv");
+            File.WriteAllText(segmentPath, "x");
+            File.WriteAllText(listPath, "relative.mp4,1.25,2.5");
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, listPath);
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.HasCount(1, segments);
+            Assert.AreEqual(segmentPath, segments[0].Path);
+            Assert.AreEqual(1.25, segments[0].StartSeconds);
+            Assert.AreEqual(2.5, segments[0].EndSeconds);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSegments_RootedEntry_PreservesAbsolutePath()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string segmentPath = Path.Combine(directory, "rooted.mp4");
+            string listPath = Path.Combine(directory, "segments.csv");
+            File.WriteAllText(segmentPath, "x");
+            File.WriteAllText(listPath, $"{segmentPath},3,4");
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, listPath);
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.HasCount(1, segments);
+            Assert.AreEqual(segmentPath, segments[0].Path);
+            Assert.AreEqual(3, segments[0].StartSeconds);
+            Assert.AreEqual(4, segments[0].EndSeconds);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSegments_MixedValidAndMalformedRows_ReturnsValidRowsInListOrder()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string firstSegmentPath = Path.Combine(directory, "later.mp4");
+            string secondSegmentPath = Path.Combine(directory, "earlier.mp4");
+            string listPath = Path.Combine(directory, "segments.csv");
+            File.WriteAllText(firstSegmentPath, "x");
+            File.WriteAllText(secondSegmentPath, "x");
+            File.WriteAllLines(
+                listPath,
+                [
+                    "later.mp4,8,9",
+                    "too-few-columns.mp4,1",
+                    "invalid-start.mp4,not-a-number,3",
+                    "invalid-end.mp4,3,not-a-number",
+                    "earlier.mp4,1,2",
+                ]);
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, listPath);
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.HasCount(2, segments);
+            Assert.AreEqual(firstSegmentPath, segments[0].Path);
+            Assert.AreEqual(8, segments[0].StartSeconds);
+            Assert.AreEqual(9, segments[0].EndSeconds);
+            Assert.AreEqual(secondSegmentPath, segments[1].Path);
+            Assert.AreEqual(1, segments[1].StartSeconds);
+            Assert.AreEqual(2, segments[1].EndSeconds);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSegments_MissingSegmentFile_OmitsEntry()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string listPath = Path.Combine(directory, "segments.csv");
+            File.WriteAllText(listPath, "missing.mp4,1,2");
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, listPath);
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.IsEmpty(segments);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void ReadSegments_EmptySegmentFile_OmitsEntry()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string segmentPath = Path.Combine(directory, "empty.mp4");
+            string listPath = Path.Combine(directory, "segments.csv");
+            File.WriteAllBytes(segmentPath, []);
+            File.WriteAllText(listPath, "empty.mp4,1,2");
+            FfmpegVideoRecorder recorder = CreateInitializedRecorder(directory, listPath);
+
+            IReadOnlyList<VideoSegment> segments = recorder.ReadSegments();
+
+            Assert.IsEmpty(segments);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static FfmpegVideoRecorder CreateInitializedRecorder(string directory, string segmentListPath)
+    {
+        FfmpegVideoRecorder recorder = CreateRecorder(directory);
+        SegmentDirectoryProperty.SetValue(recorder, directory);
+        SegmentListPathField.SetValue(recorder, segmentListPath);
+        return recorder;
+    }
+
+    private static FfmpegVideoRecorder CreateRecorder(string outputDirectory)
+        => new(
+            new VideoRecorderOptions
+            {
+                FfmpegPath = Path.Combine(outputDirectory, "missing-ffmpeg"),
+                OutputDirectory = outputDirectory,
+            },
+            outputDirectory,
+            Mock.Of<IClock>(),
+            log: null,
+            warn: null);
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "FfmpegVideoRecorderTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerSegmentPruningTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerSegmentPruningTests.cs
@@ -1,0 +1,422 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Extensions.VideoRecorder;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class VideoRecorderSessionHandlerSegmentPruningTests
+{
+    private static readonly MethodInfo OverlapsAnyFailedWindowMethod =
+        typeof(VideoRecorderSessionHandler).GetMethod(
+            "OverlapsAnyFailedWindow",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("Could not resolve OverlapsAnyFailedWindow.");
+
+    private static readonly MethodInfo TryPruneOldSegmentsMethod =
+        typeof(VideoRecorderSessionHandler).GetMethod(
+            "TryPruneOldSegments",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not resolve TryPruneOldSegments.");
+
+    [TestMethod]
+    [DynamicData(nameof(GetOverlapCases))]
+    public void OverlapsAnyFailedWindow_WindowsAndSegment_ReturnsExpectedResult(double[] failedWindows, bool expected)
+    {
+        var segment = new VideoSegment("segment.mp4", 10, 20);
+
+        bool actual = (bool)OverlapsAnyFailedWindowMethod.Invoke(null, [segment, failedWindows])!;
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    public static IEnumerable<object[]> GetOverlapCases()
+    {
+        yield return [Array.Empty<double>(), false];
+        yield return [new double[] { 20, 30 }, false];
+        yield return [new double[] { 0, 10 }, false];
+        yield return [new double[] { 15, 25 }, true];
+        yield return [new double[] { 0, 30 }, true];
+        yield return [new double[] { 0, 5, 15, 25 }, true];
+        yield return [new double[] { 0, 5, 99 }, false];
+    }
+
+    [TestMethod]
+    public async Task TryPruneOldSegments_OnFailurePassedOnly_DeletesAllFinalizedSegmentsWithoutWarning()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.OnFailure,
+                maxRetainedDuration: null,
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            await handler.ConsumeAsync(
+                null!,
+                CreateUpdate(PassedTestNodeStateProperty.CachedInstance, recordingStart.AddSeconds(15), recordingStart.AddSeconds(25)),
+                CancellationToken.None);
+
+            VideoSegment first = CreateSegment(directory, "passed-first.tmp", 0, 10);
+            VideoSegment second = CreateSegment(directory, "passed-second.tmp", 10, 20);
+            currentSegments = [first, second];
+
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(first.Path));
+            Assert.IsFalse(File.Exists(second.Path));
+            VerifyWarningCount(logger, Times.Never());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task TryPruneOldSegments_OnFailureWithFailedWindow_DeletesOnlyNonOverlappingSegments()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.OnFailure,
+                maxRetainedDuration: null,
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            await handler.ConsumeAsync(
+                null!,
+                CreateUpdate(new FailedTestNodeStateProperty("failure"), recordingStart.AddSeconds(15), recordingStart.AddSeconds(25)),
+                CancellationToken.None);
+
+            VideoSegment beforeFailure = CreateSegment(directory, "before-failure.tmp", 0, 10);
+            VideoSegment overlapsFailureStart = CreateSegment(directory, "overlaps-failure-start.tmp", 10, 20);
+            VideoSegment overlapsFailureEnd = CreateSegment(directory, "overlaps-failure-end.tmp", 20, 30);
+            VideoSegment afterFailure = CreateSegment(directory, "after-failure.tmp", 30, 40);
+            currentSegments = [beforeFailure, overlapsFailureStart, overlapsFailureEnd, afterFailure];
+
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(beforeFailure.Path));
+            Assert.IsTrue(File.Exists(overlapsFailureStart.Path));
+            Assert.IsTrue(File.Exists(overlapsFailureEnd.Path));
+            Assert.IsFalse(File.Exists(afterFailure.Path));
+            VerifyWarningCount(logger, Times.Never());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task TryPruneOldSegments_CappedFailedFootage_DeletesAtCutoffAndKeepsNewerFootage()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.OnFailure,
+                TimeSpan.FromSeconds(30),
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            await handler.ConsumeAsync(
+                null!,
+                CreateUpdate(new FailedTestNodeStateProperty("failure"), recordingStart, recordingStart.AddSeconds(100)),
+                CancellationToken.None);
+
+            VideoSegment atCutoff = CreateSegment(directory, "failed-at-cutoff.tmp", 60, 70);
+            VideoSegment afterCutoff = CreateSegment(directory, "failed-after-cutoff.tmp", 70, 71);
+            currentSegments = [atCutoff, afterCutoff];
+
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(atCutoff.Path));
+            Assert.IsTrue(File.Exists(afterCutoff.Path));
+            VerifyWarningCount(logger, Times.Once());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task TryPruneOldSegments_CapDropsOnRepeatedPasses_WarnsExactlyOnce()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.OnFailure,
+                TimeSpan.FromSeconds(30),
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            await handler.ConsumeAsync(
+                null!,
+                CreateUpdate(new FailedTestNodeStateProperty("failure"), recordingStart, recordingStart.AddSeconds(100)),
+                CancellationToken.None);
+
+            VideoSegment firstPass = CreateSegment(directory, "failed-first-pass.tmp", 0, 10);
+            currentSegments = [firstPass];
+            InvokeTryPruneOldSegments(handler);
+
+            VideoSegment secondPass = CreateSegment(directory, "failed-second-pass.tmp", 10, 20);
+            currentSegments = [secondPass];
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(firstPass.Path));
+            Assert.IsFalse(File.Exists(secondPass.Path));
+            VerifyWarningCount(logger, Times.Once());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void TryPruneOldSegments_AlwaysWithCap_DeletesAtCutoffAndKeepsNewerSegment()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.Always,
+                TimeSpan.FromSeconds(30),
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            VideoSegment atCutoff = CreateSegment(directory, "always-at-cutoff.tmp", 60, 70);
+            VideoSegment afterCutoff = CreateSegment(directory, "always-after-cutoff.tmp", 70, 71);
+            currentSegments = [atCutoff, afterCutoff];
+
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(atCutoff.Path));
+            Assert.IsTrue(File.Exists(afterCutoff.Path));
+            VerifyWarningCount(logger, Times.Once());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task TryPruneOldSegments_InFlightWatermark_DeletesBoundaryAndProtectsCurrentAndLaterSegments()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(30);
+            IReadOnlyList<VideoSegment> currentSegments = [];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.OnFailure,
+                maxRetainedDuration: null,
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out _,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            await handler.ConsumeAsync(
+                null!,
+                CreateUpdate(InProgressTestNodeStateProperty.CachedInstance, recordingStart, recordingStart),
+                CancellationToken.None);
+            now = recordingStart.AddSeconds(100);
+
+            VideoSegment atWatermark = CreateSegment(directory, "at-watermark.tmp", 20, 30);
+            VideoSegment crossesWatermark = CreateSegment(directory, "crosses-watermark.tmp", 30, 31);
+            VideoSegment afterWatermark = CreateSegment(directory, "after-watermark.tmp", 31, 40);
+            currentSegments = [atWatermark, crossesWatermark, afterWatermark];
+
+            InvokeTryPruneOldSegments(handler);
+
+            Assert.IsFalse(File.Exists(atWatermark.Path));
+            Assert.IsTrue(File.Exists(crossesWatermark.Path));
+            Assert.IsTrue(File.Exists(afterWatermark.Path));
+            VerifyWarningCount(logger, Times.Never());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public void TryPruneOldSegments_AlwaysWithoutCap_DoesNotReadOrDeleteSegments()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            DateTimeOffset recordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            DateTimeOffset now = recordingStart.AddSeconds(100);
+            VideoSegment segment = CreateSegment(directory, "unbounded-always.tmp", 0, 10);
+            IReadOnlyList<VideoSegment> currentSegments = [segment];
+            VideoRecorderSessionHandler handler = CreateHandler(
+                VideoRecorderPersistenceMode.Always,
+                maxRetainedDuration: null,
+                directory,
+                recordingStart,
+                () => now,
+                () => currentSegments,
+                out Mock<IVideoRecorder> recorder,
+                out Mock<ILogger<VideoRecorderSessionHandler>> logger);
+
+            InvokeTryPruneOldSegments(handler);
+
+            recorder.Verify(instance => instance.ReadSegments(), Times.Never());
+            Assert.IsTrue(File.Exists(segment.Path));
+            VerifyWarningCount(logger, Times.Never());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    private static VideoRecorderSessionHandler CreateHandler(
+        VideoRecorderPersistenceMode persistMode,
+        TimeSpan? maxRetainedDuration,
+        string outputDirectory,
+        DateTimeOffset recordingStart,
+        Func<DateTimeOffset> getUtcNow,
+        Func<IReadOnlyList<VideoSegment>> getSegments,
+        out Mock<IVideoRecorder> recorder,
+        out Mock<ILogger<VideoRecorderSessionHandler>> logger)
+    {
+        var options = new VideoRecorderOptions
+        {
+            OutputDirectory = outputDirectory,
+            PersistMode = persistMode,
+            MaxRetainedDuration = maxRetainedDuration,
+        };
+        var commandLineOptions = new TestCommandLineOptions(new()
+        {
+            [VideoRecorderCommandLineProvider.EnableOptionName] = [],
+        });
+        var clock = new Mock<IClock>();
+        clock.SetupGet(instance => instance.UtcNow).Returns(getUtcNow);
+        recorder = new Mock<IVideoRecorder>();
+        recorder.SetupGet(instance => instance.RecordingStartUtc).Returns(recordingStart);
+        recorder.Setup(instance => instance.ReadSegments()).Returns(getSegments);
+        logger = new Mock<ILogger<VideoRecorderSessionHandler>>();
+
+        return new VideoRecorderSessionHandler(
+            options,
+            Mock.Of<IConfiguration>(),
+            commandLineOptions,
+            Mock.Of<IMessageBus>(),
+            Mock.Of<IOutputDevice>(),
+            clock.Object,
+            logger.Object,
+            recorder.Object);
+    }
+
+    private static TestNodeUpdateMessage CreateUpdate(
+        TestNodeStateProperty state,
+        DateTimeOffset start,
+        DateTimeOffset end)
+        => new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = Guid.NewGuid().ToString("N"),
+                DisplayName = "Pruning test",
+                Properties = new PropertyBag(
+                    state,
+                    new TimingProperty(new TimingInfo(start, end, end - start))),
+            });
+
+    private static VideoSegment CreateSegment(string directory, string fileName, double startSeconds, double endSeconds)
+    {
+        string path = Path.Combine(directory, fileName);
+        File.WriteAllText(path, "segment data");
+        return new VideoSegment(path, startSeconds, endSeconds);
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"{nameof(VideoRecorderSessionHandlerSegmentPruningTests)}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteTemporaryDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static void InvokeTryPruneOldSegments(VideoRecorderSessionHandler handler)
+        => TryPruneOldSegmentsMethod.Invoke(handler, parameters: null);
+
+    private static void VerifyWarningCount(Mock<ILogger<VideoRecorderSessionHandler>> logger, Times times)
+        => logger.Verify(
+            instance => instance.Log(
+                LogLevel.Warning,
+                It.IsAny<string>(),
+                null,
+                It.IsAny<Func<string, Exception?, string>>()),
+            times);
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerVideoProductionTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerVideoProductionTests.cs
@@ -1,0 +1,479 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Extensions.VideoRecorder;
+using Microsoft.Testing.Extensions.VideoRecorder.Resources;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class VideoRecorderSessionHandlerVideoProductionTests
+{
+    private static readonly MethodInfo ProduceVideosAsyncMethod =
+        typeof(VideoRecorderSessionHandler).GetMethod(
+            "ProduceVideosAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not resolve ProduceVideosAsync.");
+
+    private static readonly FieldInfo SessionUidField =
+        typeof(VideoRecorderSessionHandler).GetField(
+            "_sessionUid",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not resolve _sessionUid.");
+
+    private static readonly DateTimeOffset RecordingStart = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_RecordingHasNotStarted_DoesNothing()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            recordingStartUtc: null);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        context.Recorder.Verify(instance => instance.ReadSegments(), Times.Never());
+        VerifyNoConcat(context.Recorder);
+        context.OutputDevice.Verify(
+            instance => instance.DisplayAsync(
+                It.IsAny<IOutputDeviceDataProducer>(),
+                It.IsAny<IOutputDeviceData>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
+        context.MessageBus.Verify(
+            instance => instance.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()),
+            Times.Never());
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerTestOnFailurePassedRecord_DoesNotConcat()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Passed test",
+            PassedTestNodeStateProperty.CachedInstance,
+            RecordingStart.AddSeconds(15),
+            RecordingStart.AddSeconds(25));
+        context.CurrentSegments = [new VideoSegment("segment.mp4", 10, 20)];
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        VerifyNoConcat(context.Recorder);
+        Assert.IsEmpty(context.PublishedData);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerTestOnFailureFailedRecord_ConcatsOnlyOverlappingSegmentsInSourceOrder()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Failed test",
+            new FailedTestNodeStateProperty("failure"),
+            RecordingStart.AddSeconds(15),
+            RecordingStart.AddSeconds(25));
+        var before = new VideoSegment("before.mp4", 0, 10);
+        var overlapsStart = new VideoSegment("overlaps-start.mp4", 10, 20);
+        var overlapsEnd = new VideoSegment("overlaps-end.mp4", 20, 30);
+        var after = new VideoSegment("after.mp4", 30, 40);
+        context.CurrentSegments = [before, overlapsStart, overlapsEnd, after];
+        IReadOnlyList<VideoSegment>? capturedSegments = null;
+        SetupConcat(context.Recorder, segments => capturedSegments = [.. segments]);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        AssertSegments(capturedSegments, overlapsStart, overlapsEnd);
+        context.Recorder.Verify(
+            instance => instance.ConcatAsync(
+                It.IsAny<IReadOnlyList<VideoSegment>>(),
+                It.IsAny<string>(),
+                null,
+                CancellationToken.None),
+            Times.Once());
+        Assert.IsEmpty(context.PublishedData);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerTestStartBeforeRecording_ClampsStartToZero()
+    {
+        DateTimeOffset recordingStart = RecordingStart.AddSeconds(10);
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            recordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Pre-recording test",
+            new FailedTestNodeStateProperty("failure"),
+            RecordingStart.AddSeconds(5),
+            RecordingStart.AddSeconds(15));
+        var beforeRecording = new VideoSegment("before-recording.mp4", -5, 0);
+        var afterRecording = new VideoSegment("after-recording.mp4", 0, 5);
+        context.CurrentSegments = [beforeRecording, afterRecording];
+        IReadOnlyList<VideoSegment>? capturedSegments = null;
+        SetupConcat(context.Recorder, segments => capturedSegments = [.. segments]);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        AssertSegments(capturedSegments, afterRecording);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerTestWithNoSurvivingOverlap_SkipsConcatAndTraces()
+    {
+        const string DisplayName = "Pruned failed test";
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            DisplayName,
+            new FailedTestNodeStateProperty("failure"),
+            RecordingStart.AddSeconds(15),
+            RecordingStart.AddSeconds(25));
+        context.CurrentSegments = [new VideoSegment("non-overlapping.mp4", 30, 40)];
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        VerifyNoConcat(context.Recorder);
+        Assert.IsEmpty(context.PublishedData);
+        context.Logger.Verify(
+            instance => instance.Log(
+                LogLevel.Trace,
+                It.Is<string>(message => message.Contains(DisplayName, StringComparison.Ordinal)),
+                null,
+                It.IsAny<Func<string, Exception?, string>>()),
+            Times.Once());
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerSessionOnFailurePassedOnly_DoesNotConcat()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerSession,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Passed test",
+            PassedTestNodeStateProperty.CachedInstance,
+            RecordingStart.AddSeconds(10),
+            RecordingStart.AddSeconds(20));
+        context.CurrentSegments = [new VideoSegment("segment.mp4", 0, 30)];
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        VerifyNoConcat(context.Recorder);
+        Assert.IsEmpty(context.PublishedData);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerSessionOnFailureWithFailure_ConcatsAllSegments()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerSession,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Failed test",
+            new FailedTestNodeStateProperty("failure"),
+            RecordingStart.AddSeconds(15),
+            RecordingStart.AddSeconds(25));
+        var first = new VideoSegment("first.mp4", 0, 10);
+        var second = new VideoSegment("second.mp4", 10, 20);
+        var third = new VideoSegment("third.mp4", 20, 30);
+        context.CurrentSegments = [first, second, third];
+        IReadOnlyList<VideoSegment>? capturedSegments = null;
+        SetupConcat(context.Recorder, segments => capturedSegments = [.. segments]);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        AssertSegments(capturedSegments, first, second, third);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerSessionAlwaysPassedOnly_ConcatsAllSegments()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.Always,
+            VideoCaptureGranularity.PerSession,
+            RecordingStart);
+        await AddRecordAsync(
+            context.Handler,
+            "Passed test",
+            PassedTestNodeStateProperty.CachedInstance,
+            RecordingStart.AddSeconds(15),
+            RecordingStart.AddSeconds(25));
+        var first = new VideoSegment("first.mp4", 0, 10);
+        var second = new VideoSegment("second.mp4", 10, 20);
+        context.CurrentSegments = [first, second];
+        IReadOnlyList<VideoSegment>? capturedSegments = null;
+        SetupConcat(context.Recorder, segments => capturedSegments = [.. segments]);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        AssertSegments(capturedSegments, first, second);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_EmptySegmentSnapshot_DisplaysDiagnosticWarning()
+    {
+        var context = new HandlerContext(
+            VideoRecorderPersistenceMode.OnFailure,
+            VideoCaptureGranularity.PerTest,
+            RecordingStart);
+
+        await InvokeProduceVideosAsync(context.Handler);
+
+        WarningMessageOutputDeviceData warning = Assert.IsInstanceOfType<WarningMessageOutputDeviceData>(
+            Assert.ContainsSingle(context.OutputData));
+        string expected = string.Format(
+            CultureInfo.CurrentCulture,
+            VideoRecorderResources.NoUsableVideoProduced,
+            -1,
+            HandlerContext.DiagnosticTail);
+        Assert.AreEqual(expected, warning.Message);
+        Assert.Contains(HandlerContext.DiagnosticTail, warning.Message);
+        VerifyNoConcat(context.Recorder);
+        Assert.IsEmpty(context.PublishedData);
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerTestConcatSucceeds_PublishesPerTestArtifact()
+    {
+        const string DisplayName = "Published failed test";
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string outputPath = Path.Combine(directory, "per-test.mp4");
+            File.WriteAllText(outputPath, string.Empty);
+            var context = new HandlerContext(
+                VideoRecorderPersistenceMode.OnFailure,
+                VideoCaptureGranularity.PerTest,
+                RecordingStart);
+            SetSessionUid(context.Handler, new SessionUid("per-test-session"));
+            await AddRecordAsync(
+                context.Handler,
+                DisplayName,
+                new FailedTestNodeStateProperty("failure"),
+                RecordingStart.AddSeconds(15),
+                RecordingStart.AddSeconds(25));
+            context.CurrentSegments = [new VideoSegment("segment.mp4", 10, 30)];
+            SetupConcat(context.Recorder, _ => { }, outputPath);
+
+            await InvokeProduceVideosAsync(context.Handler);
+
+            SessionFileArtifact artifact = Assert.IsInstanceOfType<SessionFileArtifact>(
+                Assert.ContainsSingle(context.PublishedData));
+            Assert.AreEqual(Path.GetFullPath(outputPath), artifact.FileInfo.FullName);
+            Assert.AreEqual(
+                string.Format(CultureInfo.CurrentCulture, VideoRecorderResources.ArtifactPerTestDisplayName, DisplayName),
+                artifact.DisplayName);
+            Assert.AreEqual(
+                string.Format(CultureInfo.CurrentCulture, VideoRecorderResources.ArtifactPerTestDescription, DisplayName),
+                artifact.Description);
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    [TestMethod]
+    public async Task ProduceVideosAsync_PerSessionConcatSucceeds_PublishesSessionArtifact()
+    {
+        string directory = CreateTemporaryDirectory();
+        try
+        {
+            string outputPath = Path.Combine(directory, "session.mp4");
+            File.WriteAllText(outputPath, string.Empty);
+            var context = new HandlerContext(
+                VideoRecorderPersistenceMode.Always,
+                VideoCaptureGranularity.PerSession,
+                RecordingStart);
+            SetSessionUid(context.Handler, new SessionUid("video-session"));
+            context.CurrentSegments = [new VideoSegment("segment.mp4", 0, 30)];
+            SetupConcat(context.Recorder, _ => { }, outputPath);
+
+            await InvokeProduceVideosAsync(context.Handler);
+
+            SessionFileArtifact artifact = Assert.IsInstanceOfType<SessionFileArtifact>(
+                Assert.ContainsSingle(context.PublishedData));
+            Assert.AreEqual(Path.GetFullPath(outputPath), artifact.FileInfo.FullName);
+            Assert.AreEqual(VideoRecorderResources.ArtifactSessionDisplayName, artifact.DisplayName);
+            Assert.AreEqual(VideoRecorderResources.ArtifactSessionDescription, artifact.Description);
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(directory);
+        }
+    }
+
+    private static Task AddRecordAsync(
+        VideoRecorderSessionHandler handler,
+        string displayName,
+        TestNodeStateProperty state,
+        DateTimeOffset start,
+        DateTimeOffset end)
+        => handler.ConsumeAsync(
+            null!,
+            new TestNodeUpdateMessage(
+                new SessionUid("session"),
+                new TestNode
+                {
+                    Uid = displayName,
+                    DisplayName = displayName,
+                    Properties = new PropertyBag(
+                        state,
+                        new TimingProperty(new TimingInfo(start, end, end - start))),
+                }),
+            CancellationToken.None);
+
+    private static async Task InvokeProduceVideosAsync(VideoRecorderSessionHandler handler)
+        => await (Task)ProduceVideosAsyncMethod.Invoke(handler, [CancellationToken.None])!;
+
+    private static void SetupConcat(
+        Mock<IVideoRecorder> recorder,
+        Action<IReadOnlyList<VideoSegment>> capture,
+        string? result = null)
+        => recorder
+            .Setup(instance => instance.ConcatAsync(
+                It.IsAny<IReadOnlyList<VideoSegment>>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<VideoSegment>, string, string?, CancellationToken>(
+                (segments, _, _, _) => capture(segments))
+            .ReturnsAsync(result);
+
+    private static void VerifyNoConcat(Mock<IVideoRecorder> recorder)
+        => recorder.Verify(
+            instance => instance.ConcatAsync(
+                It.IsAny<IReadOnlyList<VideoSegment>>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never());
+
+    private static void AssertSegments(IReadOnlyList<VideoSegment>? actual, params VideoSegment[] expected)
+    {
+        Assert.IsNotNull(actual);
+        Assert.HasCount(expected.Length, actual);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.AreEqual(expected[i].Path, actual[i].Path);
+            Assert.AreEqual(expected[i].StartSeconds, actual[i].StartSeconds);
+            Assert.AreEqual(expected[i].EndSeconds, actual[i].EndSeconds);
+        }
+    }
+
+    private static void SetSessionUid(VideoRecorderSessionHandler handler, SessionUid sessionUid)
+        => SessionUidField.SetValue(handler, sessionUid);
+
+    private static string CreateTemporaryDirectory()
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"{nameof(VideoRecorderSessionHandlerVideoProductionTests)}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void DeleteTemporaryDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private sealed class HandlerContext
+    {
+        public const string DiagnosticTail = "diagnostic-tail";
+
+        public HandlerContext(
+            VideoRecorderPersistenceMode persistMode,
+            VideoCaptureGranularity granularity,
+            DateTimeOffset? recordingStartUtc)
+        {
+            var options = new VideoRecorderOptions
+            {
+                OutputDirectory = Path.GetTempPath(),
+                PersistMode = persistMode,
+                Granularity = granularity,
+                IncludeChapters = false,
+            };
+            var commandLineOptions = new TestCommandLineOptions(new()
+            {
+                [VideoRecorderCommandLineProvider.EnableOptionName] = [],
+            });
+            var clock = new Mock<IClock>();
+            clock.SetupGet(instance => instance.UtcNow).Returns(RecordingStart);
+            Recorder.SetupGet(instance => instance.RecordingStartUtc).Returns(recordingStartUtc);
+            Recorder.SetupGet(instance => instance.SegmentExtension).Returns("mp4");
+            Recorder.Setup(instance => instance.ReadSegments()).Returns(() => CurrentSegments);
+            Recorder.Setup(instance => instance.DescribeLastFfmpegError()).Returns(DiagnosticTail);
+            OutputDevice
+                .Setup(instance => instance.DisplayAsync(
+                    It.IsAny<IOutputDeviceDataProducer>(),
+                    It.IsAny<IOutputDeviceData>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>(
+                    (_, data, _) => OutputData.Add(data))
+                .Returns(Task.CompletedTask);
+            MessageBus
+                .Setup(instance => instance.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()))
+                .Callback<IDataProducer, IData>((_, data) => PublishedData.Add(data))
+                .Returns(Task.CompletedTask);
+
+            Handler = new VideoRecorderSessionHandler(
+                options,
+                Mock.Of<IConfiguration>(),
+                commandLineOptions,
+                MessageBus.Object,
+                OutputDevice.Object,
+                clock.Object,
+                Logger.Object,
+                Recorder.Object);
+        }
+
+        public VideoRecorderSessionHandler Handler { get; }
+
+        public Mock<IVideoRecorder> Recorder { get; } = new();
+
+        public Mock<IOutputDevice> OutputDevice { get; } = new();
+
+        public Mock<IMessageBus> MessageBus { get; } = new();
+
+        public Mock<ILogger<VideoRecorderSessionHandler>> Logger { get; } = new();
+
+        public List<IOutputDeviceData> OutputData { get; } = [];
+
+        public List<IData> PublishedData { get; } = [];
+
+        public IReadOnlyList<VideoSegment> CurrentSegments { get; set; } = [];
+    }
+}


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Video recorder pruning and production logic had near-zero unit coverage, leaving retention boundaries, failed-window overlap, and artifact decisions without regression protection.

This adds an internal recorder abstraction so the session handler can be exercised without launching ffmpeg, then covers segment-list parsing, rolling-buffer pruning, per-test and per-session production, diagnostics, and artifact publication. The affected test slice now passes 34 tests.

Closes #10782