### PR TITLE
Emit MSTest work items in MTP TRX reports

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestTestNodeConverter.cs
@@ -146,6 +146,7 @@ internal static class MSTestTestNodeConverter
         private readonly TestMetadataProperty[] _categoryMetadata;
         private readonly TestMetadataProperty[] _traitMetadata;
         private readonly string[]? _trxCategories;
+        private readonly string[]? _trxWorkItemIds;
         private readonly TestFileLocationProperty? _fileLocation;
         private readonly ParsedManagedName? _parsedManagedName;
         private readonly string _fullClassName;
@@ -159,6 +160,7 @@ internal static class MSTestTestNodeConverter
             TestMetadataProperty[] categoryMetadata,
             TestMetadataProperty[] traitMetadata,
             string[]? trxCategories,
+            string[]? trxWorkItemIds,
             TestFileLocationProperty? fileLocation,
             ParsedManagedName? parsedManagedName,
             string fullClassName,
@@ -169,6 +171,7 @@ internal static class MSTestTestNodeConverter
             _categoryMetadata = categoryMetadata;
             _traitMetadata = traitMetadata;
             _trxCategories = trxCategories;
+            _trxWorkItemIds = trxWorkItemIds;
             _fileLocation = fileLocation;
             _parsedManagedName = parsedManagedName;
             _fullClassName = fullClassName;
@@ -229,6 +232,7 @@ internal static class MSTestTestNodeConverter
                 categoryMetadata,
                 traitMetadata,
                 categories,
+                element.WorkItemIds is { Length: > 0 } workItemIds ? [.. workItemIds] : null,
                 fileLocation,
                 parsedManagedName,
                 testMethod.FullClassName,
@@ -240,6 +244,11 @@ internal static class MSTestTestNodeConverter
             if (isTrxEnabled && _trxCategories is not null)
             {
                 properties.Add(new TrxCategoriesProperty([.. _trxCategories]));
+            }
+
+            if (isTrxEnabled && _trxWorkItemIds is not null)
+            {
+                properties.Add(new TrxWorkItemsProperty([.. _trxWorkItemIds]));
             }
 
             for (int i = 0; i < _categoryMetadata.Length; i++)

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty
+Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty.TrxWorkItemsProperty(string![]! workItemIds) -> void
+Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty.WorkItemIds.get -> string![]!
+override Microsoft.Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty.ToString() -> string!

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/TrxReportProperties.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport.Abstractions/TrxReportProperties.cs
@@ -255,6 +255,46 @@ public sealed class TrxCategoriesProperty : IProperty
 }
 
 /// <summary>
+/// A property that represents the work item IDs to be reported in the TRX file.
+/// </summary>
+public sealed class TrxWorkItemsProperty : IProperty
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TrxWorkItemsProperty"/> class.
+    /// </summary>
+    /// <param name="workItemIds">The work item IDs.</param>
+    public TrxWorkItemsProperty(string[] workItemIds)
+        => WorkItemIds = workItemIds;
+
+    /// <summary>
+    /// Gets the work item IDs.
+    /// </summary>
+    public string[] WorkItemIds { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.Append(nameof(TrxWorkItemsProperty));
+        builder.Append(" { ");
+        builder.Append($"{nameof(WorkItemIds)} = [");
+
+        for (int i = 0; i < WorkItemIds.Length; i++)
+        {
+            builder.Append(WorkItemIds[i]);
+            if (i < WorkItemIds.Length - 1)
+            {
+                builder.Append(", ");
+            }
+        }
+
+        builder.Append(']');
+        builder.Append(" }");
+        return builder.ToString();
+    }
+}
+
+/// <summary>
 /// A property that represents the value of <c>name</c> attribute on <c>UnitTest</c> XML elements under <c>TestDefinitions</c> XML element.
 /// When the property is missing, TestNode.DisplayName is used instead.
 /// This can cause issues when multiple test results are reported where different test results have different display names.

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResult.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResult.cs
@@ -41,6 +41,10 @@ internal sealed class TrxTestResult
 
     public IReadOnlyList<string>? Categories { get; init; }
 
