### PR TITLE
Add runsettings command-line validation tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/CommandLine/RunSettingsCommandLineOptionsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/CommandLine/RunSettingsCommandLineOptionsProviderTests.cs
@@ -133,28 +133,4 @@ public sealed class RunSettingsCommandLineOptionsProviderTests
         Assert.IsTrue(result.IsValid);
         Assert.IsNull(result.ErrorMessage);
     }
-
-    [TestMethod]
-    public async Task ValidateCommandLineOptionsAsync_WhenRunSettingsAreNotSupplied_IsValid()
-    {
-        // Arrange
-        var commandLineOptions = new Mock<ICommandLineOptions>(MockBehavior.Strict);
-        commandLineOptions.Setup(x => x.TryGetOptionArgumentList("settings", out It.Ref<string[]?>.IsAny))
-            .Returns((string optionName, out string[]? value) =>
-            {
-                value = null;
-                return false;
-            });
-
-        var provider = new RunSettingsCommandLineOptionsProvider(
-            new TestExtension(),
-            new Mock<IFileSystem>(MockBehavior.Strict).Object);
-
-        // Act
-        ValidationResult result = await provider.ValidateCommandLineOptionsAsync(commandLineOptions.Object);
-
-        // Assert
-        Assert.IsTrue(result.IsValid);
-        Assert.IsNull(result.ErrorMessage);
-    }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/CommandLine/RunSettingsCommandLineOptionsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/CommandLine/RunSettingsCommandLineOptionsProviderTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Testing.Extensions.VSTestBridge.CommandLine;
 using Microsoft.Testing.Extensions.VSTestBridge.Resources;
 using Microsoft.Testing.Extensions.VSTestBridge.UnitTests.Helpers;
+using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Helpers;
 
@@ -87,6 +88,70 @@ public sealed class RunSettingsCommandLineOptionsProviderTests
 
         // Act
         ValidationResult result = await provider.ValidateOptionArgumentsAsync(option, [filePath]);
+
+        // Assert
+        Assert.IsTrue(result.IsValid);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_WhenRunSettingsContainEnvironmentVariablesOnNonBrowser_IsValid()
+    {
+        // Arrange
+        // The browser-only rejection path cannot run on the net8.0/net462 unit-test hosts.
+        const string filePath = "test.runsettings";
+        const string runSettings = """
+            <RunSettings>
+                <RunConfiguration>
+                    <EnvironmentVariables>
+                        <TEST_ENV>TestValue</TEST_ENV>
+                    </EnvironmentVariables>
+                </RunConfiguration>
+            </RunSettings>
+            """;
+
+        var commandLineOptions = new Mock<ICommandLineOptions>(MockBehavior.Strict);
+        commandLineOptions.Setup(x => x.TryGetOptionArgumentList("settings", out It.Ref<string[]?>.IsAny))
+            .Returns((string optionName, out string[]? value) =>
+            {
+                value = [filePath];
+                return true;
+            });
+
+        var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        fileSystem.Setup(x => x.ExistFile(filePath)).Returns(true);
+        var fileStream = new Mock<IFileStream>();
+        fileStream.Setup(x => x.Stream).Returns(new MemoryStream(Encoding.UTF8.GetBytes(runSettings)));
+        fileSystem.Setup(x => x.NewFileStream(filePath, FileMode.Open, FileAccess.Read)).Returns(fileStream.Object);
+
+        var provider = new RunSettingsCommandLineOptionsProvider(new TestExtension(), fileSystem.Object);
+
+        // Act
+        ValidationResult result = await provider.ValidateCommandLineOptionsAsync(commandLineOptions.Object);
+
+        // Assert
+        Assert.IsTrue(result.IsValid);
+        Assert.IsNull(result.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task ValidateCommandLineOptionsAsync_WhenRunSettingsAreNotSupplied_IsValid()
+    {
+        // Arrange
+        var commandLineOptions = new Mock<ICommandLineOptions>(MockBehavior.Strict);
+        commandLineOptions.Setup(x => x.TryGetOptionArgumentList("settings", out It.Ref<string[]?>.IsAny))
+            .Returns((string optionName, out string[]? value) =>
+            {
+                value = null;
+                return false;
+            });
+
+        var provider = new RunSettingsCommandLineOptionsProvider(
+            new TestExtension(),
+            new Mock<IFileSystem>(MockBehavior.Strict).Object);
+
+        // Act
+        ValidationResult result = await provider.ValidateCommandLineOptionsAsync(commandLineOptions.Object);
 
         // Assert
         Assert.IsTrue(result.IsValid);


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

`RunSettingsCommandLineOptionsProviderBase.ValidateCommandLineOptionsAsync` had no direct unit coverage despite being shared by the VSTestBridge and MSTest runsettings providers.

This adds a focused VSTestBridge test proving validation remains valid on a non-browser host when environment-variable runsettings are supplied. The browser-only rejection branch remains outside this unit-test host because `OperatingSystem.IsBrowser()` is fixed by the target runtime.

Fixes: #10869

Fixes: #10873