### PR TITLE
Explain non-success MTP exit codes in test summaries

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -129,6 +129,7 @@ Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalProgressMessageState.Ve
 Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.UpdateProgressMessage(string! executionId, string! instanceId, string! producerUid, string! key, string? message) -> void
 Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.ClearProgressMessages() -> void
 Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.TestCompletedWithoutResult(string! executionId, string! testNodeUid) -> void
+static Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporter.GetExitCodeDescription(int exitCode) -> string!
 Microsoft.Testing.Platform.Telemetry.OpenTelemetryResultHandler.NotifyExecutionCompleted(Microsoft.Testing.Platform.Extensions.Messages.TestNode! testNode) -> void
 virtual Microsoft.Testing.Platform.OutputDevice.SimplifiedConsoleOutputDeviceBase.DisplayActiveTestProgress.get -> bool
 static Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalTestReporterCommandLineOptionsProvider.IsProgressEnabled(Microsoft.Testing.Platform.CommandLine.ICommandLineOptions! commandLineOptions) -> bool

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props
@@ -28,7 +28,7 @@
     SCOPE
       The set is the reporter + its rendering/state types + the small platform abstractions it depends on
       (IConsole/IStopwatch/IColor/System* + ILogger/LogLevel/LoggingExtensions/NopLogger +
-      RoslynString/ApplicationStateGuard/StackTraceHelper/SlowTestThresholdState/TargetFrameworkParser/
+      ExitCode/RoslynString/ApplicationStateGuard/StackTraceHelper/SlowTestThresholdState/TargetFrameworkParser/
       TestRunSummaryHelper/ZeroTestsPolicy).
       It deliberately EXCLUDES TerminalTestReporterCommandLineOptionsProvider.cs (MTP
       command-line specific - the SDK has its own CLI) and TerminalResources.cs (the hand-written [Embedded]
@@ -69,6 +69,7 @@
                                     Exclude="$(MSBuildThisFileDirectory)TerminalTestReporterCommandLineOptionsProvider.cs;$(MSBuildThisFileDirectory)TerminalResources.cs" />
 
     <!-- Small platform abstractions the reporter depends on. -->
+    <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\ExitCodes.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\RoslynString.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\ApplicationStateGuard.cs" />
     <TerminalReporterContractSource Include="$(_TerminalContractPlatform)\Helpers\StackTraceHelper.cs" />

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if !IS_CORE_MTP

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.cs
@@ -117,6 +117,36 @@ internal static partial class TerminalResources
 
     internal static string @ExitCode => GetResourceString("ExitCode");
 
+    internal static string @ExitCodeAtLeastOneTestFailedDescription => GetResourceString("ExitCodeAtLeastOneTestFailedDescription");
+
+    internal static string @ExitCodeCoverageThresholdFailedDescription => GetResourceString("ExitCodeCoverageThresholdFailedDescription");
+
+    internal static string @ExitCodeDependentProcessExitedDescription => GetResourceString("ExitCodeDependentProcessExitedDescription");
+
+    internal static string @ExitCodeGenericFailureDescription => GetResourceString("ExitCodeGenericFailureDescription");
+
+    internal static string @ExitCodeIncompatibleProtocolVersionDescription => GetResourceString("ExitCodeIncompatibleProtocolVersionDescription");
+
+    internal static string @ExitCodeInvalidCommandLineDescription => GetResourceString("ExitCodeInvalidCommandLineDescription");
+
+    internal static string @ExitCodeInvalidPlatformSetupDescription => GetResourceString("ExitCodeInvalidPlatformSetupDescription");
+
+    internal static string @ExitCodeMinimumExpectedTestsPolicyViolationDescription => GetResourceString("ExitCodeMinimumExpectedTestsPolicyViolationDescription");
+
+    internal static string @ExitCodeTestAdapterTestSessionFailureDescription => GetResourceString("ExitCodeTestAdapterTestSessionFailureDescription");
+
+    internal static string @ExitCodeTestExecutionStoppedAtDeadlineDescription => GetResourceString("ExitCodeTestExecutionStoppedAtDeadlineDescription");
+
+    internal static string @ExitCodeTestExecutionStoppedForMaxFailedTestsDescription => GetResourceString("ExitCodeTestExecutionStoppedForMaxFailedTestsDescription");
+
+    internal static string @ExitCodeTestHostProcessExitedNonGracefullyDescription => GetResourceString("ExitCodeTestHostProcessExitedNonGracefullyDescription");
+
+    internal static string @ExitCodeTestSessionAbortedDescription => GetResourceString("ExitCodeTestSessionAbortedDescription");
+
+    internal static string @ExitCodeUnknownDescription => GetResourceString("ExitCodeUnknownDescription");
+
+    internal static string @ExitCodeZeroTestsDescription => GetResourceString("ExitCodeZeroTestsDescription");
+
     internal static string @Expected => GetResourceString("Expected");
 
     internal static string @Failed => GetResourceString("Failed");
@@ -218,6 +248,10 @@ internal static partial class TerminalResources
     internal static string @TerminalTestReporterDisplayName => GetResourceString("TerminalTestReporterDisplayName");
 
     internal static string @TestDiscoverySummarySingular => GetResourceString("TestDiscoverySummarySingular");
+
+    internal static string @TestDiscoveryExitCode => GetResourceString("TestDiscoveryExitCode");
+
+    internal static string @TestRunExitCode => GetResourceString("TestRunExitCode");
 
     internal static string @TestRunSummary => GetResourceString("TestRunSummary");
 

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx
@@ -323,6 +323,14 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
     <value>Test discovery summary: found {0} test(s)</value>
     <comment>{0} is the number of discovered tests.</comment>
   </data>
+  <data name="TestDiscoveryExitCode" xml:space="preserve">
+    <value>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</value>
+    <comment>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</comment>
+  </data>
+  <data name="TestRunExitCode" xml:space="preserve">
+    <value>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</value>
+    <comment>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</comment>
+  </data>
   <data name="ActiveTestsRunning_MoreTestsCount" xml:space="preserve">
     <value>and {0} more</value>
     <comment>{0} is the number of additional active tests.</comment>
@@ -342,6 +350,51 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
   </data>
   <data name="ExitCode" xml:space="preserve">
     <value>Exit code</value>
+  </data>
+  <data name="ExitCodeAtLeastOneTestFailedDescription" xml:space="preserve">
+    <value>At least one test failed.</value>
+  </data>
+  <data name="ExitCodeCoverageThresholdFailedDescription" xml:space="preserve">
+    <value>One or more code coverage thresholds were not met.</value>
+  </data>
+  <data name="ExitCodeDependentProcessExitedDescription" xml:space="preserve">
+    <value>A dependent process exited.</value>
+  </data>
+  <data name="ExitCodeGenericFailureDescription" xml:space="preserve">
+    <value>An unexpected error occurred.</value>
+  </data>
+  <data name="ExitCodeIncompatibleProtocolVersionDescription" xml:space="preserve">
+    <value>The test platform protocol version is incompatible.</value>
+  </data>
+  <data name="ExitCodeInvalidCommandLineDescription" xml:space="preserve">
+    <value>The command-line arguments are invalid.</value>
+  </data>
+  <data name="ExitCodeInvalidPlatformSetupDescription" xml:space="preserve">
+    <value>The test platform setup or extension configuration is invalid.</value>
+  </data>
+  <data name="ExitCodeMinimumExpectedTestsPolicyViolationDescription" xml:space="preserve">
+    <value>Fewer tests ran than required by the minimum expected tests policy.</value>
+  </data>
+  <data name="ExitCodeTestAdapterTestSessionFailureDescription" xml:space="preserve">
+    <value>The test adapter reported a test session failure.</value>
+  </data>
+  <data name="ExitCodeTestExecutionStoppedAtDeadlineDescription" xml:space="preserve">
+    <value>Test execution stopped because the configured deadline was approaching.</value>
+  </data>
+  <data name="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription" xml:space="preserve">
+    <value>Test execution stopped after reaching the maximum failed tests limit.</value>
+  </data>
+  <data name="ExitCodeTestHostProcessExitedNonGracefullyDescription" xml:space="preserve">
+    <value>The test host process exited unexpectedly.</value>
+  </data>
+  <data name="ExitCodeTestSessionAbortedDescription" xml:space="preserve">
+    <value>The test session was aborted.</value>
+  </data>
+  <data name="ExitCodeUnknownDescription" xml:space="preserve">
+    <value>The exit code is not recognized.</value>
+  </data>
+  <data name="ExitCodeZeroTestsDescription" xml:space="preserve">
+    <value>No tests ran.</value>
   </data>
   <data name="FailedWithErrors" xml:space="preserve">
     <value>failed with {0} error(s)</value>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporter.Lifecycle.cs
@@ -153,7 +153,19 @@ internal sealed partial class TerminalTestReporter
 
         if (!_isHelp)
         {
-            _terminalWithProgress.WriteToTerminal(_isDiscovery ? AppendTestDiscoverySummary : AppendTestRunSummary);
+            _terminalWithProgress.WriteToTerminal(terminal =>
+            {
+                if (_isDiscovery)
+                {
+                    AppendTestDiscoverySummary(terminal);
+                }
+                else
+                {
+                    AppendTestRunSummary(terminal);
+                }
+
+                AppendExitCodeDescription(terminal, exitCode, _isDiscovery);
+            });
         }
 
         // This is relevant for HotReload scenarios. We want the next test sessions to start fresh, so we reset all
@@ -176,4 +188,36 @@ internal sealed partial class TerminalTestReporter
         _testExecutionStartTime = null;
         _testExecutionEndTime = null;
     }