+#pragma warning disable RS0051 // Internal streaming implementation detail is not a compatibility contract.
+    internal IReadOnlyList<string>? WorkItemIds { get; init; }
+#pragma warning restore RS0051
+
     public IReadOnlyList<TrxTestMetadata>? Metadata { get; init; }
 
     public IReadOnlyList<TrxTestFileArtifact>? FileArtifacts { get; init; }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
@@ -64,6 +64,13 @@ internal static class TrxTestResultExtractor
                 case TrxExceptionProperty e: trxException = GetSingleOrDefaultValue(trxException, e); break;
                 case TrxMessagesProperty msg: trxMessages = GetSingleOrDefaultValue(trxMessages, msg); break;
                 case TrxCategoriesProperty c: trxCategories = GetSingleOrDefaultValue(trxCategories, c); break;
+                case TrxWorkItemsProperty w:
+                    foreach (string workItemId in w.WorkItemIds)
+                    {
+                        (metadata ??= []).Add(new TrxTestMetadata { Key = nameof(TrxWorkItemsProperty), Value = workItemId });
+                    }
+
+                    break;
                 case TestMetadataProperty md: (metadata ??= []).Add(new TrxTestMetadata { Key = md.Key, Value = md.Value }); break;
                 case FileArtifactProperty fa: (artifacts ??= []).Add(new TrxTestFileArtifact { FullPath = fa.FileInfo.FullName }); break;
             }

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultExtractor.cs
@@ -49,6 +49,7 @@ internal static class TrxTestResultExtractor
         TrxExceptionProperty? trxException = null;
         TrxMessagesProperty? trxMessages = null;
         TrxCategoriesProperty? trxCategories = null;
+        TrxWorkItemsProperty? trxWorkItems = null;
         List<TrxTestMetadata>? metadata = null;
         List<TrxTestFileArtifact>? artifacts = null;
 
@@ -64,13 +65,7 @@ internal static class TrxTestResultExtractor
                 case TrxExceptionProperty e: trxException = GetSingleOrDefaultValue(trxException, e); break;
                 case TrxMessagesProperty msg: trxMessages = GetSingleOrDefaultValue(trxMessages, msg); break;
                 case TrxCategoriesProperty c: trxCategories = GetSingleOrDefaultValue(trxCategories, c); break;
-                case TrxWorkItemsProperty w:
-                    foreach (string workItemId in w.WorkItemIds)
-                    {
-                        (metadata ??= []).Add(new TrxTestMetadata { Key = nameof(TrxWorkItemsProperty), Value = workItemId });
-                    }
-
-                    break;
+                case TrxWorkItemsProperty w: trxWorkItems = GetSingleOrDefaultValue(trxWorkItems, w); break;
                 case TestMetadataProperty md: (metadata ??= []).Add(new TrxTestMetadata { Key = md.Key, Value = md.Value }); break;
                 case FileArtifactProperty fa: (artifacts ??= []).Add(new TrxTestFileArtifact { FullPath = fa.FileInfo.FullName }); break;
             }
@@ -126,6 +121,7 @@ internal static class TrxTestResultExtractor
             Messages = messages,
             // Copy the array so the producer's mutable array can't be observed (or mutated) downstream.
             Categories = trxCategories?.Categories is { Length: > 0 } cats ? [.. cats] : null,
+            WorkItemIds = trxWorkItems?.WorkItemIds is { Length: > 0 } workItemIds ? [.. workItemIds] : null,
             Metadata = metadata,
             FileArtifacts = artifacts,
         };

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/Streaming/TrxTestResultSerializer.cs
@@ -81,6 +81,16 @@ internal static class TrxTestResultSerializer
                 }
             }
 
+            int workItemCount = result.WorkItemIds?.Count ?? 0;
+            payload.Write(workItemCount);
+            if (result.WorkItemIds is not null)
+            {
+                foreach (string workItemId in result.WorkItemIds)
+                {
+                    payload.Write(workItemId);
+                }
+            }
+
             int metadataCount = result.Metadata?.Count ?? 0;
             payload.Write(metadataCount);
             if (result.Metadata is not null)
