### PR TITLE
Add acceptance coverage for GH history, step-summary sections, and --show-slowest-tests

### DIFF
--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/GitHubActionsReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/GitHubActionsReportTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 /// <summary>
@@ -163,6 +165,90 @@ public sealed class GitHubActionsReportTests : AcceptanceTestBase<GitHubActionsR
         result.AssertOutputContains("::warning file=src/MyTests.cs,line=9,col=1,title=Test skipped%3A SkippedTest::Not today");
     }
 
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task WhenStepSummarySectionsIsSlowTests_OnlyTheSlowestSectionIsRendered(string tfm)
+    {
+        (TestHostResult result, string summary) = await RunAsync(
+            tfm,
+            testMode: "timed",
+            extraArgs: "--report-gh-step-summary-sections slow-tests");
+
+        result.AssertExitCodeIs(ExitCode.Success);
+
+        // The slow-tests section is rendered (the tests carry a real duration)...
+        Assert.Contains("### ⏱ Slowest tests", summary);
+        Assert.Contains("SlowTest", summary);
+
+        // ...but the test-results totals table is gated out by the section selection.
+        Assert.DoesNotContain("| Total | Passed | Failed | Skipped | Flaky | Duration |", summary);
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task WhenStepSummarySectionsIsTestResults_TheSlowestSectionIsOmitted(string tfm)
+    {
+        (TestHostResult result, string summary) = await RunAsync(
+            tfm,
+            testMode: "timed",
+            extraArgs: "--report-gh-step-summary-sections test-results");
+
+        result.AssertExitCodeIs(ExitCode.Success);
+
+        // The test-results totals table is rendered...
+        Assert.Contains("| Total | Passed | Failed | Skipped | Flaky | Duration |", summary);
+
+        // ...but the slow-tests section is gated out by the section selection.
+        Assert.DoesNotContain("### ⏱ Slowest tests", summary);
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task WhenHistoryIsEnabled_SamplesPersistAndAccumulateAcrossRuns(string tfm)
+    {
+        string historyPath = Path.Combine(TestContext.TestRunDirectory!, $"gh-history-{Guid.NewGuid():N}.json");
+
+        // Each run is identified by a distinct GITHUB_RUN_ID (and a fixed RUNNER_OS so the persisted samples pass the
+        // history schema validation on the next read), so the two runs contribute two distinct samples for the test.
+        static Dictionary<string, string?> RunEnvironment(string runId) => new()
+        {
+            ["GITHUB_RUN_ID"] = runId,
+            ["RUNNER_OS"] = "TestOs",
+        };
+
+        (TestHostResult firstResult, _) = await RunAsync(
+            tfm,
+            testMode: "pass",
+            extraArgs: $"--report-gh-history \"{historyPath}\"",
+            extraEnvironmentVariables: RunEnvironment("run-1"));
+        firstResult.AssertExitCodeIs(ExitCode.Success);
+
+        Assert.IsTrue(File.Exists(historyPath), $"Expected the history snapshot to be created at '{historyPath}'.");
+
+        (TestHostResult secondResult, _) = await RunAsync(
+            tfm,
+            testMode: "pass",
+            extraArgs: $"--report-gh-history \"{historyPath}\"",
+            extraEnvironmentVariables: RunEnvironment("run-2"));
+        secondResult.AssertExitCodeIs(ExitCode.Success);
+
+        using var snapshot = JsonDocument.Parse(File.ReadAllText(historyPath));
+        JsonElement root = snapshot.RootElement;
+
+        Assert.AreEqual(1, root.GetProperty("schemaVersion").GetInt32());
+
+        JsonElement[] samples = [.. root.GetProperty("samples").EnumerateArray()];
+
+        // The second run merged with the first, so both runs' samples for the passing test survive.
+        Assert.HasCount(2, samples);
+        Assert.IsTrue(samples.All(sample => sample.GetProperty("displayName").GetString() == "PassingTest"));
+        Assert.IsTrue(samples.All(sample => sample.GetProperty("outcome").GetString() == "passed"));
+
+        string[] runIds = [.. samples.Select(sample => sample.GetProperty("runId").GetString()!).OrderBy(id => id, StringComparer.Ordinal)];
+        Assert.AreEqual("run-1", runIds[0]);
+        Assert.AreEqual("run-2", runIds[1]);
+    }
+
     private async Task<(TestHostResult Result, string Summary)> RunAsync(
         string tfm,
         string testMode,
@@ -258,6 +344,8 @@ public class DummyTestFramework : ITestFramework, IDataProducer
         //   "failex"   -> publish a single failing test carrying a real exception, so the job summary can expand it
         //                 into a collapsible section with the exception type and stack trace
         //   "pass"     -> publish a single passing test (exit code Success, unless --minimum-expected-tests forces a violation)
+        //   "timed"    -> publish several passing tests, each carrying a TimingProperty with a distinct duration, so the
+        //                 job summary's slow-tests section has real durations to rank
         //   "location" -> publish a failing and a skipped test, both carrying a TestFileLocationProperty and no
         //                 exception, so the annotations can only be pinned through the declared-location fallback
         string mode = Environment.GetEnvironmentVariable("GH_TEST_MODE") ?? "pass";
@@ -321,6 +409,30 @@ public class DummyTestFramework : ITestFramework, IDataProducer
                         new SkippedTestNodeStateProperty("Not today"),
                         new TestFileLocationProperty(file, new LinePositionSpan(new LinePosition(9, -1), new LinePosition(9, -1)))),
                 }));
