### PR TITLE
Deduplicate HangDump disposal setup

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
@@ -11,21 +11,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
 {
     public void Dispose()
     {
-        // Stop the deadline and inactivity timers so no callback can start a new dump while we tear
-        // down the pipes. The happy path disposes them in OnTestHostProcessExitedAsync, but that runs
-        // only on a clean exit; Ctrl+C or an exception skips it, so dispose here too (Timer.Dispose is
-        // idempotent, so disposing twice is safe).
-        _deadlineTimer?.Dispose();
-        _activityTimer?.Dispose();
-
-        Task? activityIndicatorTask;
-        lock (_dumpLock)
-        {
-            // Claim the gate so no timer callback can start a new dump once we begin tearing down the
-            // pipes, and capture any dump already in flight so we wait for it below.
-            _dumpTaken = 1;
-            activityIndicatorTask = _activityIndicatorTask;
-        }
+        StopTimersAndClaimDumpGate(out Task? activityIndicatorTask);
 
         if (activityIndicatorTask is not null)
         {
@@ -54,21 +40,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
 #if NETCOREAPP
     public async ValueTask DisposeAsync()
     {
-        // Stop the deadline and inactivity timers so no callback can start a new dump while we tear
-        // down the pipes. The happy path disposes them in OnTestHostProcessExitedAsync, but that runs
-        // only on a clean exit; Ctrl+C or an exception skips it, so dispose here too (Timer.Dispose is
-        // idempotent, so disposing twice is safe).
-        _deadlineTimer?.Dispose();
-        _activityTimer?.Dispose();
-
-        Task? activityIndicatorTask;
-        lock (_dumpLock)
-        {
-            // Claim the gate so no timer callback can start a new dump once we begin tearing down the
-            // pipes, and capture any dump already in flight so we await it below.
-            _dumpTaken = 1;
-            activityIndicatorTask = _activityIndicatorTask;
-        }
+        StopTimersAndClaimDumpGate(out Task? activityIndicatorTask);
 
         if (activityIndicatorTask is not null)
         {
@@ -88,4 +60,21 @@ internal sealed partial class HangDumpProcessLifetimeHandler
         _singleConnectionNamedPipeServer?.Dispose();
     }
 #endif
+
+    // Stops the deadline and inactivity timers, claims the dump gate so no timer callback can start
+    // a new dump while we tear down the pipes, and returns any dump already in flight so the caller
+    // can wait for it. The happy path disposes the timers in OnTestHostProcessExitedAsync, but that
+    // runs only on a clean exit; Ctrl+C or an exception skips it, so dispose here too (Timer.Dispose
+    // is idempotent, so disposing twice is safe).
+    private void StopTimersAndClaimDumpGate(out Task? activityIndicatorTask)
+    {
+        _deadlineTimer?.Dispose();
+        _activityTimer?.Dispose();
+
+        lock (_dumpLock)
+        {
+            _dumpTaken = 1;
+            activityIndicatorTask = _activityIndicatorTask;
+        }
+    }
 }


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Deduplicates the timer teardown and dump-gate claim shared by `Dispose()` and `DisposeAsync()` while preserving their synchronous and asynchronous wait behavior.

Closes #10847
Closes #10866