@@ -207,6 +217,17 @@ internal static class TrxTestResultSerializer
             }
         }
 
+        int workItemCount = r.ReadInt32();
+        List<string>? workItemIds = null;
+        if (workItemCount > 0)
+        {
+            workItemIds = [];
+            for (int i = 0; i < workItemCount; i++)
+            {
+                workItemIds.Add(r.ReadString());
+            }
+        }
+
         int metadataCount = r.ReadInt32();
         List<TrxTestMetadata>? metadata = null;
         if (metadataCount > 0)
@@ -248,6 +269,7 @@ internal static class TrxTestResultSerializer
             ExceptionStackTrace = exceptionStackTrace,
             Messages = messages,
             Categories = categories,
+            WorkItemIds = workItemIds,
             Metadata = metadata,
             FileArtifacts = artifacts,
         };

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.Definitions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.Definitions.cs
@@ -25,7 +25,6 @@ internal sealed partial class TrxReportEngine
         XElement? properties = null;
         XElement? owners = null;
         XElement? description = null;
-        XElement? workItems = null;
         foreach (TrxTestMetadata property in testResult.Metadata ?? [])
         {
             switch (property.Key)
@@ -45,11 +44,6 @@ internal sealed partial class TrxReportEngine
 
                 case "Description":
                     description ??= new XElement("Description", property.Value);
-                    break;
-
-                case nameof(TrxWorkItemsProperty):
-                    workItems ??= new XElement("Workitems");
-                    workItems.Add(new XElement("WorkItem", new XAttribute("id", property.Value)));
                     break;
 
                 default:
@@ -99,9 +93,9 @@ internal sealed partial class TrxReportEngine
             unitTest.Add(properties);
         }
 
-        if (workItems is not null)
+        if (testResult.WorkItemIds is { Count: > 0 } workItemIds)
         {
-            unitTest.Add(workItems);
+            unitTest.Add(new XElement("Workitems", workItemIds.Select(id => new XElement("WorkItem", new XAttribute("id", id)))));
         }
 
         return unitTest;

--- a/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.Definitions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.TrxReport/TrxReportEngine.Results.Definitions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
@@ -25,6 +25,7 @@ internal sealed partial class TrxReportEngine
         XElement? properties = null;
         XElement? owners = null;
         XElement? description = null;
+        XElement? workItems = null;
         foreach (TrxTestMetadata property in testResult.Metadata ?? [])
         {
             switch (property.Key)
@@ -44,6 +45,11 @@ internal sealed partial class TrxReportEngine
 
                 case "Description":
                     description ??= new XElement("Description", property.Value);
+                    break;
+
+                case nameof(TrxWorkItemsProperty):
+                    workItems ??= new XElement("Workitems");
+                    workItems.Add(new XElement("WorkItem", new XAttribute("id", property.Value)));
                     break;
 
                 default:
@@ -93,7 +99,11 @@ internal sealed partial class TrxReportEngine
             unitTest.Add(properties);
         }
 
