### PR TITLE
Harden acceptance test timing assertions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,6 +109,7 @@ When making change to resource files, you MUST:
   - The adapter unit-test projects (`MSTestAdapter.UnitTests`, `MSTestAdapter.PlatformServices.UnitTests`) ban MSTest's `Assert` family and require `AwesomeAssertions` (FluentAssertions-style API).
 - Acceptance integration tests run with assembly-level method parallelization. Classes that share a single generated mutable test asset across multiple methods must be marked `[DoNotParallelize]` to avoid races on `bin/obj` outputs.
 - When asserting on test-host output that contains a rendered test **duration** (e.g. `failed MyTest (040ms)`), NEVER hard-code `\(\d+ms\)`. The duration format grows leading parts (`(1s 040ms)`, `(2m 03s 040ms)`, …) on slower machines (often macOS, sometimes Windows), so a `\d+ms`-only pattern is a classic source of timing flakiness. Use the shared `AcceptanceAssert.DurationPattern` constant (or, where a duration only ever applies to skipped tests, the deterministic `(0ms)`) instead.
+- Prefer deterministic output, marker, or rendezvous assertions over wall-clock timing. When an acceptance test must assert an upper bound on `Stopwatch.Elapsed` around a real process launch, use a named limit with a generous allowance for process startup, JIT, and teardown on loaded CI agents, and add a comment explaining its relationship to the configured timeout or expected operation.
 - When running acceptance tests, you must first run `./build.sh -pack` on Linux/macOS or `.\build.cmd -pack` on Windows.
 
 ## CLI options guidelines

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/TimeoutWhenExpiresTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Platform.Acceptance.IntegrationTests;
@@ -168,11 +168,8 @@ public sealed class TimeoutWhenExpiresTests : AcceptanceTestBase<TimeoutWhenExpi
         string runSettingsFilePath = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.runsettings");
         File.WriteAllText(runSettingsFilePath, runSettings);
 
-        var stopwatch = Stopwatch.StartNew();
         TestHostResult testHostResult = await testHost.ExecuteAsync($"--settings {runSettingsFilePath}", environmentVariables: new() { [$"TIMEOUT_{InfoByKind[entryKind].EnvVarSuffix}"] = "1" });
-        stopwatch.Stop();
 