+
+    private static void AppendExitCodeDescription(ITerminal terminal, int? exitCode, bool isDiscovery)
+    {
+        if (exitCode is null or (int)ExitCode.Success)
+        {
+            return;
+        }
+
+        string description = GetExitCodeDescription(exitCode.Value);
+        string message = isDiscovery ? TerminalResources.TestDiscoveryExitCode : TerminalResources.TestRunExitCode;
+        terminal.AppendLine(string.Format(CultureInfo.CurrentCulture, message, exitCode.Value, description));
+    }
+
+    internal static string GetExitCodeDescription(int exitCode)
+        => exitCode switch
+        {
+            (int)ExitCode.GenericFailure => TerminalResources.ExitCodeGenericFailureDescription,
+            (int)ExitCode.AtLeastOneTestFailed => TerminalResources.ExitCodeAtLeastOneTestFailedDescription,
+            (int)ExitCode.TestSessionAborted => TerminalResources.ExitCodeTestSessionAbortedDescription,
+            (int)ExitCode.InvalidPlatformSetup => TerminalResources.ExitCodeInvalidPlatformSetupDescription,
+            (int)ExitCode.InvalidCommandLine => TerminalResources.ExitCodeInvalidCommandLineDescription,
+            (int)ExitCode.TestHostProcessExitedNonGracefully => TerminalResources.ExitCodeTestHostProcessExitedNonGracefullyDescription,
+            (int)ExitCode.ZeroTests => TerminalResources.ExitCodeZeroTestsDescription,
+            (int)ExitCode.MinimumExpectedTestsPolicyViolation => TerminalResources.ExitCodeMinimumExpectedTestsPolicyViolationDescription,
+            (int)ExitCode.TestAdapterTestSessionFailure => TerminalResources.ExitCodeTestAdapterTestSessionFailureDescription,
+            (int)ExitCode.DependentProcessExited => TerminalResources.ExitCodeDependentProcessExitedDescription,
+            (int)ExitCode.IncompatibleProtocolVersion => TerminalResources.ExitCodeIncompatibleProtocolVersionDescription,
+            (int)ExitCode.TestExecutionStoppedForMaxFailedTests => TerminalResources.ExitCodeTestExecutionStoppedForMaxFailedTestsDescription,
+            (int)ExitCode.CoverageThresholdFailed => TerminalResources.ExitCodeCoverageThresholdFailedDescription,
+            (int)ExitCode.TestExecutionStoppedAtDeadline => TerminalResources.ExitCodeTestExecutionStoppedAtDeadlineDescription,
+            _ => TerminalResources.ExitCodeUnknownDescription,
+        };
 }

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.cs.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Ukončovací kód</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Očekáváno</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">Oznamovatel testu terminálu</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Souhrn zjišťování testů: nalezené testy: {0}</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.de.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Exitcode</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Erwartet</target>
@@ -503,10 +578,20 @@ Der Standardwert ist 'failed', wenn '--output' auf 'Minimal' festgelegt ist, 'fa
         <target state="translated">Terminaltest-Reporter</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Zusammenfassung der Testermittlung: {0} Test(s) gefunden</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.es.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Código de salida</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Se esperaba</target>