-        // Unlike VSTest, we do not add Workitems.
+        if (workItems is not null)
+        {
+            unitTest.Add(workItems);
+        }
+
         return unitTest;
     }
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrxReportTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TrxReportTests.cs
@@ -14,6 +14,27 @@ public sealed class TrxReportTests : AcceptanceTestBase<TrxReportTests.TestAsset
 {
     [TestMethod]
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    public async Task TrxReport_WorkItemAttributes_AreIncludedInTestDefinition(string tfm)
+    {
+        string fileName = Guid.NewGuid().ToString("N");
+        var testHost = TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.ProjectName, tfm);
+        TestHostResult testHostResult = await testHost.ExecuteAsync($"--report-trx --report-trx-filename {fileName}.trx", cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.AtLeastOneTestFailed);
+
+        string trxFile = Directory.GetFiles(testHost.DirectoryName, $"{fileName}.trx", SearchOption.AllDirectories).Single();
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        var trxDocument = XDocument.Load(trxFile);
+        XElement unitTest = trxDocument
+            .Descendants(ns + "UnitTest")
+            .Single(element => element.Attribute("name")?.Value == "WorkItemTest");
+        string[] workItemIds = [.. unitTest.Element(ns + "Workitems")!.Elements(ns + "WorkItem").Select(element => element.Attribute("id")!.Value)];
+
+        Assert.AreSequenceEqual(["1234", "5678"], workItemIds);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     public async Task TrxReport_WhenTestFails_ContainsExceptionInfoInOutput(string tfm)
     {
         string fileName = Guid.NewGuid().ToString("N");
@@ -83,6 +104,13 @@ namespace MSTestTrxReport;
 [TestClass]
 public class UnitTest1
 {
+    [TestMethod]
+    [WorkItem(1234)]
+    [GitHubWorkItem("https://github.com/microsoft/testfx/issues/5678")]
+    public void WorkItemTest()
+    {
+    }
+
     [TestMethod]
     public void FailingTest()
     {

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -148,6 +148,21 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
             .Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxCategoriesProperty>().Should().BeTrue();
     }
 
+    public void ToDiscoveredTestNode_AddsTrxWorkItems_OnlyWhenTrxEnabled()
+    {
+        UnitTestElement element = CreateElement();
+        element.WorkItemIds = ["123", "456"];
+
+        MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: false)
+            .Properties.Any<Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty>().Should().BeFalse();
+
+        Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty property = MSTestTestNodeConverter
+            .ToDiscoveredTestNode(element, isTrxEnabled: true)
+            .Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty>();
+        property.WorkItemIds.Should().Equal("123", "456");
+        property.WorkItemIds.Should().NotBeSameAs(element.WorkItemIds);
+    }
+
     public void RepeatedConversions_ReuseImmutableBaseProperties_WithoutSharingNodesOrPropertyBags()
     {
         UnitTestElement element = CreateElement();

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestTestNodeConverterTests.cs
@@ -237,6 +237,25 @@ public sealed class MSTestTestNodeConverterTests : TestContainer
         }
     }
 
+    public void TrxWorkItems_AreCopiedPerNode_AndCannotCrossMutate()
+    {
+        UnitTestElement element = CreateElement();
+        element.WorkItemIds = ["123", "456"];
+
+        TestNode first = MSTestTestNodeConverter.ToDiscoveredTestNode(element, isTrxEnabled: true);
+        TestNode second = MSTestTestNodeConverter.ToInProgressTestNode(element, isTrxEnabled: true);
+
+        Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty firstWorkItems =
+            first.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty>();
+        Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty secondWorkItems =
+            second.Properties.Single<Testing.Extensions.TrxReport.Abstractions.TrxWorkItemsProperty>();
+
+        firstWorkItems.Should().NotBeSameAs(secondWorkItems);
+        firstWorkItems.WorkItemIds.Should().NotBeSameAs(secondWorkItems.WorkItemIds);
+        firstWorkItems.WorkItemIds[0] = "Mutated";
+        secondWorkItems.WorkItemIds.Should().Equal("123", "456");
+    }
+
     public void ResultDisplayNameOverride_RemainsPerResult_WhileTrxDefinitionUsesTestDefinitionName()
     {
         UnitTestElement element = CreateElement();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportPropertiesTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxReportPropertiesTests.cs
@@ -17,4 +17,10 @@ public sealed class TrxReportPropertiesTests
         => Assert.AreEqual(
             "TrxCategoriesProperty { Categories = [some category] }",
             new TrxCategoriesProperty(["some category"]).ToString());
+
+    [TestMethod]
+    public void TrxWorkItemsProperty_ToStringIsCorrect()
+        => Assert.AreEqual(
+            "TrxWorkItemsProperty { WorkItemIds = [123, 456] }",
+            new TrxWorkItemsProperty(["123", "456"]).ToString());
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxStreamingSerializerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions.Streaming;
@@ -31,6 +31,7 @@ public class TrxStreamingSerializerTests
                 new TrxStreamMessage { Kind = TrxStreamMessageKind.DebugOrTrace, Message = null },
             ],
             Categories = ["cat-a", "cat-b"],
+            WorkItemIds = ["123", "456"],
             Metadata = [new TrxTestMetadata { Key = "k", Value = "v" }],
             FileArtifacts = [new TrxTestFileArtifact { FullPath = @"c:\artifact.txt" }],
         };