-        Assert.IsLessThan(25, stopwatch.Elapsed.TotalSeconds);
         testHostResult.AssertOutputContains($"{InfoByKind[entryKind].Prefix} method '{InfoByKind[entryKind].MethodFullName}' timed out after 1000ms");
     }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/DataConsumerThroughputTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public class DataConsumerThroughputTests : AcceptanceTestBase<DataConsumerThroughputTests.TestAssetFixture>
 {
     private const string AssetName = "DataConsumerThroughputTests";
+    private static readonly TimeSpan MaximumExecutionTime = TimeSpan.FromSeconds(30);
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
@@ -21,7 +22,9 @@ public class DataConsumerThroughputTests : AcceptanceTestBase<DataConsumerThroug
         testHostResult.AssertExitCodeIs(ExitCode.Success);
         testHostResult.AssertOutputContainsSummary(failed: 0, passed: 1, skipped: 0);
 
-        Assert.IsLessThan(7, stopwatch.Elapsed.TotalSeconds, testHostResult.ToString());
+        // The consumer count scales with the available processors. The limit leaves ample room for process startup,
+        // JIT, and teardown on a loaded CI agent while still detecting a severe throughput regression.
+        Assert.IsLessThan(MaximumExecutionTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<TestHostProcessLifetimeHandlerTests.TestAssetFixture>
 {
     private const string AssetName = "TestHostProcessLifetimeHandler";
-    private static readonly TimeSpan MarkerWaitTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan RendezvousWaitTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan MaximumFinalizationTime = TimeSpan.FromSeconds(5);
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -50,8 +50,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string finalizationStartedFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.started.txt");
         string disposalFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.disposed.txt");
-        using var markerTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
-        markerTimeout.CancelAfter(MarkerWaitTimeout);
+        string executionReadyFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.ready.txt");
+        string executionReleaseFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.release.txt");
+        using var rendezvousTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        rendezvousTimeout.CancelAfter(RendezvousWaitTimeout);
 
         Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
@@ -61,21 +63,25 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["BLOCK_FINALIZATION"] = "1",
                 ["FINALIZATION_STARTED_FILE"] = finalizationStartedFile,
                 ["DISPOSAL_FILE"] = disposalFile,
+                ["EXECUTION_READY_FILE"] = executionReadyFile,
+                ["EXECUTION_RELEASE_FILE"] = executionReleaseFile,
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: markerTimeout.Token);
+            cancellationToken: rendezvousTimeout.Token);
 
-        await WaitForFileAsync(finalizationStartedFile, markerTimeout.Token);
-        markerTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
+        await WaitForFileAsync(executionReadyFile, rendezvousTimeout.Token);
+        rendezvousTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
         var stopwatch = Stopwatch.StartNew();
+        File.WriteAllText(executionReleaseFile, string.Empty);
         TestHostResult testHostResult = await executionTask;
 
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
+        Assert.IsTrue(File.Exists(finalizationStartedFile), testHostResult.ToString());
         Assert.IsFalse(File.Exists(disposalFile), testHostResult.ToString());
 
-        // Timing starts after the callback begins, excluding process startup and JIT. Five seconds gives the configured
-        // 500ms finalization budget ample CI margin while remaining below the handler's 10-second blocking duration.
+        // Timing starts before releasing execution to trigger the 500ms test-host timeout. Five seconds gives the
+        // combined test-host and finalization budgets ample CI margin while remaining below the 10-second blocker.
         Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
@@ -85,8 +91,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string disposalAttemptsFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.dispose-attempts.txt");
-        using var markerTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
-        markerTimeout.CancelAfter(MarkerWaitTimeout);
+        string executionReadyFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.ready.txt");
+        string executionReleaseFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.release.txt");
+        using var rendezvousTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        rendezvousTimeout.CancelAfter(RendezvousWaitTimeout);
 
         Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
@@ -95,21 +103,24 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["BLOCK_UNTIL_TIMEOUT"] = "1",
                 ["BLOCK_DISPOSAL"] = "1",
                 ["DISPOSAL_ATTEMPTS_FILE"] = disposalAttemptsFile,
+                ["EXECUTION_READY_FILE"] = executionReadyFile,
+                ["EXECUTION_RELEASE_FILE"] = executionReleaseFile,
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: markerTimeout.Token);
+            cancellationToken: rendezvousTimeout.Token);
 
-        await WaitForFileAsync(disposalAttemptsFile, markerTimeout.Token);
-        markerTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
+        await WaitForFileAsync(executionReadyFile, rendezvousTimeout.Token);
+        rendezvousTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
         var stopwatch = Stopwatch.StartNew();
+        File.WriteAllText(executionReleaseFile, string.Empty);
         TestHostResult testHostResult = await executionTask;
 
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.HasCount(1, File.ReadAllLines(disposalAttemptsFile), testHostResult.ToString());
 
-        // Timing starts after the first disposal attempt, excluding process startup and JIT. Five seconds gives the
-        // configured 500ms finalization budget ample CI margin while remaining below the 10-second blocking duration.
+        // Timing starts before releasing execution to trigger the 500ms test-host timeout. Five seconds gives the
+        // combined test-host and finalization budgets ample CI margin while remaining below the 10-second blocker.
         Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
@@ -267,6 +278,19 @@ public class DummyTestFramework : ITestFramework, IDataProducer
     {
         if (Environment.GetEnvironmentVariable("BLOCK_UNTIL_TIMEOUT") == "1")
         {
+            if (Environment.GetEnvironmentVariable("EXECUTION_READY_FILE") is { Length: > 0 } readyFile)
+            {
+                System.IO.File.WriteAllText(readyFile, string.Empty);
+            }
+
+            if (Environment.GetEnvironmentVariable("EXECUTION_RELEASE_FILE") is { Length: > 0 } releaseFile)
+            {
+                while (!System.IO.File.Exists(releaseFile))
+                {
+                    Thread.Sleep(10);
+                }
+            }
+
             Thread.Sleep(2000);
         }
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -50,6 +50,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string finalizationStartedFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.started.txt");
         string disposalFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.disposed.txt");
+        using var markerTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        markerTimeout.CancelAfter(MarkerWaitTimeout);
 
         Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
@@ -62,10 +64,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: TestContext.CancellationToken);
+            cancellationToken: markerTimeout.Token);
 
