### PR TITLE
Skip product CI for infrastructure-only changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -306,7 +306,8 @@ stages:
   condition: and(succeeded(), not(and(in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))))
   jobs:
 
-  # Lightweight job that classifies the PR diff into product, samples, and XML-documentation-only
+  # Lightweight job that classifies the PR diff into product, samples, infrastructure-only,
+  # and XML-documentation-only
   # scopes and exposes them as output variables. Downstream jobs use them to skip work that
   # the diff does not touch (so e.g. a samples-only Dependabot PR does not spin up
   # the full Windows/Linux/macOS product matrix, and a product-only PR does not run
@@ -314,10 +315,10 @@ stages:
   #
   # Fail-safe behaviour:
   #   - Non-PR triggers (manual queue, scheduled, etc.) leave SYSTEM_PULLREQUEST_TARGETBRANCH
-  #     empty, so we emit "true" for both change flags and "false" for XML-documentation-only.
+  #     empty, so we emit "true" for both change flags and "false" for the optimized scopes.
   #   - If the diff is empty (e.g. force-push to the same SHA), we also run everything.
-  #   - Downstream conditions treat missing product/sample outputs as changed and a missing
-  #     XML-documentation-only output as false, so classification uncertainty runs full validation.
+  #   - Downstream conditions treat missing product/sample outputs as changed and missing
+  #     optimized-scope outputs as false, so classification uncertainty runs full validation.
   - job: DetectChanges
     displayName: Detect changed paths
     pool:
@@ -336,11 +337,12 @@ stages:
         # ADO exposes the target branch as a full ref (e.g. "refs/heads/main"); strip the
         # "refs/heads/" prefix so it can be combined with the "origin/" remote-tracking prefix.
         target="${target#refs/heads/}"
+        hasProduct=true
+        hasSamples=true
+        infrastructureOnly=false
+        xmlDocsOnly=false
         if [[ -z "${target}" ]]; then
           echo "Not a PR build (SYSTEM_PULLREQUEST_TARGETBRANCH is empty); running all jobs."
-          hasProduct=true
-          hasSamples=true
-          xmlDocsOnly=false
         else
           echo "PR target branch: ${target}"
           git fetch --no-tags --depth=200 origin "${target}" 2>/dev/null \
@@ -353,30 +355,37 @@ stages:
 
           if [[ -z "${files}" ]]; then
             echo "No files changed in diff; running all jobs."
-            hasProduct=true
-            hasSamples=true
-            xmlDocsOnly=false
           else
-            # A file is a "samples-affecting" change if it lives under samples/** or it is
-            # one of the eng/ scripts that drives the samples build (build-samples.ps1).
-            # Everything else is treated as a product change.
-            samples_pattern='^(samples/|eng/build-samples\.ps1$)'
-            if echo "${files}" | grep -Eqv "${samples_pattern}"; then
-              hasProduct=true
+            # Never let a PR classify itself with code from its own branch. The trusted target-branch
+            # classifier contains a narrow infrastructure allowlist; missing, broken, unknown, and empty
+            # classifications all retain the full-validation defaults above.
+            buildClassifier="${AGENT_TEMPDIRECTORY}/classify-build-change.ps1"
+            classificationSucceeded=false
+            if ! git show "origin/${target}:eng/classify-build-change.ps1" > "${buildClassifier}"; then
+              echo "##vso[task.logissue type=warning]The trusted target branch does not contain the build change classifier; using full validation."
+            elif ! pwsh -NoProfile -File "${buildClassifier}" -SelfTest; then
+              echo "##vso[task.logissue type=warning]The trusted build change classifier failed its self-tests; using full validation."
+            elif ! classification="$(pwsh -NoProfile -File "${buildClassifier}" -Base "${base}" -Head HEAD -Repository "${BUILD_SOURCESDIRECTORY}")"; then
+              echo "##vso[task.logissue type=warning]Build change classification did not run; using full validation."
             else