@@ -503,10 +578,20 @@ El valor predeterminado es 'failed' cuando '--output' es 'Minimal', 'failed' y '
         <target state="translated">Informador de pruebas de terminal</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Resumen de detección de pruebas: se encontraron {0} pruebas</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.fr.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Code de sortie</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Attendu</target>
@@ -503,10 +578,20 @@ La valeur par défaut est 'failed' lorsque '--output' est équivalent à 'Minima
         <target state="translated">Rapporteur de test terminal</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Résumé de la découverte de tests : {0} test(s) trouvé(s)</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.it.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Codice di uscita</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Previsto</target>
@@ -503,10 +578,20 @@ Il valore predefinito è 'failed' quando '--output' è 'Minimal', 'failed' e 'sk
         <target state="translated">Reporter test terminale</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Riepilogo individuazione test: trovati {0} test</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ja.xlf
@@ -217,6 +217,81 @@
         <target state="translated">終了コード</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">予想</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">ターミナル テストの報告者</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">テスト検出の要約: {0} 個のテストが見つかりました</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ko.xlf
@@ -217,6 +217,81 @@
         <target state="translated">종료 코드</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">필요</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">터미널 테스트 보고자</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">테스트 검색 요약: {0}개의 테스트를 찾음</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pl.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Kod zakończenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Oczekiwane</target>
