### PR TITLE
Add acceptance build cache reporting

### DIFF
--- a/eng/pipelines/steps/test-windows-configuration-tests.yml
+++ b/eng/pipelines/steps/test-windows-configuration-tests.yml
@@ -135,6 +135,70 @@ steps:
   - pwsh: throw "affectedTestsMode must be 'collect' or 'run' when enableAffectedTests is true."
     displayName: Reject invalid affected-test configuration
 
+- pwsh: |
+    $summaryRoot = "$(Agent.TempDirectory)\AcceptanceMSBuildCacheLogs\$(_BuildConfig)\Summaries"
+    $summaryFiles = if (Test-Path -LiteralPath $summaryRoot -PathType Container) {
+      @(Get-ChildItem -LiteralPath $summaryRoot -Filter '*.txt' -File -ErrorAction SilentlyContinue)
+    }
+    else {
+      @()
+    }
+
+    if ($summaryFiles.Count -eq 0) {
+      Write-Host "No acceptance MSBuild cache statistics were produced. Caching was either skipped or no generated acceptance assets ran."
+      exit 0
+    }
+
+    $records = @(
+      foreach ($file in $summaryFiles) {
+        try {
+          $values = ConvertFrom-StringData -StringData (Get-Content -LiteralPath $file.FullName -Raw)
+          [pscustomobject]@{
+            Variant = $values.Variant
+            Outcome = $values.Outcome
+            HasStatistics = $values.HasStatistics -eq 'True'
+            Hits = [int]$values.Hits
+            Misses = [int]$values.Misses
+            SavedProjectSeconds = [double]::Parse(
+              $values.SavedProjectSeconds,
+              [System.Globalization.CultureInfo]::InvariantCulture)
+          }
+        }
+        catch {
+          Write-Host "##vso[task.logissue type=warning]Could not read acceptance cache summary '$($file.FullName)': $($_.Exception.Message)"
+        }
+      }
+    )
+
+    if ($records.Count -eq 0) {
+      Write-Host "No parseable acceptance MSBuild cache statistics were produced."
+      exit 0
+    }
+
+    $hits = ($records | Measure-Object -Property Hits -Sum).Sum
+    $misses = ($records | Measure-Object -Property Misses -Sum).Sum
+    $totalNodes = $hits + $misses
+    $hitRatio = if ($totalNodes -eq 0) { 0 } else { $hits / $totalNodes }
+    $savedProjectSeconds = ($records | Measure-Object -Property SavedProjectSeconds -Sum).Sum
+    $fallbacks = @($records | Where-Object Outcome -EQ 'Fallback').Count
+    $missingStatistics = @(
+      $records | Where-Object { -not $_.HasStatistics -and $_.Outcome -ne 'Fallback' }
+    ).Count
+
+    Write-Host "Acceptance MSBuild cache [${{ parameters.acceptanceTestCacheMode }}]: $($records.Count) generated build attempt(s), $hits hit node(s), $misses miss node(s), $($hitRatio.ToString('P1')) hit ratio, $($savedProjectSeconds.ToString('F1')) project-seconds saved, $fallbacks fallback(s), $missingStatistics successful attempt(s) without statistics."
+
+    $summaryPath = "$(Agent.TempDirectory)\AcceptanceMSBuildCacheSummary-$(_BuildConfig).md"
+    @"
+    # Acceptance MSBuild cache
+
+    | Mode | Generated build attempts | Hit nodes | Miss nodes | Hit ratio | Saved project time | Fallbacks | Successful attempts missing statistics |
+    | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+    | ${{ parameters.acceptanceTestCacheMode }} | $($records.Count) | $hits | $misses | $($hitRatio.ToString('P1')) | $([TimeSpan]::FromSeconds($savedProjectSeconds).ToString()) | $fallbacks | $missingStatistics |
+    "@ | Set-Content -LiteralPath $summaryPath
+    Write-Host "##vso[task.uploadsummary]$summaryPath"
+  displayName: Report acceptance MSBuild cache usage
+  condition: and(always(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
+
 # A cache hit materializes compiled outputs but does not run Arcade's restore phase, which installs the .NET runtimes
 # declared in global.json. Release gets those runtimes from its sign/pack preparation; initialize them explicitly for
 # the cached Debug leg before launching its unit-test apphosts. This template is only included when tests are enabled.

--- a/eng/pipelines/steps/test-windows-configuration-tests.yml
+++ b/eng/pipelines/steps/test-windows-configuration-tests.yml
@@ -188,14 +188,19 @@ steps:
     Write-Host "Acceptance MSBuild cache [${{ parameters.acceptanceTestCacheMode }}]: $($records.Count) generated build attempt(s), $hits hit node(s), $misses miss node(s), $($hitRatio.ToString('P1')) hit ratio, $($savedProjectSeconds.ToString('F1')) project-seconds saved, $fallbacks fallback(s), $missingStatistics successful attempt(s) without statistics."
 
     $summaryPath = "$(Agent.TempDirectory)\AcceptanceMSBuildCacheSummary-$(_BuildConfig).md"
-    @"
-    # Acceptance MSBuild cache
-
-    | Mode | Generated build attempts | Hit nodes | Miss nodes | Hit ratio | Saved project time | Fallbacks | Successful attempts missing statistics |
-    | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-    | ${{ parameters.acceptanceTestCacheMode }} | $($records.Count) | $hits | $misses | $($hitRatio.ToString('P1')) | $([TimeSpan]::FromSeconds($savedProjectSeconds).ToString()) | $fallbacks | $missingStatistics |
-    "@ | Set-Content -LiteralPath $summaryPath
-    Write-Host "##vso[task.uploadsummary]$summaryPath"
+    try {
+      @(
+        '# Acceptance MSBuild cache'
+        ''
+        '| Mode | Generated build attempts | Hit nodes | Miss nodes | Hit ratio | Saved project time | Fallbacks | Successful attempts missing statistics |'
+        '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+        "| ${{ parameters.acceptanceTestCacheMode }} | $($records.Count) | $hits | $misses | $($hitRatio.ToString('P1')) | $([TimeSpan]::FromSeconds($savedProjectSeconds).ToString()) | $fallbacks | $missingStatistics |"
+      ) | Set-Content -LiteralPath $summaryPath
+      Write-Host "##vso[task.uploadsummary]$summaryPath"
+    }
+    catch {
+      Write-Host "##vso[task.logissue type=warning]Could not publish acceptance MSBuild cache summary: $($_.Exception.Message)"
+    }
   displayName: Report acceptance MSBuild cache usage
   condition: and(always(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
+
+[TestClass]
+public sealed class TestAssetFixtureBaseTests
+{
+    [TestMethod]
+    [DataRow("Cache Hit Count:", "  Cache Hit Count: 12 cache hits", 12)]
+    [DataRow("Cache Miss Count:", "Cache Miss Count: 3 cache misses", 3)]
+    [DataRow("Cache Hit Count:", "Cache Hit Count: 0 cache hits", 0)]
+    public void TryReadCacheCount_ValidStatistic_ReturnsCount(string label, string line, int expectedCount)
+    {
+        bool result = TestAssetFixtureBase.TryReadCacheCount([line], label, out int count);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(expectedCount, count);
+    }
+
+    [TestMethod]
+    [DataRow("unrelated output")]
+    [DataRow("Cache Hit Count: invalid")]
+    [DataRow("Cache Hit Count:")]
+    public void TryReadCacheCount_MissingOrMalformedStatistic_ReturnsFalse(string line)
+    {
+        bool result = TestAssetFixtureBase.TryReadCacheCount([line], "Cache Hit Count:", out int count);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(0, count);
+    }
+
+    [TestMethod]
+    [DataRow("(saved 1.5 project-seconds)", 1.5)]
+    [DataRow("(saved 2 project-minutes)", 120)]
+    [DataRow("(saved 0.5 project-hours)", 1800)]
+    [DataRow("(saved 0 project-hours)", 0)]
+    public void TryReadSavedProjectSeconds_ValidStatistic_ConvertsToSeconds(string line, double expectedSeconds)
+    {
+        bool result = TestAssetFixtureBase.TryReadSavedProjectSeconds([line], out double savedSeconds);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(expectedSeconds, savedSeconds);
+    }
+
+    [TestMethod]
+    [DataRow("unrelated output")]
+    [DataRow("(saved invalid project-seconds)")]
+    [DataRow("(saved 2 project-days)")]
+    [DataRow("(saved 0 project-days)")]
+    [DataRow("(saved -1 project-seconds)")]
+    public void TryReadSavedProjectSeconds_MissingOrMalformedStatistic_ReturnsFalse(string line)
+    {
+        bool result = TestAssetFixtureBase.TryReadSavedProjectSeconds([line], out double savedSeconds);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(0, savedSeconds);
+    }
+}

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
+
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
 [TestClass]
@@ -12,7 +14,7 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("Cache Hit Count:", "Cache Hit Count: 0 cache hits", 0)]
     public void TryReadCacheCount_ValidStatistic_ReturnsCount(string label, string line, int expectedCount)
     {
-        bool result = TestAssetFixtureBase.TryReadCacheCount([line], label, out int count);
+        bool result = TryReadCacheCount([line], label, out int count);
 
         Assert.IsTrue(result);
         Assert.AreEqual(expectedCount, count);
@@ -24,7 +26,7 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("Cache Hit Count:")]
     public void TryReadCacheCount_MissingOrMalformedStatistic_ReturnsFalse(string line)
     {
-        bool result = TestAssetFixtureBase.TryReadCacheCount([line], "Cache Hit Count:", out int count);
+        bool result = TryReadCacheCount([line], "Cache Hit Count:", out int count);
 
         Assert.IsFalse(result);
         Assert.AreEqual(0, count);
@@ -37,7 +39,7 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("(saved 0 project-hours)", 0)]
     public void TryReadSavedProjectSeconds_ValidStatistic_ConvertsToSeconds(string line, double expectedSeconds)
     {
-        bool result = TestAssetFixtureBase.TryReadSavedProjectSeconds([line], out double savedSeconds);
+        bool result = TryReadSavedProjectSeconds([line], out double savedSeconds);
 
         Assert.IsTrue(result);
         Assert.AreEqual(expectedSeconds, savedSeconds);
@@ -51,9 +53,88 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("(saved -1 project-seconds)")]
     public void TryReadSavedProjectSeconds_MissingOrMalformedStatistic_ReturnsFalse(string line)
     {
-        bool result = TestAssetFixtureBase.TryReadSavedProjectSeconds([line], out double savedSeconds);
+        bool result = TryReadSavedProjectSeconds([line], out double savedSeconds);
 
         Assert.IsFalse(result);
         Assert.AreEqual(0, savedSeconds);
+    }
+
+    [TestMethod]
+    [DataRow(3, true, true)]
+    [DataRow(3, false, false)]
+    [DataRow(0, true, true)]
+    [DataRow(0, false, true)]
+    public void TryReadCacheStatistics_SavedTimeCompleteness_IsRequiredOnlyForHits(
+        int hitCount,
+        bool includeSavedTime,
+        bool expectedResult)
+    {
+        string savedTime = includeSavedTime ? " (saved 1.5 project-seconds)" : string.Empty;
+        string[] outputLines =
+        [
+            $"Cache Hit Count: {hitCount}{savedTime}",
+            "Cache Miss Count: 2",
+        ];
+
+        bool result = TryReadCacheStatistics(outputLines, out int parsedHitCount, out int missCount, out double savedSeconds);
+
+        Assert.AreEqual(expectedResult, result);
+        Assert.AreEqual(hitCount, parsedHitCount);
+        Assert.AreEqual(2, missCount);
+        Assert.AreEqual(includeSavedTime ? 1.5 : 0, savedSeconds);
+    }
+
+    [TestMethod]
+    public void TryReadCacheStatistics_ZeroHitsWithMalformedSavedTime_ReturnsFalse()
+    {
+        string[] outputLines =
+        [
+            "Cache Hit Count: 0 (saved invalid project-seconds)",
+            "Cache Miss Count: 2",
+        ];
+
+        bool result = TryReadCacheStatistics(outputLines, out int hitCount, out int missCount, out double savedSeconds);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(0, hitCount);
+        Assert.AreEqual(2, missCount);
+        Assert.AreEqual(0, savedSeconds);
+    }
+
+    private static bool TryReadCacheStatistics(
+        IReadOnlyList<string> outputLines,
+        out int hitCount,
+        out int missCount,
+        out double savedSeconds)
+    {
+        object?[] arguments = [outputLines, 0, 0, 0d];
+        bool result = InvokeParser<bool>(nameof(TryReadCacheStatistics), arguments);
+        hitCount = (int)arguments[1]!;
+        missCount = (int)arguments[2]!;
+        savedSeconds = (double)arguments[3]!;
+        return result;
+    }
+
+    private static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
+    {
+        object?[] arguments = [outputLines, label, 0];
+        bool result = InvokeParser<bool>(nameof(TryReadCacheCount), arguments);
+        count = (int)arguments[2]!;
+        return result;
+    }
+
+    private static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
+    {
+        object?[] arguments = [outputLines, 0d];
+        bool result = InvokeParser<bool>(nameof(TryReadSavedProjectSeconds), arguments);
+        savedSeconds = (double)arguments[1]!;
+        return result;
+    }
+
+    private static T InvokeParser<T>(string methodName, object?[] arguments)
+    {
+        MethodInfo method = typeof(TestAssetFixtureBase).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Could not find {nameof(TestAssetFixtureBase)}.{methodName}.");
+        return (T)method.Invoke(null, arguments)!;
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
@@ -24,6 +24,7 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("unrelated output")]
     [DataRow("Cache Hit Count: invalid")]
     [DataRow("Cache Hit Count:")]
+    [DataRow("Cache Hit Count: -1")]
     public void TryReadCacheCount_MissingOrMalformedStatistic_ReturnsFalse(string line)
     {
         bool result = TryReadCacheCount([line], "Cache Hit Count:", out int count);
@@ -51,6 +52,7 @@ public sealed class TestAssetFixtureBaseTests
     [DataRow("(saved 2 project-days)")]
     [DataRow("(saved 0 project-days)")]
     [DataRow("(saved -1 project-seconds)")]
+    [DataRow("(saved 1E308 project-hours)")]
     public void TryReadSavedProjectSeconds_MissingOrMalformedStatistic_ReturnsFalse(string line)
     {
         bool result = TryReadSavedProjectSeconds([line], out double savedSeconds);

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Testing.Platform.Acceptance.IntegrationTests" Key="$(VsPublicKey)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Polyfills" />
   </ItemGroup>
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/Microsoft.Testing.TestInfrastructure.csproj
@@ -25,10 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="Microsoft.Testing.Platform.Acceptance.IntegrationTests" Key="$(VsPublicKey)" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Using Include="Polyfills" />
   </ItemGroup>
 

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -290,13 +290,14 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         int cacheBuildId,
         IReadOnlyList<string> outputLines)
     {
-        bool hasHitCount = TryReadCacheCount(outputLines, "Cache Hit Count:", out int hitCount);
-        bool hasMissCount = TryReadCacheCount(outputLines, "Cache Miss Count:", out int missCount);
-        bool hasStatistics = hasHitCount && hasMissCount;
+        bool hasStatistics = TryReadCacheStatistics(
+            outputLines,
+            out int hitCount,
+            out int missCount,
+            out double savedSeconds);
         double hitRatio = hasStatistics && hitCount + missCount > 0
             ? (double)hitCount / (hitCount + missCount)
             : 0;
-        double savedSeconds = TryReadSavedProjectSeconds(outputLines, out double value) ? value : 0;
 
         Console.WriteLine(
             hasStatistics
@@ -355,7 +356,23 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         }
     }
 
-    internal static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
+    private static bool TryReadCacheStatistics(
+        IReadOnlyList<string> outputLines,
+        out int hitCount,
+        out int missCount,
+        out double savedSeconds)
+    {
+        bool hasHitCount = TryReadCacheCount(outputLines, "Cache Hit Count:", out hitCount);
+        bool hasMissCount = TryReadCacheCount(outputLines, "Cache Miss Count:", out missCount);
+        bool hasSavedTime = TryReadSavedProjectSeconds(outputLines, out savedSeconds);
+        bool hasSavedTimeText = outputLines.Any(line => line.Contains("(saved ", StringComparison.Ordinal));
+
+        return hasHitCount
+            && hasMissCount
+            && (hasSavedTime || (hitCount == 0 && !hasSavedTimeText));
+    }
+
+    private static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
     {
         string? line = outputLines.LastOrDefault(line => line.TrimStart().StartsWith(label, StringComparison.Ordinal));
         if (line is null)
@@ -374,7 +391,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         return int.TryParse(value, out count);
     }
 
-    internal static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
+    private static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
     {
         const string SavedPrefix = "(saved ";
         const string ProjectUnitPrefix = " project-";

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -355,7 +355,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         }
     }
 
-    private static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
+    internal static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
     {
         string? line = outputLines.LastOrDefault(line => line.TrimStart().StartsWith(label, StringComparison.Ordinal));
         if (line is null)
@@ -374,14 +374,20 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         return int.TryParse(value, out count);
     }
 
-    private static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
+    internal static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
     {
         const string SavedPrefix = "(saved ";
         const string ProjectUnitPrefix = " project-";
 
         string? line = outputLines.LastOrDefault(line => line.Contains(SavedPrefix, StringComparison.Ordinal));
-        int start = line?.IndexOf(SavedPrefix, StringComparison.Ordinal) ?? -1;
-        int end = line?.IndexOf(ProjectUnitPrefix, StringComparison.Ordinal) ?? -1;
+        if (line is null)
+        {
+            savedSeconds = 0;
+            return false;
+        }
+
+        int start = line.IndexOf(SavedPrefix, StringComparison.Ordinal);
+        int end = line.IndexOf(ProjectUnitPrefix, StringComparison.Ordinal);
         if (start < 0 || end <= start)
         {
             savedSeconds = 0;
@@ -405,15 +411,31 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
             return false;
         }
 
-        string unit = line.AsSpan(end + ProjectUnitPrefix.Length).TrimEnd(')').ToString();
-        savedSeconds = unit switch
+        if (!double.IsFinite(savedValue) || savedValue < 0)
         {
-            "seconds" => savedValue,
-            "minutes" => savedValue * 60,
-            "hours" => savedValue * 60 * 60,
-            _ => 0,
-        };
-        return savedSeconds > 0 || savedValue == 0;
+            savedSeconds = 0;
+            return false;
+        }
+
+        string unit = line.AsSpan(end + ProjectUnitPrefix.Length).TrimEnd(')').ToString();
+        switch (unit)
+        {
+            case "seconds":
+                savedSeconds = savedValue;
+                return true;
+
+            case "minutes":
+                savedSeconds = savedValue * 60;
+                return true;
+
+            case "hours":
+                savedSeconds = savedValue * 60 * 60;
+                return true;
+
+            default:
+                savedSeconds = 0;
+                return false;
+        }
     }
 
     private static void CleanCacheOutputs(string assetPath, string cacheVariant)

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -388,7 +388,13 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
             value = value[..separator];
         }
 
-        return int.TryParse(value, out count);
+        if (!int.TryParse(value, out count) || count < 0)
+        {
+            count = 0;
+            return false;
+        }
+
+        return true;
     }
 
     private static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