-              hasProduct=false
-            fi
-            if echo "${files}" | grep -Eq "${samples_pattern}"; then
-              hasSamples=true
-            else
-              hasSamples=false
+              classification_pattern='^hasProductChanges=(true|false);hasSamplesChanges=(true|false);infrastructureOnly=(true|false)$'
+              if [[ "${classification}" =~ ${classification_pattern} ]]; then
+                hasProduct="${BASH_REMATCH[1]}"
+                hasSamples="${BASH_REMATCH[2]}"
+                infrastructureOnly="${BASH_REMATCH[3]}"
+                classificationSucceeded=true
+              else
+                echo "##vso[task.logissue type=warning]Build change classification returned an unexpected value; using full validation."
+              fi
             fi
 
             # Never let a PR classify itself with code from its own branch. Extract the classifier from the
             # trusted target branch and fail closed when it is missing, broken, or returns an unexpected value.
             classifier="${AGENT_TEMPDIRECTORY}/classify-xml-doc-change.ps1"
             xmlDocsOnly=false
-            if ! git show "origin/${target}:eng/classify-xml-doc-change.ps1" > "${classifier}"; then
+            if [[ "${classificationSucceeded}" != "true" ]]; then
+              echo "Skipping XML documentation classification because build change classification was not trusted."
+            elif ! git show "origin/${target}:eng/classify-xml-doc-change.ps1" > "${classifier}"; then
               echo "##vso[task.logissue type=warning]The trusted target branch does not contain the XML documentation classifier; using full validation."
             elif ! pwsh -NoProfile -File "${classifier}" -SelfTest; then
               echo "##vso[task.logissue type=warning]The trusted XML documentation classifier failed its self-tests; using full validation."
@@ -393,9 +402,11 @@ stages:
 
         echo "hasProductChanges=${hasProduct}"
         echo "hasSamplesChanges=${hasSamples}"
+        echo "infrastructureOnly=${infrastructureOnly}"
         echo "xmlDocsOnly=${xmlDocsOnly}"
         echo "##vso[task.setvariable variable=hasProductChanges;isOutput=true]${hasProduct}"
         echo "##vso[task.setvariable variable=hasSamplesChanges;isOutput=true]${hasSamples}"
+        echo "##vso[task.setvariable variable=infrastructureOnly;isOutput=true]${infrastructureOnly}"
         echo "##vso[task.setvariable variable=xmlDocsOnly;isOutput=true]${xmlDocsOnly}"
       name: detect
       displayName: Classify changed files
@@ -416,9 +427,10 @@ stages:
       jobs:
       - job: Windows
         dependsOn: DetectChanges