-        await WaitForFileAsync(finalizationStartedFile, TestContext.CancellationToken)
-            .WaitAsync(MarkerWaitTimeout, TestContext.CancellationToken);
+        await WaitForFileAsync(finalizationStartedFile, markerTimeout.Token);
+        markerTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
         var stopwatch = Stopwatch.StartNew();
         TestHostResult testHostResult = await executionTask;
 
@@ -83,6 +85,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string disposalAttemptsFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.dispose-attempts.txt");
+        using var markerTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
+        markerTimeout.CancelAfter(MarkerWaitTimeout);
 
         Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
@@ -94,10 +98,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: TestContext.CancellationToken);
+            cancellationToken: markerTimeout.Token);
 
-        await WaitForFileAsync(disposalAttemptsFile, TestContext.CancellationToken)
-            .WaitAsync(MarkerWaitTimeout, TestContext.CancellationToken);
+        await WaitForFileAsync(disposalAttemptsFile, markerTimeout.Token);
+        markerTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
         var stopwatch = Stopwatch.StartNew();
         TestHostResult testHostResult = await executionTask;
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<TestHostProcessLifetimeHandlerTests.TestAssetFixture>
 {
     private const string AssetName = "TestHostProcessLifetimeHandler";
+    private static readonly TimeSpan MaximumExecutionTime = TimeSpan.FromSeconds(30);
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
@@ -66,7 +67,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.IsTrue(File.Exists(finalizationStartedFile), testHostResult.ToString());
         Assert.IsFalse(File.Exists(disposalFile), testHostResult.ToString());
-        Assert.IsLessThan(8, stopwatch.Elapsed.TotalSeconds, testHostResult.ToString());
+
+        // The configured test-host and finalization timeouts total one second. The limit leaves ample room for process
+        // startup, JIT, and teardown on a loaded CI agent while still proving that the one-minute handler is not awaited.
+        Assert.IsLessThan(MaximumExecutionTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
     [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
@@ -92,7 +96,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.IsTrue(File.Exists(disposalAttemptsFile), testHostResult.ToString());
         Assert.HasCount(1, File.ReadAllLines(disposalAttemptsFile), testHostResult.ToString());
-        Assert.IsLessThan(8, stopwatch.Elapsed.TotalSeconds, testHostResult.ToString());
+
+        // The configured test-host and finalization timeouts total one second. The limit leaves ample room for process
+        // startup, JIT, and teardown on a loaded CI agent while still proving that the one-minute disposal is not awaited.
+        Assert.IsLessThan(MaximumExecutionTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
@@ -140,6 +147,8 @@ public class Startup
 
 public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, IDisposable
 {
+    private static readonly TimeSpan BlockingOperationDuration = TimeSpan.FromMinutes(1);
+
     public string Uid => nameof(TestHostProcessLifetimeHandler);
 
     public string Version => string.Empty;
@@ -182,7 +191,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
 
         if (Environment.GetEnvironmentVariable("BLOCK_FINALIZATION") == "1")
         {
-            Thread.Sleep(10000);
+            Thread.Sleep(BlockingOperationDuration);
         }
 
         return Task.CompletedTask;
@@ -212,7 +221,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
 
         if (Environment.GetEnvironmentVariable("BLOCK_DISPOSAL") == "1")
         {
-            Thread.Sleep(10000);
+            Thread.Sleep(BlockingOperationDuration);
         }
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -7,7 +7,8 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<TestHostProcessLifetimeHandlerTests.TestAssetFixture>
 {
     private const string AssetName = "TestHostProcessLifetimeHandler";
-    private static readonly TimeSpan MaximumExecutionTime = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MarkerWaitTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MaximumFinalizationTime = TimeSpan.FromSeconds(5);
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
     [TestMethod]
@@ -49,9 +50,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string finalizationStartedFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.started.txt");
         string disposalFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.disposed.txt");
-        var stopwatch = Stopwatch.StartNew();
 
-        TestHostResult testHostResult = await testHost.ExecuteAsync(
+        Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
             new()
             {
@@ -64,13 +64,17 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
             },
             cancellationToken: TestContext.CancellationToken);
 
+        await WaitForFileAsync(finalizationStartedFile, TestContext.CancellationToken)
+            .WaitAsync(MarkerWaitTimeout, TestContext.CancellationToken);
+        var stopwatch = Stopwatch.StartNew();
+        TestHostResult testHostResult = await executionTask;
+
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
-        Assert.IsTrue(File.Exists(finalizationStartedFile), testHostResult.ToString());
         Assert.IsFalse(File.Exists(disposalFile), testHostResult.ToString());
 
-        // The configured test-host and finalization timeouts total one second. The limit leaves ample room for process
-        // startup, JIT, and teardown on a loaded CI agent while still proving that the one-minute handler is not awaited.
-        Assert.IsLessThan(MaximumExecutionTime, stopwatch.Elapsed, testHostResult.ToString());
+        // Timing starts after the callback begins, excluding process startup and JIT. Five seconds gives the configured
+        // 500ms finalization budget ample CI margin while remaining below the handler's 10-second blocking duration.
+        Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
     }
 
     [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
@@ -79,9 +83,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string disposalAttemptsFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.dispose-attempts.txt");
-        var stopwatch = Stopwatch.StartNew();
 
-        TestHostResult testHostResult = await testHost.ExecuteAsync(
+        Task<TestHostResult> executionTask = testHost.ExecuteAsync(
             "--timeout 500ms",
             new()
             {
@@ -93,13 +96,25 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
             },
             cancellationToken: TestContext.CancellationToken);
 
+        await WaitForFileAsync(disposalAttemptsFile, TestContext.CancellationToken)
+            .WaitAsync(MarkerWaitTimeout, TestContext.CancellationToken);
+        var stopwatch = Stopwatch.StartNew();
+        TestHostResult testHostResult = await executionTask;
+
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
-        Assert.IsTrue(File.Exists(disposalAttemptsFile), testHostResult.ToString());
         Assert.HasCount(1, File.ReadAllLines(disposalAttemptsFile), testHostResult.ToString());
 
-        // The configured test-host and finalization timeouts total one second. The limit leaves ample room for process
-        // startup, JIT, and teardown on a loaded CI agent while still proving that the one-minute disposal is not awaited.
-        Assert.IsLessThan(MaximumExecutionTime, stopwatch.Elapsed, testHostResult.ToString());
+        // Timing starts after the first disposal attempt, excluding process startup and JIT. Five seconds gives the
+        // configured 500ms finalization budget ample CI margin while remaining below the 10-second blocking duration.
+        Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
+    }
+
+    private static async Task WaitForFileAsync(string path, CancellationToken cancellationToken)
+    {
+        while (!File.Exists(path))
+        {
+            await Task.Delay(10, cancellationToken);
+        }
     }
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
@@ -147,8 +162,6 @@ public class Startup
 
 public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, IDisposable
 {
-    private static readonly TimeSpan BlockingOperationDuration = TimeSpan.FromMinutes(1);
-
     public string Uid => nameof(TestHostProcessLifetimeHandler);
 
     public string Version => string.Empty;
@@ -191,7 +204,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
 
         if (Environment.GetEnvironmentVariable("BLOCK_FINALIZATION") == "1")
         {
-            Thread.Sleep(BlockingOperationDuration);
+            Thread.Sleep(10000);
         }
 
         return Task.CompletedTask;
@@ -221,7 +234,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
 
         if (Environment.GetEnvironmentVariable("BLOCK_DISPOSAL") == "1")
         {
-            Thread.Sleep(BlockingOperationDuration);
+            Thread.Sleep(10000);
         }
     }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<TestHostProcessLifetimeHandlerTests.TestAssetFixture>
 {
     private const string AssetName = "TestHostProcessLifetimeHandler";
-    private static readonly TimeSpan RendezvousWaitTimeout = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan MaximumFinalizationTime = TimeSpan.FromSeconds(5);
 
     [DynamicData(nameof(TargetFrameworks.AllForDynamicData), typeof(TargetFrameworks))]
@@ -50,12 +49,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string finalizationStartedFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.started.txt");
         string disposalFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.disposed.txt");
-        string executionReadyFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.ready.txt");
-        string executionReleaseFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.release.txt");
-        using var rendezvousTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
-        rendezvousTimeout.CancelAfter(RendezvousWaitTimeout);
 
-        Task<TestHostResult> executionTask = testHost.ExecuteAsync(
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
             "--timeout 500ms",
             new()
             {
@@ -63,26 +58,18 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["BLOCK_FINALIZATION"] = "1",
                 ["FINALIZATION_STARTED_FILE"] = finalizationStartedFile,
                 ["DISPOSAL_FILE"] = disposalFile,
-                ["EXECUTION_READY_FILE"] = executionReadyFile,
-                ["EXECUTION_RELEASE_FILE"] = executionReleaseFile,
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: rendezvousTimeout.Token);
-
-        await WaitForFileAsync(executionReadyFile, rendezvousTimeout.Token);
-        rendezvousTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
-        var stopwatch = Stopwatch.StartNew();
-        File.WriteAllText(executionReleaseFile, string.Empty);
-        TestHostResult testHostResult = await executionTask;
+            cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.IsTrue(File.Exists(finalizationStartedFile), testHostResult.ToString());
         Assert.IsFalse(File.Exists(disposalFile), testHostResult.ToString());
 
-        // Timing starts before releasing execution to trigger the 500ms test-host timeout. Five seconds gives the
-        // combined test-host and finalization budgets ample CI margin while remaining below the 10-second blocker.
-        Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
+        // The child records a monotonic timestamp at callback entry, excluding process startup and JIT without a
+        // parent-observation race. Five seconds gives the 500ms budget ample margin but remains below the 10s blocker.
+        Assert.IsLessThan(MaximumFinalizationTime, GetElapsedTimeSince(finalizationStartedFile), testHostResult.ToString());
     }
 
     [DynamicData(nameof(TargetFrameworks.NetForDynamicData), typeof(TargetFrameworks))]
@@ -91,46 +78,29 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
     {
         var testHost = TestInfrastructure.TestHost.LocateFrom(AssetFixture.TargetAssetPath, AssetName, currentTfm);
         string disposalAttemptsFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.dispose-attempts.txt");
-        string executionReadyFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.ready.txt");
-        string executionReleaseFile = Path.Combine(testHost.DirectoryName, $"{Guid.NewGuid():N}.release.txt");
-        using var rendezvousTimeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationToken);
-        rendezvousTimeout.CancelAfter(RendezvousWaitTimeout);
 
-        Task<TestHostResult> executionTask = testHost.ExecuteAsync(
+        TestHostResult testHostResult = await testHost.ExecuteAsync(
             "--timeout 500ms",
             new()
             {
                 ["BLOCK_UNTIL_TIMEOUT"] = "1",
                 ["BLOCK_DISPOSAL"] = "1",
                 ["DISPOSAL_ATTEMPTS_FILE"] = disposalAttemptsFile,
-                ["EXECUTION_READY_FILE"] = executionReadyFile,
-                ["EXECUTION_RELEASE_FILE"] = executionReleaseFile,
                 ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
-            cancellationToken: rendezvousTimeout.Token);
-
-        await WaitForFileAsync(executionReadyFile, rendezvousTimeout.Token);
-        rendezvousTimeout.CancelAfter(Timeout.InfiniteTimeSpan);
-        var stopwatch = Stopwatch.StartNew();
-        File.WriteAllText(executionReleaseFile, string.Empty);
-        TestHostResult testHostResult = await executionTask;
+            cancellationToken: TestContext.CancellationToken);
 
         testHostResult.AssertExitCodeIs(ExitCode.TestHostProcessExitedNonGracefully);
         Assert.HasCount(1, File.ReadAllLines(disposalAttemptsFile), testHostResult.ToString());
 
-        // Timing starts before releasing execution to trigger the 500ms test-host timeout. Five seconds gives the
-        // combined test-host and finalization budgets ample CI margin while remaining below the 10-second blocker.
-        Assert.IsLessThan(MaximumFinalizationTime, stopwatch.Elapsed, testHostResult.ToString());
+        // The child records a monotonic timestamp at disposal entry, excluding process startup and JIT without a
+        // parent-observation race. Five seconds gives the 500ms budget ample margin but remains below the 10s blocker.
+        Assert.IsLessThan(MaximumFinalizationTime, GetElapsedTimeSince(disposalAttemptsFile), testHostResult.ToString());
     }
 
-    private static async Task WaitForFileAsync(string path, CancellationToken cancellationToken)
-    {
-        while (!File.Exists(path))
-        {
-            await Task.Delay(10, cancellationToken);
-        }
-    }
+    private static TimeSpan GetElapsedTimeSince(string timestampFile)
+        => Stopwatch.GetElapsedTime(long.Parse(File.ReadAllText(timestampFile), CultureInfo.InvariantCulture));
 
     public sealed class TestAssetFixture() : TestAssetFixtureBase()
     {
@@ -152,6 +122,8 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
 
 #file Program.cs
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Testing.Platform.Builder;
@@ -214,7 +186,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
 
         if (Environment.GetEnvironmentVariable("FINALIZATION_STARTED_FILE") is { Length: > 0 } finalizationStartedFile)
         {
-            System.IO.File.WriteAllText(finalizationStartedFile, string.Empty);
+            System.IO.File.WriteAllText(finalizationStartedFile, Stopwatch.GetTimestamp().ToString(CultureInfo.InvariantCulture));
         }
 
         if (Environment.GetEnvironmentVariable("BLOCK_FINALIZATION") == "1")
@@ -239,7 +211,7 @@ public class TestHostProcessLifetimeHandler : ITestHostProcessLifetimeHandler, I
     {
         if (Environment.GetEnvironmentVariable("DISPOSAL_ATTEMPTS_FILE") is { Length: > 0 } disposalAttemptsFile)
         {
-            System.IO.File.AppendAllText(disposalAttemptsFile, "Dispose" + Environment.NewLine);
+            System.IO.File.AppendAllText(disposalAttemptsFile, Stopwatch.GetTimestamp().ToString(CultureInfo.InvariantCulture) + Environment.NewLine);
         }
 
         if (Environment.GetEnvironmentVariable("DISPOSAL_FILE") is { Length: > 0 } disposalFile)
@@ -278,19 +250,6 @@ public class DummyTestFramework : ITestFramework, IDataProducer
     {
         if (Environment.GetEnvironmentVariable("BLOCK_UNTIL_TIMEOUT") == "1")
         {
-            if (Environment.GetEnvironmentVariable("EXECUTION_READY_FILE") is { Length: > 0 } readyFile)
-            {
-                System.IO.File.WriteAllText(readyFile, string.Empty);
-            }
-
-            if (Environment.GetEnvironmentVariable("EXECUTION_RELEASE_FILE") is { Length: > 0 } releaseFile)
-            {
-                while (!System.IO.File.Exists(releaseFile))
-                {
-                    Thread.Sleep(10);
-                }
-            }
-
             Thread.Sleep(2000);
         }
 


### PR DESCRIPTION
Hardcoded wall-clock ceilings made acceptance tests susceptible to loaded CI agents, while one attribute-precedence check raced against the exact configured timeout with no margin.

- Replace raw numeric ceilings with named `TimeSpan` limits and document their CI allowance.
- Record a monotonic timestamp in the generated child at finalization or disposal entry, so the parent measures only cleanup and teardown without process-startup overhead, polling, or observation races.
- Remove the redundant stopwatch assertion where the reported `1000ms` timeout already proves attribute precedence.
- Add contributor guidance for process-level timing assertions.

Validation: packed the repository and ran the affected MTP and MSTest acceptance classes, including the revised lifetime-handler tests across all targeted frameworks.

Fixes #10899