@@ -439,20 +445,28 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         {
             case "seconds":
                 savedSeconds = savedValue;
-                return true;
+                break;
 
             case "minutes":
                 savedSeconds = savedValue * 60;
-                return true;
+                break;
 
             case "hours":
                 savedSeconds = savedValue * 60 * 60;
-                return true;
+                break;
 
             default:
                 savedSeconds = 0;
                 return false;
         }
+
+        if (!double.IsFinite(savedSeconds))
+        {
+            savedSeconds = 0;
+            return false;
+        }
+
+        return true;
     }
 
     private static void CleanCacheOutputs(string assetPath, string cacheVariant)

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -173,9 +173,10 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         }
 
         string projectPath = ResolveEntryProject(testAsset.TargetAssetPath, testAsset.AssetId);
+        int cacheBuildId = Interlocked.Increment(ref s_cacheBinlogCounter);
         string binlogPath = Path.Combine(
             TempDirectory.TestSuiteDirectory,
-            $"{binlogBaseFileName}-{Interlocked.Increment(ref s_cacheBinlogCounter)}.binlog");
+            $"{binlogBaseFileName}-{cacheBuildId}.binlog");
         string localCacheRoot = Path.Combine(
             cacheConfiguration.CacheRoot,
             "Content",
@@ -223,6 +224,13 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
 
         if (exitCode == 0)
         {
+            ReportCacheStatistics(
+                testAsset.AssetId,
+                cacheVariant,
+                cacheConfiguration,
+                cacheBuildId,
+                [.. cacheBuild.StandardOutputLines, .. cacheBuild.ErrorOutputLines]);
+
             if (cacheVariant == "Reflection")
             {
                 // The cache provider's build assets are recorded in project.assets.json during the
@@ -256,6 +264,16 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
             + $"falling back to dotnet build.{Environment.NewLine}"
             + $"StandardOutput:{Environment.NewLine}{cacheBuild.StandardOutput}{Environment.NewLine}"
             + $"StandardError:{Environment.NewLine}{cacheBuild.ErrorOutput}");
+        WriteCacheSummary(
+            testAsset.AssetId,
+            cacheVariant,
+            cacheConfiguration,
+            cacheBuildId,
+            outcome: "Fallback",
+            hasStatistics: false,
+            hitCount: 0,
+            missCount: 0,
+            savedSeconds: 0);
         CleanCacheOutputs(testAsset.TargetAssetPath, cacheVariant);
         return await DotnetCli.RunAsync(
             dotnetBuildArguments + " --no-incremental",
@@ -263,6 +281,139 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
             warnAsError: false,
             callerMemberName: $"{binlogBaseFileName}_CacheFallback",
             cancellationToken: cancellationToken);
+    }
+
+    private static void ReportCacheStatistics(
+        string assetId,
+        string cacheVariant,
+        CacheConfiguration cacheConfiguration,
+        int cacheBuildId,
+        IReadOnlyList<string> outputLines)
+    {
+        bool hasHitCount = TryReadCacheCount(outputLines, "Cache Hit Count:", out int hitCount);
+        bool hasMissCount = TryReadCacheCount(outputLines, "Cache Miss Count:", out int missCount);
+        bool hasStatistics = hasHitCount && hasMissCount;
+        double hitRatio = hasStatistics && hitCount + missCount > 0
+            ? (double)hitCount / (hitCount + missCount)
+            : 0;
+        double savedSeconds = TryReadSavedProjectSeconds(outputLines, out double value) ? value : 0;
+
+        Console.WriteLine(
+            hasStatistics
+                ? $"Acceptance MSBuild cache [{cacheConfiguration.Mode}] {assetId}/{cacheVariant}: "
+                    + $"{hitCount} hit node(s), {missCount} miss node(s), {hitRatio:P1} hit ratio, "
+                    + $"{savedSeconds:F1} project-seconds saved."
+                : $"Acceptance MSBuild cache [{cacheConfiguration.Mode}] {assetId}/{cacheVariant}: "
+                    + "build succeeded, but MSBuildCache emitted no cache statistics.");
+
+        WriteCacheSummary(
+            assetId,
+            cacheVariant,
+            cacheConfiguration,
+            cacheBuildId,
+            outcome: "Succeeded",
+            hasStatistics,
+            hitCount,
+            missCount,
+            savedSeconds);
+    }
+
+    private static void WriteCacheSummary(
+        string assetId,
+        string cacheVariant,
+        CacheConfiguration cacheConfiguration,
+        int cacheBuildId,
+        string outcome,
+        bool hasStatistics,
+        int hitCount,
+        int missCount,
+        double savedSeconds)
+    {
+        try
+        {
+            string summaryDirectory = Path.Combine(cacheConfiguration.LogRoot, "Summaries");
+            Directory.CreateDirectory(summaryDirectory);
+            File.WriteAllLines(
+                Path.Combine(
+                    summaryDirectory,
+                    $"{cacheConfiguration.AssetKey}-{cacheVariant}-{Environment.ProcessId}-{cacheBuildId}.txt"),
+                [
+                    $"AssetId={assetId}",
+                    $"Variant={cacheVariant}",
+                    $"Mode={cacheConfiguration.Mode}",
+                    $"Outcome={outcome}",
+                    $"HasStatistics={hasStatistics}",
+                    $"Hits={hitCount}",
+                    $"Misses={missCount}",
+                    $"SavedProjectSeconds={savedSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
+                ]);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Console.WriteLine(
+                $"Could not persist acceptance MSBuild cache statistics for {assetId}/{cacheVariant}: {ex.Message}");
+        }
+    }
+
+    private static bool TryReadCacheCount(IReadOnlyList<string> outputLines, string label, out int count)
+    {
+        string? line = outputLines.LastOrDefault(line => line.TrimStart().StartsWith(label, StringComparison.Ordinal));
+        if (line is null)
+        {
+            count = 0;
+            return false;
+        }
+
+        ReadOnlySpan<char> value = line.AsSpan(line.IndexOf(label, StringComparison.Ordinal) + label.Length).TrimStart();
+        int separator = value.IndexOf(' ');
+        if (separator >= 0)
+        {
+            value = value[..separator];
+        }
+
+        return int.TryParse(value, out count);
+    }
+
+    private static bool TryReadSavedProjectSeconds(IReadOnlyList<string> outputLines, out double savedSeconds)
+    {
+        const string SavedPrefix = "(saved ";
+        const string ProjectUnitPrefix = " project-";
+
+        string? line = outputLines.LastOrDefault(line => line.Contains(SavedPrefix, StringComparison.Ordinal));
+        int start = line?.IndexOf(SavedPrefix, StringComparison.Ordinal) ?? -1;
+        int end = line?.IndexOf(ProjectUnitPrefix, StringComparison.Ordinal) ?? -1;
+        if (start < 0 || end <= start)
+        {
+            savedSeconds = 0;
+            return false;
+        }
+
+        start += SavedPrefix.Length;
+        ReadOnlySpan<char> savedValueText = line.AsSpan(start, end - start);
+        if (!double.TryParse(
+                savedValueText,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.CurrentCulture,
+                out double savedValue)
+            && !double.TryParse(
+                savedValueText,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out savedValue))
+        {
+            savedSeconds = 0;
+            return false;
+        }
+
+        string unit = line.AsSpan(end + ProjectUnitPrefix.Length).TrimEnd(')').ToString();
+        savedSeconds = unit switch
+        {
+            "seconds" => savedValue,
+            "minutes" => savedValue * 60,
+            "hours" => savedValue * 60 * 60,
+            _ => 0,
+        };
+        return savedSeconds > 0 || savedValue == 0;
     }
 
     private static void CleanCacheOutputs(string assetPath, string cacheVariant)


### PR DESCRIPTION
## Summary

- emit per-generated-asset MSBuild cache hit, miss, saved-time, and fallback metrics
- persist concurrency-safe cache summaries without allowing diagnostic I/O failures to affect acceptance tests
- aggregate the metrics into an Azure Pipelines run summary

## Investigation

The cache is active, but current hit rates are too low to materially improve the Windows Release test duration. In post-seed PR build 1574050, the solution graph reported a 52.8% hit ratio. A representative sample of 150 published acceptance binlogs contained 63 cache-enabled generated builds with 62 hit nodes and 108 miss nodes, a 36.5% hit ratio. Windows Release still took 1h12m versus 1h11m in pre-seed PR build 1572842.

Product PRs change the packed assemblies consumed by generated assets, so most affected asset fingerprints legitimately miss. The reporting added here makes that behavior, saved project time, missing statistics, and silent fallback usage visible on every run. It also captures transient plugin failures such as the guarded MSBuildCache fallback observed in main build 1574560.

## Validation

- `./build.cmd -projects "test\Utilities\Microsoft.Testing.TestInfrastructure\Microsoft.Testing.TestInfrastructure.csproj" -configuration Debug /bl:artifacts\log\cache-reporting-build-3.binlog`