### PR TITLE
Make file reporters crash resilient

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportEngine.JsonSerializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json;
@@ -132,6 +132,12 @@ internal sealed partial class CtrfReportEngine
             writer.WriteString("machine", _environment.MachineName);
             writer.WriteNumber("exitCode", _exitCode);
             writer.WriteString("testApplication", _testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
+            if (_isIncomplete)
+            {
+                writer.WriteBoolean("incomplete", true);
+                writer.WriteString("runStatus", "aborted");
+            }
+
             writer.WriteEndObject();
             writer.WriteEndObject();
 

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.CtrfReport;
@@ -24,11 +24,15 @@ public static class CtrfReportExtensions
             throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
         }
 
-        ReportProviderRegistration.AddReportProvider(
+        ReportProviderRegistration.AddReportProvider<CtrfReportGenerator, CtrfReport.CapturedTestResult>(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
+            CtrfReportGeneratorCommandLine.CtrfReportOptionName,
+            CtrfReportGenerator.JournalEnvironmentVariableName,
             () => new CtrfReportGeneratorCommandLine(),
-            serviceProvider => new CtrfReportGenerator(serviceProvider));
+            serviceProvider => new CtrfReportGenerator(serviceProvider),
+            (serviceProvider, metadata) => new CtrfReportGenerator(serviceProvider, metadata),
+            CtrfReportGenerator.DeserializeJournalRecord);
 
         artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new CtrfArtifactPostProcessor());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportGenerator.cs
@@ -1,17 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 using Microsoft.Testing.Extensions.CtrfReport.Resources;
 using Microsoft.Testing.Platform.Extensions.Messages;
 
 namespace Microsoft.Testing.Extensions.CtrfReport;
 
+#pragma warning disable RS0051 // Crash-recovery serialization is an implementation detail.
+
 internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenerator, CapturedTestResult>
 {
     internal const string CtrfArtifactKind = "microsoft.testing.ctrf";
+    internal const string JournalEnvironmentVariableName = "TESTINGPLATFORM_CTRFREPORT_JOURNAL";
 
     public CtrfReportGenerator(IServiceProvider serviceProvider)
-        : base(serviceProvider, CtrfReportGeneratorCommandLine.CtrfReportOptionName)
+        : base(serviceProvider, CtrfReportGeneratorCommandLine.CtrfReportOptionName, JournalEnvironmentVariableName)
+    {
+    }
+
+    internal CtrfReportGenerator(IServiceProvider serviceProvider, RecoveredReportMetadata recoveredMetadata)
+        : base(serviceProvider, CtrfReportGeneratorCommandLine.CtrfReportOptionName, recoveredMetadata)
     {
     }
 
@@ -33,6 +44,15 @@ internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenera
     protected override string GetGenerationLogMessage(int testResultCount)
         => $"Generating CTRF report for {testResultCount} test result(s).";
 
+    protected override string SerializeJournalRecord(ReportJournalRecord<CapturedTestResult> record)
+        => JsonSerializer.Serialize(record, typeof(ReportJournalRecord<CapturedTestResult>), ReportJournalJsonSerializerContext.Default);
+
+    internal static ReportJournalRecord<CapturedTestResult>? DeserializeJournalRecord(string json)
+        => (ReportJournalRecord<CapturedTestResult>?)JsonSerializer.Deserialize(
+            json,
+            typeof(ReportJournalRecord<CapturedTestResult>),
+            ReportJournalJsonSerializerContext.Default);
+
     protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
         => TestResultCapture.TryCapture(update.TestNode);
 
@@ -43,3 +63,8 @@ internal sealed class CtrfReportGenerator : ReportGeneratorBase<CtrfReportGenera
         CancellationToken cancellationToken)
         => new CtrfReportEngine(CreateReportEngineContext(testStartTime, exitCode, cancellationToken)).GenerateReportAsync(tests);
 }
+
+[JsonSerializable(typeof(ReportJournalRecord<CapturedTestResult>))]
+internal sealed partial class ReportJournalJsonSerializerContext : JsonSerializerContext;
+
+#pragma warning restore RS0051

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportMerger.cs
@@ -98,6 +98,7 @@ internal static partial class CtrfReportMerger
         // ones (values that differ across inputs) dropped, rather than attributing the first report's
         // environment to every merged test.
         var environments = new List<JsonObject>();
+        bool isIncomplete = false;
 
         foreach (string reportJson in inputReports)
         {
@@ -140,6 +141,10 @@ internal static partial class CtrfReportMerger
             if (root["results"]?["environment"] is JsonObject environment)
             {
                 environments.Add(environment);
+                isIncomplete |= environment["extra"] is JsonObject extra
+                    && extra["incomplete"] is JsonValue incompleteValue
+                    && incompleteValue.TryGetValue(out bool incomplete)
+                    && incomplete;
             }
 
             JsonNode? results = root["results"];
@@ -278,7 +283,17 @@ internal static partial class CtrfReportMerger
         // environment at all counts as disagreement (its fields are absent), so a common field requires
         // every accepted report to provide it. Module-specific 'extra' values (the producing test
         // application and its exit code) are always dropped.
-        if (BuildCommonEnvironment(environments, reportCount) is JsonObject commonEnvironment)
+        JsonObject? commonEnvironment = BuildCommonEnvironment(environments, reportCount);
+        if (isIncomplete)
+        {
+            commonEnvironment ??= [];
+            JsonObject extra = commonEnvironment["extra"] as JsonObject ?? [];
+            extra["incomplete"] = true;
+            extra["runStatus"] = "aborted";
+            commonEnvironment["extra"] = extra;
+        }
+
+        if (commonEnvironment is not null)
         {
             resultsObject["environment"] = commonEnvironment;
         }

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -60,6 +60,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameValidator.cs" Link="Helpers\ReportFileNameValidator.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\MergeOutputFileHelper.cs" Link="Helpers\MergeOutputFileHelper.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportEngine.cs
@@ -123,6 +123,14 @@ internal sealed class HtmlReportEngine : ReportEngineBase
         AppendStringPair(sb, "endTime", finishTime.ToString("O", CultureInfo.InvariantCulture));
         sb.Append(',');
         AppendNumberPair(sb, "exitCode", _exitCode.ToString(CultureInfo.InvariantCulture));
+        if (_isIncomplete)
+        {
+            sb.Append(',');
+            AppendBooleanPair(sb, "incomplete", true);
+            sb.Append(',');
+            AppendStringPair(sb, "runStatus", "aborted");
+        }
+
         sb.Append(',');
         AppendKey(sb, "tests");
         sb.Append('[');

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
@@ -24,11 +24,15 @@ public static class HtmlReportExtensions
             throw new InvalidOperationException(ExtensionResources.InvalidTestApplicationBuilderType);
         }
 
-        ReportProviderRegistration.AddReportProvider(
+        ReportProviderRegistration.AddReportProvider<HtmlReportGenerator, HtmlReport.CapturedTestResult>(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
+            HtmlReportGeneratorCommandLine.HtmlReportOptionName,
+            HtmlReportGenerator.JournalEnvironmentVariableName,
             () => new HtmlReportGeneratorCommandLine(),
-            serviceProvider => new HtmlReportGenerator(serviceProvider));
+            serviceProvider => new HtmlReportGenerator(serviceProvider),
+            (serviceProvider, metadata) => new HtmlReportGenerator(serviceProvider, metadata),
+            HtmlReportGenerator.DeserializeJournalRecord);
 
         artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new HtmlArtifactPostProcessor());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportGenerator.cs
@@ -1,17 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 using Microsoft.Testing.Extensions.HtmlReport.Resources;
 using Microsoft.Testing.Platform.Extensions.Messages;
 
 namespace Microsoft.Testing.Extensions.HtmlReport;
 
+#pragma warning disable RS0051 // Crash-recovery serialization is an implementation detail.
+
 internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenerator, CapturedTestResult>
 {
     internal const string HtmlArtifactKind = "microsoft.testing.html";
+    internal const string JournalEnvironmentVariableName = "TESTINGPLATFORM_HTMLREPORT_JOURNAL";
 
     public HtmlReportGenerator(IServiceProvider serviceProvider)
-        : base(serviceProvider, HtmlReportGeneratorCommandLine.HtmlReportOptionName)
+        : base(serviceProvider, HtmlReportGeneratorCommandLine.HtmlReportOptionName, JournalEnvironmentVariableName)
+    {
+    }
+
+    internal HtmlReportGenerator(IServiceProvider serviceProvider, RecoveredReportMetadata recoveredMetadata)
+        : base(serviceProvider, HtmlReportGeneratorCommandLine.HtmlReportOptionName, recoveredMetadata)
     {
     }
 
@@ -33,6 +44,15 @@ internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenera
     protected override string GetGenerationLogMessage(int testResultCount)
         => $"Generating HTML report for {testResultCount} test result(s).";
 
+    protected override string SerializeJournalRecord(ReportJournalRecord<CapturedTestResult> record)
+        => JsonSerializer.Serialize(record, typeof(ReportJournalRecord<CapturedTestResult>), ReportJournalJsonSerializerContext.Default);
+
+    internal static ReportJournalRecord<CapturedTestResult>? DeserializeJournalRecord(string json)
+        => (ReportJournalRecord<CapturedTestResult>?)JsonSerializer.Deserialize(
+            json,
+            typeof(ReportJournalRecord<CapturedTestResult>),
+            ReportJournalJsonSerializerContext.Default);
+
     protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
         => TestResultCapture.TryCapture(update.TestNode);
 
@@ -43,3 +63,8 @@ internal sealed class HtmlReportGenerator : ReportGeneratorBase<HtmlReportGenera
         CancellationToken cancellationToken)
         => new HtmlReportEngine(CreateReportEngineContext(testStartTime, exitCode, cancellationToken)).GenerateReportAsync(tests);
 }
+
+[JsonSerializable(typeof(ReportJournalRecord<CapturedTestResult>))]
+internal sealed partial class ReportJournalJsonSerializerContext : JsonSerializerContext;
+
+#pragma warning restore RS0051

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -173,6 +173,12 @@ internal static class HtmlReportMerger
             merged["exitCode"] = exitCode;
         }
 
+        if (reports.Any(IsIncomplete))
+        {
+            merged["incomplete"] = true;
+            merged["runStatus"] = "aborted";
+        }
+
         return HtmlReportEngine.RenderReport(merged.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
     }
 
@@ -571,6 +577,11 @@ internal static class HtmlReportMerger
 
         return true;
     }