-        # Release normally runs full validation and coverage for every PR, but XML-documentation-only PRs use
-        # it only for compiler and package validation. Debug remains skippable for samples-only and XML-doc-only PRs.
-        condition: and(succeededOrFailed(), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
+        # Release normally runs full validation and coverage for every non-infrastructure PR, but
+        # XML-documentation-only PRs use it only for compiler and package validation. Debug remains
+        # skippable for samples-only and XML-doc-only PRs.
+        condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.infrastructureOnly'], 'true'), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
         timeoutInMinutes: 90
         pool:
           name: NetCore-Public

--- a/eng/classify-build-change.ps1
+++ b/eng/classify-build-change.ps1
@@ -1,0 +1,295 @@
+[CmdletBinding(DefaultParameterSetName = "GitDiff")]
+param(
+    [Parameter(Mandatory, ParameterSetName = "GitDiff")]
+    [string]$Base,
+
+    [Parameter(Mandatory, ParameterSetName = "GitDiff")]
+    [string]$Head,
+
+    [Parameter(ParameterSetName = "GitDiff")]
+    [string]$Repository,
+
+    [Parameter(Mandatory, ParameterSetName = "SelfTest")]
+    [switch]$SelfTest
+)
+
+$ErrorActionPreference = "Stop"
+$PSNativeCommandUseErrorActionPreference = $false
+
+# Keep this allowlist intentionally narrow. These paths configure GitHub-only automation or repository
+# administration and are not consumed by the product build. Build pipelines, dependency configuration,
+# general documentation, and unknown paths must remain product-affecting so classification fails closed.
+$infrastructureDirectories = @(
+    ".github/agents/",
+    ".github/aw/",
+    ".github/copilot/",
+    ".github/instructions/",
+    ".github/ISSUE_TEMPLATE/",
+    ".github/policies/",
+    ".github/scripts/",
+    ".github/skills/",
+    ".github/workflows/"
+)
+$infrastructureFiles = @(
+    ".github/copilot-instructions.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/release.yml",
+    "eng/vendored-files.md"
+)
+
+function Test-SamplesAffectingPath {
+    param([string]$Path)
+
+    return (
+        $Path.StartsWith("samples/", [System.StringComparison]::Ordinal) -or
+        $Path.Equals("eng/build-samples.ps1", [System.StringComparison]::Ordinal))
+}
+
+function Test-InfrastructureOnlyPath {
+    param([string]$Path)
+
+    if ([string]::IsNullOrEmpty($Path)) {
+        return $false
+    }
+
+    foreach ($directory in $infrastructureDirectories) {
+        if ($Path.StartsWith($directory, [System.StringComparison]::Ordinal)) {
+            return $true
+        }
+    }
+
+    return $infrastructureFiles -ccontains $Path
+}
+
+function Get-Classification {
+    param([AllowEmptyCollection()][string[]]$Paths)
+
+    if (@($Paths).Count -eq 0) {
+        return [PSCustomObject][ordered]@{
+            HasProductChanges = $true
+            HasSamplesChanges = $true
+            InfrastructureOnly = $false
+        }
+    }
+
+    $hasProductChanges = $false
+    $hasSamplesChanges = $false
+    $infrastructureOnly = $true
+
+    foreach ($path in $Paths) {
+        if (Test-SamplesAffectingPath $path) {
+            $hasSamplesChanges = $true
+            $infrastructureOnly = $false
+        }
+        elseif (-not (Test-InfrastructureOnlyPath $path)) {
+            $hasProductChanges = $true
+            $infrastructureOnly = $false
+        }
+    }
+
+    return [PSCustomObject][ordered]@{
+        HasProductChanges = $hasProductChanges
+        HasSamplesChanges = $hasSamplesChanges
+        InfrastructureOnly = $infrastructureOnly
+    }
+}
+
+function Invoke-Git {
+    param(
+        [string]$Repository,
+        [string[]]$Arguments
+    )
+
+    $output = @(& git -C $Repository @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $($output -join [Environment]::NewLine)"
+    }
+
+    return $output
+}
+
+function Get-GitDiffClassification {
+    param(
+        [string]$BaseRevision,
+        [string]$HeadRevision,
+        [string]$Repository
+    )
+
+    if ([string]::IsNullOrEmpty($Repository)) {
+        $repositoryOutput = @(Invoke-Git $PSScriptRoot @("rev-parse", "--show-toplevel"))
+        $Repository = $repositoryOutput[0]
+    }
+
+    $paths = @(Invoke-Git $Repository @(
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "--diff-filter=ACDMRTUXB",
+        $BaseRevision,
+        $HeadRevision,
+        "--"
+    ))
+
+    return Get-Classification $paths
+}
+
+function Format-Classification {
+    param([PSCustomObject]$Classification)
+
+    $hasProductChanges = $Classification.HasProductChanges.ToString().ToLowerInvariant()
+    $hasSamplesChanges = $Classification.HasSamplesChanges.ToString().ToLowerInvariant()
+    $infrastructureOnly = $Classification.InfrastructureOnly.ToString().ToLowerInvariant()
+
+    return "hasProductChanges=$hasProductChanges;hasSamplesChanges=$hasSamplesChanges;infrastructureOnly=$infrastructureOnly"
+}
+
+function Assert-Classification {
+    param(
+        [string]$Name,
+        [string[]]$Paths,
+        [bool]$HasProductChanges,
+        [bool]$HasSamplesChanges,
+        [bool]$InfrastructureOnly
+    )
+
+    $actual = Get-Classification $Paths
+    if (
+        $actual.HasProductChanges -ne $HasProductChanges -or
+        $actual.HasSamplesChanges -ne $HasSamplesChanges -or
+        $actual.InfrastructureOnly -ne $InfrastructureOnly
+    ) {
+        throw "Self-test '$Name' expected product=$HasProductChanges, samples=$HasSamplesChanges, infrastructure=$InfrastructureOnly but got $(Format-Classification $actual)."
+    }
+}
+
+function Invoke-GitDiffSelfTest {
+    $repository = Join-Path ([System.IO.Path]::GetTempPath()) "testfx-build-change-classifier-$([System.Guid]::NewGuid().ToString('N'))"
+    [System.IO.Directory]::CreateDirectory($repository) | Out-Null
+
+    try {
+        $null = Invoke-Git $repository @("init", "--quiet")
+        $null = Invoke-Git $repository @("config", "user.name", "Build change classifier")
+        $null = Invoke-Git $repository @("config", "user.email", "classifier@example.invalid")
+
+        [System.IO.File]::WriteAllText((Join-Path $repository "README.md"), "Base`n")
+        $null = Invoke-Git $repository @("add", "--all")
+        $null = Invoke-Git $repository @("commit", "--quiet", "-m", "Base")
+        $baseRevision = @(Invoke-Git $repository @("rev-parse", "HEAD"))[0]
+
+        $workflowDirectory = Join-Path $repository ".github/workflows"
+        [System.IO.Directory]::CreateDirectory($workflowDirectory) | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $workflowDirectory "triage.yml"), "name: Triage`n")
+        $null = Invoke-Git $repository @("add", "--all")
+        $null = Invoke-Git $repository @("commit", "--quiet", "-m", "Infrastructure")
+        $infrastructureRevision = @(Invoke-Git $repository @("rev-parse", "HEAD"))[0]
+        $classification = Get-GitDiffClassification $baseRevision $infrastructureRevision $repository
+        $formattedClassification = Format-Classification $classification
+        if ($formattedClassification -cne "hasProductChanges=false;hasSamplesChanges=false;infrastructureOnly=true") {
+            throw "Git self-test expected an infrastructure-only diff but got '$formattedClassification'."
+        }
+
+        $samplesDirectory = Join-Path $repository "samples"
+        [System.IO.Directory]::CreateDirectory($samplesDirectory) | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $samplesDirectory "Sample.cs"), "class Sample { }`n")
+        $null = Invoke-Git $repository @("add", "--all")
+        $null = Invoke-Git $repository @("commit", "--quiet", "-m", "Samples")
+        $samplesRevision = @(Invoke-Git $repository @("rev-parse", "HEAD"))[0]
+        $classification = Get-GitDiffClassification $infrastructureRevision $samplesRevision $repository
+        $formattedClassification = Format-Classification $classification
+        if ($formattedClassification -cne "hasProductChanges=false;hasSamplesChanges=true;infrastructureOnly=false") {
+            throw "Git self-test expected a samples-only diff but got '$formattedClassification'."
+        }
+
+        $productDirectory = Join-Path $repository "src"
+        [System.IO.Directory]::CreateDirectory($productDirectory) | Out-Null
+        [System.IO.File]::WriteAllText((Join-Path $productDirectory "Product.cs"), "class Product { }`n")
+        $null = Invoke-Git $repository @("add", "--all")
+        $null = Invoke-Git $repository @("commit", "--quiet", "-m", "Product")
+        $productRevision = @(Invoke-Git $repository @("rev-parse", "HEAD"))[0]
+        $classification = Get-GitDiffClassification $baseRevision $productRevision $repository
+        $formattedClassification = Format-Classification $classification
+        if ($formattedClassification -cne "hasProductChanges=true;hasSamplesChanges=true;infrastructureOnly=false") {
+            throw "Git self-test expected a mixed infrastructure, samples, and product diff but got '$formattedClassification'."
+        }
+
+        $classification = Get-GitDiffClassification $productRevision $productRevision $repository
+        $formattedClassification = Format-Classification $classification
+        if ($formattedClassification -cne "hasProductChanges=true;hasSamplesChanges=true;infrastructureOnly=false") {
+            throw "Git self-test expected an empty diff to run full validation but got '$formattedClassification'."
+        }
+
+        try {
+            $null = Get-GitDiffClassification "missing-revision" $productRevision $repository
+            throw "Git self-test expected an invalid revision to fail."
+        }
+        catch {
+            if ($_.Exception.Message -eq "Git self-test expected an invalid revision to fail.") {
+                throw
+            }
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $repository -Recurse -Force
+    }
+}
+
+function Invoke-SelfTest {
+    foreach ($pathCase in @(
+        @{ Path = ".github/workflows/triage.yml"; Infrastructure = $true; Samples = $false },
+        @{ Path = ".github/scripts/triage.py"; Infrastructure = $true; Samples = $false },
+        @{ Path = ".github/policies/LabelManagement.yml"; Infrastructure = $true; Samples = $false },
+        @{ Path = ".github/PULL_REQUEST_TEMPLATE.md"; Infrastructure = $true; Samples = $false },
+        @{ Path = "eng/vendored-files.md"; Infrastructure = $true; Samples = $false },
+        @{ Path = ".github/dependabot.yml"; Infrastructure = $false; Samples = $false },
+        @{ Path = "azure-pipelines.yml"; Infrastructure = $false; Samples = $false },
+        @{ Path = "eng/pipelines/steps/build.yml"; Infrastructure = $false; Samples = $false },
+        @{ Path = "eng/vendored-files.json"; Infrastructure = $false; Samples = $false },
+        @{ Path = "docs/operational.md"; Infrastructure = $false; Samples = $false },
+        @{ Path = "src/Product.cs"; Infrastructure = $false; Samples = $false },
+        @{ Path = "unknown/new-location.txt"; Infrastructure = $false; Samples = $false },
+        @{ Path = "samples/public/Sample.cs"; Infrastructure = $false; Samples = $true },
+        @{ Path = "eng/build-samples.ps1"; Infrastructure = $false; Samples = $true }
+    )) {
+        $actualInfrastructure = Test-InfrastructureOnlyPath $pathCase.Path
+        $actualSamples = Test-SamplesAffectingPath $pathCase.Path
+        if ($actualInfrastructure -ne $pathCase.Infrastructure -or $actualSamples -ne $pathCase.Samples) {
+            throw "Path self-test '$($pathCase.Path)' produced infrastructure=$actualInfrastructure, samples=$actualSamples."
+        }
+    }
+
+    Assert-Classification "Infrastructure only" @(
+        ".github/workflows/triage.yml",
+        ".github/scripts/triage.py",
+        "eng/vendored-files.md"
+    ) $false $false $true
+    Assert-Classification "Infrastructure and product" @(
+        ".github/workflows/triage.yml",
+        "src/Product.cs"
+    ) $true $false $false
+    Assert-Classification "Infrastructure and samples" @(
+        ".github/policies/LabelManagement.yml",
+        "samples/public/Sample.cs"
+    ) $false $true $false
+    Assert-Classification "Samples only" @(
+        "samples/public/Sample.cs",
+        "eng/build-samples.ps1"
+    ) $false $true $false
+    Assert-Classification "XML documentation path remains product-affecting" @(
+        "src/TestFramework/Assert.cs"
+    ) $true $false $false
+    Assert-Classification "Unknown path" @(
+        "unknown/new-location.txt"
+    ) $true $false $false
+    Assert-Classification "Empty diff" @() $true $true $false
+
+    Invoke-GitDiffSelfTest
+
+    Write-Output "Build change classifier self-tests passed."
+}
+
+if ($SelfTest) {
+    Invoke-SelfTest
+    exit 0
+}
+
+Write-Output (Format-Classification (Get-GitDiffClassification $Base $Head $Repository))


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->
Infrastructure-only pull requests currently run the full Windows, Linux, macOS, and application-model product matrix even when they cannot affect shipped product, packaging, builds, or tests.

This adds a trusted target-branch classifier with a narrow allowlist for GitHub automation and repository administration plus `eng/vendored-files.md`. Proven infrastructure-only diffs skip product and samples legs. Azure pipeline definitions, build inputs, dependency configuration, general documentation, unknown paths, mixed diffs, classifier failures, empty diffs, and non-PR builds continue to fail closed to full validation. Existing samples and XML-documentation-only behavior remains intact.

Validation:
- `pwsh -NoProfile -File .\eng\classify-build-change.ps1 -SelfTest`
- `pwsh -NoProfile -File .\eng\classify-xml-doc-change.ps1 -SelfTest`
- Parsed `azure-pipelines.yml` and the embedded `DetectChanges` Bash script.

Issue: N/A