### PR TITLE
Cache failed-test windows during video pruning

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
@@ -77,12 +77,14 @@ internal sealed partial class VideoRecorderSessionHandler
         lock (_stateGate)
         {
             _inFlight.Remove(testUid);
+            _testRecords.Add(new TestRecord(update.TestNode.DisplayName, start, end, isFailure, OutcomeText(state)));
             if (isFailure)
             {
                 _anyTestFailed = true;
+                DateTimeOffset recordingStart = _recorder.RecordingStartUtc ?? start;
+                _failedWindows.Add((start - recordingStart).TotalSeconds);
+                _failedWindows.Add((end - recordingStart).TotalSeconds);
             }
-
-            _testRecords.Add(new TestRecord(update.TestNode.DisplayName, start, end, isFailure, OutcomeText(state)));
         }
 
         TryPruneOldSegments();

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Testing.Extensions.VideoRecorder.Resources;
 using Microsoft.Testing.Platform.Extensions.Messages;
-using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.VideoRecorder;
 
@@ -83,7 +82,6 @@ internal sealed partial class VideoRecorderSessionHandler
             {
                 _anyTestFailed = true;
                 DateTimeOffset? recordingStart = _recorder.RecordingStartUtc;
-                RoslynDebug.Assert(recordingStart is not null, "Recording must start before test updates are consumed.");
                 if (recordingStart is not null)
                 {
                     _failedWindows = new FailedWindow(

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.DataConsumer.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Testing.Extensions.VideoRecorder.Resources;
 using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.VideoRecorder;
 
@@ -81,9 +82,15 @@ internal sealed partial class VideoRecorderSessionHandler
             if (isFailure)
             {
                 _anyTestFailed = true;
-                DateTimeOffset recordingStart = _recorder.RecordingStartUtc ?? start;
-                _failedWindows.Add((start - recordingStart).TotalSeconds);
-                _failedWindows.Add((end - recordingStart).TotalSeconds);
+                DateTimeOffset? recordingStart = _recorder.RecordingStartUtc;
+                RoslynDebug.Assert(recordingStart is not null, "Recording must start before test updates are consumed.");
+                if (recordingStart is not null)
+                {
+                    _failedWindows = new FailedWindow(
+                        (start - recordingStart.Value).TotalSeconds,
+                        (end - recordingStart.Value).TotalSeconds,
+                        _failedWindows);
+                }
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.SegmentPruning.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.SegmentPruning.cs
@@ -27,7 +27,7 @@ internal sealed partial class VideoRecorderSessionHandler
         }
 
         double nowOffset = (_clock.UtcNow - recordingStart).TotalSeconds;
-        double[] failedWindows;
+        FailedWindow? failedWindows;
         double watermark;
         lock (_stateGate)
         {
@@ -35,7 +35,7 @@ internal sealed partial class VideoRecorderSessionHandler
                 ? nowOffset
                 : _inFlight.Values.Min(start => (start - recordingStart).TotalSeconds);
 
-            failedWindows = [.. _failedWindows];
+            failedWindows = _failedWindows;
         }
 
         double ageCutoff = cap is { } c ? nowOffset - c.TotalSeconds : double.NegativeInfinity;
@@ -84,11 +84,11 @@ internal sealed partial class VideoRecorderSessionHandler
         }
     }
 
-    private static bool OverlapsAnyFailedWindow(VideoSegment segment, double[] failedWindows)
+    private static bool OverlapsAnyFailedWindow(VideoSegment segment, FailedWindow? failedWindow)
     {
-        for (int i = 0; i + 1 < failedWindows.Length; i += 2)
+        for (; failedWindow is not null; failedWindow = failedWindow.Next)
         {
-            if (segment.Overlaps(failedWindows[i], failedWindows[i + 1]))
+            if (segment.Overlaps(failedWindow.StartSeconds, failedWindow.EndSeconds))
             {
                 return true;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.SegmentPruning.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.SegmentPruning.cs
@@ -35,10 +35,7 @@ internal sealed partial class VideoRecorderSessionHandler
                 ? nowOffset
                 : _inFlight.Values.Min(start => (start - recordingStart).TotalSeconds);
 
-            failedWindows = _testRecords
-                .Where(record => record.IsFailure)
-                .SelectMany(record => new[] { (record.Start - recordingStart).TotalSeconds, (record.End - recordingStart).TotalSeconds })
-                .ToArray();
+            failedWindows = [.. _failedWindows];
         }
 
         double ageCutoff = cap is { } c ? nowOffset - c.TotalSeconds : double.NegativeInfinity;

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
@@ -55,9 +55,8 @@ internal sealed partial class VideoRecorderSessionHandler :
     private readonly List<TestRecord> _testRecords = [];
     private readonly Dictionary<string, DateTimeOffset> _inFlight = [];
 
-    // Incrementally maintained alongside _testRecords so TryPruneOldSegments (invoked on every
-    // test completion) doesn't have to re-filter the whole accumulated _testRecords list each time.
-    private readonly List<double> _failedWindows = [];
+    // A persistent stack keeps both failure insertion and pruning snapshots O(1).
+    private FailedWindow? _failedWindows;
 
     private SessionUid? _sessionUid;
     private bool _anyTestFailed;
@@ -185,5 +184,21 @@ internal sealed partial class VideoRecorderSessionHandler :
         {
             DeleteDirectoryQuietly(_recorder.SegmentDirectory);
         }
+    }
+
+    private sealed class FailedWindow
+    {
+        public FailedWindow(double startSeconds, double endSeconds, FailedWindow? next)
+        {
+            StartSeconds = startSeconds;
+            EndSeconds = endSeconds;
+            Next = next;
+        }
+
+        public double StartSeconds { get; }
+
+        public double EndSeconds { get; }
+
+        public FailedWindow? Next { get; }
     }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderSessionHandler.cs
@@ -55,6 +55,10 @@ internal sealed partial class VideoRecorderSessionHandler :
     private readonly List<TestRecord> _testRecords = [];
     private readonly Dictionary<string, DateTimeOffset> _inFlight = [];
 
+    // Incrementally maintained alongside _testRecords so TryPruneOldSegments (invoked on every
+    // test completion) doesn't have to re-filter the whole accumulated _testRecords list each time.
+    private readonly List<double> _failedWindows = [];
+
     private SessionUid? _sessionUid;
     private bool _anyTestFailed;
     private int _bufferDropWarned;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerSegmentPruningTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/VideoRecorderSessionHandlerSegmentPruningTests.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 [TestClass]
 public sealed class VideoRecorderSessionHandlerSegmentPruningTests
 {
+    private static readonly Type FailedWindowType =
+        typeof(VideoRecorderSessionHandler).GetNestedType("FailedWindow", BindingFlags.NonPublic)
+        ?? throw new InvalidOperationException("Could not resolve FailedWindow.");
+
+    private static readonly ConstructorInfo FailedWindowConstructor =
+        FailedWindowType.GetConstructor([typeof(double), typeof(double), FailedWindowType])
+        ?? throw new InvalidOperationException("Could not resolve the FailedWindow constructor.");
+
     private static readonly MethodInfo OverlapsAnyFailedWindowMethod =
         typeof(VideoRecorderSessionHandler).GetMethod(
             "OverlapsAnyFailedWindow",
@@ -38,8 +46,13 @@ public sealed class VideoRecorderSessionHandlerSegmentPruningTests
     public void OverlapsAnyFailedWindow_WindowsAndSegment_ReturnsExpectedResult(double[] failedWindows, bool expected)
     {
         var segment = new VideoSegment("segment.mp4", 10, 20);
+        object? failedWindow = null;
+        for (int i = 0; i + 1 < failedWindows.Length; i += 2)
+        {
+            failedWindow = FailedWindowConstructor.Invoke([failedWindows[i], failedWindows[i + 1], failedWindow]);
+        }
 
-        bool actual = (bool)OverlapsAnyFailedWindowMethod.Invoke(null, [segment, failedWindows])!;
+        bool actual = (bool)OverlapsAnyFailedWindowMethod.Invoke(null, [segment, failedWindow])!;
 
         Assert.AreEqual(expected, actual);
     }


### PR DESCRIPTION
`TryPruneOldSegments` ran after every completed test and rebuilt failed-test windows by rescanning all accumulated records, making cumulative pruning work quadratic for long runs.

Maintain failed-window boundaries incrementally as failing tests complete, then snapshot the cached boundaries during pruning. This preserves pruning behavior while avoiding the repeated full-history scan.

Fixes #10823