@@ -59,6 +60,8 @@ public class TrxStreamingSerializerTests
         Assert.IsNull(round.Messages[2].Message);
         Assert.IsNotNull(round.Categories);
         Assert.AreSequenceEqual(["cat-a", "cat-b"], round.Categories.ToArray());
+        Assert.IsNotNull(round.WorkItemIds);
+        Assert.AreSequenceEqual(["123", "456"], round.WorkItemIds.ToArray());
         Assert.IsNotNull(round.Metadata);
         Assert.AreEqual("k", round.Metadata[0].Key);
         Assert.AreEqual("v", round.Metadata[0].Value);
@@ -84,6 +87,7 @@ public class TrxStreamingSerializerTests
         TrxTestResult round = WriteAndReadOne(original);
         Assert.IsNull(round.Messages);
         Assert.IsNull(round.Categories);
+        Assert.IsNull(round.WorkItemIds);
         Assert.IsNull(round.Metadata);
         Assert.IsNull(round.FileArtifacts);
         Assert.IsNull(round.TestMethodIdentifier);
@@ -105,6 +109,7 @@ public class TrxStreamingSerializerTests
             Outcome = TrxTestOutcome.Passed,
             Messages = [],
             Categories = [],
+            WorkItemIds = [],
             Metadata = [],
             FileArtifacts = [],
         };
@@ -112,6 +117,7 @@ public class TrxStreamingSerializerTests
         TrxTestResult round = WriteAndReadOne(original);
         Assert.IsNull(round.Messages);
         Assert.IsNull(round.Categories);
+        Assert.IsNull(round.WorkItemIds);
         Assert.IsNull(round.Metadata);
         Assert.IsNull(round.FileArtifacts);
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
@@ -45,6 +45,23 @@ public class TrxTestResultExtractorTests
         Assert.IsFalse(wasTruncated);
         Assert.AreEqual("small", result.ExceptionMessage);
         Assert.AreEqual("stack", result.ExceptionStackTrace);
+    }
+
+    [TestMethod]
+    public void Extract_WorkItems_ProjectsIdsAsTrxMetadata()
+    {
+        string[] workItemIds = ["123", "456"];
+        var bag = new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new TrxWorkItemsProperty(workItemIds));
+
+        (TrxTestResult result, _) = TrxTestResultExtractor.Extract(new TestNodeUpdateMessage(
+            new SessionUid("1"),
+            new TestNode { Uid = "u", DisplayName = "d", Properties = bag }));
+
+        Assert.IsNotNull(result.Metadata);
+        Assert.AreSequenceEqual(workItemIds, result.Metadata.Select(metadata => metadata.Value).ToArray());
+        Assert.IsTrue(result.Metadata.All(metadata => metadata.Key == nameof(TrxWorkItemsProperty)));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTestResultExtractorTests.cs
@@ -48,7 +48,7 @@ public class TrxTestResultExtractorTests
     }
 
     [TestMethod]
-    public void Extract_WorkItems_ProjectsIdsAsTrxMetadata()
+    public void Extract_WorkItems_CopiesIds()
     {
         string[] workItemIds = ["123", "456"];
         var bag = new PropertyBag(
@@ -59,9 +59,9 @@ public class TrxTestResultExtractorTests
             new SessionUid("1"),
             new TestNode { Uid = "u", DisplayName = "d", Properties = bag }));
 