+        }
+        else if (mode == "timed")
+        {
+            (string Uid, string DisplayName, TimeSpan Duration)[] timedTests =
+            [
+                ("test-1", "SlowTest", TimeSpan.FromSeconds(5)),
+                ("test-2", "MediumTest", TimeSpan.FromSeconds(3)),
+                ("test-3", "FastTest", TimeSpan.FromSeconds(1)),
+            ];
+
+            foreach ((string uid, string displayName, TimeSpan duration) in timedTests)
+            {
+                DateTimeOffset start = DateTimeOffset.UtcNow;
+                await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+                    context.Request.Session.SessionUid,
+                    new TestNode()
+                    {
+                        Uid = uid,
+                        DisplayName = displayName,
+                        Properties = new PropertyBag(
+                            PassedTestNodeStateProperty.CachedInstance,
+                            new TimingProperty(new TimingInfo(start, start + duration, duration))),
+                    }));
+            }
         }
         else if (mode == "pass")
         {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ShowSlowestTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ShowSlowestTestsTests.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+/// <summary>
+/// End-to-end coverage for the terminal reporter's opt-in <c>--show-slowest-tests</c> section: drives a real
+/// Microsoft.Testing.Platform session whose tests report distinct, deterministic durations and asserts that the
+/// section is rendered, is capped at the requested count, and ranks the tests from slowest to fastest.
+/// </summary>
+[TestClass]
+public sealed class ShowSlowestTestsTests : AcceptanceTestBase<ShowSlowestTestsTests.TestAssetFixture>
+{
+    private const string AssetName = "ShowSlowestTestsBehavior";
+
+    public TestContext TestContext { get; set; } = null!;
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task WhenEnabled_RanksTestsSlowestFirstAndHonorsTheRequestedCount(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+
+        TestHostResult result = await testHost.ExecuteAsync(
+            "--show-slowest-tests 3",
+            cancellationToken: TestContext.CancellationToken);
+
+        result.AssertExitCodeIs(ExitCode.Success);
+
+        // The opt-in section header is emitted because at least one timed test was recorded.
+        result.AssertOutputContains("Slowest tests:");
+
+        // Only the three slowest tests are listed; the fastest test is dropped by the count cap.
+        result.AssertOutputContains("AlphaSlow");
+        result.AssertOutputContains("BravoMedium");
+        result.AssertOutputContains("CharlieFast");
+        result.AssertOutputDoesNotContain("DeltaTiny");
+
+        // The ranking is deterministic: 5s > 3s > 1s, so the names appear slowest-first.
+        string output = result.StandardOutput;
+        int slowIndex = output.IndexOf("AlphaSlow", StringComparison.Ordinal);
+        int mediumIndex = output.IndexOf("BravoMedium", StringComparison.Ordinal);
+        int fastIndex = output.IndexOf("CharlieFast", StringComparison.Ordinal);
+
+        Assert.IsGreaterThan(-1, slowIndex);
+        Assert.IsLessThan(mediumIndex, slowIndex);
+        Assert.IsLessThan(fastIndex, mediumIndex);
+    }
+
+    [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
+    [TestMethod]
+    public async Task WhenNotRequested_NoSlowestTestsSectionIsRendered(string tfm)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
+
+        TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
+
+        result.AssertExitCodeIs(ExitCode.Success);
+        result.AssertOutputDoesNotContain("Slowest tests:");
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string Sources = """
+#file ShowSlowestTestsBehavior.csproj
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$TargetFrameworks$</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+  </ItemGroup>
+</Project>
+
+#file Program.cs
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+
+public class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+        builder.RegisterTestFramework(
+            _ => new TestFrameworkCapabilities(),
+            (_, __) => new DummyTestFramework());
+        using ITestApplication app = await builder.BuildAsync();
+        return await app.RunAsync();
+    }
+}
+
+public class DummyTestFramework : ITestFramework, IDataProducer
+{
+    public string Uid => nameof(DummyTestFramework);
+    public string Version => "2.0.0";
+    public string DisplayName => nameof(DummyTestFramework);
+    public string Description => nameof(DummyTestFramework);
+    public Type[] DataTypesProduced => [typeof(TestNodeUpdateMessage)];
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+        => Task.FromResult(new CreateTestSessionResult() { IsSuccess = true });
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+        => Task.FromResult(new CloseTestSessionResult() { IsSuccess = true });
+
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        // Deterministic, well-separated durations so the ranking is unambiguous:
+        //   AlphaSlow (5s) > BravoMedium (3s) > CharlieFast (1s) > DeltaTiny (0.2s).
+        // With --show-slowest-tests 3 the fastest (DeltaTiny) must be dropped by the count cap.
+        await PublishTimedTestAsync(context, "test-1", "AlphaSlow", TimeSpan.FromSeconds(5));
+        await PublishTimedTestAsync(context, "test-2", "BravoMedium", TimeSpan.FromSeconds(3));
+        await PublishTimedTestAsync(context, "test-3", "CharlieFast", TimeSpan.FromSeconds(1));
+        await PublishTimedTestAsync(context, "test-4", "DeltaTiny", TimeSpan.FromMilliseconds(200));
+
+        context.Complete();
+    }
+
+    private Task PublishTimedTestAsync(ExecuteRequestContext context, string uid, string displayName, TimeSpan duration)
+    {
+        DateTimeOffset start = DateTimeOffset.UtcNow;
+        return context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+            context.Request.Session.SessionUid,
+            new TestNode()
+            {
+                Uid = uid,
+                DisplayName = displayName,
+                Properties = new PropertyBag(
+                    PassedTestNodeStateProperty.CachedInstance,
+                    new TimingProperty(new TimingInfo(start, start + duration, duration))),
+            }));
+    }
+}
+""";
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate() => (AssetName, AssetName,
+            Sources
+                .PatchTargetFrameworks(TargetFrameworks.All)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
+    }
+}


### PR DESCRIPTION
## Why

While reviewing MTP 2.4 readiness we found a few user-facing behaviors that were only exercised by unit tests and had no end-to-end coverage. This adds acceptance tests that drive real Microsoft.Testing.Platform sessions so the behaviors are validated the way users actually hit them.

## What

Two areas, both under `test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/`:

**GitHub Actions report (`GitHubActionsReportTests.cs`)**
- New `"timed"` mode on the existing `DummyTestFramework` that publishes several passing tests, each carrying a `TimingProperty` with a distinct duration, so the job summary has real durations to rank.
- `--report-gh-step-summary-sections` gating: one test asserts `slow-tests` renders the slowest section while the test-results totals table is gated out, and its inverse asserts `test-results` keeps the totals table while omitting the slowest section.
- `--report-gh-history` persistence: runs the same asset twice with distinct `GITHUB_RUN_ID` values (and a fixed `RUNNER_OS` so the persisted samples pass schema validation on the next read), then parses the JSON snapshot and asserts the schema version plus two accumulated `passed` samples, one per run id. This is the first coverage that the history file actually survives and merges across separate runs.

**Terminal `--show-slowest-tests` (`ShowSlowestTestsTests.cs`, new)**
- An active acceptance test (the pre-existing console assertion for this was `[Ignore]`d). A dedicated asset publishes four passing tests with well-separated durations, and the test asserts the `Slowest tests:` section is rendered, ranked slowest-first, capped at the requested count (the fastest test is dropped at `--show-slowest-tests 3`), and absent when the option is not passed.

## Notes for reviewers

- No product code changed; this is test-only. OpenTelemetry code and tests were intentionally left untouched (owned by a separate change).
- History determinism relies on distinct `GITHUB_RUN_ID` per run and a fixed `RUNNER_OS`; the comment in the test explains why.
- Validated with `build.cmd -pack -c Release` then running both classes in Release: ShowSlowestTestsTests 6/6 and GitHubActionsReportTests 39/39 passed across net462/net8.0/net10.0.