### PR TITLE
Add benchmarks for data source display names

### DIFF
--- a/src/TestFramework/TestFramework/TestFramework.csproj
+++ b/src/TestFramework/TestFramework/TestFramework.csproj
@@ -69,6 +69,7 @@
     <InternalsVisibleTo Include="MSTest.TestFramework.Extensions" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.TestPlatform.TestFramework.UnitTests" Key="$(VsPublicKey)" />
     <InternalsVisibleTo Include="MSTestAdapter.PlatformServices.UnitTests" Key="$(VsPublicKey)" />
+    <InternalsVisibleTo Include="MSTest.Performance.Benchmarks" Key="$(VsPublicKey)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Performance/MSTest.Performance.Benchmarks/MSTest.Performance.Benchmarks.csproj
+++ b/test/Performance/MSTest.Performance.Benchmarks/MSTest.Performance.Benchmarks.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTest.TestAdapter\MSTest.TestAdapter.csproj" />
     <ProjectReference Include="$(RepoRoot)src\Adapter\MSTestAdapter.PlatformServices\MSTestAdapter.PlatformServices.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\TestFramework\TestFramework\TestFramework.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Performance/MSTest.Performance.Benchmarks/TestDataSourceUtilitiesBenchmarks.cs
+++ b/test/Performance/MSTest.Performance.Benchmarks/TestDataSourceUtilitiesBenchmarks.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+using BenchmarkDotNet.Attributes;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
+
+namespace MSTest.Performance.Benchmarks;
+
+/// <summary>
+/// Measures the per-data-row display-name computation used by <c>[DataRow]</c>/<c>[DynamicData]</c> tests.
+/// This runs once per generated test case during discovery and execution, so it is a hot path for
+/// projects with large data-driven test suites.
+/// </summary>
+[MemoryDiagnoser]
+public class TestDataSourceUtilitiesBenchmarks
+{
+    private static readonly MethodInfo SingleParameterMethod = typeof(TestDataSourceUtilitiesBenchmarks).GetMethod(
+        nameof(SampleObjectArrayMethod), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static readonly MethodInfo MultiParameterMethod = typeof(TestDataSourceUtilitiesBenchmarks).GetMethod(
+        nameof(SampleMixedTypeMethod), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private object?[] _mixedTypeArguments = null!;
+    private object?[] _objectArrayArgument = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _mixedTypeArguments = ["some string", 42, 'c', null, new[] { 1, 2, 3 }];
+        _objectArrayArgument = [_mixedTypeArguments];
+    }
+
+    [Benchmark(Baseline = true)]
+    public string? ComputeDisplayNameForMixedTypeArguments()
+        => TestDataSourceUtilities.ComputeDefaultDisplayName(MultiParameterMethod, _mixedTypeArguments);
+
+    [Benchmark]
+    public string? ComputeDisplayNameForObjectArrayArgument()
+        => TestDataSourceUtilities.ComputeDefaultDisplayName(SingleParameterMethod, _objectArrayArgument);
+
+    private static void SampleMixedTypeMethod(string s, int i, char c, object? o, int[] arr)
+    {
+    }
+
+    private static void SampleObjectArrayMethod(object[] data)
+    {
+    }
+}


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

`TestDataSourceUtilities.ComputeDefaultDisplayName` is a hot path for data-driven test discovery and execution, but it had no dedicated regression benchmark. This adds allocation-tracked BenchmarkDotNet coverage for mixed-type arguments and the single `object[]` argument path, along with the project reference and internals visibility required to exercise the implementation directly.

The change is benchmark infrastructure only and does not alter production behavior.

Closes #10867