+
+    private static bool IsIncomplete(JsonObject report)
+        => report["incomplete"] is JsonValue value
+            && value.TryGetValue(out bool incomplete)
+            && incomplete;
 
     private static void CountOutcome(string outcome, ref int passed, ref int failed, ref int skipped, ref int timedOut, ref int errored)
     {

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -62,6 +62,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
   </ItemGroup>
 

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Templates/report-template.html
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Templates/report-template.html
@@ -361,6 +361,16 @@ button.chevron:focus-visible { outline: 2px solid var(--accent); outline-offset:
   font-size: 13px;
 }
 
+.incomplete-banner {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border: 1px solid var(--error);
+  border-radius: 6px;
+  color: var(--error);
+  background: var(--error-bg);
+  font-weight: 600;
+}
+
 .pager {
   display: flex;
   gap: 8px;
@@ -519,6 +529,9 @@ footer {
 </header>
 
 <main>
+  <div id="incomplete-banner" class="incomplete-banner" role="alert" hidden>
+    This report is incomplete because the test host terminated unexpectedly. Tests absent from this report did not necessarily pass.
+  </div>
   <section class="summary-cards" id="summary-cards"></section>
   <section class="meta" id="meta"></section>
 
@@ -562,6 +575,7 @@ footer {
   var rawData = document.getElementById("mtp-data").textContent;
   var report = JSON.parse(rawData);
   var tests = report.tests || [];
+  document.getElementById("incomplete-banner").hidden = !report.incomplete;
 
   // Outcome ordering: failed first, then errored, timed out, skipped, passed.
   var OUTCOME_ORDER = { failed: 0, errored: 1, timedOut: 2, skipped: 3, passed: 4 };

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
@@ -52,7 +52,7 @@ internal sealed class JUnitReportEngine : ReportEngineBase
         // prevents concurrent runs that happen to produce the same default file name
         // (same second / same results dir) from clobbering each other's tmp file.
         string tempPath = finalPath + "." + Path.GetRandomFileName() + ".tmp";
-        await new JUnitXmlWriter(_fileSystem, _environment, _testFramework, _exitCode, _cancellationToken)
+        await new JUnitXmlWriter(_fileSystem, _environment, _testFramework, _exitCode, _cancellationToken, _isIncomplete)
             .WriteXmlAsync(tempPath, suites)
             .ConfigureAwait(false);
 

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport;
@@ -24,11 +24,15 @@ public static class JUnitReportExtensions
             throw new InvalidOperationException(ExtensionResources.JUnitReportRequiresArtifactPostProcessing);
         }
 
-        ReportProviderRegistration.AddReportProvider(
+        ReportProviderRegistration.AddReportProvider<JUnitReportGenerator, JUnitReport.CapturedTestResult>(
             builder,
             ExtensionResources.InvalidTestApplicationBuilderType,
+            JUnitReportGeneratorCommandLine.JUnitReportOptionName,
+            JUnitReportGenerator.JournalEnvironmentVariableName,
             () => new JUnitReportGeneratorCommandLine(),
-            serviceProvider => new JUnitReportGenerator(serviceProvider));
+            serviceProvider => new JUnitReportGenerator(serviceProvider),
+            (serviceProvider, metadata) => new JUnitReportGenerator(serviceProvider, metadata),
+            JUnitReportGenerator.DeserializeJournalRecord);
 
         artifactPostProcessingBuilder.ArtifactPostProcessing.AddArtifactPostProcessor(_ => new JUnitArtifactPostProcessor());
     }

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -62,7 +62,7 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
             typeof(ReportJournalRecord<CapturedTestResult>),
             ReportJournalJsonSerializerContext.Default);
 
-    protected override async Task OnTestNodeUpdateAsync(TestNodeUpdateMessage update, CancellationToken cancellationToken)
+    protected override void OnTestNodeUpdate(TestNodeUpdateMessage update)
     {
         // Record the parent chain entry for EVERY update so non-terminal parent
         // nodes (Discovered / InProgress) are still available when reconstructing
@@ -75,7 +75,7 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
         string rawUid = TestResultCaptureHelper.Truncate(update.TestNode.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!;
         _parentChain[rawUid] = TestResultCapture.GetParentChainEntry(update);
 
-        await base.OnTestNodeUpdateAsync(update, cancellationToken).ConfigureAwait(false);
+        base.OnTestNodeUpdate(update);
     }
 
     protected override ReportJournalParentEntry? CaptureParentEntry(TestNodeUpdateMessage update)

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportGenerator.cs
@@ -1,14 +1,20 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using Microsoft.Testing.Extensions.JUnitReport.Resources;
 using Microsoft.Testing.Platform.Extensions.Messages;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
+#pragma warning disable RS0051 // Crash-recovery serialization is an implementation detail.
+
 internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGenerator, CapturedTestResult>
 {
     internal const string JUnitArtifactKind = "microsoft.testing.junit";
+    internal const string JournalEnvironmentVariableName = "TESTINGPLATFORM_JUNITREPORT_JOURNAL";
 
     // Parent chain for ALL TestNodeUpdateMessages (including Discovered / InProgress).
     // Keyed by the TestNodeUid value after truncation to TestResultCaptureHelper.MaxIdentityFieldLength
@@ -20,7 +26,12 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
     private readonly Dictionary<string, TestResultCapture.ParentChainEntry> _parentChain = [];
 
     public JUnitReportGenerator(IServiceProvider serviceProvider)
-        : base(serviceProvider, JUnitReportGeneratorCommandLine.JUnitReportOptionName)
+        : base(serviceProvider, JUnitReportGeneratorCommandLine.JUnitReportOptionName, JournalEnvironmentVariableName)
+    {
+    }
+
+    internal JUnitReportGenerator(IServiceProvider serviceProvider, RecoveredReportMetadata recoveredMetadata)
+        : base(serviceProvider, JUnitReportGeneratorCommandLine.JUnitReportOptionName, recoveredMetadata)
     {
     }
 
@@ -42,7 +53,16 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
     protected override string GetGenerationLogMessage(int testResultCount)
         => $"Generating JUnit XML report for {testResultCount} test result(s).";
 
-    protected override void OnTestNodeUpdate(TestNodeUpdateMessage update)
+    protected override string SerializeJournalRecord(ReportJournalRecord<CapturedTestResult> record)
+        => JsonSerializer.Serialize(record, typeof(ReportJournalRecord<CapturedTestResult>), ReportJournalJsonSerializerContext.Default);
+
+    internal static ReportJournalRecord<CapturedTestResult>? DeserializeJournalRecord(string json)
+        => (ReportJournalRecord<CapturedTestResult>?)JsonSerializer.Deserialize(
+            json,
+            typeof(ReportJournalRecord<CapturedTestResult>),
+            ReportJournalJsonSerializerContext.Default);
+
+    protected override async Task OnTestNodeUpdateAsync(TestNodeUpdateMessage update, CancellationToken cancellationToken)
     {
         // Record the parent chain entry for EVERY update so non-terminal parent
         // nodes (Discovered / InProgress) are still available when reconstructing
@@ -55,8 +75,23 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
         string rawUid = TestResultCaptureHelper.Truncate(update.TestNode.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!;
         _parentChain[rawUid] = TestResultCapture.GetParentChainEntry(update);
 
-        base.OnTestNodeUpdate(update);
+        await base.OnTestNodeUpdateAsync(update, cancellationToken).ConfigureAwait(false);
     }
+
+    protected override ReportJournalParentEntry? CaptureParentEntry(TestNodeUpdateMessage update)
+    {
+        string rawUid = TestResultCaptureHelper.Truncate(update.TestNode.Uid.Value, TestResultCaptureHelper.MaxIdentityFieldLength)!;
+        TestResultCapture.ParentChainEntry parent = TestResultCapture.GetParentChainEntry(update);
+        return new ReportJournalParentEntry
+        {
+            Uid = rawUid,
+            DisplayName = parent.DisplayName,
+            ParentUid = parent.ParentRawUid,
+        };
+    }
+
+    protected override void RestoreParentEntry(ReportJournalParentEntry parent)
+        => _parentChain[parent.Uid] = new TestResultCapture.ParentChainEntry(parent.DisplayName, parent.ParentUid);
 
     protected override CapturedTestResult? TryCapture(TestNodeUpdateMessage update)
         // A test framework that retries a test in-process reports every attempt under the same test node uid.
@@ -74,3 +109,8 @@ internal sealed class JUnitReportGenerator : ReportGeneratorBase<JUnitReportGene
         CancellationToken cancellationToken)
         => new JUnitReportEngine(CreateReportEngineContext(testStartTime, exitCode, cancellationToken)).GenerateReportAsync(tests, _parentChain);
 }
+
+[JsonSerializable(typeof(ReportJournalRecord<CapturedTestResult>))]
+internal sealed partial class ReportJournalJsonSerializerContext : JsonSerializerContext;
+
+#pragma warning restore RS0051

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
@@ -67,6 +67,7 @@ internal static class JUnitReportMerger
         long totalSkipped = 0;
         double totalTime = 0;
         DateTimeOffset? earliestTimestamp = null;
+        XElement? recoveryProperties = FindRecoveryProperties(inputReports);
 
         var mergedRoot = new XElement(RootElementName);
         int suiteId = 0;
@@ -91,6 +92,7 @@ internal static class JUnitReportMerger
             {
                 var clonedSuite = new XElement(suite);
                 clonedSuite.SetAttributeValue("id", suiteId++);
+                ApplyRecoveryProperties(clonedSuite, recoveryProperties);
                 mergedRoot.Add(clonedSuite);
 
                 // Derive aggregates from the per-suite counters rather than trusting the (optional)
@@ -199,6 +201,7 @@ internal static class JUnitReportMerger
         var suiteIndices = new Dictionary<string, int>(StringComparer.Ordinal);
         DateTimeOffset? earliestTimestamp = null;
         XElement? finalSuiteProperties = null;
+        XElement? recoveryProperties = FindRecoveryProperties(inputReports);
 
         foreach (XDocument report in inputReports)
         {
@@ -277,6 +280,8 @@ internal static class JUnitReportMerger
                         duplicateProperties.Remove();
                     }
                 }
+
+                ApplyRecoveryProperties(mergedSuite, recoveryProperties);
             }
 
             long failures = 0;
@@ -336,6 +341,66 @@ internal static class JUnitReportMerger
 
     private static bool IsProperties(XElement element)
         => element.Name.LocalName == "properties";
+
+    private static XElement? FindRecoveryProperties(IReadOnlyList<XDocument> reports)
+    {
+        foreach (XDocument report in reports)
+        {
+            foreach (XElement properties in GetSuites(report).SelectMany(suite => suite.Elements().Where(IsProperties)))
+            {
+                if (ReadSuiteProperty(properties, "incomplete") == "true")
+                {
+                    var recoveryProperties = new XElement("properties");
+                    CopyProperty(properties, recoveryProperties, "exit-code");
+                    recoveryProperties.Add(
+                        new XElement("property", new XAttribute("name", "run-status"), new XAttribute("value", "aborted")),
+                        new XElement("property", new XAttribute("name", "incomplete"), new XAttribute("value", "true")));
+                    return recoveryProperties;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static void ApplyRecoveryProperties(XElement suite, XElement? recoveryProperties)
+    {
+        if (recoveryProperties is null)
+        {
+            return;
+        }
+
+        XElement properties = suite.Elements().FirstOrDefault(IsProperties) ?? new XElement("properties");
+        if (properties.Parent is null)
+        {
+            suite.AddFirst(properties);
+        }
+
+        foreach (XElement recoveryProperty in recoveryProperties.Elements("property"))
+        {
+            string name = recoveryProperty.Attribute("name")!.Value;
+            properties.Elements("property")
+                .Where(property => property.Attribute("name")?.Value == name)
+                .Remove();
+            properties.Add(new XElement(recoveryProperty));
+        }
+    }
+
+    private static string? ReadSuiteProperty(XElement properties, string name)
+        => properties.Elements("property")
+            .FirstOrDefault(property => property.Attribute("name")?.Value == name)
+            ?.Attribute("value")
+            ?.Value;
+
+    private static void CopyProperty(XElement source, XElement destination, string name)
+    {
+        XElement? property = source.Elements("property")
+            .FirstOrDefault(candidate => candidate.Attribute("name")?.Value == name);
+        if (property is not null)
+        {
+            destination.Add(new XElement(property));
+        }
+    }
 
     private static string BuildSuiteIdentity(XElement suite)
         => BuildIdentity(

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportMerger.cs
@@ -351,7 +351,6 @@ internal static class JUnitReportMerger
                 if (ReadSuiteProperty(properties, "incomplete") == "true")
                 {
                     var recoveryProperties = new XElement("properties");
-                    CopyProperty(properties, recoveryProperties, "exit-code");
                     recoveryProperties.Add(
                         new XElement("property", new XAttribute("name", "run-status"), new XAttribute("value", "aborted")),
                         new XElement("property", new XAttribute("name", "incomplete"), new XAttribute("value", "true")));
@@ -391,16 +390,6 @@ internal static class JUnitReportMerger
             .FirstOrDefault(property => property.Attribute("name")?.Value == name)
             ?.Attribute("value")
             ?.Value;
-
-    private static void CopyProperty(XElement source, XElement destination, string name)
-    {
-        XElement? property = source.Elements("property")
-            .FirstOrDefault(candidate => candidate.Attribute("name")?.Value == name);
-        if (property is not null)
-        {
-            destination.Add(new XElement(property));
-        }
-    }
 
     private static string BuildSuiteIdentity(XElement suite)
         => BuildIdentity(

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitXmlWriter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitXmlWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;
@@ -7,12 +7,15 @@ using Microsoft.Testing.Platform.Helpers;
 
 namespace Microsoft.Testing.Extensions.JUnitReport;
 
+#pragma warning disable RS0051 // Recovery status is reporter implementation detail, not package API.
+
 internal sealed class JUnitXmlWriter(
     IFileSystem fileSystem,
     IEnvironment environment,
     ITestFramework testFramework,
     int exitCode,
-    CancellationToken cancellationToken)
+    CancellationToken cancellationToken,
+    bool isIncomplete = false)
 {
     public async Task WriteXmlAsync(string tempPath, SuiteSet suites)
     {
@@ -51,6 +54,11 @@ internal sealed class JUnitXmlWriter(
         {
             cancellationToken.ThrowIfCancellationRequested();
             await WriteSuiteAsync(writer, suite, suiteId++).ConfigureAwait(false);
+        }
+
+        if (isIncomplete && suiteId == 0)
+        {
+            await WriteMetadataOnlySuiteAsync(writer, suites).ConfigureAwait(false);
         }
 
         await writer.WriteEndElementAsync().ConfigureAwait(false);
@@ -154,6 +162,28 @@ internal sealed class JUnitXmlWriter(
         }
 
         await WritePropertyAsync(writer, "exit-code", exitCode.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        if (isIncomplete)
+        {
+            await WritePropertyAsync(writer, "run-status", "aborted").ConfigureAwait(false);
+            await WritePropertyAsync(writer, "incomplete", "true").ConfigureAwait(false);
+        }
+
+        await writer.WriteEndElementAsync().ConfigureAwait(false);
+    }
+
+    private async Task WriteMetadataOnlySuiteAsync(XmlWriter writer, SuiteSet suites)
+    {
+        await writer.WriteStartElementAsync(prefix: null, localName: "testsuite", ns: null).ConfigureAwait(false);
+        WriteAttribute(writer, "name", suites.Name);
+        WriteAttribute(writer, "tests", "0");
+        WriteAttribute(writer, "failures", "0");
+        WriteAttribute(writer, "errors", "0");
+        WriteAttribute(writer, "skipped", "0");
+        WriteAttribute(writer, "time", "0.000");
+        WriteAttribute(writer, "timestamp", FormatTimestamp(suites.Timestamp));
+        WriteAttribute(writer, "hostname", environment.MachineName);
+        WriteAttribute(writer, "id", "0");
+        await WriteSuitePropertiesAsync(writer).ConfigureAwait(false);
         await writer.WriteEndElementAsync().ConfigureAwait(false);
     }
 
@@ -345,3 +375,5 @@ internal sealed class JUnitXmlWriter(
     private static string FormatTimestamp(DateTimeOffset timestamp)
         => timestamp.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
 }
+
+#pragma warning restore RS0051

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitXmlWriter.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitXmlWriter.cs
@@ -17,6 +17,16 @@ internal sealed class JUnitXmlWriter(
     CancellationToken cancellationToken,
     bool isIncomplete = false)
 {
+    public JUnitXmlWriter(
+        IFileSystem fileSystem,
+        IEnvironment environment,
+        ITestFramework testFramework,
+        int exitCode,
+        CancellationToken cancellationToken)
+        : this(fileSystem, environment, testFramework, exitCode, cancellationToken, isIncomplete: false)
+    {
+    }
+
     public async Task WriteXmlAsync(string tempPath, SuiteSet suites)
     {
         var settings = new XmlWriterSettings

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -40,6 +40,10 @@ $(CommonProductDescription)]]></PackageDescription>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Microsoft.Testing.Platform.csproj" />
   </ItemGroup>
 
@@ -56,6 +60,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\TestResultCaptureHelper.cs" Link="Helpers\TestResultCaptureHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\Microsoft.Testing.Platform\Services\ArtifactNamingHelper.cs" Link="Services\ArtifactNamingHelper.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -92,6 +92,8 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher, ITestHost
     private const string ConnectBackEnvironmentVariablePrefix = "TESTINGPLATFORM_TESTHOSTCONTROLLER_";
     private const string HangDumpPipeEnvironmentVariableName = "TESTINGPLATFORM_HANGDUMP_PIPENAME";
     private const string LogicalRunIdEnvironmentVariableName = "TESTINGPLATFORM_LOGICAL_RUN_ID";
+    // These names must match the reporter packages' JournalEnvironmentVariableName constants. They are repeated
+    // here intentionally so PackagedApp does not take dependencies on every report package just to forward launch metadata.
     private const string CtrfReportJournalEnvironmentVariableName = "TESTINGPLATFORM_CTRFREPORT_JOURNAL";
     private const string HtmlReportJournalEnvironmentVariableName = "TESTINGPLATFORM_HTMLREPORT_JOURNAL";
     private const string JUnitReportJournalEnvironmentVariableName = "TESTINGPLATFORM_JUNITREPORT_JOURNAL";

--- a/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.PackagedApp/PackagedAppTestHostLauncher.cs
@@ -92,7 +92,11 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher, ITestHost
     private const string ConnectBackEnvironmentVariablePrefix = "TESTINGPLATFORM_TESTHOSTCONTROLLER_";
     private const string HangDumpPipeEnvironmentVariableName = "TESTINGPLATFORM_HANGDUMP_PIPENAME";
     private const string LogicalRunIdEnvironmentVariableName = "TESTINGPLATFORM_LOGICAL_RUN_ID";
+    private const string CtrfReportJournalEnvironmentVariableName = "TESTINGPLATFORM_CTRFREPORT_JOURNAL";
+    private const string HtmlReportJournalEnvironmentVariableName = "TESTINGPLATFORM_HTMLREPORT_JOURNAL";
+    private const string JUnitReportJournalEnvironmentVariableName = "TESTINGPLATFORM_JUNITREPORT_JOURNAL";
     private const string RetryAttemptEnvironmentVariableName = "TESTINGPLATFORM_DOTNETTEST_ATTEMPTNUMBER";
+    private const string RetryRecoveredArtifactManifestEnvironmentVariableName = "TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST";
     private const string TrxTestRunIdEnvironmentVariableName = "TESTINGPLATFORM_TRX_TESTRUN_ID";
     private const string TrxPipeEnvironmentVariableName = "TRXNAMEDPIPENAME";
 
@@ -388,7 +392,11 @@ internal sealed class PackagedAppTestHostLauncher : ITestHostLauncher, ITestHost
         foreach (KeyValuePair<string, string?> environmentVariable in context.EnvironmentVariables)
         {
             if (environmentVariable.Key.StartsWith(ConnectBackEnvironmentVariablePrefix, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(environmentVariable.Key, CtrfReportJournalEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(environmentVariable.Key, HtmlReportJournalEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(environmentVariable.Key, JUnitReportJournalEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(environmentVariable.Key, RetryAttemptEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(environmentVariable.Key, RetryRecoveredArtifactManifestEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(environmentVariable.Key, LogicalRunIdEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(environmentVariable.Key, TrxTestRunIdEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(environmentVariable.Key, TrxPipeEnvironmentVariableName, StringComparison.OrdinalIgnoreCase)

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -7,6 +7,7 @@ using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.RetryFailedTests.Serializers;
 using Microsoft.Testing.Platform.Extensions.TestHostOrchestrator;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
@@ -20,6 +21,12 @@ namespace Microsoft.Testing.Extensions.Policy;
 [UnsupportedOSPlatform("browser")]
 internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutputDeviceDataProducer, ITestHostControllerConnectionAuthorizationConsumer
 {
+    private const long MaxRecoveredArtifactManifestBytes = 16L * 1024 * 1024;
+    private const int MaxRecoveredArtifactManifestLineBytes = 64 * 1024;
+    private const int MaxRecoveredArtifactManifestRecords = 10_000;
+    private const int MaxRecoveredArtifactPathChars = 32 * 1024;
+    private const int MaxRecoveredArtifactKindChars = 1024;
+
     private readonly IServiceProvider _serviceProvider;
     private readonly ICommandLineOptions _commandLineOptions;
     private readonly IFileSystem _fileSystem;
@@ -232,6 +239,12 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 attemptCount,
                 userMaxRetryCount,
                 cancellationToken).ConfigureAwait(false);
+
+            CollectRecoveredArtifacts(
+                fileSystem,
+                attemptResult.RecoveredArtifactManifestPath,
+                retryFailedTestsPipeServer.Artifacts,
+                logger);
 
             if (attemptResult.ExitedBeforeConnect)
             {
@@ -462,4 +475,180 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
     private static bool IsHotReloadEnabled(IEnvironment environment)
         => environment.GetEnvironmentVariable(EnvironmentVariableConstants.DOTNET_WATCH) == "1"
         || environment.GetEnvironmentVariable(EnvironmentVariableConstants.TESTINGPLATFORM_HOTRELOAD_ENABLED) == "1";
+
+    private static void CollectRecoveredArtifacts(
+        IFileSystem fileSystem,
+        string manifestPath,
+        List<ArtifactRequest> artifacts,
+        ILogger logger)
+    {
+        try
+        {
+            if (!fileSystem.ExistFile(manifestPath))
+            {
+                return;
+            }
+
+            using IFileStream stream = fileSystem.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            var reader = new BoundedManifestLineReader(stream.Stream);
+            int recordCount = 0;
+            while (recordCount++ < MaxRecoveredArtifactManifestRecords)
+            {
+                BoundedManifestLineReadResult readResult = reader.ReadLine(out string line);
+                if (readResult == BoundedManifestLineReadResult.End)
+                {
+                    return;
+                }
+
+                if (readResult == BoundedManifestLineReadResult.LimitExceeded)
+                {
+                    logger.LogWarning($"Stopped reading recovered retry artifact manifest '{manifestPath}' because it exceeded a configured size limit.");
+                    return;
+                }
+
+                int separatorIndex = line.IndexOf('\t');
+                if (separatorIndex <= 0)
+                {
+                    logger.LogWarning($"Ignoring malformed recovered retry artifact manifest entry in '{manifestPath}'.");
+                    continue;
+                }
+
+                try
+                {
+                    string path = Encoding.UTF8.GetString(Convert.FromBase64String(line.Substring(0, separatorIndex)));
+                    string encodedKind = line.Substring(separatorIndex + 1);
+                    string? kind = encodedKind == "-"
+                        ? null
+                        : Encoding.UTF8.GetString(Convert.FromBase64String(encodedKind));
+                    if (path.Length > MaxRecoveredArtifactPathChars
+                        || kind?.Length > MaxRecoveredArtifactKindChars)
+                    {
+                        logger.LogWarning($"Ignoring oversized recovered retry artifact manifest entry in '{manifestPath}'.");
+                        continue;
+                    }
+
+                    if (!fileSystem.ExistFile(path))
+                    {
+                        logger.LogWarning($"Ignoring recovered retry artifact '{path}' because it does not exist.");
+                        continue;
+                    }
+
+                    if (kind is not null)
+                    {
+                        artifacts.RemoveAll(artifact => string.Equals(artifact.Kind, kind, StringComparison.Ordinal));
+                    }
+                    else if (artifacts.Any(artifact => string.Equals(artifact.Path, path, StringComparison.Ordinal)))
+                    {
+                        continue;
+                    }
+
+                    artifacts.Add(new ArtifactRequest(path, kind));
+                }
+                catch (Exception ex) when (ex is FormatException or ArgumentException or NotSupportedException or PathTooLongException)
+                {
+                    logger.LogWarning($"Ignoring malformed recovered retry artifact manifest entry in '{manifestPath}': {ex.Message}");
+                }
+            }
+
+            logger.LogWarning($"Stopped reading recovered retry artifact manifest '{manifestPath}' after the maximum of {MaxRecoveredArtifactManifestRecords} records.");
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning($"Failed to read recovered retry artifact manifest '{manifestPath}': {ex}");
+        }
+        finally
+        {
+            try
+            {
+                if (fileSystem.ExistFile(manifestPath))
+                {
+                    fileSystem.DeleteFile(manifestPath);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning($"Failed to delete recovered retry artifact manifest '{manifestPath}': {ex}");
+            }
+        }
+    }
+
+    private enum BoundedManifestLineReadResult
+    {
+        Line,
+        End,
+        LimitExceeded,
+    }
+
+    private sealed class BoundedManifestLineReader(Stream stream)
+    {
+        private const int BufferSize = 8192;
+
+        private readonly byte[] _readBuffer = new byte[BufferSize];
+        private readonly byte[] _lineBuffer = new byte[MaxRecoveredArtifactManifestLineBytes];
+        private int _readOffset;
+        private int _readCount;
+        private long _bytesRead;
+
+        public BoundedManifestLineReadResult ReadLine(out string line)
+        {
+            int lineLength = 0;
+            while (TryReadByte(out byte value))
+            {
+                if (++_bytesRead > MaxRecoveredArtifactManifestBytes)
+                {
+                    line = string.Empty;
+                    return BoundedManifestLineReadResult.LimitExceeded;
+                }
+
+                if (value == (byte)'\n')
+                {
+                    return DecodeLine(lineLength, out line);
+                }
+
+                if (lineLength >= MaxRecoveredArtifactManifestLineBytes)
+                {
+                    line = string.Empty;
+                    return BoundedManifestLineReadResult.LimitExceeded;
+                }
+
+                _lineBuffer[lineLength++] = value;
+            }
+
+            if (lineLength == 0)
+            {
+                line = string.Empty;
+                return BoundedManifestLineReadResult.End;
+            }
+
+            return DecodeLine(lineLength, out line);
+        }
+
+        private BoundedManifestLineReadResult DecodeLine(int lineLength, out string line)
+        {
+            if (lineLength > 0 && _lineBuffer[lineLength - 1] == (byte)'\r')
+            {
+                lineLength--;
+            }
+
+            line = Encoding.UTF8.GetString(_lineBuffer, 0, lineLength);
+            return BoundedManifestLineReadResult.Line;
+        }
+
+        private bool TryReadByte(out byte value)
+        {
+            if (_readOffset >= _readCount)
+            {
+                _readCount = stream.Read(_readBuffer, 0, _readBuffer.Length);
+                _readOffset = 0;
+                if (_readCount == 0)
+                {
+                    value = default;
+                    return false;
+                }
+            }
+
+            value = _readBuffer[_readOffset++];
+            return true;
+        }
+    }
 }

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -246,17 +246,19 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
                 retryFailedTestsPipeServer.Artifacts,
                 logger);
 
-            if (attemptResult.ExitedBeforeConnect)
-            {
-                return (int)ExitCode.GenericFailure;
-            }
-
             attemptArtifacts.AddRange(RetryArtifactProcessor.SnapshotAttemptArtifacts(
                 fileSystem,
                 retryFailedTestsPipeServer.Artifacts,
                 attemptCount,
                 currentTryResultFolder,
                 retryRootFolder));
+
+            if (attemptResult.ExitedBeforeConnect)
+            {
+                exitCodes.Add((int)ExitCode.GenericFailure);
+                retryInterrupted = true;
+                break;
+            }
 
             exitCodes.Add(attemptResult.ExitCode);
 

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryOrchestrator.cs
@@ -214,6 +214,7 @@ internal sealed class RetryOrchestrator : ITestHostExecutionOrchestrator, IOutpu
             }
 
             currentTryResultFolder = Path.Combine(retryRootFolder, attemptCount.ToString(CultureInfo.InvariantCulture));
+            fileSystem.CreateDirectory(currentTryResultFolder);
 
             // Prepare the pipe server that collects the child process's failed test UIDs.
             using RetryFailedTestsPipeServer retryFailedTestsPipeServer = new(_serviceProvider, lastListOfFailedId ?? [], logger);

--- a/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Retry/RetryTestHostRunner.cs
@@ -30,6 +30,10 @@ internal static class RetryTestHostRunner
         public required int ExitCode { get; init; }
 
         public required bool ExitedBeforeConnect { get; init; }
+
+#pragma warning disable RS0051 // Retry-attempt transport detail, not package API.
+        public required string RecoveredArtifactManifestPath { get; init; }
+#pragma warning restore RS0051
     }
 
     public static async Task<AttemptResult> RunAttemptAsync(
@@ -66,6 +70,15 @@ internal static class RetryTestHostRunner
         {
             UseShellExecute = false,
         };
+        string recoveredArtifactManifestPath = Path.Combine(
+            Path.GetTempPath(),
+            $"testfx-retry-recovered-artifacts-{Guid.NewGuid():N}.txt");
+        processStartInfo.EnvironmentVariables["TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST"] =
+            recoveredArtifactManifestPath;
+        using var manifestOwnership = new RecoveredArtifactManifestOwnership(
+            serviceProvider.GetFileSystem(),
+            recoveredArtifactManifestPath,
+            logger);
 
         // Tell the launched test host which retry attempt it is, so it can report an explicit AttemptNumber in
         // its dotnet test handshake instead of the consumer having to infer it from a change in InstanceId.
@@ -143,7 +156,13 @@ internal static class RetryTestHostRunner
             else
             {
                 await outputDevice.DisplayAsync(producer, new ErrorMessageOutputDeviceData(string.Format(CultureInfo.InvariantCulture, ExtensionResources.TestHostProcessExitedBeforeRetryCouldConnect, testHostProcess.ExitCode)), cancellationToken).ConfigureAwait(false);
-                return new AttemptResult { ExitCode = testHostProcess.ExitCode, ExitedBeforeConnect = true };
+                manifestOwnership.Transfer();
+                return new AttemptResult
+                {
+                    ExitCode = testHostProcess.ExitCode,
+                    ExitedBeforeConnect = true,
+                    RecoveredArtifactManifestPath = recoveredArtifactManifestPath,
+                };
             }
         }
         catch (OperationCanceledException)
@@ -158,7 +177,43 @@ internal static class RetryTestHostRunner
 
         await testHostProcess.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
 
-        return new AttemptResult { ExitCode = testHostProcess.ExitCode, ExitedBeforeConnect = false };
+        manifestOwnership.Transfer();
+        return new AttemptResult
+        {
+            ExitCode = testHostProcess.ExitCode,
+            ExitedBeforeConnect = false,
+            RecoveredArtifactManifestPath = recoveredArtifactManifestPath,
+        };
+    }
+
+    private sealed class RecoveredArtifactManifestOwnership(
+        IFileSystem fileSystem,
+        string path,
+        ILogger logger) : IDisposable
+    {
+        private bool _transferred;
+
+        public void Transfer() => _transferred = true;
+
+        public void Dispose()
+        {
+            if (_transferred)
+            {
+                return;
+            }
+
+            try
+            {
+                if (fileSystem.ExistFile(path))
+                {
+                    fileSystem.DeleteFile(path);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning($"Failed to delete recovered retry artifact manifest '{path}' after retry launch failed: {ex}");
+            }
+        }
     }
 
     private static async Task TerminateAndWaitForExitAsync(IProcess testHostProcess, ILogger logger)

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform;
@@ -10,6 +10,8 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions;
 
+#pragma warning disable RS0051 // Report engine internals are shared-source implementation detail, not package API.
+
 internal readonly record struct ReportEngineContext(
     IFileSystem FileSystem,
     ITestApplicationModuleInfo TestApplicationModuleInfo,
@@ -20,7 +22,9 @@ internal readonly record struct ReportEngineContext(
     ITestFramework TestFramework,
     DateTimeOffset TestStartTime,
     int ExitCode,
-    CancellationToken CancellationToken);
+    CancellationToken CancellationToken,
+    int? ProcessId = null,
+    bool IsIncomplete = false);
 
 /// <summary>
 /// Shared base class for report engine implementations (CTRF, JUnit, HTML, ...) that all consume
@@ -40,6 +44,8 @@ internal abstract class ReportEngineBase
     protected readonly DateTimeOffset _testStartTime;
     protected readonly int _exitCode;
     protected readonly CancellationToken _cancellationToken;
+    protected readonly int? _processId;
+    protected readonly bool _isIncomplete;
 #pragma warning restore SA1401
 
     protected ReportEngineBase(ReportEngineContext context)
@@ -54,6 +60,8 @@ internal abstract class ReportEngineBase
         _testStartTime = context.TestStartTime;
         _exitCode = context.ExitCode;
         _cancellationToken = context.CancellationToken;
+        _processId = context.ProcessId;
+        _isIncomplete = context.IsIncomplete;
     }
 
     internal static string GetProvidedFileName(string[]? providedFileName)
@@ -67,7 +75,7 @@ internal abstract class ReportEngineBase
     protected string ResolveProvidedFileName(string template)
     {
         string processName = Path.GetFileNameWithoutExtension(_testApplicationModuleInfo.GetCurrentTestApplicationFullPath());
-        string processId = _environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        string processId = (_processId ?? _environment.ProcessId).ToString(CultureInfo.InvariantCulture);
         return ReportFileNameHelper.ResolveAndSanitize(template, processName, processId, _clock.UtcNow);
     }
 
@@ -125,3 +133,5 @@ internal abstract class ReportEngineBase
 #endif
     }
 }
+
+#pragma warning restore RS0051

--- a/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportEngineBase.cs
@@ -24,7 +24,59 @@ internal readonly record struct ReportEngineContext(
     int ExitCode,
     CancellationToken CancellationToken,
     int? ProcessId = null,
-    bool IsIncomplete = false);
+    bool IsIncomplete = false)
+{
+    public ReportEngineContext(
+        IFileSystem fileSystem,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        IEnvironment environment,
+        ICommandLineOptions commandLineOptions,
+        IConfiguration configuration,
+        IClock clock,
+        ITestFramework testFramework,
+        DateTimeOffset testStartTime,
+        int exitCode,
+        CancellationToken cancellationToken)
+        : this(
+            fileSystem,
+            testApplicationModuleInfo,
+            environment,
+            commandLineOptions,
+            configuration,
+            clock,
+            testFramework,
+            testStartTime,
+            exitCode,
+            cancellationToken,
+            ProcessId: null,
+            IsIncomplete: false)
+    {
+    }
+
+    public void Deconstruct(
+        out IFileSystem fileSystem,
+        out ITestApplicationModuleInfo testApplicationModuleInfo,
+        out IEnvironment environment,
+        out ICommandLineOptions commandLineOptions,
+        out IConfiguration configuration,
+        out IClock clock,
+        out ITestFramework testFramework,
+        out DateTimeOffset testStartTime,
+        out int exitCode,
+        out CancellationToken cancellationToken)
+    {
+        fileSystem = FileSystem;
+        testApplicationModuleInfo = TestApplicationModuleInfo;
+        environment = Environment;
+        commandLineOptions = CommandLineOptions;
+        configuration = Configuration;
+        clock = Clock;
+        testFramework = TestFramework;
+        testStartTime = TestStartTime;
+        exitCode = ExitCode;
+        cancellationToken = CancellationToken;
+    }
+}
 
 /// <summary>
 /// Shared base class for report engine implementations (CTRF, JUnit, HTML, ...) that all consume

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -203,7 +203,8 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
         testSessionContext.CancellationToken.ThrowIfCancellationRequested();
-        _testStartTime = Clock.UtcNow;
+        DateTimeOffset testStartTime = Clock.UtcNow;
+        _testStartTime = testStartTime;
         if (_journalPath is not null)
         {
             if (ReportControllerMode.IsSupported)
@@ -215,7 +216,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
                 TryWriteJournalBatch(
                 [
                     ReportJournalRecord<TCapturedTestResult>.CreateHeader(
-                        _testStartTime.Value,
+                        testStartTime,
                         Environment.ProcessId,
                         TestFramework),
                 ]);
@@ -223,7 +224,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
 
             EnqueueJournalRecord(
                 ReportJournalRecord<TCapturedTestResult>.CreateHeader(
-                    _testStartTime.Value,
+                    testStartTime,
                     Environment.ProcessId,
                     TestFramework),
                 inlineAlreadyWritten: !ReportControllerMode.IsSupported);

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -56,6 +56,11 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     private int _droppedJournalRecords;
     private bool _disposed;
 
+    protected ReportGeneratorBase(IServiceProvider serviceProvider, string optionName)
+        : this(serviceProvider, optionName, journalEnvironmentVariableName: string.Empty)
+    {
+    }
+
     protected ReportGeneratorBase(IServiceProvider serviceProvider, string optionName, string journalEnvironmentVariableName)
         : this(
             (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetConfiguration(),
@@ -71,7 +76,8 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             serviceProvider.GetLoggerFactory().CreateLogger<TGenerator>(),
             serviceProvider.GetTask(),
             optionName,
-            serviceProvider.GetCommandLineOptions().IsOptionSet(PlatformCommandLineProvider.TestHostControllerPIDOptionKey)
+            journalEnvironmentVariableName.Length > 0
+                && serviceProvider.GetCommandLineOptions().IsOptionSet(PlatformCommandLineProvider.TestHostControllerPIDOptionKey)
                 ? serviceProvider.GetEnvironment().GetEnvironmentVariable(journalEnvironmentVariableName)
                 : null,
             recoveredMetadata: null)
@@ -98,6 +104,36 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             optionName,
             journalPath: null,
             recoveredMetadata)
+    {
+    }
+
+    protected ReportGeneratorBase(
+        IConfiguration configuration,
+        ICommandLineOptions commandLineOptions,
+        IFileSystem fileSystem,
+        ITestApplicationModuleInfo testApplicationModuleInfo,
+        IMessageBus messageBus,
+        IClock clock,
+        IEnvironment environment,
+        IOutputDevice outputDevice,
+        ITestFramework testFramework,
+        ITestApplicationProcessExitCode testApplicationProcessExitCode,
+        ILogger<TGenerator> logger,
+        string optionName)
+        : this(
+            configuration,
+            commandLineOptions,
+            fileSystem,
+            testApplicationModuleInfo,
+            messageBus,
+            clock,
+            environment,
+            outputDevice,
+            testFramework,
+            testApplicationProcessExitCode,
+            logger,
+            new SystemTask(),
+            optionName)
     {
     }
 
@@ -190,14 +226,16 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
 
-    public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         if (value is TestNodeUpdateMessage update)
         {
-            await OnTestNodeUpdateAsync(update, cancellationToken).ConfigureAwait(false);
+            OnTestNodeUpdate(update);
         }
+
+        return Task.CompletedTask;
     }
 
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
@@ -274,7 +312,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     // (parameterized rows, in-process retries, framework quirks). CTRF groups only
     // in-process updates explicitly tagged with RetryAttemptProperty; out-of-process
     // retry inference occurs only during an explicit CollapseRetryAttempts merge.
-    protected virtual Task OnTestNodeUpdateAsync(TestNodeUpdateMessage update, CancellationToken cancellationToken)
+    protected virtual void OnTestNodeUpdate(TestNodeUpdateMessage update)
     {
         TCapturedTestResult? captured = TryCapture(update);
         if (captured is not null)
@@ -290,8 +328,6 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
                 EnqueueJournalRecord(ReportJournalRecord<TCapturedTestResult>.CreateTest(captured, parent));
             }
         }
-
-        return Task.CompletedTask;
     }
 
     protected virtual ReportJournalParentEntry? CaptureParentEntry(TestNodeUpdateMessage update) => null;

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -29,6 +29,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     where TCapturedTestResult : class
 {
     private const int JournalBatchSize = 64;
+    private const int JournalCompletionReserveBytes = 64 * 1024;
     private const int JournalFlushIntervalMilliseconds = 500;
     private const int JournalQueueCapacity = 4096;
     private static readonly TimeSpan JournalShutdownTimeout = TimeSpan.FromSeconds(30);
@@ -51,8 +52,12 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     private BlockingCollection<ReportJournalRecord<TCapturedTestResult>>? _journalQueue;
     private Task? _journalWriterTask;
     private volatile bool _journalFailed;
+    private volatile bool _journalBudgetExceeded;
     private volatile bool _journalCompletionTimedOut;
     private volatile bool _writeCompletionRecord;
+    private string? _completedReportFileName;
+    private long _journalBytesWritten;
+    private int _journalRecordsWritten;
     private int _droppedJournalRecords;
     private bool _disposed;
 
@@ -299,11 +304,17 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
                     ArtifactDescription,
                     ArtifactKind)).ConfigureAwait(false);
 
-            await CompleteJournalAsync(writeCompletionRecord: true, cancellationToken).ConfigureAwait(false);
+            await CompleteJournalAsync(
+                writeCompletionRecord: true,
+                new FileInfo(reportFileName).FullName,
+                cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            await CompleteJournalAsync(writeCompletionRecord: false, CancellationToken.None).ConfigureAwait(false);
+            await CompleteJournalAsync(
+                writeCompletionRecord: false,
+                reportFileName: null,
+                CancellationToken.None).ConfigureAwait(false);
         }
     }
 
@@ -376,6 +387,12 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             return;
         }
 
+        if (_journalBudgetExceeded)
+        {
+            RecordDroppedJournalRecords(1, "its configured size or record limit was reached");
+            return;
+        }
+
         if (_journalQueue is null)
         {
             TryWriteJournalBatch([record]);
@@ -386,25 +403,25 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         {
             if (_journalQueue.IsAddingCompleted || !_journalQueue.TryAdd(record))
             {
-                RecordDroppedJournalRecord();
+                RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
             }
         }
         catch (ObjectDisposedException)
         {
-            RecordDroppedJournalRecord();
+            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
         }
         catch (InvalidOperationException)
         {
-            RecordDroppedJournalRecord();
+            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
         }
     }
 
-    private void RecordDroppedJournalRecord()
+    private void RecordDroppedJournalRecords(int count, string reason)
     {
-        if (Interlocked.Increment(ref _droppedJournalRecords) == 1)
+        if (Interlocked.Add(ref _droppedJournalRecords, count) == count)
         {
             _logger.LogWarning(
-                $"Report recovery journal '{_journalPath}' writer queue is full or unavailable. Records are being dropped without affecting normal report generation; crash recovery may be partial.");
+                $"Report recovery journal '{_journalPath}' dropped records because {reason}. Normal report generation is unaffected; crash recovery may be partial.");
         }
     }
 
@@ -434,7 +451,12 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
 
             if (_writeCompletionRecord)
             {
-                await WriteJournalBatchAsync([ReportJournalRecord<TCapturedTestResult>.CreateCompletion()]).ConfigureAwait(false);
+                ApplicationStateGuard.Ensure(_completedReportFileName is not null);
+                await WriteJournalBatchAsync(
+                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
+                        _completedReportFileName,
+                        Volatile.Read(ref _droppedJournalRecords))],
+                    isCompletion: true).ConfigureAwait(false);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -450,11 +472,13 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         }
     }
 
-    private void TryWriteJournalBatch(IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records)
+    private void TryWriteJournalBatch(
+        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
+        bool isCompletion = false)
     {
         try
         {
-            WriteJournalBatchAsync(records).GetAwaiter().GetResult();
+            WriteJournalBatchAsync(records, isCompletion).GetAwaiter().GetResult();
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -464,7 +488,9 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         }
     }
 
-    private async Task WriteJournalBatchAsync(IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records)
+    private async Task WriteJournalBatchAsync(
+        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
+        bool isCompletion = false)
     {
         _journalStream ??= FileSystem.NewFileStream(
             _journalPath!,
@@ -473,9 +499,33 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             FileShare.ReadWrite);
 
         var batch = new StringBuilder();
+        int accepted = 0;
+        long maxBytes = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalBytes
+            - (isCompletion ? 0 : JournalCompletionReserveBytes);
+        int maxRecords = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordCount
+            - (isCompletion ? 0 : 1);
         foreach (ReportJournalRecord<TCapturedTestResult> record in records)
         {
-            batch.Append(SerializeJournalRecord(record)).Append('\n');
+            string serializedRecord = SerializeJournalRecord(record);
+            int recordBytes = Encoding.UTF8.GetByteCount(serializedRecord) + 1;
+            if (recordBytes > ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordBytes
+                || _journalBytesWritten + recordBytes > maxBytes
+                || _journalRecordsWritten >= maxRecords)
+            {
+                _journalBudgetExceeded = true;
+                RecordDroppedJournalRecords(records.Count - accepted, "its configured size or record limit was reached");
+                break;
+            }
+
+            batch.Append(serializedRecord).Append('\n');
+            _journalBytesWritten += recordBytes;
+            _journalRecordsWritten++;
+            accepted++;
+        }
+
+        if (batch.Length == 0)
+        {
+            return;
         }
 
         byte[] bytes = Encoding.UTF8.GetBytes(batch.ToString());
@@ -487,7 +537,10 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         await _journalStream.Stream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
-    private async Task CompleteJournalAsync(bool writeCompletionRecord, CancellationToken cancellationToken)
+    private async Task CompleteJournalAsync(
+        bool writeCompletionRecord,
+        string? reportFileName,
+        CancellationToken cancellationToken)
     {
         if (_journalPath is null || _journalCompletionTimedOut)
         {
@@ -498,7 +551,12 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         {
             if (writeCompletionRecord && !_journalFailed)
             {
-                TryWriteJournalBatch([ReportJournalRecord<TCapturedTestResult>.CreateCompletion()]);
+                ApplicationStateGuard.Ensure(reportFileName is not null);
+                TryWriteJournalBatch(
+                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
+                        reportFileName,
+                        Volatile.Read(ref _droppedJournalRecords))],
+                    isCompletion: true);
             }
 
             DisposeJournalStream();
@@ -508,6 +566,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         if (!_journalQueue.IsAddingCompleted)
         {
             _writeCompletionRecord = writeCompletionRecord;
+            _completedReportFileName = reportFileName;
             _journalQueue.CompleteAdding();
         }
 
@@ -531,7 +590,7 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         if (dropped > 0)
         {
             await _logger.LogWarningAsync(
-                $"Report recovery journal '{_journalPath}' dropped {dropped} record(s) because its bounded writer queue was full or unavailable. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
+                $"Report recovery journal '{_journalPath}' dropped {dropped} record(s) because its bounded writer queue was full or unavailable, or its safety limits were reached. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
         }
     }
 

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.CommandLine;
@@ -16,14 +16,23 @@ using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions;
 
+#pragma warning disable RS0051 // Reporter lifecycle internals are shared-source implementation detail, not package API.
+#pragma warning disable CA1416 // BlockingCollection is unreachable on single-threaded browser/WASI runtimes.
+
 internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     IDataConsumer,
     ITestSessionLifetimeHandler,
     IDataProducer,
-    IOutputDeviceDataProducer
+    IOutputDeviceDataProducer,
+    IDisposable
     where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
     where TCapturedTestResult : class
 {
+    private const int JournalBatchSize = 64;
+    private const int JournalFlushIntervalMilliseconds = 500;
+    private const int JournalQueueCapacity = 4096;
+    private static readonly TimeSpan JournalShutdownTimeout = TimeSpan.FromSeconds(30);
+
     // MTP guarantees that ConsumeAsync is called sequentially (never concurrently)
     // for a given consumer instance, so List<T> is safe here without locking.
     private readonly List<TCapturedTestResult> _tests = [];
@@ -31,11 +40,23 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     private readonly IOutputDevice _outputDevice;
     private readonly ITestApplicationProcessExitCode _testApplicationProcessExitCode;
     private readonly ILogger<TGenerator> _logger;
+    private readonly ITask _task;
     private readonly bool _isEnabled;
+    private readonly string? _journalPath;
+    private readonly int? _recoveredProcessId;
+    private readonly bool _isRecoveredReportIncomplete;
 
     private DateTimeOffset? _testStartTime;
+    private IFileStream? _journalStream;
+    private BlockingCollection<ReportJournalRecord<TCapturedTestResult>>? _journalQueue;
+    private Task? _journalWriterTask;
+    private volatile bool _journalFailed;
+    private volatile bool _journalCompletionTimedOut;
+    private volatile bool _writeCompletionRecord;
+    private int _droppedJournalRecords;
+    private bool _disposed;
 
-    protected ReportGeneratorBase(IServiceProvider serviceProvider, string optionName)
+    protected ReportGeneratorBase(IServiceProvider serviceProvider, string optionName, string journalEnvironmentVariableName)
         : this(
             (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetConfiguration(),
             serviceProvider.GetCommandLineOptions(),
@@ -48,7 +69,35 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             serviceProvider.GetTestFramework(),
             serviceProvider.GetTestApplicationProcessExitCode(),
             serviceProvider.GetLoggerFactory().CreateLogger<TGenerator>(),
-            optionName)
+            serviceProvider.GetTask(),
+            optionName,
+            serviceProvider.GetCommandLineOptions().IsOptionSet(PlatformCommandLineProvider.TestHostControllerPIDOptionKey)
+                ? serviceProvider.GetEnvironment().GetEnvironmentVariable(journalEnvironmentVariableName)
+                : null,
+            recoveredMetadata: null)
+    {
+    }
+
+    protected ReportGeneratorBase(
+        IServiceProvider serviceProvider,
+        string optionName,
+        RecoveredReportMetadata recoveredMetadata)
+        : this(
+            (serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider))).GetConfiguration(),
+            serviceProvider.GetCommandLineOptions(),
+            serviceProvider.GetRequiredService<IFileSystem>(),
+            serviceProvider.GetTestApplicationModuleInfo(),
+            serviceProvider.GetMessageBus(),
+            serviceProvider.GetSystemClock(),
+            serviceProvider.GetEnvironment(),
+            serviceProvider.GetOutputDevice(),
+            new RecoveredTestFramework(recoveredMetadata),
+            serviceProvider.GetTestApplicationProcessExitCode(),
+            serviceProvider.GetLoggerFactory().CreateLogger<TGenerator>(),
+            serviceProvider.GetTask(),
+            optionName,
+            journalPath: null,
+            recoveredMetadata)
     {
     }
 
@@ -64,7 +113,10 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         ITestFramework testFramework,
         ITestApplicationProcessExitCode testApplicationProcessExitCode,
         ILogger<TGenerator> logger,
-        string optionName)
+        ITask task,
+        string optionName,
+        string? journalPath = null,
+        RecoveredReportMetadata? recoveredMetadata = null)
     {
         Configuration = configuration;
         CommandLineOptions = commandLineOptions;
@@ -77,7 +129,11 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         TestFramework = testFramework;
         _testApplicationProcessExitCode = testApplicationProcessExitCode;
         _logger = logger;
+        _task = task;
         _isEnabled = commandLineOptions.IsOptionSet(optionName);
+        _journalPath = journalPath;
+        _recoveredProcessId = recoveredMetadata?.ProcessId;
+        _isRecoveredReportIncomplete = recoveredMetadata?.IsIncomplete == true;
     }
 
     public Type[] DataTypesConsumed { get; } =
@@ -127,27 +183,52 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
             TestFramework,
             testStartTime,
             exitCode,
-            cancellationToken);
+            cancellationToken,
+            _recoveredProcessId,
+            _isRecoveredReportIncomplete);
 
     /// <inheritdoc />
     public Task<bool> IsEnabledAsync() => Task.FromResult(_isEnabled);
 
-    public Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
+    public async Task ConsumeAsync(IDataProducer dataProducer, IData value, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         if (value is TestNodeUpdateMessage update)
         {
-            OnTestNodeUpdate(update);
+            await OnTestNodeUpdateAsync(update, cancellationToken).ConfigureAwait(false);
         }
-
-        return Task.CompletedTask;
     }
 
     public Task OnTestSessionStartingAsync(ITestSessionContext testSessionContext)
     {
         testSessionContext.CancellationToken.ThrowIfCancellationRequested();
         _testStartTime = Clock.UtcNow;
+        if (_journalPath is not null)
+        {
+            if (ReportControllerMode.IsSupported)
+            {
+                StartJournalWriter();
+            }
+            else
+            {
+                TryWriteJournalBatch(
+                [
+                    ReportJournalRecord<TCapturedTestResult>.CreateHeader(
+                        _testStartTime.Value,
+                        Environment.ProcessId,
+                        TestFramework),
+                ]);
+            }
+
+            EnqueueJournalRecord(
+                ReportJournalRecord<TCapturedTestResult>.CreateHeader(
+                    _testStartTime.Value,
+                    Environment.ProcessId,
+                    TestFramework),
+                inlineAlreadyWritten: !ReportControllerMode.IsSupported);
+        }
+
         return Task.CompletedTask;
     }
 
@@ -158,24 +239,33 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
 
         DateTimeOffset testStartTime = _testStartTime ?? throw ApplicationStateGuard.Unreachable();
 
-        await _logger.LogTraceAsync(GetGenerationLogMessage(_tests.Count)).ConfigureAwait(false);
-
-        int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
-        (string reportFileName, string? warning) = await GenerateReportAsync([.. _tests], testStartTime, exitCode, cancellationToken).ConfigureAwait(false);
-
-        if (warning is not null)
+        try
         {
-            await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
-        }
+            await _logger.LogTraceAsync(GetGenerationLogMessage(_tests.Count)).ConfigureAwait(false);
 
-        await _messageBus.PublishAsync(
-            this,
-            new SessionFileArtifact(
-                testSessionContext.SessionUid,
-                new FileInfo(reportFileName),
-                ArtifactDisplayName,
-                ArtifactDescription,
-                ArtifactKind)).ConfigureAwait(false);
+            int exitCode = _testApplicationProcessExitCode.GetProcessExitCode();
+            (string reportFileName, string? warning) = await GenerateReportAsync([.. _tests], testStartTime, exitCode, cancellationToken).ConfigureAwait(false);
+
+            if (warning is not null)
+            {
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
+            }
+
+            await _messageBus.PublishAsync(
+                this,
+                new SessionFileArtifact(
+                    testSessionContext.SessionUid,
+                    new FileInfo(reportFileName),
+                    ArtifactDisplayName,
+                    ArtifactDescription,
+                    ArtifactKind)).ConfigureAwait(false);
+
+            await CompleteJournalAsync(writeCompletionRecord: true, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            await CompleteJournalAsync(writeCompletionRecord: false, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 
     // Capture every update unconditionally — no UID-based deduplication. HTML, JUnit,
@@ -183,13 +273,316 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     // (parameterized rows, in-process retries, framework quirks). CTRF groups only
     // in-process updates explicitly tagged with RetryAttemptProperty; out-of-process
     // retry inference occurs only during an explicit CollapseRetryAttempts merge.
-    protected virtual void OnTestNodeUpdate(TestNodeUpdateMessage update)
+    protected virtual Task OnTestNodeUpdateAsync(TestNodeUpdateMessage update, CancellationToken cancellationToken)
     {
         TCapturedTestResult? captured = TryCapture(update);
         if (captured is not null)
         {
             _tests.Add(captured);
         }
+
+        if (_journalPath is not null && !_journalFailed)
+        {
+            ReportJournalParentEntry? parent = CaptureParentEntry(update);
+            if (captured is not null || parent is not null)
+            {
+                EnqueueJournalRecord(ReportJournalRecord<TCapturedTestResult>.CreateTest(captured, parent));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    protected virtual ReportJournalParentEntry? CaptureParentEntry(TestNodeUpdateMessage update) => null;
+
+    protected virtual void RestoreParentEntry(ReportJournalParentEntry parent)
+    {
+    }
+
+    internal async Task<(string FileName, string? Warning)> GenerateRecoveredReportAsync(
+        ReportJournalReadResult<TCapturedTestResult> journal,
+        int exitCode,
+        CancellationToken cancellationToken)
+    {
+        foreach (ReportJournalParentEntry parent in journal.Parents)
+        {
+            RestoreParentEntry(parent);
+        }
+
+        return await GenerateReportAsync(
+            [.. journal.Results],
+            journal.Metadata.StartTime,
+            exitCode,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal string RecoveredArtifactDisplayName => ArtifactDisplayName;
+
+    internal string RecoveredArtifactDescription => ArtifactDescription;
+
+    internal string? RecoveredArtifactKind => ArtifactKind;
+
+    private void StartJournalWriter()
+    {
+#pragma warning disable IDE0028 // Explicit ConcurrentQueue documents FIFO ordering.
+        _journalQueue = new(new ConcurrentQueue<ReportJournalRecord<TCapturedTestResult>>(), JournalQueueCapacity);
+#pragma warning restore IDE0028
+        _journalWriterTask = _task.RunLongRunning(WriteJournalLoopAsync, $"{DisplayName} recovery journal writer", CancellationToken.None);
+    }
+
+    private void EnqueueJournalRecord(
+        ReportJournalRecord<TCapturedTestResult> record,
+        bool inlineAlreadyWritten = false)
+    {
+        if (inlineAlreadyWritten || _journalFailed)
+        {
+            return;
+        }
+
+        if (_journalQueue is null)
+        {
+            TryWriteJournalBatch([record]);
+            return;
+        }
+
+        try
+        {
+            if (_journalQueue.IsAddingCompleted || !_journalQueue.TryAdd(record))
+            {
+                RecordDroppedJournalRecord();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            RecordDroppedJournalRecord();
+        }
+        catch (InvalidOperationException)
+        {
+            RecordDroppedJournalRecord();
+        }
+    }
+
+    private void RecordDroppedJournalRecord()
+    {
+        if (Interlocked.Increment(ref _droppedJournalRecords) == 1)
+        {
+            _logger.LogWarning(
+                $"Report recovery journal '{_journalPath}' writer queue is full or unavailable. Records are being dropped without affecting normal report generation; crash recovery may be partial.");
+        }
+    }
+
+    private async Task WriteJournalLoopAsync()
+    {
+        ApplicationStateGuard.Ensure(_journalQueue is not null);
+        var batch = new List<ReportJournalRecord<TCapturedTestResult>>(JournalBatchSize);
+        try
+        {
+            while (!_journalQueue.IsCompleted)
+            {
+                if (!_journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? first, JournalFlushIntervalMilliseconds))
+                {
+                    continue;
+                }
+
+                batch.Add(first);
+                while (batch.Count < JournalBatchSize
+                    && _journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? next))
+                {
+                    batch.Add(next);
+                }
+
+                await WriteJournalBatchAsync(batch).ConfigureAwait(false);
+                batch.Clear();
+            }
+
+            if (_writeCompletionRecord)
+            {
+                await WriteJournalBatchAsync([ReportJournalRecord<TCapturedTestResult>.CreateCompletion()]).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _journalFailed = true;
+            int dropped = batch.Count + DrainJournalQueue();
+            Interlocked.Add(ref _droppedJournalRecords, dropped);
+            await LogJournalFailureAsync(ex).ConfigureAwait(false);
+        }
+        finally
+        {
+            DisposeJournalStream();
+        }
+    }
+
+    private void TryWriteJournalBatch(IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records)
+    {
+        try
+        {
+            WriteJournalBatchAsync(records).GetAwaiter().GetResult();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _journalFailed = true;
+            _ = LogJournalFailureAsync(ex);
+            DisposeJournalStream();
+        }
+    }
+
+    private async Task WriteJournalBatchAsync(IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records)
+    {
+        _journalStream ??= FileSystem.NewFileStream(
+            _journalPath!,
+            FileMode.Append,
+            FileAccess.Write,
+            FileShare.ReadWrite);
+
+        var batch = new StringBuilder();
+        foreach (ReportJournalRecord<TCapturedTestResult> record in records)
+        {
+            batch.Append(SerializeJournalRecord(record)).Append('\n');
+        }
+
+        byte[] bytes = Encoding.UTF8.GetBytes(batch.ToString());
+#if NETCOREAPP
+        await _journalStream.Stream.WriteAsync(bytes.AsMemory(), CancellationToken.None).ConfigureAwait(false);
+#else
+        await _journalStream.Stream.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None).ConfigureAwait(false);
+#endif
+        await _journalStream.Stream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private async Task CompleteJournalAsync(bool writeCompletionRecord, CancellationToken cancellationToken)
+    {
+        if (_journalPath is null || _journalCompletionTimedOut)
+        {
+            return;
+        }
+
+        if (_journalQueue is null)
+        {
+            if (writeCompletionRecord && !_journalFailed)
+            {
+                TryWriteJournalBatch([ReportJournalRecord<TCapturedTestResult>.CreateCompletion()]);
+            }
+
+            DisposeJournalStream();
+            return;
+        }
+
+        if (!_journalQueue.IsAddingCompleted)
+        {
+            _writeCompletionRecord = writeCompletionRecord;
+            _journalQueue.CompleteAdding();
+        }
+
+        if (_journalWriterTask is not null)
+        {
+            Task timeout = _task.Delay(JournalShutdownTimeout, cancellationToken);
+            Task completed = await Task.WhenAny(_journalWriterTask, timeout).ConfigureAwait(false);
+            if (completed != _journalWriterTask)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _journalCompletionTimedOut = true;
+                await _logger.LogWarningAsync(
+                    $"Report recovery journal '{_journalPath}' writer did not drain within the hang timeout. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
+                return;
+            }
+
+            await _journalWriterTask.ConfigureAwait(false);
+        }
+
+        int dropped = Volatile.Read(ref _droppedJournalRecords);
+        if (dropped > 0)
+        {
+            await _logger.LogWarningAsync(
+                $"Report recovery journal '{_journalPath}' dropped {dropped} record(s) because its bounded writer queue was full or unavailable. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
+        }
+    }
+
+    private int DrainJournalQueue()
+    {
+        if (_journalQueue is null)
+        {
+            return 0;
+        }
+
+        if (!_journalQueue.IsAddingCompleted)
+        {
+            _journalQueue.CompleteAdding();
+        }
+
+        int count = 0;
+        while (_journalQueue.TryTake(out _))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private Task LogJournalFailureAsync(Exception exception)
+        => _logger.LogWarningAsync(
+            $"Report recovery journal '{_journalPath}' could not be written. The report will still be generated in process, but it might not be recoverable after a crash. Reason: {exception.Message}");
+
+    private void DisposeJournalStream()
+    {
+        IFileStream? stream = Interlocked.Exchange(ref _journalStream, null);
+        try
+        {
+            stream?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug($"Failed to close report recovery journal '{_journalPath}': {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_journalQueue is not null)
+        {
+            if (!_journalQueue.IsAddingCompleted)
+            {
+                _journalQueue.CompleteAdding();
+            }
+
+            if (_journalCompletionTimedOut)
+            {
+                _disposed = true;
+                return;
+            }
+
+            try
+            {
+                if (_journalWriterTask is not null
+                    && !_journalWriterTask.Wait(JournalShutdownTimeout))
+                {
+                    _journalCompletionTimedOut = true;
+                    _logger.LogWarning(
+                        $"Report recovery journal '{_journalPath}' writer did not stop within the hang timeout during disposal. The writer will be abandoned until process exit.");
+                    _disposed = true;
+                    return;
+                }
+
+                _journalWriterTask?.GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"Failed to drain report recovery journal '{_journalPath}' during disposal: {ex.Message}");
+            }
+
+            _journalQueue.Dispose();
+        }
+        else
+        {
+            DisposeJournalStream();
+        }
+
+        _disposed = true;
     }
 
     protected abstract string ArtifactDisplayName { get; }
@@ -206,6 +599,8 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
 
     protected abstract string GetGenerationLogMessage(int testResultCount);
 
+    protected abstract string SerializeJournalRecord(ReportJournalRecord<TCapturedTestResult> record);
+
     protected abstract TCapturedTestResult? TryCapture(TestNodeUpdateMessage update);
 
     protected abstract Task<(string FileName, string? Warning)> GenerateReportAsync(
@@ -214,3 +609,6 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
         int exitCode,
         CancellationToken cancellationToken);
 }
+
+#pragma warning restore RS0051
+#pragma warning restore CA1416

--- a/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
@@ -4,6 +4,7 @@
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.Testing.Platform.Extensions.TestHost;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Services;
 
@@ -13,6 +14,26 @@ namespace Microsoft.Testing.Extensions;
 
 internal static class ReportProviderRegistration
 {
+    public static void AddReportProvider<TGenerator>(
+        ITestApplicationBuilder builder,
+        string invalidBuilderTypeErrorMessage,
+        Func<ICommandLineOptionsProvider> commandLineFactory,
+        Func<IServiceProvider, TGenerator> generatorFactory)
+        where TGenerator : class, IDataConsumer, ITestSessionLifetimeHandler
+    {
+        if (builder is not TestApplicationBuilder)
+        {
+            throw new InvalidOperationException(invalidBuilderTypeErrorMessage);
+        }
+
+        var compositeReportGenerator = new CompositeExtensionFactory<TGenerator>(generatorFactory);
+        builder.TestHost.AddDataConsumer(compositeReportGenerator);
+        builder.TestHost.AddTestSessionLifetimeHandler(compositeReportGenerator);
+
+        ICommandLineOptionsProvider commandLine = commandLineFactory();
+        builder.CommandLine.AddProvider(() => commandLine);
+    }
+
     /// <summary>
     /// Registers a report generator as both a data consumer and a test session lifetime handler, along with its
     /// command-line options provider, applying the shared <c>TestApplicationBuilder</c> implementation guard.

--- a/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportProviderRegistration.cs
@@ -1,12 +1,15 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Builder;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
-using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Services;
 
 namespace Microsoft.Testing.Extensions;
+
+#pragma warning disable RS0051 // Reporter registration plumbing is shared-source implementation detail, not package API.
 
 internal static class ReportProviderRegistration
 {
@@ -15,18 +18,28 @@ internal static class ReportProviderRegistration
     /// command-line options provider, applying the shared <c>TestApplicationBuilder</c> implementation guard.
     /// </summary>
     /// <typeparam name="TGenerator">The report generator type.</typeparam>
+    /// <typeparam name="TCapturedTestResult">The reporter-specific durable result DTO.</typeparam>
     /// <param name="builder">The test application builder.</param>
     /// <param name="invalidBuilderTypeErrorMessage">
     /// The error message used when <paramref name="builder"/> is not a <c>TestApplicationBuilder</c>.
     /// </param>
+    /// <param name="optionName">The command-line option that enables the reporter.</param>
+    /// <param name="journalEnvironmentVariableName">The environment variable used to pass the journal path to the child.</param>
     /// <param name="commandLineFactory">The factory that creates the command-line options provider associated with the report.</param>
     /// <param name="generatorFactory">The factory that creates the report generator from the service provider.</param>
-    public static void AddReportProvider<TGenerator>(
+    /// <param name="recoveredGeneratorFactory">The factory that creates a controller-side generator from recovered metadata.</param>
+    /// <param name="journalDeserializer">The source-generated deserializer for reporter journal records.</param>
+    public static void AddReportProvider<TGenerator, TCapturedTestResult>(
         ITestApplicationBuilder builder,
         string invalidBuilderTypeErrorMessage,
+        string optionName,
+        string journalEnvironmentVariableName,
         Func<ICommandLineOptionsProvider> commandLineFactory,
-        Func<IServiceProvider, TGenerator> generatorFactory)
-        where TGenerator : class, IDataConsumer, ITestSessionLifetimeHandler
+        Func<IServiceProvider, TGenerator> generatorFactory,
+        Func<IServiceProvider, RecoveredReportMetadata, TGenerator> recoveredGeneratorFactory,
+        Func<string, ReportJournalRecord<TCapturedTestResult>?> journalDeserializer)
+        where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
+        where TCapturedTestResult : class
     {
         if (builder is not TestApplicationBuilder)
         {
@@ -38,7 +51,28 @@ internal static class ReportProviderRegistration
         builder.TestHost.AddDataConsumer(compositeReportGenerator);
         builder.TestHost.AddTestSessionLifetimeHandler(compositeReportGenerator);
 
+        if (ReportControllerMode.IsSupported)
+        {
+            var journal = new ReportJournalConfiguration(journalEnvironmentVariableName);
+            builder.TestHostControllers.AddEnvironmentVariableProvider(serviceProvider =>
+                new ReportJournalEnvironmentVariableProvider(
+                    serviceProvider.GetCommandLineOptions(),
+                    serviceProvider.GetConfiguration(),
+                    serviceProvider.GetRequiredService<IFileSystem>(),
+                    optionName,
+                    journal));
+            builder.TestHostControllers.AddProcessLifetimeHandler(serviceProvider =>
+                new ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>(
+                    serviceProvider,
+                    optionName,
+                    journal,
+                    recoveredGeneratorFactory,
+                    journalDeserializer));
+        }
+
         ICommandLineOptionsProvider commandLine = commandLineFactory();
         builder.CommandLine.AddProvider(() => commandLine);
     }
 }
+
+#pragma warning restore RS0051

--- a/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
@@ -179,11 +179,6 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
             }
 
             ReportJournalReadResult<TCapturedTestResult> journal = ReadJournal(path, testHostProcessInformation);
-            if (journal.Completed)
-            {
-                return;
-            }
-
             TGenerator generator = _generatorFactory(_serviceProvider, journal.Metadata);
             (string fileName, string? warning) = await generator.GenerateRecoveredReportAsync(
                 journal,
@@ -197,7 +192,9 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
 
             await _outputDevice.DisplayAsync(
                 this,
-                new WarningMessageOutputDeviceData($"The test host terminated before report generation completed. Recovered {journal.Results.Count} terminal test result(s); the generated report is marked incomplete."),
+                new WarningMessageOutputDeviceData(journal.Completed
+                    ? $"The test host terminated before report artifact delivery was confirmed. Re-generated the report from {journal.Results.Count} journaled terminal test result(s) and marked it incomplete."
+                    : $"The test host terminated before report generation completed. Recovered {journal.Results.Count} terminal test result(s); the generated report is marked incomplete."),
                 cancellationToken).ConfigureAwait(false);
             if (journal.IsPartial)
             {

--- a/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
@@ -47,8 +47,7 @@ internal sealed class ReportJournalConfiguration(string environmentVariableName)
     {
         if (_path is null)
         {
-            string directory = configuration.GetTestResultDirectory();
-            fileSystem.CreateDirectory(directory);
+            string directory = fileSystem.CreateDirectory(configuration.GetTestResultDirectory());
             _path = Path.Combine(directory, $"report-recovery-{Guid.NewGuid():N}.jsonl");
         }
 

--- a/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
@@ -1,0 +1,595 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+#if !NETCOREAPP
+using Polyfills;
+#endif
+
+namespace Microsoft.Testing.Extensions;
+
+#pragma warning disable RS0051 // Recovery infrastructure is shared-source implementation detail, not package API.
+
+internal static class ReportControllerMode
+{
+    [UnsupportedOSPlatformGuard("android")]
+    [UnsupportedOSPlatformGuard("browser")]
+    [UnsupportedOSPlatformGuard("ios")]
+    [UnsupportedOSPlatformGuard("tvos")]
+    [UnsupportedOSPlatformGuard("wasi")]
+    public static bool IsSupported { get; } =
+        !OperatingSystem.IsAndroid()
+        && !OperatingSystem.IsBrowser()
+        && !OperatingSystem.IsIOS()
+        && !OperatingSystem.IsTvOS()
+        && !OperatingSystem.IsWasi();
+}
+
+internal sealed class ReportJournalConfiguration(string environmentVariableName)
+{
+    private string? _path;
+
+    public string EnvironmentVariableName { get; } = environmentVariableName;
+
+    public string GetOrCreatePath(IConfiguration configuration, IFileSystem fileSystem)
+    {
+        if (_path is null)
+        {
+            string directory = configuration.GetTestResultDirectory();
+            fileSystem.CreateDirectory(directory);
+            _path = Path.Combine(directory, $"report-recovery-{Guid.NewGuid():N}.jsonl");
+        }
+
+        return _path;
+    }
+}
+
+internal sealed class ReportJournalEnvironmentVariableProvider(
+    ICommandLineOptions commandLineOptions,
+    IConfiguration configuration,
+    IFileSystem fileSystem,
+    string optionName,
+    ReportJournalConfiguration journal) : ITestHostEnvironmentVariableProvider
+{
+    public string Uid => $"{nameof(ReportJournalEnvironmentVariableProvider)}.{journal.EnvironmentVariableName}";
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => Uid;
+
+    public string Description => Uid;
+
+    public Task<bool> IsEnabledAsync()
+        => Task.FromResult(commandLineOptions.IsOptionSet(optionName) && ReportControllerMode.IsSupported);
+
+    public Task UpdateAsync(IEnvironmentVariables environmentVariables)
+    {
+        string path = journal.GetOrCreatePath(configuration, fileSystem);
+        using (fileSystem.NewFileStream(path, FileMode.Create))
+        {
+        }
+
+        environmentVariables.SetVariable(new EnvironmentVariable(
+            journal.EnvironmentVariableName,
+            path,
+            isSecret: false,
+            isLocked: true));
+        return Task.CompletedTask;
+    }
+
+    public Task<ValidationResult> ValidateTestHostEnvironmentVariablesAsync(IReadOnlyEnvironmentVariables environmentVariables)
+        => environmentVariables.TryGetVariable(journal.EnvironmentVariableName, out OwnedEnvironmentVariable? variable)
+            && variable.Value == journal.GetOrCreatePath(configuration, fileSystem)
+                ? ValidationResult.ValidTask
+                : ValidationResult.InvalidTask($"The report recovery environment variable '{journal.EnvironmentVariableName}' is missing or invalid.");
+}
+
+internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult> :
+    ITestHostProcessLifetimeHandler,
+    IDataProducer,
+    IOutputDeviceDataProducer,
+    IDisposable
+    where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
+    where TCapturedTestResult : class
+{
+    internal const long MaxJournalBytes = 256L * 1024 * 1024;
+    internal const int MaxJournalRecordBytes = 4 * 1024 * 1024;
+    internal const int MaxJournalRecordChars = 4 * 1024 * 1024;
+    internal const int MaxJournalRecordCount = 500_000;
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ICommandLineOptions _commandLineOptions;
+    private readonly IConfiguration _configuration;
+    private readonly IFileSystem _fileSystem;
+    private readonly IMessageBus _messageBus;
+    private readonly IOutputDevice _outputDevice;
+    private readonly IClock _clock;
+    private readonly IEnvironment _environment;
+    private readonly ILogger _logger;
+    private readonly string _optionName;
+    private readonly ReportJournalConfiguration _journal;
+    private readonly Func<IServiceProvider, RecoveredReportMetadata, TGenerator> _generatorFactory;
+    private readonly Func<string, ReportJournalRecord<TCapturedTestResult>?> _journalDeserializer;
+
+    public ReportProcessLifetimeHandler(
+        IServiceProvider serviceProvider,
+        string optionName,
+        ReportJournalConfiguration journal,
+        Func<IServiceProvider, RecoveredReportMetadata, TGenerator> generatorFactory,
+        Func<string, ReportJournalRecord<TCapturedTestResult>?> journalDeserializer)
+    {
+        _serviceProvider = serviceProvider;
+        _commandLineOptions = serviceProvider.GetCommandLineOptions();
+        _configuration = serviceProvider.GetConfiguration();
+        _fileSystem = serviceProvider.GetRequiredService<IFileSystem>();
+        _messageBus = serviceProvider.GetMessageBus();
+        _outputDevice = serviceProvider.GetOutputDevice();
+        _clock = serviceProvider.GetSystemClock();
+        _environment = serviceProvider.GetEnvironment();
+        _logger = serviceProvider.GetLoggerFactory().CreateLogger(typeof(ReportProcessLifetimeHandler<,>).FullName!);
+        _optionName = optionName;
+        _journal = journal;
+        _generatorFactory = generatorFactory;
+        _journalDeserializer = journalDeserializer;
+    }
+
+    public string Uid => $"{nameof(ReportProcessLifetimeHandler<,>)}.{_journal.EnvironmentVariableName}";
+
+    public string Version => ExtensionVersion.DefaultSemVer;
+
+    public string DisplayName => Uid;
+
+    public string Description => Uid;
+
+    public Type[] DataTypesProduced { get; } = [typeof(FileArtifact)];
+
+    public Task<bool> IsEnabledAsync()
+        => Task.FromResult(_commandLineOptions.IsOptionSet(_optionName) && ReportControllerMode.IsSupported);
+
+    public Task BeforeTestHostProcessStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task OnTestHostProcessStartedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    public async Task OnTestHostProcessExitedAsync(ITestHostProcessInformation testHostProcessInformation, CancellationToken cancellationToken)
+    {
+        string path = _journal.GetOrCreatePath(_configuration, _fileSystem);
+        if (!_fileSystem.ExistFile(path))
+        {
+            return;
+        }
+
+        try
+        {
+            if (testHostProcessInformation.HasExitedGracefully)
+            {
+                return;
+            }
+
+            ReportJournalReadResult<TCapturedTestResult> journal = ReadJournal(path, testHostProcessInformation);
+            if (journal.Completed)
+            {
+                return;
+            }
+
+            TGenerator generator = _generatorFactory(_serviceProvider, journal.Metadata);
+            (string fileName, string? warning) = await generator.GenerateRecoveredReportAsync(
+                journal,
+                testHostProcessInformation.ExitCode,
+                cancellationToken).ConfigureAwait(false);
+
+            if (warning is not null)
+            {
+                await _outputDevice.DisplayAsync(this, new WarningMessageOutputDeviceData(warning), cancellationToken).ConfigureAwait(false);
+            }
+
+            await _outputDevice.DisplayAsync(
+                this,
+                new WarningMessageOutputDeviceData($"The test host terminated before report generation completed. Recovered {journal.Results.Count} terminal test result(s); the generated report is marked incomplete."),
+                cancellationToken).ConfigureAwait(false);
+            if (journal.IsPartial)
+            {
+                await _outputDevice.DisplayAsync(
+                    this,
+                    new WarningMessageOutputDeviceData("Report recovery stopped before the end of the journal because it was truncated, corrupt, or exceeded a safety limit. The recovered report contains only the valid bounded prefix."),
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            await _messageBus.PublishAsync(
+                this,
+                new FileArtifact(
+                    new FileInfo(fileName),
+                    generator.RecoveredArtifactDisplayName,
+                    generator.RecoveredArtifactDescription,
+                    generator.RecoveredArtifactKind)).ConfigureAwait(false);
+            await WriteRetryArtifactManifestAsync(
+                fileName,
+                generator.RecoveredArtifactKind,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await _logger.LogErrorAsync($"Failed to recover report data from '{path}'.", ex).ConfigureAwait(false);
+            await _outputDevice.DisplayAsync(
+                this,
+                new WarningMessageOutputDeviceData($"The test host terminated before report generation completed, but the partial report could not be recovered: {ex.Message}"),
+                cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            TryDeleteJournal(path);
+        }
+    }
+
+    private async Task WriteRetryArtifactManifestAsync(
+        string artifactPath,
+        string? artifactKind,
+        CancellationToken cancellationToken)
+    {
+        const string retryArtifactManifestEnvironmentVariable = "TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST";
+        string? manifestPath = _environment.GetEnvironmentVariable(retryArtifactManifestEnvironmentVariable);
+        if (manifestPath is null || manifestPath.Length == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            string? directory = Path.GetDirectoryName(manifestPath);
+            if (directory is not null && directory.Length > 0)
+            {
+                _fileSystem.CreateDirectory(directory);
+            }
+
+            string encodedPath = Convert.ToBase64String(Encoding.UTF8.GetBytes(artifactPath));
+            string encodedKind = artifactKind is null
+                ? "-"
+                : Convert.ToBase64String(Encoding.UTF8.GetBytes(artifactKind));
+            using IFileStream stream = _fileSystem.NewFileStream(
+                manifestPath,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.Read);
+            using var writer = new StreamWriter(stream.Stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+#if NETCOREAPP
+            await writer.WriteLineAsync($"{encodedPath}\t{encodedKind}".AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
+            cancellationToken.ThrowIfCancellationRequested();
+            await writer.WriteLineAsync($"{encodedPath}\t{encodedKind}").ConfigureAwait(false);
+#endif
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            await _logger.LogWarningAsync(
+                $"Failed to register recovered report '{artifactPath}' with retry artifact consolidation: {ex.Message}").ConfigureAwait(false);
+        }
+    }
+
+    private void TryDeleteJournal(string path)
+    {
+        try
+        {
+            if (_fileSystem.ExistFile(path))
+            {
+                _fileSystem.DeleteFile(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug($"Failed to delete report recovery journal '{path}': {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+        => TryDeleteJournal(_journal.GetOrCreatePath(_configuration, _fileSystem));
+
+    private ReportJournalReadResult<TCapturedTestResult> ReadJournal(
+        string path,
+        ITestHostProcessInformation processInformation)
+    {
+        ReportJournalRecord<TCapturedTestResult>? header = null;
+        List<TCapturedTestResult> results = [];
+        List<ReportJournalParentEntry> parents = [];
+        bool completed = false;
+        bool isPartial = false;
+        int recordCount = 0;
+
+        using IFileStream stream = _fileSystem.NewFileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        var reader = new BoundedUtf8LineReader(stream.Stream, MaxJournalBytes, MaxJournalRecordBytes, MaxJournalRecordChars);
+        while (recordCount < MaxJournalRecordCount)
+        {
+            BoundedLineReadResult readResult = reader.ReadLine(out string? line);
+            if (readResult == BoundedLineReadResult.End)
+            {
+                break;
+            }
+
+            if (readResult == BoundedLineReadResult.LimitExceeded)
+            {
+                isPartial = true;
+                _logger.LogWarning($"Stopped reading report recovery journal '{path}' because it exceeded a configured size limit.");
+                break;
+            }
+
+            recordCount++;
+            try
+            {
+                ReportJournalRecord<TCapturedTestResult>? record = _journalDeserializer(line!);
+                if (record is null)
+                {
+                    _logger.LogDebug("Stopped reading the report recovery journal at an invalid record.");
+                    isPartial = true;
+                    break;
+                }
+
+                switch (record.Type)
+                {
+                    case ReportJournalRecordType.Header:
+                        header = record;
+                        break;
+                    case ReportJournalRecordType.Test:
+                        if (record.Result is not null)
+                        {
+                            results.Add(record.Result);
+                        }
+
+                        if (record.Parent is not null)
+                        {
+                            parents.Add(record.Parent);
+                        }
+
+                        break;
+                    case ReportJournalRecordType.Completion:
+                        completed = true;
+                        break;
+                }
+
+                if (completed)
+                {
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"Stopped reading the report recovery journal at an incomplete record: {ex.Message}");
+                isPartial = true;
+                break;
+            }
+        }
+
+        if (!completed && recordCount >= MaxJournalRecordCount)
+        {
+            isPartial = true;
+            _logger.LogWarning($"Stopped reading report recovery journal '{path}' after the maximum of {MaxJournalRecordCount} records.");
+        }
+
+        var metadata = new RecoveredReportMetadata
+        {
+            StartTime = header?.StartTime ?? _clock.UtcNow,
+            ProcessId = processInformation.PID,
+            FrameworkUid = header?.FrameworkUid ?? "unknown",
+            FrameworkVersion = header?.FrameworkVersion ?? string.Empty,
+            FrameworkDisplayName = header?.FrameworkDisplayName ?? "unknown",
+            IsIncomplete = true,
+        };
+        return new ReportJournalReadResult<TCapturedTestResult>(metadata, results, parents, completed, isPartial);
+    }
+}
+
+internal enum BoundedLineReadResult
+{
+    Line,
+    End,
+    LimitExceeded,
+}
+
+internal sealed class BoundedUtf8LineReader
+{
+    private const int BufferSize = 8192;
+
+    private readonly Stream _stream;
+    private readonly long _maxBytes;
+    private readonly int _maxLineBytes;
+    private readonly int _maxLineChars;
+    private readonly byte[] _readBuffer = new byte[BufferSize];
+    private readonly byte[] _lineBuffer;
+    private int _readOffset;
+    private int _readCount;
+    private long _bytesRead;
+
+    public BoundedUtf8LineReader(Stream stream, long maxBytes, int maxLineBytes, int maxLineChars)
+    {
+        _stream = stream;
+        _maxBytes = maxBytes;
+        _maxLineBytes = maxLineBytes;
+        _maxLineChars = maxLineChars;
+        _lineBuffer = new byte[maxLineBytes];
+    }
+
+    public BoundedLineReadResult ReadLine(out string? line)
+    {
+        int lineLength = 0;
+        while (TryReadByte(out byte value))
+        {
+            if (++_bytesRead > _maxBytes)
+            {
+                line = null;
+                return BoundedLineReadResult.LimitExceeded;
+            }
+
+            if (value == (byte)'\n')
+            {
+                return DecodeLine(lineLength, out line);
+            }
+
+            if (lineLength >= _maxLineBytes)
+            {
+                line = null;
+                return BoundedLineReadResult.LimitExceeded;
+            }
+
+            _lineBuffer[lineLength++] = value;
+        }
+
+        if (lineLength == 0)
+        {
+            line = null;
+            return BoundedLineReadResult.End;
+        }
+
+        return DecodeLine(lineLength, out line);
+    }
+
+    private BoundedLineReadResult DecodeLine(int lineLength, out string? line)
+    {
+        if (lineLength > 0 && _lineBuffer[lineLength - 1] == (byte)'\r')
+        {
+            lineLength--;
+        }
+
+        line = Encoding.UTF8.GetString(_lineBuffer, 0, lineLength);
+        if (line.Length > _maxLineChars)
+        {
+            line = null;
+            return BoundedLineReadResult.LimitExceeded;
+        }
+
+        return BoundedLineReadResult.Line;
+    }
+
+    private bool TryReadByte(out byte value)
+    {
+        if (_readOffset >= _readCount)
+        {
+            _readCount = _stream.Read(_readBuffer, 0, _readBuffer.Length);
+            _readOffset = 0;
+            if (_readCount == 0)
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        value = _readBuffer[_readOffset++];
+        return true;
+    }
+}
+
+internal enum ReportJournalRecordType
+{
+    Header,
+    Test,
+    Completion,
+}
+
+internal sealed class ReportJournalRecord<TCapturedTestResult>
+    where TCapturedTestResult : class
+{
+    public ReportJournalRecordType Type { get; set; }
+
+    public DateTimeOffset? StartTime { get; set; }
+
+    public int? ProcessId { get; set; }
+
+    public string? FrameworkUid { get; set; }
+
+    public string? FrameworkVersion { get; set; }
+
+    public string? FrameworkDisplayName { get; set; }
+
+    public TCapturedTestResult? Result { get; set; }
+
+    public ReportJournalParentEntry? Parent { get; set; }
+
+    public static ReportJournalRecord<TCapturedTestResult> CreateHeader(
+        DateTimeOffset startTime,
+        int processId,
+        ITestFramework testFramework)
+        => new()
+        {
+            Type = ReportJournalRecordType.Header,
+            StartTime = startTime,
+            ProcessId = processId,
+            FrameworkUid = testFramework.Uid,
+            FrameworkVersion = testFramework.Version,
+            FrameworkDisplayName = testFramework.DisplayName,
+        };
+
+    public static ReportJournalRecord<TCapturedTestResult> CreateTest(
+        TCapturedTestResult? result,
+        ReportJournalParentEntry? parent)
+        => new()
+        {
+            Type = ReportJournalRecordType.Test,
+            Result = result,
+            Parent = parent,
+        };
+
+    public static ReportJournalRecord<TCapturedTestResult> CreateCompletion()
+        => new() { Type = ReportJournalRecordType.Completion };
+}
+
+internal sealed class ReportJournalParentEntry
+{
+    public string Uid { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? ParentUid { get; set; }
+}
+
+internal sealed record ReportJournalReadResult<TCapturedTestResult>(
+    RecoveredReportMetadata Metadata,
+    IReadOnlyList<TCapturedTestResult> Results,
+    IReadOnlyList<ReportJournalParentEntry> Parents,
+    bool Completed,
+    bool IsPartial)
+    where TCapturedTestResult : class;
+
+internal sealed class RecoveredReportMetadata
+{
+    public DateTimeOffset StartTime { get; set; }
+
+    public int ProcessId { get; set; }
+
+    public string FrameworkUid { get; set; } = string.Empty;
+
+    public string FrameworkVersion { get; set; } = string.Empty;
+
+    public string FrameworkDisplayName { get; set; } = string.Empty;
+
+    public bool IsIncomplete { get; set; }
+}
+
+internal sealed class RecoveredTestFramework(RecoveredReportMetadata metadata) : ITestFramework
+{
+    public string Uid => metadata.FrameworkUid;
+
+    public string Version => metadata.FrameworkVersion;
+
+    public string DisplayName => metadata.FrameworkDisplayName;
+
+    public string Description => DisplayName;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context) => throw new NotSupportedException();
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context) => throw new NotSupportedException();
+
+    public Task ExecuteRequestAsync(ExecuteRequestContext context) => throw new NotSupportedException();
+}
+
+#pragma warning restore RS0051

--- a/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportRecovery.cs
@@ -179,10 +179,21 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
 
             ReportJournalReadResult<TCapturedTestResult> journal = ReadJournal(path, testHostProcessInformation);
             TGenerator generator = _generatorFactory(_serviceProvider, journal.Metadata);
-            (string fileName, string? warning) = await generator.GenerateRecoveredReportAsync(
-                journal,
-                testHostProcessInformation.ExitCode,
-                cancellationToken).ConfigureAwait(false);
+            bool republishCompletedReport = journal.CompletedReportFileName is not null
+                && _fileSystem.ExistFile(journal.CompletedReportFileName);
+            string fileName;
+            string? warning = null;
+            if (republishCompletedReport)
+            {
+                fileName = journal.CompletedReportFileName!;
+            }
+            else
+            {
+                (fileName, warning) = await generator.GenerateRecoveredReportAsync(
+                    journal,
+                    testHostProcessInformation.ExitCode,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             if (warning is not null)
             {
@@ -191,11 +202,13 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
 
             await _outputDevice.DisplayAsync(
                 this,
-                new WarningMessageOutputDeviceData(journal.Completed
-                    ? $"The test host terminated before report artifact delivery was confirmed. Re-generated the report from {journal.Results.Count} journaled terminal test result(s) and marked it incomplete."
+                new WarningMessageOutputDeviceData(republishCompletedReport
+                    ? $"The test host terminated before report artifact delivery was confirmed. Re-published the completed report '{fileName}'."
+                    : journal.Completed
+                    ? $"The test host terminated before report artifact delivery was confirmed, but the completed report file was unavailable. Re-generated it from {journal.Results.Count} journaled terminal test result(s) and marked it incomplete."
                     : $"The test host terminated before report generation completed. Recovered {journal.Results.Count} terminal test result(s); the generated report is marked incomplete."),
                 cancellationToken).ConfigureAwait(false);
-            if (journal.IsPartial)
+            if (journal.IsPartial && !republishCompletedReport)
             {
                 await _outputDevice.DisplayAsync(
                     this,
@@ -299,6 +312,8 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
         List<TCapturedTestResult> results = [];
         List<ReportJournalParentEntry> parents = [];
         bool completed = false;
+        string? completedReportFileName = null;
+        int droppedJournalRecords = 0;
         bool isPartial = false;
         int recordCount = 0;
 
@@ -349,6 +364,8 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
                         break;
                     case ReportJournalRecordType.Completion:
                         completed = true;
+                        completedReportFileName = record.ReportFileName;
+                        droppedJournalRecords = record.DroppedJournalRecords;
                         break;
                 }
 
@@ -380,7 +397,14 @@ internal sealed class ReportProcessLifetimeHandler<TGenerator, TCapturedTestResu
             FrameworkDisplayName = header?.FrameworkDisplayName ?? "unknown",
             IsIncomplete = true,
         };
-        return new ReportJournalReadResult<TCapturedTestResult>(metadata, results, parents, completed, isPartial);
+        return new ReportJournalReadResult<TCapturedTestResult>(
+            metadata,
+            results,
+            parents,
+            completed,
+            completedReportFileName,
+            droppedJournalRecords,
+            isPartial || droppedJournalRecords > 0);
     }
 }
 
@@ -509,6 +533,10 @@ internal sealed class ReportJournalRecord<TCapturedTestResult>
 
     public ReportJournalParentEntry? Parent { get; set; }
 
+    public string? ReportFileName { get; set; }
+
+    public int DroppedJournalRecords { get; set; }
+
     public static ReportJournalRecord<TCapturedTestResult> CreateHeader(
         DateTimeOffset startTime,
         int processId,
@@ -533,8 +561,15 @@ internal sealed class ReportJournalRecord<TCapturedTestResult>
             Parent = parent,
         };
 
-    public static ReportJournalRecord<TCapturedTestResult> CreateCompletion()
-        => new() { Type = ReportJournalRecordType.Completion };
+    public static ReportJournalRecord<TCapturedTestResult> CreateCompletion(
+        string reportFileName,
+        int droppedJournalRecords)
+        => new()
+        {
+            Type = ReportJournalRecordType.Completion,
+            ReportFileName = reportFileName,
+            DroppedJournalRecords = droppedJournalRecords,
+        };
 }
 
 internal sealed class ReportJournalParentEntry
@@ -551,6 +586,8 @@ internal sealed record ReportJournalReadResult<TCapturedTestResult>(
     IReadOnlyList<TCapturedTestResult> Results,
     IReadOnlyList<ReportJournalParentEntry> Parents,
     bool Completed,
+    string? CompletedReportFileName,
+    int DroppedJournalRecords,
     bool IsPartial)
     where TCapturedTestResult : class;
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
@@ -383,6 +383,7 @@ public class DummyTestFramework : ITestFramework, IDataProducer
         {
             string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_CTRFREPORT_JOURNAL")
                 ?? throw new InvalidOperationException("CTRF report recovery journal was not configured.");
+            bool journalReady = false;
             for (int i = 0; i < 100; i++)
             {
                 using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -395,10 +396,16 @@ public class DummyTestFramework : ITestFramework, IDataProducer
 
                 if (lineCount == 3)
                 {
+                    journalReady = true;
                     break;
                 }
 
                 await Task.Delay(50);
+            }
+
+            if (!journalReady)
+            {
+                throw new TimeoutException("CTRF report recovery journal did not contain the expected results before the crash deadline.");
             }
 
             Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/CtrfReportTests.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
@@ -49,6 +51,38 @@ public class CtrfReportTests : AcceptanceTestBase<CtrfReportTests.TestAssetFixtu
         Assert.IsTrue(match.Success, $"CTRF report path not found in output:\n{testHostResult.StandardOutput}");
 
         AssertCtrfReportShape(match.Value);
+    }
+
+    [TestMethod]
+    public async Task Ctrf_WhenTestHostCrashes_RecoversCompletedResultsAndMarksReportIncomplete()
+    {
+        string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, TargetFrameworks.NetCurrent);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--report-ctrf --report-ctrf-filename crash-{{pid}}.ctrf.json --results-directory \"{resultDirectory}\"",
+            new() { ["CRASHPROCESS"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        string[] files = Directory.GetFiles(resultDirectory, "crash-*.ctrf.json");
+        Assert.HasCount(1, files);
+        testHostResult.AssertOutputContains("Out of process file artifacts produced:");
+        testHostResult.AssertOutputContains(files[0]);
+
+        Match pidMatch = Regex.Match(testHostResult.StandardOutput, @"CRASHED_CHILD_PID=(\d+)");
+        Assert.IsTrue(pidMatch.Success, testHostResult.StandardOutput);
+        Assert.AreEqual($"crash-{pidMatch.Groups[1].Value}.ctrf.json", Path.GetFileName(files[0]));
+
+        using var document = JsonDocument.Parse(File.ReadAllText(files[0]));
+        JsonElement results = document.RootElement.GetProperty("results");
+        JsonElement extra = results.GetProperty("environment").GetProperty("extra");
+        Assert.IsTrue(extra.GetProperty("incomplete").GetBoolean());
+        Assert.AreEqual("aborted", extra.GetProperty("runStatus").GetString());
+        JsonElement[] tests = results.GetProperty("tests").EnumerateArray().ToArray();
+        Assert.HasCount(2, tests);
+        Assert.AreEqual("PassingTest", tests[0].GetProperty("name").GetString());
+        Assert.AreEqual("FailingTest", tests[1].GetProperty("name").GetString());
     }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -344,6 +378,33 @@ public class DummyTestFramework : ITestFramework, IDataProducer
                     new FailedTestNodeStateProperty("Expected 1 but got 2"),
                     new FileArtifactProperty(new FileInfo(attachmentPath), "failure.log", "Failure diagnostics")),
             }));
+
+        if (Environment.GetEnvironmentVariable("CRASHPROCESS") == "1")
+        {
+            string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_CTRFREPORT_JOURNAL")
+                ?? throw new InvalidOperationException("CTRF report recovery journal was not configured.");
+            for (int i = 0; i < 100; i++)
+            {
+                using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                int lineCount = 0;
+                while (lineCount < 3 && reader.ReadLine() is not null)
+                {
+                    lineCount++;
+                }
+
+                if (lineCount == 3)
+                {
+                    break;
+                }
+
+                await Task.Delay(50);
+            }
+
+            Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");
+            await Console.Out.FlushAsync();
+            Environment.FailFast("CRASHPROCESS");
+        }
 
         // 3) Distinct executions with the same UID must remain separate results.
         await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HtmlReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HtmlReportTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -47,6 +47,36 @@ public class HtmlReportTests : AcceptanceTestBase<HtmlReportTests.TestAssetFixtu
         string htmlContent = File.ReadAllText(match.Value);
         Assert.Contains("<!DOCTYPE html>", htmlContent, "Generated file does not appear to be a valid HTML report.");
         Assert.Contains("id=\"mtp-data\"", htmlContent, "Generated HTML report does not contain embedded JSON data.");
+    }
+
+    [TestMethod]
+    public async Task Html_WhenTestHostCrashes_RecoversCompletedResultsAndMarksReportIncomplete()
+    {
+        string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, TargetFrameworks.NetCurrent);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--report-html --report-html-filename crash-{{pid}}.html --results-directory \"{resultDirectory}\"",
+            new() { ["CRASHPROCESS"] = "1" },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        string[] files = Directory.GetFiles(resultDirectory, "crash-*.html");
+        Assert.HasCount(1, files);
+        testHostResult.AssertOutputContains("Out of process file artifacts produced:");
+        testHostResult.AssertOutputContains(files[0]);
+
+        Match pidMatch = Regex.Match(testHostResult.StandardOutput, @"CRASHED_CHILD_PID=(\d+)");
+        Assert.IsTrue(pidMatch.Success, testHostResult.StandardOutput);
+        Assert.AreEqual($"crash-{pidMatch.Groups[1].Value}.html", Path.GetFileName(files[0]));
+
+        string content = File.ReadAllText(files[0]);
+        Assert.Contains("<!DOCTYPE html>", content);
+        Assert.Contains("\"incomplete\":true", content);
+        Assert.Contains("\"runStatus\":\"aborted\"", content);
+        Assert.Contains("\"displayName\":\"PassingTest\"", content);
+        Assert.DoesNotContain("\"displayName\":\"NeverReachedTest\"", content);
+        Assert.Contains("Tests absent from this report did not necessarily pass.", content);
     }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -188,6 +218,36 @@ public class DummyTestFramework : ITestFramework, IDataProducer
                 DisplayName = "PassingTest",
                 Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
             }));
+        if (Environment.GetEnvironmentVariable("CRASHPROCESS") == "1")
+        {
+            string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_HTMLREPORT_JOURNAL")
+                ?? throw new InvalidOperationException("HTML report recovery journal was not configured.");
+            for (int i = 0; i < 100; i++)
+            {
+                using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using var reader = new StreamReader(stream);
+                if (reader.ReadLine() is not null && reader.ReadLine() is not null)
+                {
+                    break;
+                }
+
+                await Task.Delay(50);
+            }
+
+            Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");
+            await Console.Out.FlushAsync();
+            Environment.FailFast("CRASHPROCESS");
+        }
+
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
+            context.Request.Session.SessionUid,
+            new TestNode()
+            {
+                Uid = "test-2",
+                DisplayName = "NeverReachedTest",
+                Properties = new PropertyBag(PassedTestNodeStateProperty.CachedInstance),
+            }));
+
         context.Complete();
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HtmlReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/HtmlReportTests.cs
@@ -222,16 +222,23 @@ public class DummyTestFramework : ITestFramework, IDataProducer
         {
             string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_HTMLREPORT_JOURNAL")
                 ?? throw new InvalidOperationException("HTML report recovery journal was not configured.");
+            bool journalReady = false;
             for (int i = 0; i < 100; i++)
             {
                 using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var reader = new StreamReader(stream);
                 if (reader.ReadLine() is not null && reader.ReadLine() is not null)
                 {
+                    journalReady = true;
                     break;
                 }
 
                 await Task.Delay(50);
+            }
+
+            if (!journalReady)
+            {
+                throw new TimeoutException("HTML report recovery journal did not contain the expected result before the crash deadline.");
             }
 
             Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/JUnitReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/JUnitReportTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -45,6 +45,43 @@ public class JUnitReportTests : AcceptanceTestBase<JUnitReportTests.TestAssetFix
         Assert.IsTrue(match.Success, $"JUnit report path not found in output:\n{testHostResult.StandardOutput}");
 
         AssertSinglePassingTestJUnitReportShape(match.Value);
+    }
+
+    [TestMethod]
+    public async Task JUnit_WhenTestHostCrashes_RecoversCompletedResultsAndParentPath()
+    {
+        string resultDirectory = Path.Combine(AssetFixture.TargetAssetPath, Guid.NewGuid().ToString("N"));
+        var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, TestAssetFixture.AssetName, TargetFrameworks.NetCurrent);
+
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
+            $"--report-junit --report-junit-filename crash-{{pid}}.xml --results-directory \"{resultDirectory}\"",
+            new()
+            {
+                ["CRASHPROCESS"] = "1",
+                ["JUNIT_REPORT_EMIT_MIXED"] = "1",
+            },
+            cancellationToken: TestContext.CancellationToken);
+
+        testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        string[] files = Directory.GetFiles(resultDirectory, "crash-*.xml");
+        Assert.HasCount(1, files);
+        testHostResult.AssertOutputContains("Out of process file artifacts produced:");
+        testHostResult.AssertOutputContains(files[0]);
+
+        Match pidMatch = Regex.Match(testHostResult.StandardOutput, @"CRASHED_CHILD_PID=(\d+)");
+        Assert.IsTrue(pidMatch.Success, testHostResult.StandardOutput);
+        Assert.AreEqual($"crash-{pidMatch.Groups[1].Value}.xml", Path.GetFileName(files[0]));
+
+        string content = File.ReadAllText(files[0]);
+        var document = System.Xml.Linq.XDocument.Parse(content);
+        Assert.HasCount(2, document.Descendants("testcase").ToArray());
+        Assert.Contains("name=\"incomplete\" value=\"true\"", content);
+        Assert.Contains("name=\"run-status\" value=\"aborted\"", content);
+        Assert.Contains("PassingTest", content);
+        Assert.Contains("FailingChild", content);
+        Assert.Contains("Container1", content);
+        Assert.DoesNotContain("SkippedChild", content);
+        Assert.DoesNotContain("ErroredChild", content);
     }
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -377,6 +414,33 @@ public class DummyTestFramework : ITestFramework, IDataProducer
                     Properties = new PropertyBag(new FailedTestNodeStateProperty(new InvalidOperationException("boom"))),
                 },
                 parentTestNodeUid: "container-1"));
+
+            if (Environment.GetEnvironmentVariable("CRASHPROCESS") == "1")
+            {
+                string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_JUNITREPORT_JOURNAL")
+                    ?? throw new InvalidOperationException("JUnit report recovery journal was not configured.");
+                for (int i = 0; i < 100; i++)
+                {
+                    using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var reader = new StreamReader(stream);
+                    int lineCount = 0;
+                    while (lineCount < 4 && reader.ReadLine() is not null)
+                    {
+                        lineCount++;
+                    }
+
+                    if (lineCount == 4)
+                    {
+                        break;
+                    }
+
+                    await Task.Delay(50);
+                }
+
+                Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");
+                await Console.Out.FlushAsync();
+                Environment.FailFast("CRASHPROCESS");
+            }
 
             await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(
                 context.Request.Session.SessionUid,

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/JUnitReportTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/JUnitReportTests.cs
@@ -419,6 +419,7 @@ public class DummyTestFramework : ITestFramework, IDataProducer
             {
                 string journalPath = Environment.GetEnvironmentVariable("TESTINGPLATFORM_JUNITREPORT_JOURNAL")
                     ?? throw new InvalidOperationException("JUnit report recovery journal was not configured.");
+                bool journalReady = false;
                 for (int i = 0; i < 100; i++)
                 {
                     using FileStream stream = File.Open(journalPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
@@ -431,10 +432,16 @@ public class DummyTestFramework : ITestFramework, IDataProducer
 
                     if (lineCount == 4)
                     {
+                        journalReady = true;
                         break;
                     }
 
                     await Task.Delay(50);
+                }
+
+                if (!journalReady)
+                {
+                    throw new TimeoutException("JUnit report recovery journal did not contain the expected results before the crash deadline.");
                 }
 
                 Console.WriteLine($"CRASHED_CHILD_PID={System.Diagnostics.Process.GetCurrentProcess().Id}");

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -176,7 +176,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         string resultDirectory = Path.Combine(testHost.DirectoryName, Guid.NewGuid().ToString("N"));
         TestHostResult testHostResult = await testHost.ExecuteAsync(
-            $"--retry-failed-tests 1 --results-directory {resultDirectory}",
+            $"--retry-failed-tests 1 --results-directory {resultDirectory} --report-html --report-junit",
             new()
             {
                 { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
@@ -202,6 +202,18 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         // Nothing recovered, so nothing is flaky.
         testHostResult.AssertOutputDoesNotContain("  flaky:");
         testHostResult.AssertOutputDoesNotContain("Flaky tests:");
+
+        string htmlReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.html", SearchOption.TopDirectoryOnly).Single());
+        Assert.Contains("TestMethod2", htmlReport);
+        Assert.Contains("TestMethod3", htmlReport);
+        Assert.Contains(@"""incomplete"":true", htmlReport);
+        Assert.Contains(@"""runStatus"":""aborted""", htmlReport);
+
+        string junitReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.xml", SearchOption.TopDirectoryOnly).Single());
+        Assert.Contains("TestMethod2", junitReport);
+        Assert.Contains("TestMethod3", junitReport);
+        Assert.Contains(@"name=""incomplete"" value=""true""", junitReport);
+        Assert.Contains(@"name=""run-status"" value=""aborted""", junitReport);
     }
 
     /// <summary>
@@ -718,13 +730,13 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
 
     [TestMethod]
     [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
-    public async Task RetryFailedTests_HtmlReport_ContainsCompleteRunAndRetryHistory(string tfm)
+    public async Task RetryFailedTests_HtmlAndJUnitReports_AreConsolidatedWithRetryHistory(string tfm)
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, tfm);
         string resultDirectory = Path.Combine(testHost.DirectoryName, Guid.NewGuid().ToString("N"));
 
         TestHostResult testHostResult = await testHost.ExecuteAsync(
-            $"--retry-failed-tests 1 --results-directory \"{resultDirectory}\" --report-html",
+            $"--retry-failed-tests 1 --results-directory \"{resultDirectory}\" --report-html --report-junit",
             new()
             {
                 { EnvironmentVariableConstants.TESTINGPLATFORM_TELEMETRY_OPTOUT, "1" },
@@ -734,14 +746,23 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
             cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.Success);
-        string reportPath = Directory.GetFiles(resultDirectory, "*.html", SearchOption.TopDirectoryOnly).Single();
-        string report = File.ReadAllText(reportPath);
-        Assert.Contains(@"""total"":3", report, report);
-        Assert.Contains(@"""passed"":3", report, report);
-        Assert.Contains(@"""flaky"":1", report, report);
-        Assert.Contains(@"""retryAttempts""", report, report);
-        Assert.Contains("Retry history", report, report);
-        Assert.Contains("badge flaky", report, report);
+        string htmlReportPath = Directory.GetFiles(resultDirectory, "*.html", SearchOption.TopDirectoryOnly).Single();
+        string htmlReport = File.ReadAllText(htmlReportPath);
+        Assert.Contains(@"""total"":3", htmlReport, htmlReport);
+        Assert.Contains(@"""passed"":3", htmlReport, htmlReport);
+        Assert.Contains(@"""flaky"":1", htmlReport, htmlReport);
+        Assert.Contains(@"""retryAttempts""", htmlReport, htmlReport);
+        Assert.Contains("Retry history", htmlReport, htmlReport);
+        Assert.Contains("badge flaky", htmlReport, htmlReport);
+
+        string junitReportPath = Directory.GetFiles(resultDirectory, "*.xml", SearchOption.TopDirectoryOnly).Single();
+        string junitReport = File.ReadAllText(junitReportPath);
+        Assert.Contains(@"tests=""3"" failures=""0""", junitReport, junitReport);
+        Assert.HasCount(1, Regex.Matches(junitReport, @"<testcase name=""TestMethod1"""), junitReport);
+
+        string retriesDirectory = Path.Combine(resultDirectory, "Retries");
+        Assert.HasCount(2, Directory.GetFiles(retriesDirectory, "*.html", SearchOption.AllDirectories));
+        Assert.HasCount(2, Directory.GetFiles(retriesDirectory, "*.xml", SearchOption.AllDirectories));
     }
 
     private static string ReadRequiredStringProperty(string filePath, string propertyName)
@@ -765,6 +786,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
                 .PatchTargetFrameworks(TargetFrameworks.All)
                 .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion)
                 .PatchCodeWithReplace("$MicrosoftTestingExtensionsCtrfReportVersion$", MicrosoftTestingExtensionsCtrfReportVersion)
+                .PatchCodeWithReplace("$MicrosoftTestingExtensionsJUnitReportVersion$", MicrosoftTestingExtensionsJUnitReportVersion)
                 .PatchCodeWithReplace("$MicrosoftTestingExtensionsGitHubActionsReportVersion$", MicrosoftTestingExtensionsGitHubActionsReportVersion));
 
         private const string TestCode = """
@@ -784,6 +806,7 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         <PackageReference Include="Microsoft.Testing.Extensions.CtrfReport" Version="$MicrosoftTestingExtensionsCtrfReportVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="$MicrosoftTestingExtensionsGitHubActionsReportVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.HtmlReport" Version="$MicrosoftTestingPlatformVersion$" />
+        <PackageReference Include="Microsoft.Testing.Extensions.JUnitReport" Version="$MicrosoftTestingExtensionsJUnitReportVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.Retry" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$MicrosoftTestingPlatformVersion$" />
         <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="$MicrosoftTestingPlatformVersion$" />
@@ -823,6 +846,7 @@ public class Program
         builder.AddTrxReportProvider();
 #pragma warning disable TPEXP // Type is for evaluation purposes only and is subject to change or removal in future updates.
         builder.AddCtrfReportProvider();
+        builder.AddJUnitReportProvider();
 #pragma warning restore TPEXP
         builder.AddGitHubActionsProvider();
         builder.AddHtmlReportProvider();

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -206,12 +206,15 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         string htmlReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.html", SearchOption.TopDirectoryOnly).Single());
         Assert.Contains("TestMethod2", htmlReport);
         Assert.Contains("TestMethod3", htmlReport);
+        Assert.Contains(@"""total"":3", htmlReport);
+        Assert.Contains(@"""failed"":1", htmlReport);
         Assert.Contains(@"""incomplete"":true", htmlReport);
         Assert.Contains(@"""runStatus"":""aborted""", htmlReport);
 
         string junitReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.xml", SearchOption.TopDirectoryOnly).Single());
         Assert.Contains("TestMethod2", junitReport);
         Assert.Contains("TestMethod3", junitReport);
+        Assert.Contains(@"tests=""3"" failures=""1""", junitReport);
         Assert.Contains(@"name=""incomplete"" value=""true""", junitReport);
         Assert.Contains(@"name=""run-status"" value=""aborted""", junitReport);
     }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/RetryFailedTestsTests.cs
@@ -204,19 +204,48 @@ public class RetryFailedTestsTests : AcceptanceTestBase<RetryFailedTestsTests.Te
         testHostResult.AssertOutputDoesNotContain("Flaky tests:");
 
         string htmlReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.html", SearchOption.TopDirectoryOnly).Single());
-        Assert.Contains("TestMethod2", htmlReport);
-        Assert.Contains("TestMethod3", htmlReport);
-        Assert.Contains(@"""total"":3", htmlReport);
-        Assert.Contains(@"""failed"":1", htmlReport);
-        Assert.Contains(@"""incomplete"":true", htmlReport);
-        Assert.Contains(@"""runStatus"":""aborted""", htmlReport);
+        const string htmlDataStart = "<script id=\"mtp-data\" type=\"application/json\">";
+        const string htmlDataEnd = "</script>";
+        int htmlDataStartIndex = htmlReport.IndexOf(htmlDataStart, StringComparison.Ordinal);
+        Assert.IsGreaterThanOrEqualTo(0, htmlDataStartIndex, htmlReport);
+        htmlDataStartIndex += htmlDataStart.Length;
+        int htmlDataEndIndex = htmlReport.IndexOf(htmlDataEnd, htmlDataStartIndex, StringComparison.Ordinal);
+        Assert.IsGreaterThan(htmlDataStartIndex, htmlDataEndIndex, htmlReport);
+        using var htmlDocument = System.Text.Json.JsonDocument.Parse(
+            htmlReport.Substring(htmlDataStartIndex, htmlDataEndIndex - htmlDataStartIndex));
+        System.Text.Json.JsonElement htmlRoot = htmlDocument.RootElement;
+        Assert.AreEqual(3, htmlRoot.GetProperty("summary").GetProperty("total").GetInt32());
+        Assert.AreEqual(1, htmlRoot.GetProperty("summary").GetProperty("failed").GetInt32());
+        Assert.IsTrue(htmlRoot.GetProperty("incomplete").GetBoolean());
+        Assert.AreEqual("aborted", htmlRoot.GetProperty("runStatus").GetString());
+        string[] htmlTestNames =
+        [
+            .. htmlRoot.GetProperty("tests").EnumerateArray()
+                .Select(test => test.GetProperty("displayName").GetString()!),
+        ];
+        Assert.Contains("TestMethod2", htmlTestNames);
+        Assert.Contains("TestMethod3", htmlTestNames);
 
         string junitReport = File.ReadAllText(Directory.GetFiles(resultDirectory, "*.xml", SearchOption.TopDirectoryOnly).Single());
-        Assert.Contains("TestMethod2", junitReport);
-        Assert.Contains("TestMethod3", junitReport);
-        Assert.Contains(@"tests=""3"" failures=""1""", junitReport);
-        Assert.Contains(@"name=""incomplete"" value=""true""", junitReport);
-        Assert.Contains(@"name=""run-status"" value=""aborted""", junitReport);
+        var junitDocument = System.Xml.Linq.XDocument.Parse(junitReport);
+        System.Xml.Linq.XElement junitRoot = junitDocument.Root!;
+        Assert.AreEqual("3", junitRoot.Attribute("tests")!.Value);
+        Assert.AreEqual("1", junitRoot.Attribute("failures")!.Value);
+        string[] junitTestNames =
+        [
+            .. junitRoot.Descendants("testcase").Select(test => test.Attribute("name")!.Value),
+        ];
+        Assert.Contains("TestMethod2", junitTestNames);
+        Assert.Contains("TestMethod3", junitTestNames);
+        System.Xml.Linq.XElement[] junitProperties = [.. junitRoot.Descendants("property")];
+        Assert.Contains(
+            property => property.Attribute("name")?.Value == "incomplete"
+                && property.Attribute("value")?.Value == "true",
+            junitProperties);
+        Assert.Contains(
+            property => property.Attribute("name")?.Value == "run-status"
+                && property.Attribute("value")?.Value == "aborted",
+            junitProperties);
     }
 
     /// <summary>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
@@ -84,6 +84,20 @@ public class CtrfReportEngineTests
 
         JsonElement testArray = results.GetProperty("tests");
         Assert.AreEqual(3, testArray.GetArrayLength());
+    }
+
+    [TestMethod]
+    public async Task GenerateReportAsync_WhenRecoveredAfterCrash_MarksEnvironmentIncomplete()
+    {
+        using var memoryStream = new MemoryFileStream();
+        CtrfReportEngine engine = CreateEngine(memoryStream, isIncomplete: true);
+
+        await engine.GenerateReportAsync([Captured("p1", "Recovered test", "passed")]);
+
+        using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
+        JsonElement extra = document.RootElement.GetProperty("results").GetProperty("environment").GetProperty("extra");
+        Assert.IsTrue(extra.GetProperty("incomplete").GetBoolean());
+        Assert.AreEqual("aborted", extra.GetProperty("runStatus").GetString());
     }
 
     [TestMethod]
@@ -1147,15 +1161,15 @@ public class CtrfReportEngineTests
         Assert.AreNotEqual(document.RootElement.GetProperty("reportId").GetString(), runId);
     }
 
-    private CtrfReportEngine CreateEngine(MemoryFileStream stream)
+    private CtrfReportEngine CreateEngine(MemoryFileStream stream, bool isIncomplete = false)
     {
         _ = _fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);
         _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>())).Returns(stream);
 
-        return CreateEngine();
+        return CreateEngine(isIncomplete);
     }
 
-    private CtrfReportEngine CreateEngine()
+    private CtrfReportEngine CreateEngine(bool isIncomplete = false)
     {
         _ = _configurationMock.SetupGet(_ => _[It.IsAny<string>()]).Returns(string.Empty);
         _ = _environmentMock.SetupGet(_ => _.MachineName).Returns("MachineName");
@@ -1175,7 +1189,8 @@ public class CtrfReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None));
+            CancellationToken.None,
+            IsIncomplete: isIncomplete));
     }
 
     internal sealed class MemoryFileStream : IFileStream

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportEngineTests.cs
@@ -95,9 +95,12 @@ public class CtrfReportEngineTests
         await engine.GenerateReportAsync([Captured("p1", "Recovered test", "passed")]);
 
         using var document = JsonDocument.Parse(memoryStream.GetUtf8Content());
-        JsonElement extra = document.RootElement.GetProperty("results").GetProperty("environment").GetProperty("extra");
+        JsonElement results = document.RootElement.GetProperty("results");
+        JsonElement extra = results.GetProperty("environment").GetProperty("extra");
         Assert.IsTrue(extra.GetProperty("incomplete").GetBoolean());
         Assert.AreEqual("aborted", extra.GetProperty("runStatus").GetString());
+        JsonElement test = Assert.ContainsSingle(results.GetProperty("tests").EnumerateArray());
+        Assert.AreEqual("Recovered test", test.GetProperty("name").GetString());
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
@@ -175,9 +175,10 @@ public sealed class CtrfReportGeneratorLifecycleTests
             .GetType("Microsoft.Testing.Extensions.ReportGeneratorBase`2", throwOnError: true)!
             .GetField("JournalQueueCapacity", BindingFlags.Static | BindingFlags.NonPublic)!
             .GetRawConstantValue()!;
-        int resultCount = queueCapacity + 2;
+        int resultCount = queueCapacity + 1;
 
         await context.Generator.OnTestSessionStartingAsync(sessionContext).ConfigureAwait(false);
+        await context.JournalStream.WaitForWriteStartAsync().ConfigureAwait(false);
         for (int i = 0; i < resultCount; i++)
         {
             Task consume = context.Generator.ConsumeAsync(
@@ -361,6 +362,7 @@ public sealed class CtrfReportGeneratorLifecycleTests
     private sealed class MemoryFileStream : IFileStream
     {
         private readonly TaskCompletionSource<object?> _writeGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> _writeStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly CountingMemoryStream _stream;
 
         public MemoryFileStream()
@@ -375,7 +377,7 @@ public sealed class CtrfReportGeneratorLifecycleTests
                 _writeGate.SetResult(null);
             }
 
-            _stream = new(throwOnWrite, _writeGate.Task);
+            _stream = new(throwOnWrite, _writeGate.Task, _writeStarted);
         }
 
         public int FlushCount => _stream.FlushCount;
@@ -387,6 +389,8 @@ public sealed class CtrfReportGeneratorLifecycleTests
         string IFileStream.Name => string.Empty;
 
         public string GetUtf8Content() => Encoding.UTF8.GetString(_stream.ToArray());
+
+        public Task WaitForWriteStartAsync() => _writeStarted.Task;
 
         public void ReleaseWrites() => _writeGate.TrySetResult(null);
 
@@ -400,12 +404,16 @@ public sealed class CtrfReportGeneratorLifecycleTests
         ValueTask IAsyncDisposable.DisposeAsync() => _stream.DisposeAsync();
 #endif
 
-        private sealed class CountingMemoryStream(bool throwOnWrite, Task writeGate) : MemoryStream
+        private sealed class CountingMemoryStream(
+            bool throwOnWrite,
+            Task writeGate,
+            TaskCompletionSource<object?> writeStarted) : MemoryStream
         {
             public int FlushCount { get; private set; }
 
             public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
+                writeStarted.TrySetResult(null);
                 await writeGate.ConfigureAwait(false);
                 if (throwOnWrite)
                 {
@@ -418,6 +426,7 @@ public sealed class CtrfReportGeneratorLifecycleTests
 #if NETCOREAPP
             public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {
+                writeStarted.TrySetResult(null);
                 await writeGate.ConfigureAwait(false);
                 if (throwOnWrite)
                 {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
@@ -96,6 +96,76 @@ public sealed class CtrfReportGeneratorLifecycleTests
     }
 
     [TestMethod]
+    public async Task ControllerChild_WritesPersistentJournalAndCompletesAfterArtifactPublicationAsync()
+    {
+        GeneratorTestContext context = CreateGenerator(optionIsSet: true, isControllerChild: true);
+        var sessionContext = new TestSessionContextStub();
+
+        await context.Generator.OnTestSessionStartingAsync(sessionContext).ConfigureAwait(false);
+        await context.Generator.ConsumeAsync(
+            null!,
+            CreateMessage("passed", PassedTestNodeStateProperty.CachedInstance),
+            CancellationToken.None).ConfigureAwait(false);
+        await context.Generator.OnTestSessionFinishingAsync(sessionContext).ConfigureAwait(false);
+
+        Assert.HasCount(1, context.JournalContentsAtArtifactPublication);
+        Assert.DoesNotContain(@"""Type"":2", context.JournalContentsAtArtifactPublication[0]);
+        Assert.Contains(@"""Type"":2", context.JournalStream.GetUtf8Content());
+        Assert.IsTrue(context.JournalStream.FlushCount is 2 or 3);
+        Assert.IsTrue(context.JournalStream.IsDisposed);
+        _fileSystemMock.Verify(
+            fileSystem => fileSystem.NewFileStream(
+                context.JournalPath,
+                FileMode.Append,
+                FileAccess.Write,
+                FileShare.ReadWrite),
+            Times.Once);
+
+        context.Generator.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ControllerChild_WhenJournalWriteFails_StillPublishesNormalArtifactAsync()
+    {
+        GeneratorTestContext context = CreateGenerator(optionIsSet: true, isControllerChild: true, journalWriteFails: true);
+        var sessionContext = new TestSessionContextStub();
+
+        await context.Generator.OnTestSessionStartingAsync(sessionContext).ConfigureAwait(false);
+        await context.Generator.ConsumeAsync(
+            null!,
+            CreateMessage("passed", PassedTestNodeStateProperty.CachedInstance),
+            CancellationToken.None).ConfigureAwait(false);
+        await context.Generator.OnTestSessionFinishingAsync(sessionContext).ConfigureAwait(false);
+
+        Assert.HasCount(1, context.PublishedArtifacts);
+        Assert.IsTrue(context.JournalStream.IsDisposed);
+        using var document = JsonDocument.Parse(context.ReportStream.GetUtf8Content());
+        Assert.AreEqual(1, document.RootElement.GetProperty("results").GetProperty("summary").GetProperty("passed").GetInt32());
+    }
+
+    [TestMethod]
+    public async Task ControllerChild_ConsumeDoesNotWaitForJournalDiskWriteAsync()
+    {
+        GeneratorTestContext context = CreateGenerator(optionIsSet: true, isControllerChild: true, blockJournalWrites: true);
+        var sessionContext = new TestSessionContextStub();
+
+        Task start = context.Generator.OnTestSessionStartingAsync(sessionContext);
+        Assert.IsTrue(start.IsCompleted);
+        await start.ConfigureAwait(false);
+        Task consume = context.Generator.ConsumeAsync(
+            null!,
+            CreateMessage("passed", PassedTestNodeStateProperty.CachedInstance),
+            CancellationToken.None);
+        Assert.IsTrue(consume.IsCompleted);
+        await consume.ConfigureAwait(false);
+
+        context.JournalStream.ReleaseWrites();
+        await context.Generator.OnTestSessionFinishingAsync(sessionContext).ConfigureAwait(false);
+
+        Assert.Contains(@"""Type"":2", context.JournalStream.GetUtf8Content());
+    }
+
+    [TestMethod]
     public async Task OnTestSessionFinishingAsync_WithoutWarning_PublishesArtifactWithoutOutputAsync()
     {
         GeneratorTestContext context = CreateGenerator(optionIsSet: true);
@@ -113,24 +183,38 @@ public sealed class CtrfReportGeneratorLifecycleTests
             Times.Never);
     }
 
-    private GeneratorTestContext CreateGenerator(bool optionIsSet)
+    private GeneratorTestContext CreateGenerator(
+        bool optionIsSet,
+        bool isControllerChild = false,
+        bool journalWriteFails = false,
+        bool blockJournalWrites = false)
     {
         var reportStream = new MemoryFileStream();
+        var journalStream = new MemoryFileStream(journalWriteFails, blockJournalWrites);
+        const string journalPath = "report-recovery.jsonl";
         var messageBusMock = new Mock<IMessageBus>();
         var outputDeviceMock = new Mock<IOutputDevice>();
         var loggerFactoryMock = new Mock<ILoggerFactory>();
         var testApplicationProcessExitCodeMock = new Mock<ITestApplicationProcessExitCode>();
         List<SessionFileArtifact> publishedArtifacts = [];
+        List<string> journalContentsAtArtifactPublication = [];
 
         _ = _fileSystemMock.Setup(fileSystem => fileSystem.ExistFile(It.IsAny<string>())).Returns(false);
         _ = _fileSystemMock
             .Setup(fileSystem => fileSystem.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>()))
             .Returns(reportStream);
+        _ = _fileSystemMock
+            .Setup(fileSystem => fileSystem.NewFileStream(journalPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            .Returns(journalStream);
         _ = _configurationMock.SetupGet(configuration => configuration[It.IsAny<string>()]).Returns(string.Empty);
         _ = _environmentMock.SetupGet(environment => environment.MachineName).Returns("MachineName");
         _ = _environmentMock
             .Setup(environment => environment.GetEnvironmentVariable(It.IsAny<string>()))
             .Returns("user");
+        _ = _environmentMock
+            .Setup(environment => environment.GetEnvironmentVariable(CtrfReportGenerator.JournalEnvironmentVariableName))
+            .Returns(journalPath);
+        _ = _environmentMock.SetupGet(environment => environment.ProcessId).Returns(42);
         _ = _testApplicationModuleInfoMock
             .Setup(moduleInfo => moduleInfo.GetCurrentTestApplicationFullPath())
             .Returns("TestAppPath");
@@ -139,7 +223,11 @@ public sealed class CtrfReportGeneratorLifecycleTests
         _ = _testFrameworkMock.SetupGet(testFramework => testFramework.DisplayName).Returns("Fake");
         _ = messageBusMock
             .Setup(messageBus => messageBus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()))
-            .Callback<IDataProducer, IData>((_, data) => publishedArtifacts.Add((SessionFileArtifact)data))
+            .Callback<IDataProducer, IData>((_, data) =>
+            {
+                journalContentsAtArtifactPublication.Add(journalStream.GetUtf8Content());
+                publishedArtifacts.Add((SessionFileArtifact)data);
+            })
             .Returns(Task.CompletedTask);
         _ = loggerFactoryMock
             .Setup(loggerFactory => loggerFactory.CreateLogger(It.IsAny<string>()))
@@ -148,9 +236,16 @@ public sealed class CtrfReportGeneratorLifecycleTests
             .Setup(exitCode => exitCode.GetProcessExitCode())
             .Returns(0);
 
-        Dictionary<string, string[]> options = optionIsSet
-            ? new() { [CtrfReportGeneratorCommandLine.CtrfReportOptionName] = [] }
-            : [];
+        Dictionary<string, string[]> options = [];
+        if (optionIsSet)
+        {
+            options[CtrfReportGeneratorCommandLine.CtrfReportOptionName] = [];
+        }
+
+        if (isControllerChild)
+        {
+            options[PlatformCommandLineProvider.TestHostControllerPIDOptionKey] = ["1"];
+        }
 
         ServiceProvider serviceProvider = new();
         serviceProvider.AddService(_configurationMock.Object);
@@ -165,12 +260,16 @@ public sealed class CtrfReportGeneratorLifecycleTests
         serviceProvider.AddService(_testFrameworkMock.Object);
         serviceProvider.AddService(testApplicationProcessExitCodeMock.Object);
         serviceProvider.AddService(loggerFactoryMock.Object);
+        serviceProvider.AddService(new SystemTask());
 
         return new(
             new CtrfReportGenerator(serviceProvider),
             outputDeviceMock,
             publishedArtifacts,
-            reportStream);
+            reportStream,
+            journalStream,
+            journalContentsAtArtifactPublication,
+            journalPath);
     }
 
     private static TestNodeUpdateMessage CreateMessage(string uid, IProperty state)
@@ -187,7 +286,10 @@ public sealed class CtrfReportGeneratorLifecycleTests
         CtrfReportGenerator generator,
         Mock<IOutputDevice> outputDeviceMock,
         List<SessionFileArtifact> publishedArtifacts,
-        MemoryFileStream reportStream)
+        MemoryFileStream reportStream,
+        MemoryFileStream journalStream,
+        List<string> journalContentsAtArtifactPublication,
+        string journalPath)
     {
         public CtrfReportGenerator Generator { get; } = generator;
 
@@ -196,6 +298,12 @@ public sealed class CtrfReportGeneratorLifecycleTests
         public List<SessionFileArtifact> PublishedArtifacts { get; } = publishedArtifacts;
 
         public MemoryFileStream ReportStream { get; } = reportStream;
+
+        public MemoryFileStream JournalStream { get; } = journalStream;
+
+        public List<string> JournalContentsAtArtifactPublication { get; } = journalContentsAtArtifactPublication;
+
+        public string JournalPath { get; } = journalPath;
     }
 
     private sealed class TestSessionContextStub : ITestSessionContext
@@ -207,7 +315,27 @@ public sealed class CtrfReportGeneratorLifecycleTests
 
     private sealed class MemoryFileStream : IFileStream
     {
-        private readonly MemoryStream _stream = new();
+        private readonly TaskCompletionSource<object?> _writeGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly CountingMemoryStream _stream;
+
+        public MemoryFileStream()
+            : this(throwOnWrite: false, blockWrites: false)
+        {
+        }
+
+        public MemoryFileStream(bool throwOnWrite, bool blockWrites)
+        {
+            if (!blockWrites)
+            {
+                _writeGate.SetResult(null);
+            }
+
+            _stream = new(throwOnWrite, _writeGate.Task);
+        }
+
+        public int FlushCount => _stream.FlushCount;
+
+        public bool IsDisposed { get; private set; }
 
         Stream IFileStream.Stream => _stream;
 
@@ -215,10 +343,51 @@ public sealed class CtrfReportGeneratorLifecycleTests
 
         public string GetUtf8Content() => Encoding.UTF8.GetString(_stream.ToArray());
 
-        void IDisposable.Dispose() => _stream.Dispose();
+        public void ReleaseWrites() => _writeGate.TrySetResult(null);
+
+        void IDisposable.Dispose()
+        {
+            IsDisposed = true;
+            _stream.Dispose();
+        }
 
 #if NETCOREAPP
         ValueTask IAsyncDisposable.DisposeAsync() => _stream.DisposeAsync();
 #endif
+
+        private sealed class CountingMemoryStream(bool throwOnWrite, Task writeGate) : MemoryStream
+        {
+            public int FlushCount { get; private set; }
+
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                await writeGate.ConfigureAwait(false);
+                if (throwOnWrite)
+                {
+                    throw new IOException("Simulated journal write failure.");
+                }
+
+                await base.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            }
+
+#if NETCOREAPP
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            {
+                await writeGate.ConfigureAwait(false);
+                if (throwOnWrite)
+                {
+                    throw new IOException("Simulated journal write failure.");
+                }
+
+                await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+            }
+#endif
+
+            public override void Flush()
+            {
+                FlushCount++;
+                base.Flush();
+            }
+        }
     }
 }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportGeneratorLifecycleTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 
 using Microsoft.Testing.Extensions.CtrfReport;
@@ -166,6 +167,45 @@ public sealed class CtrfReportGeneratorLifecycleTests
     }
 
     [TestMethod]
+    public async Task ControllerChild_BoundedJournalOverflow_DoesNotBlockAndNormalReportStillCompletesAsync()
+    {
+        GeneratorTestContext context = CreateGenerator(optionIsSet: true, isControllerChild: true, blockJournalWrites: true);
+        var sessionContext = new TestSessionContextStub();
+        int queueCapacity = (int)typeof(CtrfReportEngine).Assembly
+            .GetType("Microsoft.Testing.Extensions.ReportGeneratorBase`2", throwOnError: true)!
+            .GetField("JournalQueueCapacity", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetRawConstantValue()!;
+        int resultCount = queueCapacity + 2;
+
+        await context.Generator.OnTestSessionStartingAsync(sessionContext).ConfigureAwait(false);
+        for (int i = 0; i < resultCount; i++)
+        {
+            Task consume = context.Generator.ConsumeAsync(
+                null!,
+                CreateMessage(i.ToString(CultureInfo.InvariantCulture), PassedTestNodeStateProperty.CachedInstance),
+                CancellationToken.None);
+            Assert.IsTrue(consume.IsCompleted);
+            await consume.ConfigureAwait(false);
+        }
+
+        context.JournalStream.ReleaseWrites();
+        await context.Generator.OnTestSessionFinishingAsync(sessionContext).ConfigureAwait(false);
+
+        Assert.HasCount(1, context.PublishedArtifacts);
+        using var document = JsonDocument.Parse(context.ReportStream.GetUtf8Content());
+        Assert.AreEqual(
+            resultCount,
+            document.RootElement.GetProperty("results").GetProperty("summary").GetProperty("tests").GetInt32());
+        context.LoggerMock.Verify(
+            logger => logger.Log(
+                LogLevel.Warning,
+                It.Is<string>(message => message.Contains("dropped", StringComparison.OrdinalIgnoreCase)),
+                null,
+                It.IsAny<Func<string, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    [TestMethod]
     public async Task OnTestSessionFinishingAsync_WithoutWarning_PublishesArtifactWithoutOutputAsync()
     {
         GeneratorTestContext context = CreateGenerator(optionIsSet: true);
@@ -195,6 +235,7 @@ public sealed class CtrfReportGeneratorLifecycleTests
         var messageBusMock = new Mock<IMessageBus>();
         var outputDeviceMock = new Mock<IOutputDevice>();
         var loggerFactoryMock = new Mock<ILoggerFactory>();
+        var loggerMock = new Mock<ILogger>();
         var testApplicationProcessExitCodeMock = new Mock<ITestApplicationProcessExitCode>();
         List<SessionFileArtifact> publishedArtifacts = [];
         List<string> journalContentsAtArtifactPublication = [];
@@ -231,7 +272,7 @@ public sealed class CtrfReportGeneratorLifecycleTests
             .Returns(Task.CompletedTask);
         _ = loggerFactoryMock
             .Setup(loggerFactory => loggerFactory.CreateLogger(It.IsAny<string>()))
-            .Returns(Mock.Of<ILogger>());
+            .Returns(loggerMock.Object);
         _ = testApplicationProcessExitCodeMock
             .Setup(exitCode => exitCode.GetProcessExitCode())
             .Returns(0);
@@ -269,7 +310,8 @@ public sealed class CtrfReportGeneratorLifecycleTests
             reportStream,
             journalStream,
             journalContentsAtArtifactPublication,
-            journalPath);
+            journalPath,
+            loggerMock);
     }
 
     private static TestNodeUpdateMessage CreateMessage(string uid, IProperty state)
@@ -289,7 +331,8 @@ public sealed class CtrfReportGeneratorLifecycleTests
         MemoryFileStream reportStream,
         MemoryFileStream journalStream,
         List<string> journalContentsAtArtifactPublication,
-        string journalPath)
+        string journalPath,
+        Mock<ILogger> loggerMock)
     {
         public CtrfReportGenerator Generator { get; } = generator;
 
@@ -304,6 +347,8 @@ public sealed class CtrfReportGeneratorLifecycleTests
         public List<string> JournalContentsAtArtifactPublication { get; } = journalContentsAtArtifactPublication;
 
         public string JournalPath { get; } = journalPath;
+
+        public Mock<ILogger> LoggerMock { get; } = loggerMock;
     }
 
     private sealed class TestSessionContextStub : ITestSessionContext

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/CtrfReportMergerTests.cs
@@ -166,6 +166,24 @@ public sealed class CtrfReportMergerTests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Merge_WhenAnyInputIsIncomplete_PropagatesRecoveryMetadata(bool collapseRetryAttempts)
+    {
+        JsonObject incomplete = JsonNode.Parse(BuildReport(testEntries: [Test("incomplete", "failed")]))!.AsObject();
+        incomplete["results"]!["environment"]!["extra"]!["incomplete"] = true;
+        incomplete["results"]!["environment"]!["extra"]!["runStatus"] = "aborted";
+
+        JsonNode merged = JsonNode.Parse(CtrfReportMerger.Merge(
+            [incomplete.ToJsonString(), BuildReport(testEntries: [Test("complete", "passed")])],
+            collapseRetryAttempts ? CtrfMergeMode.CollapseRetryAttempts : CtrfMergeMode.Concatenate))!;
+        JsonNode extra = merged["results"]!["environment"]!["extra"]!;
+
+        Assert.IsTrue((bool)extra["incomplete"]!);
+        Assert.AreEqual("aborted", (string?)extra["runStatus"]);
+    }
+
+    [TestMethod]
     public void Merge_DerivesDeterministicReportIdNotReusingInput()
     {
         string a = BuildReport();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Reflection;
+using System.Text.Json.Nodes;
 
 using Microsoft.Testing.Extensions.HtmlReport;
 using Microsoft.Testing.Platform.CommandLine;
@@ -61,6 +62,37 @@ public class HtmlReportEngineTests
         Assert.Contains("\"passed\":1", html);
         Assert.Contains("\"failed\":1", html);
         Assert.Contains("\"skipped\":1", html);
+    }
+
+    [TestMethod]
+    public async Task GenerateReportAsync_WhenRecoveredAfterCrash_MarksReportIncomplete()
+    {
+        using var memoryStream = new MemoryFileStream();
+        HtmlReportEngine engine = CreateEngine(memoryStream, isIncomplete: true);
+
+        await engine.GenerateReportAsync([Captured("p1", "Recovered test", "passed")]);
+
+        string html = memoryStream.GetUtf8Content();
+        Assert.Contains("\"incomplete\":true", html);
+        Assert.Contains("\"runStatus\":\"aborted\"", html);
+        Assert.Contains("Tests absent from this report did not necessarily pass.", html);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Merge_WhenAnyInputIsIncomplete_PropagatesRecoveryMetadata(bool collapseRetryAttempts)
+    {
+        string complete = BuildMergeInput("complete", incomplete: false);
+        string incomplete = BuildMergeInput("incomplete", incomplete: true);
+
+        string merged = HtmlReportMerger.Merge(
+            [incomplete, complete],
+            collapseRetryAttempts ? HtmlMergeMode.CollapseRetryAttempts : HtmlMergeMode.Concatenate);
+        JsonObject report = JsonNode.Parse(HtmlReportEngine.ExtractReportJson(merged))!.AsObject();
+
+        Assert.IsTrue((bool)report["incomplete"]!);
+        Assert.AreEqual("aborted", (string?)report["runStatus"]);
     }
 
     [TestMethod]
@@ -680,15 +712,49 @@ public class HtmlReportEngineTests
             ErrorMessage = errorMessage,
         };
 
-    private HtmlReportEngine CreateEngine(MemoryFileStream stream)
+    private static string BuildMergeInput(string uid, bool incomplete)
+    {
+        var report = new JsonObject
+        {
+            ["schemaVersion"] = "1",
+            ["generator"] = "Microsoft.Testing.Extensions.HtmlReport",
+            ["generatorVersion"] = "1.0.0",
+            ["testApplication"] = "app",
+            ["machineName"] = "machine",
+            ["userName"] = "user",
+            ["framework"] = "framework",
+            ["frameworkUid"] = "framework",
+            ["frameworkVersion"] = "1.0.0",
+            ["startTime"] = "2026-08-31T12:00:00.0000000+00:00",
+            ["endTime"] = "2026-08-31T12:00:01.0000000+00:00",
+            ["exitCode"] = incomplete ? 1 : 0,
+            ["tests"] = new JsonArray(new JsonObject
+            {
+                ["uid"] = uid,
+                ["displayName"] = uid,
+                ["outcome"] = "passed",
+                ["durationMs"] = 1,
+            }),
+            ["summary"] = new JsonObject(),
+        };
+        if (incomplete)
+        {
+            report["incomplete"] = true;
+            report["runStatus"] = "aborted";
+        }
+
+        return HtmlReportEngine.RenderReport(report.ToJsonString());
+    }
+
+    private HtmlReportEngine CreateEngine(MemoryFileStream stream, bool isIncomplete = false)
     {
         _ = _fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);
         _ = _fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>())).Returns(stream);
 
-        return CreateEngine();
+        return CreateEngine(isIncomplete);
     }
 
-    private HtmlReportEngine CreateEngine()
+    private HtmlReportEngine CreateEngine(bool isIncomplete = false)
     {
         _ = _configurationMock.SetupGet(_ => _[It.IsAny<string>()]).Returns(string.Empty);
         _ = _environmentMock.SetupGet(_ => _.MachineName).Returns("MachineName");
@@ -708,7 +774,8 @@ public class HtmlReportEngineTests
             _testFrameworkMock.Object,
             DateTimeOffset.UtcNow,
             0,
-            CancellationToken.None));
+            CancellationToken.None,
+            IsIncomplete: isIncomplete));
     }
 
     internal sealed class MemoryFileStream : IFileStream

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HtmlReportEngineTests.cs
@@ -75,6 +75,7 @@ public class HtmlReportEngineTests
         string html = memoryStream.GetUtf8Content();
         Assert.Contains("\"incomplete\":true", html);
         Assert.Contains("\"runStatus\":\"aborted\"", html);
+        Assert.Contains("\"displayName\":\"Recovered test\"", html);
         Assert.Contains("Tests absent from this report did not necessarily pass.", html);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportEngineApiTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportEngineApiTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.JUnitReport;
@@ -64,6 +64,57 @@ public sealed class JUnitReportEngineApiTests
         fileSystemMock.Verify(x => x.NewFileStream(It.Is<string>(path => path.StartsWith(expectedPrefix) && path.EndsWith(".tmp")), FileMode.Create), Times.Once);
         fileSystemMock.Verify(x => x.MoveFile(It.Is<string>(path => path.StartsWith(expectedPrefix) && path.EndsWith(".tmp")), fileName, overwrite: true), Times.Once);
     }
+
+    [TestMethod]
+    public async Task GenerateReportAsync_WhenRecoveredAfterCrash_WritesMetadataOnlyIncompleteSuite()
+    {
+        using var stream = new MemoryFileStream();
+        var fileSystem = new Mock<IFileSystem>();
+        var moduleInfo = new Mock<ITestApplicationModuleInfo>();
+        var environment = new Mock<IEnvironment>();
+        var commandLineOptions = new Mock<ICommandLineOptions>();
+        var configuration = new Mock<IConfiguration>();
+        var clock = new Mock<IClock>();
+        var testFramework = new Mock<ITestFramework>();
+        fileSystem.Setup(x => x.NewFileStream(It.IsAny<string>(), FileMode.Create)).Returns(stream);
+        fileSystem.Setup(x => x.ExistFile(It.IsAny<string>())).Returns(false);
+        moduleInfo.Setup(x => x.GetCurrentTestApplicationFullPath()).Returns("My.Test.Module.dll");
+        configuration.SetupGet(x => x[It.IsAny<string>()]).Returns("/results");
+        testFramework.SetupGet(x => x.DisplayName).Returns("Fake");
+
+        var engine = new JUnitReportEngine(new(
+            fileSystem.Object,
+            moduleInfo.Object,
+            environment.Object,
+            commandLineOptions.Object,
+            configuration.Object,
+            clock.Object,
+            testFramework.Object,
+            DateTimeOffset.UtcNow,
+            137,
+            CancellationToken.None,
+            IsIncomplete: true));
+
+        await engine.GenerateReportAsync([], new Dictionary<string, TestResultCapture.ParentChainEntry>());
+
+        string xml = Encoding.UTF8.GetString(stream.Stream.ToArray());
+        XElement root = XDocument.Parse(xml).Root!;
+        Assert.IsNull(root.Attribute("exit-code"));
+        Assert.IsNull(root.Attribute("status"));
+        Assert.IsNull(root.Attribute("incomplete"));
+        XElement suite = Assert.ContainsSingle(root.Elements("testsuite"));
+        Assert.AreEqual("0", suite.Attribute("tests")!.Value);
+        Assert.AreEqual("137", ReadProperty(suite, "exit-code"));
+        Assert.AreEqual("aborted", ReadProperty(suite, "run-status"));
+        Assert.AreEqual("true", ReadProperty(suite, "incomplete"));
+    }
+
+    private static string? ReadProperty(XElement suite, string name)
+        => suite.Element("properties")?
+            .Elements("property")
+            .SingleOrDefault(property => property.Attribute("name")?.Value == name)?
+            .Attribute("value")?
+            .Value;
 
     private sealed class MemoryFileStream : IFileStream
     {

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportMergerTests.cs
@@ -253,7 +253,7 @@ public sealed class JUnitReportMergerTests
             .Elements("testsuite")
             .Last();
 
-        Assert.AreEqual("137", ReadSuiteProperty(suite, "exit-code"));
+        Assert.AreEqual("0", ReadSuiteProperty(suite, "exit-code"));
         Assert.AreEqual("aborted", ReadSuiteProperty(suite, "run-status"));
         Assert.AreEqual("true", ReadSuiteProperty(suite, "incomplete"));
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportMergerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/JUnitReportMergerTests.cs
@@ -236,6 +236,29 @@ public sealed class JUnitReportMergerTests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Merge_WhenAnyInputIsIncomplete_PropagatesRecoveryProperties(bool collapseRetryAttempts)
+    {
+        XElement incompleteSuite = SuiteWithExitCode("Suite", exitCode: 137);
+        incompleteSuite.Element("properties")!.Add(
+            new XElement("property", new XAttribute("name", "run-status"), new XAttribute("value", "aborted")),
+            new XElement("property", new XAttribute("name", "incomplete"), new XAttribute("value", "true")));
+
+        XElement suite = JUnitReportMerger.Merge(
+            [BuildReport(suites: [incompleteSuite]), BuildReport(suites: [SuiteWithExitCode("Suite", exitCode: 0)])],
+            "run",
+            collapseRetryAttempts ? JUnitMergeMode.CollapseRetryAttempts : JUnitMergeMode.Concatenate)
+            .Root!
+            .Elements("testsuite")
+            .Last();
+
+        Assert.AreEqual("137", ReadSuiteProperty(suite, "exit-code"));
+        Assert.AreEqual("aborted", ReadSuiteProperty(suite, "run-status"));
+        Assert.AreEqual("true", ReadSuiteProperty(suite, "incomplete"));
+    }
+
+    [TestMethod]
     public void MergeRetryAttempts_PreservesSameIdentityOccurrencesWithinAnAttempt()
     {
         XDocument firstAttempt = BuildReport(suites:
@@ -429,6 +452,13 @@ public sealed class JUnitReportMergerTests
                     ? null
                     : new XElement("property", new XAttribute("name", "original-name"), new XAttribute("value", originalName))),
             outcomeElement);
+
+    private static string? ReadSuiteProperty(XElement suite, string name)
+        => suite.Element("properties")?
+            .Elements("property")
+            .SingleOrDefault(property => property.Attribute("name")?.Value == name)?
+            .Attribute("value")?
+            .Value;
 
     private static XDocument BuildReport(
         long tests = 1,

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/PackagedAppTestHostLauncherTests.cs
@@ -272,6 +272,34 @@ public sealed class PackagedAppTestHostLauncherTests
             Assert.AreEqual(expected, await launcher.IsEnabledAsync());
         });
 
+    [TestMethod]
+    public void GetConnectBackEnvironment_IncludesReporterRecoveryTransport()
+    {
+#pragma warning disable TPEXP // TestHostLaunchContext is experimental.
+        var context = new TestHostLaunchContext(
+            "testhost.exe",
+            [],
+            new Dictionary<string, string?>
+            {
+                ["TESTINGPLATFORM_CTRFREPORT_JOURNAL"] = "ctrf.jsonl",
+                ["TESTINGPLATFORM_HTMLREPORT_JOURNAL"] = "html.jsonl",
+                ["TESTINGPLATFORM_JUNITREPORT_JOURNAL"] = "junit.jsonl",
+                ["TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST"] = "retry.txt",
+                ["TESTINGPLATFORM_SECRET"] = "must-not-flow",
+            },
+            workingDirectory: null);
+#pragma warning restore TPEXP
+
+        var environment =
+            PackagedAppTestHostLauncher.GetConnectBackEnvironment(context).ToDictionary();
+
+        Assert.AreEqual("ctrf.jsonl", environment["TESTINGPLATFORM_CTRFREPORT_JOURNAL"]);
+        Assert.AreEqual("html.jsonl", environment["TESTINGPLATFORM_HTMLREPORT_JOURNAL"]);
+        Assert.AreEqual("junit.jsonl", environment["TESTINGPLATFORM_JUNITREPORT_JOURNAL"]);
+        Assert.AreEqual("retry.txt", environment["TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST"]);
+        Assert.IsFalse(environment.ContainsKey("TESTINGPLATFORM_SECRET"));
+    }
+
     /// <summary>
     /// Places a manifest at the layout root and the app <paramref name="appSubdirectoryDepth"/>
     /// directory levels below it, then asserts whether the launcher's upward probe still finds it.

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq.Expressions;
 using System.Reflection;
 
 using Microsoft.Testing.Extensions.CtrfReport;
@@ -123,7 +124,7 @@ public sealed class ReportRecoverySerializationTests
     }
 
     [TestMethod]
-    public async Task OnTestHostProcessExitedAsync_CompletionRecord_SkipsRegenerationAndDeletesJournalAsync()
+    public async Task OnTestHostProcessExitedAsync_CompletionRecord_RegeneratesAndPublishesReportAsync()
     {
         const string journal = """
             {"Type":0,"StartTime":"2026-08-31T12:00:00+00:00","ProcessId":42,"FrameworkUid":"framework","FrameworkVersion":"1.0","FrameworkDisplayName":"Framework"}
@@ -131,10 +132,14 @@ public sealed class ReportRecoverySerializationTests
 
             """;
         var fileSystem = new Mock<IFileSystem>();
-        _ = fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        _ = fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>()))
+            .Returns<string>(path => path.EndsWith(".jsonl", StringComparison.Ordinal));
         _ = fileSystem
             .Setup(fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             .Returns(() => new MemoryFileStream(journal));
+        _ = fileSystem
+            .Setup(fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Create))
+            .Returns(() => new WritableMemoryFileStream());
         object handler = CreateHandler(
             typeof(CtrfReportEngine),
             fileSystem.Object,
@@ -145,13 +150,18 @@ public sealed class ReportRecoverySerializationTests
             new TestHostProcessInformation(314, 1, hasExitedGracefully: false),
             CancellationToken.None);
 
-        messageBus.Verify(bus => bus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()), Times.Never);
+        messageBus.Verify(
+            bus => bus.PublishAsync(
+                It.IsAny<IDataProducer>(),
+                It.Is<FileArtifact>(artifact => artifact.Kind == "microsoft.testing.ctrf")),
+            Times.Once);
         outputDevice.Verify(
             device => device.DisplayAsync(
                 It.IsAny<IOutputDeviceDataProducer>(),
-                It.IsAny<IOutputDeviceData>(),
+                It.Is<WarningMessageOutputDeviceData>(message =>
+                    message.Message.Contains("before report artifact delivery was confirmed", StringComparison.Ordinal)),
                 It.IsAny<CancellationToken>()),
-            Times.Never);
+            Times.Once);
         fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
     }
 
@@ -190,7 +200,16 @@ public sealed class ReportRecoverySerializationTests
         var configuration = new Mock<IConfiguration>();
         _ = configuration.SetupGet(c => c[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("results");
         messageBus = new Mock<IMessageBus>();
+        _ = messageBus
+            .Setup(bus => bus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()))
+            .Returns(Task.CompletedTask);
         outputDevice = new Mock<IOutputDevice>();
+        _ = outputDevice
+            .Setup(device => device.DisplayAsync(
+                It.IsAny<IOutputDeviceDataProducer>(),
+                It.IsAny<IOutputDeviceData>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
         var loggerFactory = new Mock<ILoggerFactory>();
         _ = loggerFactory.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
 
@@ -201,21 +220,38 @@ public sealed class ReportRecoverySerializationTests
         serviceProvider.AddService(messageBus.Object);
         serviceProvider.AddService(outputDevice.Object);
         serviceProvider.AddService(Mock.Of<IClock>(clock => clock.UtcNow == DateTimeOffset.UtcNow));
-        serviceProvider.AddService(Mock.Of<IEnvironment>());
+        serviceProvider.AddService(Mock.Of<IEnvironment>(environment => environment.MachineName == "machine"));
+        serviceProvider.AddService(Mock.Of<ITestApplicationModuleInfo>(
+            module => module.GetCurrentTestApplicationFullPath() == "testhost.dll"));
+        serviceProvider.AddService(Mock.Of<ITestApplicationProcessExitCode>(
+            exitCode => exitCode.GetProcessExitCode() == 1));
         serviceProvider.AddService(loggerFactory.Object);
+        serviceProvider.AddService(new SystemTask());
 
         MethodInfo deserializeMethod = generatorType.GetMethod(
             "DeserializeJournalRecord",
             BindingFlags.Static | BindingFlags.NonPublic)!;
         Type deserializerType = handlerType.GetConstructors().Single().GetParameters()[4].ParameterType;
         var deserializer = Delegate.CreateDelegate(deserializerType, deserializeMethod);
+        Type factoryType = handlerType.GetConstructors().Single().GetParameters()[3].ParameterType;
+        Type[] factoryArguments = factoryType.GetGenericArguments();
+        ParameterExpression serviceProviderParameter = Expression.Parameter(factoryArguments[0], "serviceProvider");
+        ParameterExpression metadataParameter = Expression.Parameter(factoryArguments[1], "metadata");
+        ConstructorInfo recoveredConstructor = generatorType
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single(constructor => constructor.GetParameters().Length == 2);
+        Delegate generatorFactory = Expression.Lambda(
+            factoryType,
+            Expression.New(recoveredConstructor, serviceProviderParameter, metadataParameter),
+            serviceProviderParameter,
+            metadataParameter).Compile();
 
         return Activator.CreateInstance(
             handlerType,
             serviceProvider,
             "report",
             journalConfiguration,
-            null,
+            generatorFactory,
             deserializer)!;
     }
 
@@ -231,6 +267,21 @@ public sealed class ReportRecoverySerializationTests
     private sealed class MemoryFileStream(string content) : IFileStream
     {
         private readonly MemoryStream _stream = new(Encoding.UTF8.GetBytes(content));
+
+        Stream IFileStream.Stream => _stream;
+
+        string IFileStream.Name => string.Empty;
+
+        void IDisposable.Dispose() => _stream.Dispose();
+
+#if NETCOREAPP
+        ValueTask IAsyncDisposable.DisposeAsync() => _stream.DisposeAsync();
+#endif
+    }
+
+    private sealed class WritableMemoryFileStream : IFileStream
+    {
+        private readonly MemoryStream _stream = new();
 
         Stream IFileStream.Stream => _stream;
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
@@ -27,6 +27,28 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 public sealed class ReportRecoverySerializationTests
 {
     [TestMethod]
+    public void ReportJournalConfiguration_RelativeResultsDirectory_UsesCreatedFullPath()
+    {
+        const string relativeDirectory = "relative-results";
+        string fullDirectory = Path.GetFullPath(relativeDirectory);
+        var configuration = new Mock<IConfiguration>();
+        configuration.SetupGet(value => value[PlatformConfigurationConstants.PlatformResultDirectory])
+            .Returns(relativeDirectory);
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(value => value.CreateDirectory(relativeDirectory)).Returns(fullDirectory);
+        Type journalConfigurationType = typeof(CtrfReportEngine).Assembly
+            .GetType("Microsoft.Testing.Extensions.ReportJournalConfiguration", throwOnError: true)!;
+        object journalConfiguration = Activator.CreateInstance(journalConfigurationType, "TEST_REPORT_JOURNAL")!;
+
+        string path = (string)journalConfigurationType
+            .GetMethod("GetOrCreatePath", BindingFlags.Instance | BindingFlags.Public)!
+            .Invoke(journalConfiguration, [configuration.Object, fileSystem.Object])!;
+
+        Assert.AreEqual(fullDirectory, Path.GetDirectoryName(path));
+        Assert.EndsWith(".jsonl", path, StringComparison.Ordinal);
+    }
+
+    [TestMethod]
     [DataRow(typeof(HtmlReportEngine), "Microsoft.Testing.Extensions.HtmlReport.HtmlReportGenerator", "Outcome", "passed")]
     [DataRow(typeof(JUnitReportEngine), "Microsoft.Testing.Extensions.JUnitReport.JUnitReportGenerator", "Outcome", "passed")]
     [DataRow(typeof(CtrfReportEngine), "Microsoft.Testing.Extensions.CtrfReport.CtrfReportGenerator", "Status", "passed")]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
@@ -146,16 +146,18 @@ public sealed class ReportRecoverySerializationTests
     }
 
     [TestMethod]
-    public async Task OnTestHostProcessExitedAsync_CompletionRecord_RegeneratesAndPublishesReportAsync()
+    public async Task OnTestHostProcessExitedAsync_CompletionRecord_RepublishesCompletedReportAsync()
     {
         const string journal = """
             {"Type":0,"StartTime":"2026-08-31T12:00:00+00:00","ProcessId":42,"FrameworkUid":"framework","FrameworkVersion":"1.0","FrameworkDisplayName":"Framework"}
-            {"Type":2}
+            {"Type":2,"ReportFileName":"completed.ctrf.json","DroppedJournalRecords":2}
 
             """;
         var fileSystem = new Mock<IFileSystem>();
         _ = fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>()))
-            .Returns<string>(path => path.EndsWith(".jsonl", StringComparison.Ordinal));
+            .Returns<string>(path =>
+                path.EndsWith(".jsonl", StringComparison.Ordinal)
+                || path == "completed.ctrf.json");
         _ = fileSystem
             .Setup(fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             .Returns(() => new MemoryFileStream(journal));
@@ -175,15 +177,20 @@ public sealed class ReportRecoverySerializationTests
         messageBus.Verify(
             bus => bus.PublishAsync(
                 It.IsAny<IDataProducer>(),
-                It.Is<FileArtifact>(artifact => artifact.Kind == "microsoft.testing.ctrf")),
+                It.Is<FileArtifact>(artifact =>
+                    artifact.Kind == "microsoft.testing.ctrf"
+                    && artifact.FileInfo.Name == "completed.ctrf.json")),
             Times.Once);
         outputDevice.Verify(
             device => device.DisplayAsync(
                 It.IsAny<IOutputDeviceDataProducer>(),
                 It.Is<WarningMessageOutputDeviceData>(message =>
-                    message.Message.Contains("before report artifact delivery was confirmed", StringComparison.Ordinal)),
+                    message.Message.Contains("Re-published the completed report", StringComparison.Ordinal)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+        fileSystem.Verify(
+            fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Create),
+            Times.Never);
         fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
     }
 
@@ -221,6 +228,9 @@ public sealed class ReportRecoverySerializationTests
 
         var configuration = new Mock<IConfiguration>();
         _ = configuration.SetupGet(c => c[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("results");
+        _ = Mock.Get(fileSystem)
+            .Setup(fs => fs.CreateDirectory(It.IsAny<string>()))
+            .Returns<string>(Path.GetFullPath);
         messageBus = new Mock<IMessageBus>();
         _ = messageBus
             .Setup(bus => bus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()))

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/ReportRecoverySerializationTests.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.CtrfReport;
+using Microsoft.Testing.Extensions.HtmlReport;
+using Microsoft.Testing.Extensions.JUnitReport;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
+using Microsoft.Testing.Platform.Extensions.TestHostControllers;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.OutputDevice;
+using Microsoft.Testing.Platform.Services;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class ReportRecoverySerializationTests
+{
+    [TestMethod]
+    [DataRow(typeof(HtmlReportEngine), "Microsoft.Testing.Extensions.HtmlReport.HtmlReportGenerator", "Outcome", "passed")]
+    [DataRow(typeof(JUnitReportEngine), "Microsoft.Testing.Extensions.JUnitReport.JUnitReportGenerator", "Outcome", "passed")]
+    [DataRow(typeof(CtrfReportEngine), "Microsoft.Testing.Extensions.CtrfReport.CtrfReportGenerator", "Status", "passed")]
+    public void DeserializeJournalRecord_UsesGeneratedMetadata(
+        Type assemblyMarker,
+        string generatorTypeName,
+        string formatPropertyName,
+        string formatPropertyValue)
+    {
+        Type generatorType = assemblyMarker.Assembly.GetType(generatorTypeName, throwOnError: true)!;
+        MethodInfo deserialize = generatorType.GetMethod(
+            "DeserializeJournalRecord",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        string formatSpecificProperties = generatorTypeName.Contains("JUnit", StringComparison.Ordinal)
+            ? $"""
+              "RawUid":"test-1","{formatPropertyName}":"{formatPropertyValue}"
+              """
+            : $"""
+              "{formatPropertyName}":"{formatPropertyValue}"
+              """;
+        string json = $$"""
+            {
+              "Type": 1,
+              "Result": {
+                "Uid": "test-1",
+                "DisplayName": "Recovered test",
+                {{formatSpecificProperties}}
+              }
+            }
+            """;
+
+        object record = deserialize.Invoke(null, [json])!;
+        object result = record.GetType().GetProperty("Result")!.GetValue(record)!;
+
+        Assert.AreEqual("Recovered test", result.GetType().GetProperty("DisplayName")!.GetValue(result));
+        Assert.AreEqual(formatPropertyValue, result.GetType().GetProperty(formatPropertyName)!.GetValue(result));
+    }
+
+    [TestMethod]
+    public void ReadJournal_TruncatedTail_ReturnsValidPrefix()
+    {
+        const string path = "journal.jsonl";
+        const string journal = """
+            {"Type":0,"StartTime":"2026-08-31T12:00:00+00:00","ProcessId":42,"FrameworkUid":"framework","FrameworkVersion":"1.0","FrameworkDisplayName":"Framework"}
+            {"Type":1,"Result":{"Uid":"test-1","DisplayName":"Recovered test","Status":"passed"}}
+            {"Type":1,"Result":{"Uid":"truncated"
+            """;
+        var fileSystem = new Mock<IFileSystem>();
+        _ = fileSystem
+            .Setup(fs => fs.NewFileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(() => new MemoryFileStream(journal));
+        object handler = CreateHandler(typeof(CtrfReportEngine), fileSystem.Object, out _, out _);
+
+        MethodInfo readJournal = handler.GetType().GetMethod("ReadJournal", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        object recovered = readJournal.Invoke(handler, [path, new TestHostProcessInformation(314, 1, hasExitedGracefully: false)])!;
+        var results = (System.Collections.IEnumerable)recovered.GetType().GetProperty("Results")!.GetValue(recovered)!;
+        object[] recoveredResults = [.. results.Cast<object>()];
+
+        Assert.HasCount(1, recoveredResults);
+        Assert.AreEqual("Recovered test", recoveredResults[0].GetType().GetProperty("DisplayName")!.GetValue(recoveredResults[0]));
+        object metadata = recovered.GetType().GetProperty("Metadata")!.GetValue(recovered)!;
+        Assert.AreEqual(314, metadata.GetType().GetProperty("ProcessId")!.GetValue(metadata));
+        Assert.IsTrue((bool)metadata.GetType().GetProperty("IsIncomplete")!.GetValue(metadata)!);
+        Assert.IsTrue((bool)recovered.GetType().GetProperty("IsPartial")!.GetValue(recovered)!);
+        Assert.IsFalse((bool)recovered.GetType().GetProperty("Completed")!.GetValue(recovered)!);
+    }
+
+    [TestMethod]
+    public void ReadJournal_OversizedRecord_StopsAtBoundedPrefix()
+    {
+        const string path = "journal.jsonl";
+        Type handlerOpenType = typeof(CtrfReportEngine).Assembly
+            .GetType("Microsoft.Testing.Extensions.ReportProcessLifetimeHandler`2", throwOnError: true)!;
+        Type handlerType = handlerOpenType.MakeGenericType(
+            typeof(CtrfReportEngine).Assembly.GetType("Microsoft.Testing.Extensions.CtrfReport.CtrfReportGenerator", true)!,
+            typeof(CtrfReportEngine).Assembly.GetType("Microsoft.Testing.Extensions.CtrfReport.CapturedTestResult", true)!);
+        int maxRecordBytes = (int)handlerType.GetField("MaxJournalRecordBytes", BindingFlags.Static | BindingFlags.NonPublic)!.GetRawConstantValue()!;
+        string journal = """
+            {"Type":1,"Result":{"Uid":"test-1","DisplayName":"Recovered test","Status":"passed"}}
+            """
+            + "\n"
+            + new string('x', maxRecordBytes + 1);
+        var fileSystem = new Mock<IFileSystem>();
+        _ = fileSystem
+            .Setup(fs => fs.NewFileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(() => new MemoryFileStream(journal));
+        object handler = CreateHandler(typeof(CtrfReportEngine), fileSystem.Object, out _, out _);
+
+        MethodInfo readJournal = handler.GetType().GetMethod("ReadJournal", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        object recovered = readJournal.Invoke(handler, [path, new TestHostProcessInformation(314, 1, hasExitedGracefully: false)])!;
+        var results = (System.Collections.IEnumerable)recovered.GetType().GetProperty("Results")!.GetValue(recovered)!;
+
+        Assert.HasCount(1, results.Cast<object>());
+        Assert.IsTrue((bool)recovered.GetType().GetProperty("IsPartial")!.GetValue(recovered)!);
+    }
+
+    [TestMethod]
+    public async Task OnTestHostProcessExitedAsync_CompletionRecord_SkipsRegenerationAndDeletesJournalAsync()
+    {
+        const string journal = """
+            {"Type":0,"StartTime":"2026-08-31T12:00:00+00:00","ProcessId":42,"FrameworkUid":"framework","FrameworkVersion":"1.0","FrameworkDisplayName":"Framework"}
+            {"Type":2}
+
+            """;
+        var fileSystem = new Mock<IFileSystem>();
+        _ = fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        _ = fileSystem
+            .Setup(fs => fs.NewFileStream(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(() => new MemoryFileStream(journal));
+        object handler = CreateHandler(
+            typeof(CtrfReportEngine),
+            fileSystem.Object,
+            out Mock<IMessageBus> messageBus,
+            out Mock<IOutputDevice> outputDevice);
+
+        await ((ITestHostProcessLifetimeHandler)handler).OnTestHostProcessExitedAsync(
+            new TestHostProcessInformation(314, 1, hasExitedGracefully: false),
+            CancellationToken.None);
+
+        messageBus.Verify(bus => bus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()), Times.Never);
+        outputDevice.Verify(
+            device => device.DisplayAsync(
+                It.IsAny<IOutputDeviceDataProducer>(),
+                It.IsAny<IOutputDeviceData>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task OnTestHostProcessExitedAsync_GracefulExit_OnlyDeletesJournalAsync()
+    {
+        var fileSystem = new Mock<IFileSystem>();
+        _ = fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        object handler = CreateHandler(typeof(CtrfReportEngine), fileSystem.Object, out Mock<IMessageBus> messageBus, out _);
+
+        await ((ITestHostProcessLifetimeHandler)handler).OnTestHostProcessExitedAsync(
+            new TestHostProcessInformation(314, 0, hasExitedGracefully: true),
+            CancellationToken.None);
+
+        fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
+        fileSystem.Verify(
+            fs => fs.NewFileStream(It.IsAny<string>(), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()),
+            Times.Never);
+        messageBus.Verify(bus => bus.PublishAsync(It.IsAny<IDataProducer>(), It.IsAny<IData>()), Times.Never);
+    }
+
+    private static object CreateHandler(
+        Type assemblyMarker,
+        IFileSystem fileSystem,
+        out Mock<IMessageBus> messageBus,
+        out Mock<IOutputDevice> outputDevice)
+    {
+        Assembly assembly = assemblyMarker.Assembly;
+        Type generatorType = assembly.GetType("Microsoft.Testing.Extensions.CtrfReport.CtrfReportGenerator", throwOnError: true)!;
+        Type capturedResultType = assembly.GetType("Microsoft.Testing.Extensions.CtrfReport.CapturedTestResult", throwOnError: true)!;
+        Type handlerType = assembly.GetType("Microsoft.Testing.Extensions.ReportProcessLifetimeHandler`2", throwOnError: true)!
+            .MakeGenericType(generatorType, capturedResultType);
+        Type journalConfigurationType = assembly.GetType("Microsoft.Testing.Extensions.ReportJournalConfiguration", throwOnError: true)!;
+        object journalConfiguration = Activator.CreateInstance(journalConfigurationType, "TEST_REPORT_JOURNAL")!;
+
+        var configuration = new Mock<IConfiguration>();
+        _ = configuration.SetupGet(c => c[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("results");
+        messageBus = new Mock<IMessageBus>();
+        outputDevice = new Mock<IOutputDevice>();
+        var loggerFactory = new Mock<ILoggerFactory>();
+        _ = loggerFactory.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+
+        var serviceProvider = new ServiceProvider();
+        serviceProvider.AddService(new TestCommandLineOptions(new() { ["report"] = [] }));
+        serviceProvider.AddService(configuration.Object);
+        serviceProvider.AddService(fileSystem);
+        serviceProvider.AddService(messageBus.Object);
+        serviceProvider.AddService(outputDevice.Object);
+        serviceProvider.AddService(Mock.Of<IClock>(clock => clock.UtcNow == DateTimeOffset.UtcNow));
+        serviceProvider.AddService(Mock.Of<IEnvironment>());
+        serviceProvider.AddService(loggerFactory.Object);
+
+        MethodInfo deserializeMethod = generatorType.GetMethod(
+            "DeserializeJournalRecord",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        Type deserializerType = handlerType.GetConstructors().Single().GetParameters()[4].ParameterType;
+        var deserializer = Delegate.CreateDelegate(deserializerType, deserializeMethod);
+
+        return Activator.CreateInstance(
+            handlerType,
+            serviceProvider,
+            "report",
+            journalConfiguration,
+            null,
+            deserializer)!;
+    }
+
+    private sealed class TestHostProcessInformation(int pid, int exitCode, bool hasExitedGracefully) : ITestHostProcessInformation
+    {
+        public int PID { get; } = pid;
+
+        public int ExitCode { get; } = exitCode;
+
+        public bool HasExitedGracefully { get; } = hasExitedGracefully;
+    }
+
+    private sealed class MemoryFileStream(string content) : IFileStream
+    {
+        private readonly MemoryStream _stream = new(Encoding.UTF8.GetBytes(content));
+
+        Stream IFileStream.Stream => _stream;
+
+        string IFileStream.Name => string.Empty;
+
+        void IDisposable.Dispose() => _stream.Dispose();
+
+#if NETCOREAPP
+        ValueTask IAsyncDisposable.DisposeAsync() => _stream.DisposeAsync();
+#endif
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -204,9 +204,12 @@ public class RetryTests
         fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
         serviceProvider.AddService(fileSystem.Object);
         Mock<ITestHostLauncher> launcher = new();
+        string? expectedManifestPath = null;
         launcher.SetupGet(value => value.DisplayName).Returns("launcher");
         launcher.SetupGet(value => value.Uid).Returns("launcher");
         launcher.Setup(value => value.LaunchTestHostAsync(It.IsAny<TestHostLaunchContext>(), It.IsAny<CancellationToken>()))
+            .Callback<TestHostLaunchContext, CancellationToken>((context, _) =>
+                expectedManifestPath = context.EnvironmentVariables["TESTINGPLATFORM_RETRY_RECOVERED_ARTIFACT_MANIFEST"])
             .ThrowsAsync(new InvalidOperationException("launch failed"));
         serviceProvider.AddService(launcher.Object);
         using var server = new RetryFailedTestsPipeServer(serviceProvider, [], Mock.Of<ILogger>());
@@ -223,7 +226,8 @@ public class RetryTests
             userMaxRetryCount: 2,
             CancellationToken.None));
 
-        fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
+        Assert.IsNotNull(expectedManifestPath);
+        fileSystem.Verify(fs => fs.DeleteFile(expectedManifestPath), Times.Once);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -65,6 +65,7 @@ public class RetryTests
         loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
         serviceProvider.AddService(loggerFactory.Object);
         serviceProvider.AddService(new SystemTask());
+        serviceProvider.AddService(Mock.Of<IFileSystem>());
         Mock<ITestApplicationCancellationTokenSource> cancellationTokenSource = new();
         cancellationTokenSource.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
         serviceProvider.AddService(cancellationTokenSource.Object);
@@ -108,6 +109,7 @@ public class RetryTests
         loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
         serviceProvider.AddService(loggerFactory.Object);
         serviceProvider.AddService(new SystemTask());
+        serviceProvider.AddService(Mock.Of<IFileSystem>());
         Mock<ITestApplicationCancellationTokenSource> cancellationTokenSource = new();
         cancellationTokenSource.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
         serviceProvider.AddService(cancellationTokenSource.Object);
@@ -153,6 +155,9 @@ public class RetryTests
         loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
         serviceProvider.AddService(loggerFactory.Object);
         serviceProvider.AddService(new SystemTask());
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        serviceProvider.AddService(fileSystem.Object);
         Mock<ITestApplicationCancellationTokenSource> applicationCancellation = new();
         applicationCancellation.SetupGet(x => x.CancellationToken).Returns(CancellationToken.None);
         serviceProvider.AddService(applicationCancellation.Object);
@@ -179,6 +184,45 @@ public class RetryTests
 
         Assert.IsTrue(launcher.Handle.TerminateCalled);
         Assert.IsTrue(launcher.Handle.Disposed);
+        fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task RunAttemptAsync_LauncherFailure_DeletesRecoveredArtifactManifest()
+    {
+        ServiceProvider serviceProvider = new();
+        serviceProvider.AddService(Mock.Of<IEnvironment>());
+        serviceProvider.AddService(Mock.Of<IProcessHandler>());
+        serviceProvider.AddService(new SystemTask());
+        serviceProvider.AddService(Mock.Of<ITestApplicationCancellationTokenSource>(
+            source => source.CancellationToken == CancellationToken.None));
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+        serviceProvider.AddService(loggerFactory.Object);
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        serviceProvider.AddService(fileSystem.Object);
+        Mock<ITestHostLauncher> launcher = new();
+        launcher.SetupGet(value => value.DisplayName).Returns("launcher");
+        launcher.SetupGet(value => value.Uid).Returns("launcher");
+        launcher.Setup(value => value.LaunchTestHostAsync(It.IsAny<TestHostLaunchContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("launch failed"));
+        serviceProvider.AddService(launcher.Object);
+        using var server = new RetryFailedTestsPipeServer(serviceProvider, [], Mock.Of<ILogger>());
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => RetryTestHostRunner.RunAttemptAsync(
+            serviceProvider,
+            Mock.Of<IOutputDeviceDataProducer>(),
+            Mock.Of<IOutputDevice>(),
+            Mock.Of<ILogger>(),
+            server,
+            new ExecutableInfo("testhost.exe", [], string.Empty),
+            [],
+            attemptCount: 1,
+            userMaxRetryCount: 2,
+            CancellationToken.None));
+
+        fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -292,17 +292,21 @@ public class RetryTests
     public void CollectRecoveredArtifacts_RecordLimit_IsEnforcedAndManifestIsDeleted()
     {
         const string manifestPath = "recovered-artifacts.txt";
+        const string recoveredArtifactPath = "recovered.xml";
         int maxRecords = (int)typeof(RetryOrchestrator)
             .GetField("MaxRecoveredArtifactManifestRecords", BindingFlags.Static | BindingFlags.NonPublic)!
             .GetRawConstantValue()!;
         var manifest = new StringBuilder();
-        for (int i = 0; i <= maxRecords; i++)
+        for (int i = 0; i < maxRecords; i++)
         {
             manifest.AppendLine("malformed");
         }
 
+        manifest.AppendLine(CreateManifestLine(recoveredArtifactPath, "microsoft.testing.junit"));
+
         var fileSystem = new Mock<IFileSystem>();
         fileSystem.Setup(fs => fs.ExistFile(manifestPath)).Returns(true);
+        fileSystem.Setup(fs => fs.ExistFile(recoveredArtifactPath)).Returns(true);
         fileSystem.Setup(fs => fs.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             .Returns(new ReadOnlyMemoryFileStream(manifest.ToString()));
         List<ArtifactRequest> artifacts = [];

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -4,6 +4,7 @@
 #pragma warning restore IDE0073 // The file header does not match the required text
 
 using System.IO.Pipes;
+using System.Reflection;
 
 using Microsoft.Testing.Extensions.Policy;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
@@ -223,6 +224,89 @@ public class RetryTests
             CancellationToken.None));
 
         fileSystem.Verify(fs => fs.DeleteFile(It.IsAny<string>()), Times.Once);
+    }
+
+    [TestMethod]
+    public void CollectRecoveredArtifacts_MalformedAndMissingEntries_AreIgnoredAndManifestIsDeleted()
+    {
+        const string manifestPath = "recovered-artifacts.txt";
+        const string missingArtifactPath = "missing.xml";
+        string manifest = $"not-base64\t-{Environment.NewLine}{CreateManifestLine(missingArtifactPath, "microsoft.testing.junit")}";
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>()))
+            .Returns<string>(path => path == manifestPath);
+        fileSystem.Setup(fs => fs.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(new ReadOnlyMemoryFileStream(manifest));
+        List<ArtifactRequest> artifacts = [];
+
+        InvokeCollectRecoveredArtifacts(fileSystem.Object, manifestPath, artifacts);
+
+        Assert.IsEmpty(artifacts);
+        fileSystem.Verify(fs => fs.DeleteFile(manifestPath), Times.Once);
+    }
+
+    [TestMethod]
+    public void CollectRecoveredArtifacts_RecoveredKind_ReplacesPreviouslyPublishedArtifact()
+    {
+        const string manifestPath = "recovered-artifacts.txt";
+        const string recoveredArtifactPath = "recovered.xml";
+        const string kind = "microsoft.testing.junit";
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(It.IsAny<string>())).Returns(true);
+        fileSystem.Setup(fs => fs.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(new ReadOnlyMemoryFileStream(CreateManifestLine(recoveredArtifactPath, kind)));
+        List<ArtifactRequest> artifacts = [new("original.xml", kind)];
+
+        InvokeCollectRecoveredArtifacts(fileSystem.Object, manifestPath, artifacts);
+
+        ArtifactRequest artifact = Assert.ContainsSingle(artifacts);
+        Assert.AreEqual(recoveredArtifactPath, artifact.Path);
+        Assert.AreEqual(kind, artifact.Kind);
+        fileSystem.Verify(fs => fs.DeleteFile(manifestPath), Times.Once);
+    }
+
+    [TestMethod]
+    public void CollectRecoveredArtifacts_OversizedLine_IsRejectedAndManifestIsDeleted()
+    {
+        const string manifestPath = "recovered-artifacts.txt";
+        int maxLineBytes = (int)typeof(RetryOrchestrator)
+            .GetField("MaxRecoveredArtifactManifestLineBytes", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetRawConstantValue()!;
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(manifestPath)).Returns(true);
+        fileSystem.Setup(fs => fs.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(new ReadOnlyMemoryFileStream(new string('x', maxLineBytes + 1)));
+        List<ArtifactRequest> artifacts = [];
+
+        InvokeCollectRecoveredArtifacts(fileSystem.Object, manifestPath, artifacts);
+
+        Assert.IsEmpty(artifacts);
+        fileSystem.Verify(fs => fs.DeleteFile(manifestPath), Times.Once);
+    }
+
+    [TestMethod]
+    public void CollectRecoveredArtifacts_RecordLimit_IsEnforcedAndManifestIsDeleted()
+    {
+        const string manifestPath = "recovered-artifacts.txt";
+        int maxRecords = (int)typeof(RetryOrchestrator)
+            .GetField("MaxRecoveredArtifactManifestRecords", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetRawConstantValue()!;
+        var manifest = new StringBuilder();
+        for (int i = 0; i <= maxRecords; i++)
+        {
+            manifest.AppendLine("malformed");
+        }
+
+        var fileSystem = new Mock<IFileSystem>();
+        fileSystem.Setup(fs => fs.ExistFile(manifestPath)).Returns(true);
+        fileSystem.Setup(fs => fs.NewFileStream(manifestPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            .Returns(new ReadOnlyMemoryFileStream(manifest.ToString()));
+        List<ArtifactRequest> artifacts = [];
+
+        InvokeCollectRecoveredArtifacts(fileSystem.Object, manifestPath, artifacts);
+
+        Assert.IsEmpty(artifacts);
+        fileSystem.Verify(fs => fs.DeleteFile(manifestPath), Times.Once);
     }
 
     [TestMethod]
@@ -1032,11 +1116,37 @@ public class RetryTests
         return serviceProvider;
     }
 
+    private static string CreateManifestLine(string path, string? kind)
+        => $"{Convert.ToBase64String(Encoding.UTF8.GetBytes(path))}\t{(kind is null ? "-" : Convert.ToBase64String(Encoding.UTF8.GetBytes(kind)))}";
+
+    private static void InvokeCollectRecoveredArtifacts(
+        IFileSystem fileSystem,
+        string manifestPath,
+        List<ArtifactRequest> artifacts)
+        => typeof(RetryOrchestrator)
+            .GetMethod("CollectRecoveredArtifacts", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, [fileSystem, manifestPath, artifacts, Mock.Of<ILogger>()]);
+
     private static string CreateTemporaryDirectory()
     {
         string directory = Path.Combine(Path.GetTempPath(), $"retry-artifact-processor-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         return directory;
+    }
+
+    private sealed class ReadOnlyMemoryFileStream(string content) : IFileStream
+    {
+        private readonly MemoryStream _stream = new(Encoding.UTF8.GetBytes(content));
+
+        Stream IFileStream.Stream => _stream;
+
+        string IFileStream.Name => string.Empty;
+
+        void IDisposable.Dispose() => _stream.Dispose();
+
+#if NETCOREAPP
+        ValueTask IAsyncDisposable.DisposeAsync() => _stream.DisposeAsync();
+#endif
     }
 
     private sealed class TestArtifactPostProcessor : IArtifactPostProcessor


### PR DESCRIPTION
HTML, JUnit, and CTRF reports were lost when the test host crashed before session finalization. This gives those file reporters the same controller-backed recovery principle as TRX while preserving their existing successful-run behavior.

## Summary

- enable controller-backed recovery by default on supported platforms
- journal terminal results through bounded asynchronous writers and reconstruct valid partial reports after abnormal termination
- mark recovered output incomplete/aborted and preserve that state through module and retry merging
- forward recovery transport through packaged-app activation and retain recovered retry-attempt artifacts

Normal successful reports remain child-generated so existing artifact publication and retry behavior do not change. The surviving controller only reconstructs a report when the child exits abnormally; bounded queues, parsing limits, and shutdown timeouts keep recovery from destabilizing the controller.

## Testing

- `.\build.cmd -pack -c Release` (0 warnings, 0 errors)
- targeted reporter/recovery unit tests: 740 passed, 6 skipped across net462, net472, net8.0, and net9.0
- targeted reporter/retry acceptance tests: 58 passed