### PR TITLE
Improve VSTest CLI migration guidance

### DIFF
--- a/docs/RFCs/015-Command-Line-Option-Mappings.md
+++ b/docs/RFCs/015-Command-Line-Option-Mappings.md
@@ -4,6 +4,13 @@
 - [ ] Under discussion
 - [ ] Implementation
 - [ ] Shipped
+- [x] Rejected
+
+## Decision
+
+The mapping extensibility API was rejected in favor of value-aware migration diagnostics. MTP keeps VSTest options such as `--logger` and `--collect` invalid, but recognizes common values and reports the canonical MTP options and extension packages to use instead.
+
+This preserves the single-owner command-line option model and avoids making a temporary migration aid into permanent public API. The decision can be revisited if migration telemetry or supported tooling that injects immutable VSTest arguments demonstrates that diagnostics are insufficient. In that case, prefer a narrow, hidden, first-party compatibility shim with an explicit removal release over a general public mapping API.
 
 ## Summary
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -66,11 +66,11 @@ An MSTest attribute (`[CIConditionAttribute]`) in `Microsoft.VisualStudio.TestTo
 
 ### CodeCoverage
 
-An MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) that instruments .NET assemblies and collects code-coverage data during a test run. It is developed and maintained in the `devdiv/DevDiv/vs-code-coverage` repository and consumed by this project as a Maestro-managed dependency. The extension supports the `--coverage` command-line option; VSTest-compatible `--collect "XPlat Code Coverage"` and `--collect "Code Coverage"` forms are proposed via a [command-line option mapping](#commandlineoptionmapping) (see `docs/RFCs/015-Command-Line-Option-Mappings.md`).
+An MTP extension (`Microsoft.Testing.Extensions.CodeCoverage`) that instruments .NET assemblies and collects code-coverage data during a test run. It is developed and maintained in the `devdiv/DevDiv/vs-code-coverage` repository and consumed by this project as a Maestro-managed dependency. The extension supports the `--coverage` command-line option. VSTest-compatible `--collect "XPlat Code Coverage"` and `--collect "Code Coverage"` forms are rejected with migration guidance rather than mapped to MTP options.
 
 ### CommandLineOptionMapping
 
-A proposed MTP extensibility point (see `docs/RFCs/015-Command-Line-Option-Mappings.md`) that would let an extension declaratively accept a user-facing option (e.g. `--collect "XPlat Code Coverage"`) and rewrite it at parse time into one or more first-class MTP options (e.g. `--coverage`). In RFC 015, this is expressed via `ICommandLineOptionMappingProvider`. Intended to smooth migration from VSTest by allowing legacy `--logger` and `--collect` argument forms to be forwarded to their MTP equivalents without polluting the canonical MTP option set.
+A rejected MTP extensibility proposal (see `docs/RFCs/015-Command-Line-Option-Mappings.md`) that would have allowed extensions to rewrite VSTest-style options into canonical MTP options. MTP instead keeps those options invalid and provides value-aware migration diagnostics. The decision can be revisited if migration data demonstrates that actionable diagnostics are insufficient.
 
 ### ConditionBaseAttribute
 

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
@@ -282,18 +282,16 @@ internal static partial class CommandLineOptionsValidator
 
         if (value is not null
             && IsVSTestNamedValue(value, "console")
-            && GetVSTestSubOptionValue(value, "verbosity") is { } verbosity)
-        {
-            if (verbosity.Equals("minimal", StringComparison.OrdinalIgnoreCase)
+            && GetVSTestSubOptionValue(value, "verbosity") is { } verbosity
+            && (verbosity.Equals("minimal", StringComparison.OrdinalIgnoreCase)
                 || verbosity.Equals("normal", StringComparison.OrdinalIgnoreCase)
-                || verbosity.Equals("detailed", StringComparison.OrdinalIgnoreCase))
-            {
-                stringBuilder.AppendLine(string.Format(
-                    CultureInfo.InvariantCulture,
-                    PlatformResources.CommandLineVSTestConsoleLoggerReplacement,
-                    verbosity.ToLowerInvariant()));
-                return;
-            }
+                || verbosity.Equals("detailed", StringComparison.OrdinalIgnoreCase)))
+        {
+            stringBuilder.AppendLine(string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.CommandLineVSTestConsoleLoggerReplacement,
+                verbosity.ToLowerInvariant()));
+            return;
         }
 
         stringBuilder.AppendLine(PlatformResources.CommandLineVSTestLoggerGuidance);

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
@@ -131,7 +131,7 @@ internal static partial class CommandLineOptionsValidator
             if (!validOptionNames.Contains(optionRecord.Name))
             {
                 stringBuilder ??= new();
-                AppendUnknownOptionError(stringBuilder, optionRecord.Name, validOptionNames, visibleOptionNames, includeKnownExtensionOptions);
+                AppendUnknownOptionError(stringBuilder, optionRecord.Name, optionRecord.Arguments, validOptionNames, visibleOptionNames, includeKnownExtensionOptions);
             }
         }
 
@@ -147,7 +147,7 @@ internal static partial class CommandLineOptionsValidator
                 {
                     stringBuilder ??= new();
                     StringBuilder innerErrorBuilder = new();
-                    AppendUnknownOptionError(innerErrorBuilder, entry.OptionName, validOptionNames, visibleOptionNames, includeKnownExtensionOptions);
+                    AppendUnknownOptionError(innerErrorBuilder, entry.OptionName, entry.Arguments, validOptionNames, visibleOptionNames, includeKnownExtensionOptions);
                     string innerError = innerErrorBuilder.ToTrimmedString();
                     stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.JsonCommandLineOptionsValidationErrorPrefix, innerError));
                 }
@@ -185,11 +185,18 @@ internal static partial class CommandLineOptionsValidator
     private static void AppendUnknownOptionError(
         StringBuilder stringBuilder,
         string unknownOptionName,
+        IReadOnlyList<string> arguments,
         HashSet<string> validOptionNames,
         HashSet<string> visibleOptionNames,
         bool includeKnownExtensionOptions)
     {
         stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineUnknownOption, unknownOptionName));
+
+        if (includeKnownExtensionOptions
+            && TryAppendVSTestOptionGuidance(stringBuilder, unknownOptionName, arguments))
+        {
+            return;
+        }
 
         if (includeKnownExtensionOptions
             && GetKnownExtensionPackage(unknownOptionName) is { } packageName)
@@ -217,6 +224,108 @@ internal static partial class CommandLineOptionsValidator
         {
             AppendMissingExtensionSuggestion(stringBuilder, suggestedOptionName, suggestedPackageName);
         }
+    }
+
+    private static bool TryAppendVSTestOptionGuidance(
+        StringBuilder stringBuilder,
+        string unknownOptionName,
+        IReadOnlyList<string> arguments)
+    {
+        bool isLogger = unknownOptionName.Equals("logger", StringComparison.OrdinalIgnoreCase);
+        bool isCollect = unknownOptionName.Equals("collect", StringComparison.OrdinalIgnoreCase);
+        if (!isLogger && !isCollect)
+        {
+            return false;
+        }
+
+        stringBuilder.AppendLine(string.Format(
+            CultureInfo.InvariantCulture,
+            PlatformResources.CommandLineVSTestOptionUnsupported,
+            unknownOptionName));
+
+        string? value = arguments.Count == 1 ? arguments[0] : null;
+        if (isLogger)
+        {
+            AppendVSTestLoggerGuidance(stringBuilder, value);
+        }
+        else
+        {
+            AppendVSTestCollectGuidance(stringBuilder, value);
+        }
+
+        return true;
+    }
+
+    private static void AppendVSTestLoggerGuidance(StringBuilder stringBuilder, string? value)
+    {
+        if (value is not null
+            && (value.Equals("trx", StringComparison.OrdinalIgnoreCase)
+                || value.StartsWith("trx;", StringComparison.OrdinalIgnoreCase)))
+        {
+            string replacement = value.Split(';').Skip(1).Any(static segment =>
+                segment.StartsWith("LogFileName=", StringComparison.OrdinalIgnoreCase)
+                && segment.Length > "LogFileName=".Length)
+                ? "'--report-trx' and '--report-trx-filename <FILE>'"
+                : "'--report-trx'";
+            stringBuilder.AppendLine(string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.CommandLineVSTestReplacementSuggestion,
+                replacement));
+            AppendMissingExtensionSuggestion(stringBuilder, "report-trx", "Microsoft.Testing.Extensions.TrxReport");
+            return;
+        }
+
+        if (value is not null
+            && value.StartsWith("console;", StringComparison.OrdinalIgnoreCase)
+            && value.Split(';').Skip(1).FirstOrDefault(static segment =>
+                segment.StartsWith("verbosity=", StringComparison.OrdinalIgnoreCase)) is { } verbositySegment)
+        {
+            string verbosity = verbositySegment.Substring("verbosity=".Length);
+            if (verbosity.Equals("minimal", StringComparison.OrdinalIgnoreCase)
+                || verbosity.Equals("normal", StringComparison.OrdinalIgnoreCase)
+                || verbosity.Equals("detailed", StringComparison.OrdinalIgnoreCase))
+            {
+                stringBuilder.AppendLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    PlatformResources.CommandLineVSTestConsoleLoggerReplacement,
+                    verbosity.ToLowerInvariant()));
+                return;
+            }
+        }
+
+        stringBuilder.AppendLine(PlatformResources.CommandLineVSTestLoggerGuidance);
+    }
+
+    private static void AppendVSTestCollectGuidance(StringBuilder stringBuilder, string? value)
+    {
+        if (value?.Equals("Code Coverage", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            stringBuilder.AppendLine(string.Format(
+                CultureInfo.InvariantCulture,
+                PlatformResources.CommandLineVSTestReplacementSuggestion,
+                "'--coverage'"));
+            AppendMissingExtensionSuggestion(stringBuilder, "coverage", "Microsoft.Testing.Extensions.CodeCoverage");
+            return;
+        }
+
+        if (value?.Equals("XPlat Code Coverage", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            stringBuilder.AppendLine(PlatformResources.CommandLineVSTestXPlatCoverageReplacement);
+            AppendMissingExtensionSuggestion(stringBuilder, "coverage", "Microsoft.Testing.Extensions.CodeCoverage");
+            return;
+        }
+
+        if (value is not null
+            && (value.Equals("blame", StringComparison.OrdinalIgnoreCase)
+                || value.StartsWith("blame;", StringComparison.OrdinalIgnoreCase)))
+        {
+            stringBuilder.AppendLine(PlatformResources.CommandLineVSTestBlameReplacement);
+            AppendMissingExtensionSuggestion(stringBuilder, "crashdump", "Microsoft.Testing.Extensions.CrashDump");
+            AppendMissingExtensionSuggestion(stringBuilder, "hangdump", "Microsoft.Testing.Extensions.HangDump");
+            return;
+        }
+
+        stringBuilder.AppendLine(PlatformResources.CommandLineVSTestCollectorGuidance);
     }
 
     private static void AppendMissingExtensionSuggestion(StringBuilder stringBuilder, string optionName, string packageName)

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsValidator.UnknownAndBootstrapValidation.cs
@@ -193,7 +193,7 @@ internal static partial class CommandLineOptionsValidator
         stringBuilder.AppendLine(string.Format(CultureInfo.InvariantCulture, PlatformResources.CommandLineUnknownOption, unknownOptionName));
 
         if (includeKnownExtensionOptions
-            && TryAppendVSTestOptionGuidance(stringBuilder, unknownOptionName, arguments))
+            && TryAppendVSTestOptionGuidance(stringBuilder, unknownOptionName, arguments, validOptionNames))
         {
             return;
         }
@@ -229,7 +229,8 @@ internal static partial class CommandLineOptionsValidator
     private static bool TryAppendVSTestOptionGuidance(
         StringBuilder stringBuilder,
         string unknownOptionName,
-        IReadOnlyList<string> arguments)
+        IReadOnlyList<string> arguments,
+        HashSet<string> validOptionNames)
     {
         bool isLogger = unknownOptionName.Equals("logger", StringComparison.OrdinalIgnoreCase);
         bool isCollect = unknownOptionName.Equals("collect", StringComparison.OrdinalIgnoreCase);
@@ -246,41 +247,43 @@ internal static partial class CommandLineOptionsValidator
         string? value = arguments.Count == 1 ? arguments[0] : null;
         if (isLogger)
         {
-            AppendVSTestLoggerGuidance(stringBuilder, value);
+            AppendVSTestLoggerGuidance(stringBuilder, value, validOptionNames);
         }
         else
         {
-            AppendVSTestCollectGuidance(stringBuilder, value);
+            AppendVSTestCollectGuidance(stringBuilder, value, validOptionNames);
         }
 
         return true;
     }
 
-    private static void AppendVSTestLoggerGuidance(StringBuilder stringBuilder, string? value)
+    private static void AppendVSTestLoggerGuidance(
+        StringBuilder stringBuilder,
+        string? value,
+        HashSet<string> validOptionNames)
     {
         if (value is not null
-            && (value.Equals("trx", StringComparison.OrdinalIgnoreCase)
-                || value.StartsWith("trx;", StringComparison.OrdinalIgnoreCase)))
+            && IsVSTestNamedValue(value, "trx"))
         {
-            string replacement = value.Split(';').Skip(1).Any(static segment =>
-                segment.StartsWith("LogFileName=", StringComparison.OrdinalIgnoreCase)
-                && segment.Length > "LogFileName=".Length)
-                ? "'--report-trx' and '--report-trx-filename <FILE>'"
+            string replacement = GetVSTestSubOptionValue(value, "LogFileName") is not null
+                ? "'--report-trx', '--report-trx-filename <FILE>'"
                 : "'--report-trx'";
             stringBuilder.AppendLine(string.Format(
                 CultureInfo.InvariantCulture,
                 PlatformResources.CommandLineVSTestReplacementSuggestion,
                 replacement));
-            AppendMissingExtensionSuggestion(stringBuilder, "report-trx", "Microsoft.Testing.Extensions.TrxReport");
+            AppendMissingExtensionSuggestionIfNeeded(
+                stringBuilder,
+                validOptionNames,
+                "report-trx",
+                "Microsoft.Testing.Extensions.TrxReport");
             return;
         }
 
         if (value is not null
-            && value.StartsWith("console;", StringComparison.OrdinalIgnoreCase)
-            && value.Split(';').Skip(1).FirstOrDefault(static segment =>
-                segment.StartsWith("verbosity=", StringComparison.OrdinalIgnoreCase)) is { } verbositySegment)
+            && IsVSTestNamedValue(value, "console")
+            && GetVSTestSubOptionValue(value, "verbosity") is { } verbosity)
         {
-            string verbosity = verbositySegment.Substring("verbosity=".Length);
             if (verbosity.Equals("minimal", StringComparison.OrdinalIgnoreCase)
                 || verbosity.Equals("normal", StringComparison.OrdinalIgnoreCase)
                 || verbosity.Equals("detailed", StringComparison.OrdinalIgnoreCase))
@@ -296,36 +299,83 @@ internal static partial class CommandLineOptionsValidator
         stringBuilder.AppendLine(PlatformResources.CommandLineVSTestLoggerGuidance);
     }
 
-    private static void AppendVSTestCollectGuidance(StringBuilder stringBuilder, string? value)
+    private static void AppendVSTestCollectGuidance(
+        StringBuilder stringBuilder,
+        string? value,
+        HashSet<string> validOptionNames)
     {
-        if (value?.Equals("Code Coverage", StringComparison.OrdinalIgnoreCase) == true)
+        if (value is not null
+            && IsVSTestNamedValue(value, "Code Coverage"))
         {
+            string replacement = GetVSTestSubOptionValue(value, "Format") is { } format
+                ? $"'--coverage', '--coverage-output-format {format}'"
+                : "'--coverage'";
             stringBuilder.AppendLine(string.Format(
                 CultureInfo.InvariantCulture,
                 PlatformResources.CommandLineVSTestReplacementSuggestion,
-                "'--coverage'"));
-            AppendMissingExtensionSuggestion(stringBuilder, "coverage", "Microsoft.Testing.Extensions.CodeCoverage");
-            return;
-        }
-
-        if (value?.Equals("XPlat Code Coverage", StringComparison.OrdinalIgnoreCase) == true)
-        {
-            stringBuilder.AppendLine(PlatformResources.CommandLineVSTestXPlatCoverageReplacement);
-            AppendMissingExtensionSuggestion(stringBuilder, "coverage", "Microsoft.Testing.Extensions.CodeCoverage");
+                replacement));
+            AppendMissingExtensionSuggestionIfNeeded(
+                stringBuilder,
+                validOptionNames,
+                "coverage",
+                "Microsoft.Testing.Extensions.CodeCoverage");
             return;
         }
 
         if (value is not null
-            && (value.Equals("blame", StringComparison.OrdinalIgnoreCase)
-                || value.StartsWith("blame;", StringComparison.OrdinalIgnoreCase)))
+            && IsVSTestNamedValue(value, "XPlat Code Coverage"))
+        {
+            stringBuilder.AppendLine(PlatformResources.CommandLineVSTestXPlatCoverageReplacement);
+            AppendMissingExtensionSuggestionIfNeeded(
+                stringBuilder,
+                validOptionNames,
+                "coverage",
+                "Microsoft.Testing.Extensions.CodeCoverage");
+            return;
+        }
+
+        if (value is not null
+            && IsVSTestNamedValue(value, "blame"))
         {
             stringBuilder.AppendLine(PlatformResources.CommandLineVSTestBlameReplacement);
-            AppendMissingExtensionSuggestion(stringBuilder, "crashdump", "Microsoft.Testing.Extensions.CrashDump");
-            AppendMissingExtensionSuggestion(stringBuilder, "hangdump", "Microsoft.Testing.Extensions.HangDump");
+            AppendMissingExtensionSuggestionIfNeeded(
+                stringBuilder,
+                validOptionNames,
+                "crashdump",
+                "Microsoft.Testing.Extensions.CrashDump");
+            AppendMissingExtensionSuggestionIfNeeded(
+                stringBuilder,
+                validOptionNames,
+                "hangdump",
+                "Microsoft.Testing.Extensions.HangDump");
             return;
         }
 
         stringBuilder.AppendLine(PlatformResources.CommandLineVSTestCollectorGuidance);
+    }
+
+    private static bool IsVSTestNamedValue(string value, string name)
+        => value.Equals(name, StringComparison.OrdinalIgnoreCase)
+            || value.StartsWith($"{name};", StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetVSTestSubOptionValue(string value, string subOptionName)
+    {
+        string prefix = $"{subOptionName}=";
+        return value.Split(';').Skip(1).FirstOrDefault(segment =>
+            segment.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            && segment.Length > prefix.Length)?[prefix.Length..];
+    }
+
+    private static void AppendMissingExtensionSuggestionIfNeeded(
+        StringBuilder stringBuilder,
+        HashSet<string> validOptionNames,
+        string optionName,
+        string packageName)
+    {
+        if (!validOptionNames.Contains(optionName))
+        {
+            AppendMissingExtensionSuggestion(stringBuilder, optionName, packageName);
+        }
     }
 
     private static void AppendMissingExtensionSuggestion(StringBuilder stringBuilder, string optionName, string packageName)

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -467,6 +467,34 @@
     <value>Unknown option '--{0}'</value>
     <comment>{0} is the unknown option name without the leading dashes.</comment>
   </data>
+  <data name="CommandLineVSTestOptionUnsupported" xml:space="preserve">
+    <value>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</value>
+    <comment>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</comment>
+  </data>
+  <data name="CommandLineVSTestReplacementSuggestion" xml:space="preserve">
+    <value>Use {0} instead.</value>
+    <comment>{0} is one or more replacement MTP command-line options, including their leading dashes.</comment>
+  </data>
+  <data name="CommandLineVSTestConsoleLoggerReplacement" xml:space="preserve">
+    <value>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</value>
+    <comment>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</comment>
+  </data>
+  <data name="CommandLineVSTestXPlatCoverageReplacement" xml:space="preserve">
+    <value>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</value>
+    <comment>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</comment>
+  </data>
+  <data name="CommandLineVSTestBlameReplacement" xml:space="preserve">
+    <value>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</value>
+    <comment>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</comment>
+  </data>
+  <data name="CommandLineVSTestLoggerGuidance" xml:space="preserve">
+    <value>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</value>
+    <comment>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</comment>
+  </data>
+  <data name="CommandLineVSTestCollectorGuidance" xml:space="preserve">
+    <value>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</value>
+    <comment>{Locked="MTP"}</comment>
+  </data>
   <data name="CommandLineOptionSuggestion" xml:space="preserve">
     <value>Did you mean '--{0}'?</value>
     <comment>{0} is the suggested option name without the leading dashes.</comment>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/PlatformResources.resx
@@ -477,7 +477,7 @@
   </data>
   <data name="CommandLineVSTestConsoleLoggerReplacement" xml:space="preserve">
     <value>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</value>
-    <comment>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</comment>
+    <comment>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</comment>
   </data>
   <data name="CommandLineVSTestXPlatCoverageReplacement" xml:space="preserve">
     <value>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</value>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Příkazový řádek: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.cs.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.de.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Befehlszeile: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.es.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Línea de comandos: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.fr.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Ligne de commande : {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.it.xlf
@@ -282,6 +282,41 @@
         <target state="translated">Eseguire '--help' per visualizzare le opzioni registrate da questa applicazione di test. Se l'opzione appartiene a un'estensione, assicurarsi che sia fatto riferimento al relativo pacchetto e che l'estensione sia registrata.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Riga di comando: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ja.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">コマンド ライン: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -282,6 +282,41 @@
         <target state="translated">'--help'를 실행하여 이 테스트 애플리케이션에서 등록된 옵션을 확인합니다. 옵션이 확장에 속하는 경우 패키지가 참조되고 확장이 등록되어 있는지 확인합니다.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">명령줄: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ko.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Wiersz polecenia: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pt-BR.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Linha de comando: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Командная строка: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.ru.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">Komut satırı: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.tr.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -282,6 +282,41 @@
         <target state="new">Run '--help' to see the options registered by this test application. If the option belongs to an extension, ensure its package is referenced and the extension is registered.</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">命令行: {0}</target>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -295,7 +295,7 @@
       <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
         <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
         <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
-        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output {0}'"}</note>
       </trans-unit>
       <trans-unit id="CommandLineVSTestLoggerGuidance">
         <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hant.xlf
@@ -282,6 +282,41 @@
         <target state="translated">執行 '--help' 以查看此測試應用程式註冊的選項。如果該選項屬於延伸模組，請確認已參考其套件，且已註冊該延伸模組。</target>
         <note>{Locked="'--help'"}</note>
       </trans-unit>
+      <trans-unit id="CommandLineVSTestBlameReplacement">
+        <source>Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</source>
+        <target state="new">Use '--crashdump' and/or '--hangdump' instead. MTP separates crash and hang diagnostics, so there is no one-to-one replacement for the VSTest blame collector.</target>
+        <note>{Locked="'--crashdump'"}{Locked="'--hangdump'"}{Locked="MTP"}{Locked="VSTest"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestCollectorGuidance">
+        <source>MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses collector-specific options. Consult the extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestConsoleLoggerReplacement">
+        <source>For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</source>
+        <target state="new">For comparable console verbosity, use '--output {0}'. MTP console output is configured differently, so this is not an exact replacement.</target>
+        <note>{0} is the MTP output verbosity. {Locked="MTP"}{Locked="'--output"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestLoggerGuidance">
+        <source>MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</source>
+        <target state="new">MTP uses reporter-specific options such as '--report-trx', '--report-html', and '--report-junit'. Consult the reporter extension's documentation for its MTP option.</target>
+        <note>{Locked="MTP"}{Locked="'--report-trx'"}{Locked="'--report-html'"}{Locked="'--report-junit'"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestOptionUnsupported">
+        <source>Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</source>
+        <target state="new">Option '--{0}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.</target>
+        <note>{0} is the unsupported VSTest option name without the leading dashes. {Locked="VSTest"}{Locked="Microsoft.Testing.Platform"}</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestReplacementSuggestion">
+        <source>Use {0} instead.</source>
+        <target state="new">Use {0} instead.</target>
+        <note>{0} is one or more replacement MTP command-line options, including their leading dashes.</note>
+      </trans-unit>
+      <trans-unit id="CommandLineVSTestXPlatCoverageReplacement">
+        <source>For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</source>
+        <target state="new">For MTP code coverage, use '--coverage'. This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.</target>
+        <note>{Locked="MTP"}{Locked="'--coverage'"}{Locked="Coverlet"}{Locked="'XPlat Code Coverage'"}</note>
+      </trans-unit>
       <trans-unit id="CommandLineValidationCommandLine">
         <source>Command line: {0}</source>
         <target state="translated">命令列: {0}</target>

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -763,6 +763,36 @@ public sealed class CommandLineHandlerTests
     }
 
     [TestMethod]
+    [DataRow("crashdump", "Microsoft.Testing.Extensions.CrashDump", "--hangdump", "Microsoft.Testing.Extensions.HangDump")]
+    [DataRow("hangdump", "Microsoft.Testing.Extensions.HangDump", "--crashdump", "Microsoft.Testing.Extensions.CrashDump")]
+    public async Task ParseAndValidateAsync_VSTestBlameWithOneRegisteredReplacement_SuggestsOtherExtension(
+        string registeredReplacement,
+        string registeredPackageName,
+        string missingReplacement,
+        string missingPackageName)
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse(["--collect", "blame"], new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
+        [
+            new ExtensionCommandLineProviderMockValidConfiguration(registeredReplacement),
+        ];
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>());
+
+        Assert.IsFalse(result.IsValid);
+        Assert.DoesNotContain(
+            $"Option '--{registeredReplacement}' is provided by the '{registeredPackageName}' extension.",
+            result.ErrorMessage);
+        Assert.Contains(
+            $"Option '{missingReplacement}' is provided by the '{missingPackageName}' extension. Add a package reference to use it.",
+            result.ErrorMessage);
+    }
+
+    [TestMethod]
     public async Task ParseAndValidateAsync_VSTestOptionInTestConfig_SuggestsMTPReplacement()
     {
         CommandLineParseResult parseResult = CommandLineParser.Parse([], new SystemEnvironment());

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -659,6 +659,8 @@ public sealed class CommandLineHandlerTests
     [TestMethod]
     [DataRow("logger", "trx", "Use '--report-trx' instead.")]
     [DataRow("logger", "trx;LogFileName=results.trx", "Use '--report-trx', '--report-trx-filename <FILE>' instead.")]
+    [DataRow("logger", "console;verbosity=minimal", "For comparable console verbosity, use '--output minimal'.")]
+    [DataRow("logger", "console;verbosity=normal", "For comparable console verbosity, use '--output normal'.")]
     [DataRow("logger", "console;verbosity=detailed", "For comparable console verbosity, use '--output detailed'.")]
     [DataRow("logger", "custom", "MTP uses reporter-specific options")]
     [DataRow("collect", "Code Coverage", "Use '--coverage' instead.")]
@@ -733,16 +735,17 @@ public sealed class CommandLineHandlerTests
     }
 
     [TestMethod]
-    [DataRow("logger", "trx", "report-trx", "Microsoft.Testing.Extensions.TrxReport")]
-    [DataRow("collect", "Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
-    [DataRow("collect", "XPlat Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
-    [DataRow("collect", "blame", "crashdump", "Microsoft.Testing.Extensions.CrashDump")]
-    [DataRow("collect", "blame", "hangdump", "Microsoft.Testing.Extensions.HangDump")]
+    [DataRow("logger", "trx", "report-trx", "Microsoft.Testing.Extensions.TrxReport", "Use '--report-trx' instead.")]
+    [DataRow("collect", "Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage", "Use '--coverage' instead.")]
+    [DataRow("collect", "XPlat Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage", "For MTP code coverage, use '--coverage'.")]
+    [DataRow("collect", "blame", "crashdump", "Microsoft.Testing.Extensions.CrashDump", "Use '--crashdump' and/or '--hangdump' instead.")]
+    [DataRow("collect", "blame", "hangdump", "Microsoft.Testing.Extensions.HangDump", "Use '--crashdump' and/or '--hangdump' instead.")]
     public async Task ParseAndValidateAsync_VSTestOptionWithRegisteredReplacement_DoesNotSuggestPackage(
         string option,
         string argument,
         string registeredReplacement,
-        string packageName)
+        string packageName,
+        string expectedGuidance)
     {
         CommandLineParseResult parseResult = CommandLineParser.Parse([$"--{option}", argument], new SystemEnvironment());
         ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
@@ -760,6 +763,7 @@ public sealed class CommandLineHandlerTests
         Assert.DoesNotContain(
             $"Option '--{registeredReplacement}' is provided by the '{packageName}' extension. Add a package reference to use it.",
             result.ErrorMessage);
+        Assert.Contains(expectedGuidance, result.ErrorMessage);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -657,6 +657,97 @@ public sealed class CommandLineHandlerTests
     }
 
     [TestMethod]
+    [DataRow("logger", "trx", "Use '--report-trx' instead.")]
+    [DataRow("logger", "trx;LogFileName=results.trx", "Use '--report-trx' and '--report-trx-filename <FILE>' instead.")]
+    [DataRow("logger", "console;verbosity=detailed", "For comparable console verbosity, use '--output detailed'.")]
+    [DataRow("logger", "custom", "MTP uses reporter-specific options")]
+    [DataRow("collect", "Code Coverage", "Use '--coverage' instead.")]
+    [DataRow("collect", "XPlat Code Coverage", "This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.")]
+    [DataRow("collect", "blame", "there is no one-to-one replacement for the VSTest blame collector.")]
+    [DataRow("collect", "custom", "MTP uses collector-specific options.")]
+    public async Task ParseAndValidateAsync_VSTestOption_SuggestsMTPReplacement(
+        string option,
+        string argument,
+        string expectedGuidance)
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse([$"--{option}", argument], new SystemEnvironment());
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>());
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains($"Option '--{option}' uses VSTest syntax, which is not supported by Microsoft.Testing.Platform.", result.ErrorMessage);
+        Assert.Contains(expectedGuidance, result.ErrorMessage);
+    }
+
+    [TestMethod]
+    [DataRow("logger", "MTP uses reporter-specific options")]
+    [DataRow("collect", "MTP uses collector-specific options")]
+    public async Task ParseAndValidateAsync_VSTestOptionWithoutArgument_ProvidesGeneralGuidance(
+        string option,
+        string expectedGuidance)
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse([$"--{option}"], new SystemEnvironment());
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>());
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(expectedGuidance, result.ErrorMessage);
+    }
+
+    [TestMethod]
+    [DataRow("logger", "trx", "--report-trx", "Microsoft.Testing.Extensions.TrxReport")]
+    [DataRow("collect", "Code Coverage", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "XPlat Code Coverage", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "blame", "--crashdump", "Microsoft.Testing.Extensions.CrashDump")]
+    [DataRow("collect", "blame", "--hangdump", "Microsoft.Testing.Extensions.HangDump")]
+    public async Task ParseAndValidateAsync_VSTestOption_SuggestsRequiredExtension(
+        string option,
+        string argument,
+        string replacement,
+        string packageName)
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse([$"--{option}", argument], new SystemEnvironment());
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>());
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(
+            $"Option '{replacement}' is provided by the '{packageName}' extension. Add a package reference to use it.",
+            result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ParseAndValidateAsync_VSTestOptionInTestConfig_SuggestsMTPReplacement()
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse([], new SystemEnvironment());
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            _extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>(),
+            [new JsonCommandLineOptionEntry("logger", ["trx"], isDisabled: false)]);
+
+        Assert.IsFalse(result.IsValid);
+        Assert.Contains(
+            "In testconfig.json under 'commandLineOptions': Unknown option '--logger'",
+            result.ErrorMessage);
+        Assert.Contains("Use '--report-trx' instead.", result.ErrorMessage);
+    }
+
+    [TestMethod]
     [DataRow("--report-azdo", "Microsoft.Testing.Extensions.AzureDevOpsReport")]
     [DataRow("--coverage-output-format", "Microsoft.Testing.Extensions.CodeCoverage")]
     [DataRow("--crashdump-type", "Microsoft.Testing.Extensions.CrashDump")]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/CommandLine/CommandLineHandlerTests.cs
@@ -658,11 +658,13 @@ public sealed class CommandLineHandlerTests
 
     [TestMethod]
     [DataRow("logger", "trx", "Use '--report-trx' instead.")]
-    [DataRow("logger", "trx;LogFileName=results.trx", "Use '--report-trx' and '--report-trx-filename <FILE>' instead.")]
+    [DataRow("logger", "trx;LogFileName=results.trx", "Use '--report-trx', '--report-trx-filename <FILE>' instead.")]
     [DataRow("logger", "console;verbosity=detailed", "For comparable console verbosity, use '--output detailed'.")]
     [DataRow("logger", "custom", "MTP uses reporter-specific options")]
     [DataRow("collect", "Code Coverage", "Use '--coverage' instead.")]
+    [DataRow("collect", "Code Coverage;Format=cobertura", "Use '--coverage', '--coverage-output-format cobertura' instead.")]
     [DataRow("collect", "XPlat Code Coverage", "This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.")]
+    [DataRow("collect", "XPlat Code Coverage;Format=cobertura", "This is not a transparent replacement for Coverlet's 'XPlat Code Coverage' collector.")]
     [DataRow("collect", "blame", "there is no one-to-one replacement for the VSTest blame collector.")]
     [DataRow("collect", "custom", "MTP uses collector-specific options.")]
     public async Task ParseAndValidateAsync_VSTestOption_SuggestsMTPReplacement(
@@ -705,7 +707,9 @@ public sealed class CommandLineHandlerTests
     [TestMethod]
     [DataRow("logger", "trx", "--report-trx", "Microsoft.Testing.Extensions.TrxReport")]
     [DataRow("collect", "Code Coverage", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "Code Coverage;Format=cobertura", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
     [DataRow("collect", "XPlat Code Coverage", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "XPlat Code Coverage;Format=cobertura", "--coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
     [DataRow("collect", "blame", "--crashdump", "Microsoft.Testing.Extensions.CrashDump")]
     [DataRow("collect", "blame", "--hangdump", "Microsoft.Testing.Extensions.HangDump")]
     public async Task ParseAndValidateAsync_VSTestOption_SuggestsRequiredExtension(
@@ -725,6 +729,36 @@ public sealed class CommandLineHandlerTests
         Assert.IsFalse(result.IsValid);
         Assert.Contains(
             $"Option '{replacement}' is provided by the '{packageName}' extension. Add a package reference to use it.",
+            result.ErrorMessage);
+    }
+
+    [TestMethod]
+    [DataRow("logger", "trx", "report-trx", "Microsoft.Testing.Extensions.TrxReport")]
+    [DataRow("collect", "Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "XPlat Code Coverage", "coverage", "Microsoft.Testing.Extensions.CodeCoverage")]
+    [DataRow("collect", "blame", "crashdump", "Microsoft.Testing.Extensions.CrashDump")]
+    [DataRow("collect", "blame", "hangdump", "Microsoft.Testing.Extensions.HangDump")]
+    public async Task ParseAndValidateAsync_VSTestOptionWithRegisteredReplacement_DoesNotSuggestPackage(
+        string option,
+        string argument,
+        string registeredReplacement,
+        string packageName)
+    {
+        CommandLineParseResult parseResult = CommandLineParser.Parse([$"--{option}", argument], new SystemEnvironment());
+        ICommandLineOptionsProvider[] extensionCommandLineOptionsProviders =
+        [
+            new ExtensionCommandLineProviderMockValidConfiguration(registeredReplacement),
+        ];
+
+        ValidationResult result = await CommandLineOptionsValidator.ValidateAsync(
+            parseResult,
+            _systemCommandLineOptionsProviders,
+            extensionCommandLineOptionsProviders,
+            Mock.Of<ICommandLineOptions>());
+
+        Assert.IsFalse(result.IsValid);
+        Assert.DoesNotContain(
+            $"Option '--{registeredReplacement}' is provided by the '{packageName}' extension. Add a package reference to use it.",
             result.ErrorMessage);
     }
 


### PR DESCRIPTION
MTP currently reports VSTest-specific `--logger` and `--collect` arguments as generic unknown options, leaving users without an actionable migration path. This change keeps those arguments invalid while explaining the canonical MTP replacement instead of introducing a permanent compatibility mapping API.

## Summary

- Add value-aware guidance for TRX, console verbosity, Microsoft and XPlat code coverage, and blame arguments.
- Include required extension package hints where applicable and call out cases that are not one-to-one replacements.
- Preserve MTP's single-owner command-line option model and existing invalid-command-line behavior.
- Record RFC 015 as rejected while leaving room to reconsider a narrow temporary shim if migration data shows diagnostics are insufficient.
- Regenerate localized resource files and cover CLI and `testconfig.json` diagnostics with unit tests.

## Testing

- Focused `Microsoft.Testing.Platform.UnitTests` project build
- `CommandLineHandlerTests`: 85 passed
- Direct executable check for `--logger trx` returning the replacement guidance and invalid-command-line exit code

Fixes: #7249