-        Assert.IsNotNull(result.Metadata);
-        Assert.AreSequenceEqual(workItemIds, result.Metadata.Select(metadata => metadata.Value).ToArray());
-        Assert.IsTrue(result.Metadata.All(metadata => metadata.Key == nameof(TrxWorkItemsProperty)));
+        Assert.IsNotNull(result.WorkItemIds);
+        Assert.AreSequenceEqual(workItemIds, result.WorkItemIds.ToArray());
+        Assert.AreNotSame(workItemIds, result.WorkItemIds);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -965,7 +965,8 @@ public class TrxTests
         using MemoryFileStream memoryStream = new();
         var propertyBag = new PropertyBag(
             new PassedTestNodeStateProperty(),
-            new TrxWorkItemsProperty(["123", "456"]));
+            new TrxWorkItemsProperty(["123", "456"]),
+            new TestMetadataProperty(nameof(TrxWorkItemsProperty), "NotAWorkItem"));
         TrxReportEngine trxReportEngine = GenerateTrxReportEngine(memoryStream);
 
         (string fileName, string? warning) = await trxReportEngine.GenerateReportAsync([CreateTestNodeUpdate("test()", "TestMethod", propertyBag)]);
@@ -977,6 +978,9 @@ public class TrxTests
         XElement unitTest = memoryStream.TrxContent.Descendants(ns + "UnitTest").Single();
         string[] workItemIds = [.. unitTest.Element(ns + "Workitems")!.Elements(ns + "WorkItem").Select(element => element.Attribute("id")!.Value)];
         Assert.AreSequenceEqual(["123", "456"], workItemIds);
+        XElement metadataProperty = unitTest.Element(ns + "Properties")!.Element(ns + "Property")!;
+        Assert.AreEqual(nameof(TrxWorkItemsProperty), metadataProperty.Element(ns + "Key")!.Value);
+        Assert.AreEqual("NotAWorkItem", metadataProperty.Element(ns + "Value")!.Value);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/TrxTests.cs
@@ -960,6 +960,26 @@ public class TrxTests
     }
 
     [TestMethod]
+    public async Task TrxReportEngine_GenerateReportAsync_WithWorkItems_TrxContainsWorkItems()
+    {
+        using MemoryFileStream memoryStream = new();
+        var propertyBag = new PropertyBag(
+            new PassedTestNodeStateProperty(),
+            new TrxWorkItemsProperty(["123", "456"]));
+        TrxReportEngine trxReportEngine = GenerateTrxReportEngine(memoryStream);
+
+        (string fileName, string? warning) = await trxReportEngine.GenerateReportAsync([CreateTestNodeUpdate("test()", "TestMethod", propertyBag)]);
+
+        Assert.IsNull(warning);
+        AssertExpectedTrxFileName(fileName);
+        Assert.IsNotNull(memoryStream.TrxContent);
+        XNamespace ns = "http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
+        XElement unitTest = memoryStream.TrxContent.Descendants(ns + "UnitTest").Single();
+        string[] workItemIds = [.. unitTest.Element(ns + "Workitems")!.Elements(ns + "WorkItem").Select(element => element.Attribute("id")!.Value)];
+        Assert.AreSequenceEqual(["123", "456"], workItemIds);
+    }
+
+    [TestMethod]
     public async Task TrxReportEngine_GenerateReportAsync_WithTrxTestDefinitionName_UnitTestNameIsFromTrxTestDefinitionName()
     {
         // Arrange


### PR DESCRIPTION
MTP-generated TRX reports currently drop `[WorkItem]` and `[GitHubWorkItem]` metadata that VSTest preserves. This breaks work-item links used by CI dashboards, Azure DevOps test results, and downstream triage tooling when projects migrate to MTP.

## Changes

- Add a dedicated `TrxWorkItemsProperty` and populate it from MSTest discovery metadata when TRX reporting is enabled.
- Preserve work-item IDs through the TRX streaming metadata path and emit schema-compatible `<Workitems><WorkItem id="..." /></Workitems>` definitions.
- Add converter, streaming, renderer, and multi-target acceptance coverage for both work-item attributes.

## Validation

- Release build and package creation
- 158 focused TRX unit tests
- 49 MSTest adapter converter tests
- 3 work-item TRX acceptance cases

Fixes #10849