@@ -503,10 +578,20 @@ Domyślną wartością jest 'failed', gdy opcja '--output' ma wartość 'Minimal
         <target state="translated">Raport testowy terminalu</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Podsumowanie odnajdywania testów: znalezione testy: {0}</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.pt-BR.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Código de saída</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Esperado</target>
@@ -503,10 +578,20 @@ O padrão é ''failed'' quando ''--output'' é ''Minimal'', ''failed'' e ''skipp
         <target state="translated">Relator de teste do terminal</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Resumo da descoberta de teste: {0} teste(s) encontrado(s)</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.ru.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Код завершения</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Ожидалось</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">Средство отчетности о тесте для терминала</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Сводка по обнаружению тестов: найдены тесты ({0})</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.tr.xlf
@@ -217,6 +217,81 @@
         <target state="translated">Çıkış kodu</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">Beklenen</target>
@@ -503,10 +578,20 @@ Geçerli değerler 'passed', 'failed' (hatalı, zaman aşımına uğramış ve i
         <target state="translated">Terminal test raporlayıcısı</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">Test bulma özeti: {0} test bulundu</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hans.xlf
@@ -217,6 +217,81 @@
         <target state="translated">退出代码</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">预期</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">终端测试报告器</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">测试发现摘要: 找到 {0} 个测试</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/xlf/TerminalResources.zh-Hant.xlf
@@ -217,6 +217,81 @@
         <target state="translated">結束代碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExitCodeAtLeastOneTestFailedDescription">
+        <source>At least one test failed.</source>
+        <target state="new">At least one test failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeCoverageThresholdFailedDescription">
+        <source>One or more code coverage thresholds were not met.</source>
+        <target state="new">One or more code coverage thresholds were not met.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeDependentProcessExitedDescription">
+        <source>A dependent process exited.</source>
+        <target state="new">A dependent process exited.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeGenericFailureDescription">
+        <source>An unexpected error occurred.</source>
+        <target state="new">An unexpected error occurred.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeIncompatibleProtocolVersionDescription">
+        <source>The test platform protocol version is incompatible.</source>
+        <target state="new">The test platform protocol version is incompatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidCommandLineDescription">
+        <source>The command-line arguments are invalid.</source>
+        <target state="new">The command-line arguments are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeInvalidPlatformSetupDescription">
+        <source>The test platform setup or extension configuration is invalid.</source>
+        <target state="new">The test platform setup or extension configuration is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeMinimumExpectedTestsPolicyViolationDescription">
+        <source>Fewer tests ran than required by the minimum expected tests policy.</source>
+        <target state="new">Fewer tests ran than required by the minimum expected tests policy.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestAdapterTestSessionFailureDescription">
+        <source>The test adapter reported a test session failure.</source>
+        <target state="new">The test adapter reported a test session failure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedAtDeadlineDescription">
+        <source>Test execution stopped because the configured deadline was approaching.</source>
+        <target state="new">Test execution stopped because the configured deadline was approaching.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestExecutionStoppedForMaxFailedTestsDescription">
+        <source>Test execution stopped after reaching the maximum failed tests limit.</source>
+        <target state="new">Test execution stopped after reaching the maximum failed tests limit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestHostProcessExitedNonGracefullyDescription">
+        <source>The test host process exited unexpectedly.</source>
+        <target state="new">The test host process exited unexpectedly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeTestSessionAbortedDescription">
+        <source>The test session was aborted.</source>
+        <target state="new">The test session was aborted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeUnknownDescription">
+        <source>The exit code is not recognized.</source>
+        <target state="new">The exit code is not recognized.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExitCodeZeroTestsDescription">
+        <source>No tests ran.</source>
+        <target state="new">No tests ran.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Expected">
         <source>Expected</source>
         <target state="translated">預期</target>
@@ -503,10 +578,20 @@ Default is 'failed' when '--output' is 'Minimal', 'failed' and 'skipped' when it
         <target state="translated">終端機測試報告者</target>
         <note />
       </trans-unit>
+      <trans-unit id="TestDiscoveryExitCode">
+        <source>Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test discovery completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
+      </trans-unit>
       <trans-unit id="TestDiscoverySummarySingular">
         <source>Test discovery summary: found {0} test(s)</source>
         <target state="translated">測試探索摘要: 找到 {0} 個測試</target>
         <note>{0} is the number of discovered tests.</note>
+      </trans-unit>
+      <trans-unit id="TestRunExitCode">
+        <source>Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</source>
+        <target state="new">Test run completed with non-success exit code: {0}. {1} See: https://aka.ms/testingplatform/exitcodes</target>
+        <note>{0} is the numeric exit code. {1} is a concise description of the exit code. {Locked="https://aka.ms/testingplatform/exitcodes"}</note>
       </trans-unit>
       <trans-unit id="TestRunSummary">
         <source>Test run summary:</source>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TerminalReporterExitCodeTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TerminalReporterExitCodeTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class TerminalReporterExitCodeTests : AcceptanceTestBase<TerminalReporterExitCodeTests.TestAssetFixture>
+{
+    private const string AssetName = "TerminalReporterExitCode";
+    private const string DiscoveryExitCodeMessage = "Test discovery completed with non-success exit code: 5. The command-line arguments are invalid. See: https://aka.ms/testingplatform/exitcodes";
+    private const string RunExitCodeMessage = "Test run completed with non-success exit code: 5. The command-line arguments are invalid. See: https://aka.ms/testingplatform/exitcodes";
+
+    [DataRow("", RunExitCodeMessage)]
+    [DataRow("discover", DiscoveryExitCodeMessage)]
+    [TestMethod]
+    public async Task InvalidCommandLineExitCode_PrintsDescriptionAsFinalLine(string command, string expected)
+    {
+        var testHost = TestInfrastructure.TestHost.LocateFrom(
+            AssetFixture.TargetAssetPath,
+            AssetName,
+            TargetFrameworks.NetCurrent);
+
+        TestHostResult result = await testHost.ExecuteAsync(command, cancellationToken: TestContext.CancellationToken);
+
+        result.AssertExitCodeIs(ExitCode.Success);
+        Assert.AreEqual(expected, result.StandardOutput.TrimEnd().Split(Environment.NewLine)[^1]);
+    }
+
+    public sealed class TestAssetFixture() : TestAssetFixtureBase()
+    {
+        private const string Sources = """
+            #file TerminalReporterExitCode.csproj
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>$TargetFramework$</TargetFramework>
+                <OutputType>Exe</OutputType>
+                <UseAppHost>true</UseAppHost>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <LangVersion>preview</LangVersion>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include="$PolyfillsPath$/**/*.cs" Link="Polyfills/%(RecursiveDir)%(Filename)%(Extension)" />
+                <Using Include="System.Collections" />
+                <Using Include="System.Collections.Concurrent" />
+                <Using Include="System.Diagnostics" />
+                <Using Include="System.Diagnostics.CodeAnalysis" />
+                <Using Include="System.Globalization" />
+                <Using Include="System.Reflection" />
+                <Using Include="System.Runtime.CompilerServices" />
+                <Using Include="System.Runtime.InteropServices" />
+                <Using Include="System.Runtime.Versioning" />
+                <Using Include="System.Text" />
+                <Using Include="System.Text.RegularExpressions" />
+                <Using Include="System.Xml" />
+                <Using Include="System.Xml.Linq" />
+                <Using Include="System.Xml.XPath" />
+              </ItemGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.Testing.Platform" Version="$MicrosoftTestingPlatformVersion$" />
+              </ItemGroup>
+              <Import Project="$TerminalReporterContractProps$" />
+              <ItemGroup>
+                <EmbeddedResource Update="$TerminalResourcesResx$"
+                                  GenerateSource="false"
+                                  LogicalName="Microsoft.Testing.Platform.OutputDevice.Terminal.TerminalResources.resources" />
+              </ItemGroup>
+            </Project>
+
+            #file Program.cs
+            using Microsoft.Testing.Platform.Helpers;
+            using Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+            bool isDiscovery = Array.IndexOf(args, "discover") >= 0;
+            using var reporter = new TerminalTestReporter(
+                new SystemConsole(),
+                new TerminalTestReporterOptions
+                {
+                    AnsiMode = AnsiMode.NoAnsi,
+                    ShowProgress = static () => false,
+                    ShowAssembly = true,
+                });
+
+            reporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery, isHelp: false, isRetry: false);
+            reporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: (int)ExitCode.InvalidCommandLine);
+            return 0;
+            """;
+
+        protected override IReadOnlyList<MetadataMode> SourceGenMetadataModes => [];
+
+        public string TargetAssetPath => GetAssetPath(AssetName);
+
+        public override (string ID, string Name, string Code) GetAssetsToGenerate()
+        {
+            string repoRoot = RootFinder.Find().Replace('\\', '/').TrimEnd('/');
+            string terminalResourcesResx = $"{repoRoot}/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalResources.resx";
+            string code = Sources
+                .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
+                .PatchCodeWithReplace("$PolyfillsPath$", $"{repoRoot}/src/Polyfills")
+                .PatchCodeWithReplace(
+                    "$TerminalReporterContractProps$",
+                    $"{repoRoot}/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalReporterContract.props")
+                .PatchCodeWithReplace("$TerminalResourcesResx$", terminalResourcesResx);
+
+            return (
+                AssetName,
+                AssetName,
+                $"{code}{Environment.NewLine}#file TerminalResources.cs{Environment.NewLine}{CreateTerminalResourcesAccessor(terminalResourcesResx)}");
+        }
+
+        private static string CreateTerminalResourcesAccessor(string resxPath)
+        {
+            // Generated acceptance assets do not import the repo's Arcade resx source generator. Emit the same
+            // strongly typed accessor shape so this external consumer still compiles the real neutral resource.
+            var builder = new StringBuilder(
+                """
+                using System.Resources;
+
+                namespace Microsoft.Testing.Platform.OutputDevice.Terminal;
+
+                internal static partial class TerminalResources
+                {
+                    private static readonly ResourceManager ResourceManager = new(typeof(TerminalResources));
+
+                    internal static string GetResourceString(string resourceKey) => ResourceManager.GetString(resourceKey)!;
+
+                """);
+
+            foreach (string name in XDocument.Load(resxPath).Root!.Elements("data").Select(static element => element.Attribute("name")!.Value))
+            {
+                builder.AppendLine(CultureInfo.InvariantCulture, $"    internal static string @{name} => GetResourceString(\"{name}\");");
+            }
+
+            builder.Append('}');
+            return builder.ToString();
+        }
+    }
+
+    public TestContext TestContext { get; set; }
+}

--- a/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/TerminalReporterContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/TerminalReporterContractTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.OutputDevice.Terminal;

--- a/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/TerminalReporterContractTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.TerminalReporterContract.UnitTests/TerminalReporterContractTests.cs
@@ -26,6 +26,7 @@ public sealed class TerminalReporterContractTests
         // Microsoft.Testing.Platform. A missing/renamed string would fail the build, not just this test.
         Assert.IsFalse(string.IsNullOrEmpty(TerminalResources.TestRunSummary));
         Assert.IsFalse(string.IsNullOrEmpty(TerminalResources.Passed));
+        Assert.IsFalse(string.IsNullOrEmpty(TerminalResources.TestRunExitCode));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -3207,6 +3207,42 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TestExecutionCompleted_WithInvalidCommandLineExitCode_PrintsDescriptionAndDocumentationLink()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: (int)ExitCode.InvalidCommandLine);
+
+        string expected = string.Format(
+            CultureInfo.CurrentCulture,
+            TerminalResources.TestRunExitCode,
+            (int)ExitCode.InvalidCommandLine,
+            TerminalResources.ExitCodeInvalidCommandLineDescription);
+        Assert.Contains(expected, stringBuilderConsole.Output);
+    }
+
+    [TestMethod]
+    public void GetExitCodeDescription_MapsEveryKnownFailureExitCode()
+    {
+        foreach (ExitCode exitCode in (ExitCode[])Enum.GetValues(typeof(ExitCode)))
+        {
+            if (exitCode == ExitCode.Success)
+            {
+                continue;
+            }
+
+            Assert.AreNotEqual(
+                TerminalResources.ExitCodeUnknownDescription,
+                TerminalTestReporter.GetExitCodeDescription((int)exitCode),
+                $"Exit code '{exitCode}' should have a description.");
+        }
+
+        Assert.AreEqual(TerminalResources.ExitCodeUnknownDescription, TerminalTestReporter.GetExitCodeDescription(42));
+    }
+
+    [TestMethod]
     public void TestExecutionCompleted_WhenHandshakeFailures_PrintsRecapAndFailsRun()
     {
         var stringBuilderConsole = new StringBuilderConsole();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -3224,6 +3224,23 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
+    public void TestExecutionCompleted_InDiscoveryModeWithInvalidCommandLineExitCode_PrintsDiscoveryDescription()
+    {
+        var stringBuilderConsole = new StringBuilderConsole();
+        TerminalTestReporter terminalReporter = CreateOrchestratorReporter(stringBuilderConsole);
+        terminalReporter.TestExecutionStarted(DateTimeOffset.MinValue, workerCount: 1, isDiscovery: true, isHelp: false, isRetry: false);
+
+        terminalReporter.TestExecutionCompleted(DateTimeOffset.MaxValue, exitCode: (int)ExitCode.InvalidCommandLine);
+
+        string expected = string.Format(
+            CultureInfo.CurrentCulture,
+            TerminalResources.TestDiscoveryExitCode,
+            (int)ExitCode.InvalidCommandLine,
+            TerminalResources.ExitCodeInvalidCommandLineDescription);
+        Assert.Contains(expected, stringBuilderConsole.Output);
+    }
+
+    [TestMethod]
     public void GetExitCodeDescription_MapsEveryKnownFailureExitCode()
     {
         foreach (ExitCode exitCode in (ExitCode[])Enum.GetValues(typeof(ExitCode)))


### PR DESCRIPTION
The `dotnet test` summary currently reports only a numeric MTP exit code and a documentation link, which makes common failures such as invalid command-line arguments unnecessarily opaque.

## Changes

- Add concise, localized descriptions for every known non-success MTP exit code.
- Include the description in run and discovery summaries while preserving the exit-code documentation link.
- Use an explicit fallback for unrecognized exit codes.
- Keep the standalone terminal-reporter contract aligned and regenerate the XLIFF localization inputs.
- Add acceptance coverage that compiles the shared reporter into an external consumer, executes it as a process, and verifies the final stdout line for run and discovery modes.

For example, exit code 5 is now reported as:

```text
Test run completed with non-success exit code: 5. The command-line arguments are invalid. See: https://aka.ms/testingplatform/exitcodes
```

## Validation

- Built `Microsoft.Testing.Platform.UnitTests` for all target frameworks.
- Built and ran `Microsoft.Testing.Platform.TerminalReporterContract.UnitTests`.
- Ran all 183 `TerminalTestReporterTests` plus focused exit-code mapping tests.
- Built `Microsoft.Testing.Platform.Acceptance.IntegrationTests` in Release and passed both external-process exit-code summary scenarios.

## Downstream consideration

`dotnet/sdk` vendors this terminal reporter from testfx, so the SDK copy must be synchronized before the improved message appears in `dotnet test`.