### PR TITLE
Stop repeated acceptance cache failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -434,11 +434,10 @@ stages:
         # XML-documentation-only PRs use it only for compiler and package validation. Debug remains
         # skippable for samples-only and XML-doc-only PRs.
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.infrastructureOnly'], 'true'), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
-        # A completely cold acceptance cache builds every generated fixture. Cold or pool-congested
-        # Release runs can spend more than 135 minutes in the test step after setup and still need
-        # time to finish the suite and publish diagnostics. Keep completion headroom without changing
-        # the test command's existing failure semantics.
-        timeoutInMinutes: 180
+        # A completely cold acceptance cache builds every generated fixture. Keep enough headroom
+        # for that bootstrap path while retaining a bounded timeout that still detects pathologically
+        # slow or hung agents. Warm PR runs remain substantially faster.
+        timeoutInMinutes: 150
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -435,9 +435,9 @@ stages:
         # skippable for samples-only and XML-doc-only PRs.
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.infrastructureOnly'], 'true'), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
         # A completely cold acceptance cache builds every generated fixture. Keep enough headroom
-        # for that bootstrap path while retaining a bounded timeout that still detects pathologically
-        # slow or hung agents. Warm PR runs remain substantially faster.
-        timeoutInMinutes: 150
+        # for that bootstrap path; warm PR runs remain substantially faster and the test command
+        # retains its existing failure semantics.
+        timeoutInMinutes: 120
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -435,10 +435,10 @@ stages:
         # skippable for samples-only and XML-doc-only PRs.
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.infrastructureOnly'], 'true'), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
         # A completely cold acceptance cache builds every generated fixture. Cold or pool-congested
-        # Release runs can spend about 105 minutes in the test step after setup and still need time
-        # to finish the suite and publish diagnostics. Keep completion headroom without changing the
-        # test command's existing failure semantics.
-        timeoutInMinutes: 150
+        # Release runs can spend more than 135 minutes in the test step after setup and still need
+        # time to finish the suite and publish diagnostics. Keep completion headroom without changing
+        # the test command's existing failure semantics.
+        timeoutInMinutes: 180
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -434,10 +434,11 @@ stages:
         # XML-documentation-only PRs use it only for compiler and package validation. Debug remains
         # skippable for samples-only and XML-doc-only PRs.
         condition: and(succeededOrFailed(), ne(dependencies.DetectChanges.outputs['detect.infrastructureOnly'], 'true'), or(eq(variables._BuildConfig, 'Release'), and(ne(dependencies.DetectChanges.outputs['detect.xmlDocsOnly'], 'true'), ne(dependencies.DetectChanges.outputs['detect.hasProductChanges'], 'false'))))
-        # A completely cold acceptance cache builds every generated fixture. Keep enough headroom
-        # for that bootstrap path; warm PR runs remain substantially faster and the test command
-        # retains its existing failure semantics.
-        timeoutInMinutes: 120
+        # A completely cold acceptance cache builds every generated fixture. Cold or pool-congested
+        # Release runs can spend about 105 minutes in the test step after setup and still need time
+        # to finish the suite and publish diagnostics. Keep completion headroom without changing the
+        # test command's existing failure semantics.
+        timeoutInMinutes: 150
         pool:
           name: NetCore-Public
           demands: ImageOverride -equals windows.vs2026preview.scout.amd64.open

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestAssetFixtureBaseTests.cs
@@ -103,6 +103,73 @@ public sealed class TestAssetFixtureBaseTests
         Assert.AreEqual(0, savedSeconds);
     }
 
+    [TestMethod]
+    public async Task AcceptanceCacheCircuitBreaker_SuccessfulProbeEnablesWaitingAttempts()
+    {
+        using TempDirectory cacheRoot = new();
+        using CircuitBreakerProxy firstCircuitBreaker = new(cacheRoot.Path);
+        using CircuitBreakerProxy secondCircuitBreaker = new(cacheRoot.Path);
+        using CacheLeaseProxy probe = await firstCircuitBreaker.EnterAsync();
+        Task<CacheLeaseProxy> waitingAttempt = secondCircuitBreaker.EnterAsync();
+
+        Assert.IsTrue(probe.ShouldUseCache);
+        Assert.IsFalse(waitingAttempt.IsCompleted);
+
+        probe.Complete(succeeded: true);
+
+        using CacheLeaseProxy attempt = await waitingAttempt;
+        Assert.IsTrue(attempt.ShouldUseCache);
+        attempt.Complete(succeeded: true);
+    }
+
+    [TestMethod]
+    public async Task AcceptanceCacheCircuitBreaker_FailedProbeDisablesWaitingAndFutureAttempts()
+    {
+        using TempDirectory cacheRoot = new();
+        using CircuitBreakerProxy firstCircuitBreaker = new(cacheRoot.Path);
+        using CircuitBreakerProxy secondCircuitBreaker = new(cacheRoot.Path);
+        using CacheLeaseProxy probe = await firstCircuitBreaker.EnterAsync();
+        Task<CacheLeaseProxy> waitingAttempt = secondCircuitBreaker.EnterAsync();
+
+        probe.Complete(succeeded: false);
+
+        using CacheLeaseProxy attempt = await waitingAttempt;
+        using CacheLeaseProxy laterAttempt = await firstCircuitBreaker.EnterAsync();
+        Assert.IsFalse(attempt.ShouldUseCache);
+        Assert.IsFalse(laterAttempt.ShouldUseCache);
+    }
+
+    [TestMethod]
+    public async Task AcceptanceCacheCircuitBreaker_FailureAfterProbeDisablesFutureAttempts()
+    {
+        using TempDirectory cacheRoot = new();
+        using CircuitBreakerProxy firstCircuitBreaker = new(cacheRoot.Path);
+        using CircuitBreakerProxy secondCircuitBreaker = new(cacheRoot.Path);
+        using CacheLeaseProxy probe = await firstCircuitBreaker.EnterAsync();
+        probe.Complete(succeeded: true);
+        using CacheLeaseProxy attempt = await secondCircuitBreaker.EnterAsync();
+
+        attempt.Complete(succeeded: false);
+
+        using CacheLeaseProxy laterAttempt = await firstCircuitBreaker.EnterAsync();
+        Assert.IsFalse(laterAttempt.ShouldUseCache);
+    }
+
+    [TestMethod]
+    public async Task AcceptanceCacheCircuitBreaker_AbandonedProbeDisablesWaitingAttempts()
+    {
+        using TempDirectory cacheRoot = new();
+        using CircuitBreakerProxy firstCircuitBreaker = new(cacheRoot.Path);
+        using CircuitBreakerProxy secondCircuitBreaker = new(cacheRoot.Path);
+        CacheLeaseProxy probe = await firstCircuitBreaker.EnterAsync();
+        Task<CacheLeaseProxy> waitingAttempt = secondCircuitBreaker.EnterAsync();
+
+        probe.Dispose();
+
+        using CacheLeaseProxy attempt = await waitingAttempt;
+        Assert.IsFalse(attempt.ShouldUseCache);
+    }
+
     private static bool TryReadCacheStatistics(
         IReadOnlyList<string> outputLines,
         out int hitCount,
@@ -138,5 +205,49 @@ public sealed class TestAssetFixtureBaseTests
         MethodInfo method = typeof(TestAssetFixtureBase).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException($"Could not find {nameof(TestAssetFixtureBase)}.{methodName}.");
         return (T)method.Invoke(null, arguments)!;
+    }
+
+    private sealed class CircuitBreakerProxy : IDisposable
+    {
+        private static readonly Type CircuitBreakerType = typeof(TestAssetFixtureBase).Assembly.GetType(
+            "Microsoft.Testing.TestInfrastructure.AcceptanceCacheCircuitBreaker",
+            throwOnError: true)!;
+
+        private static readonly MethodInfo EnterAsyncMethod = CircuitBreakerType.GetMethod("EnterAsync")!;
+
+        private readonly object _instance;
+
+        public CircuitBreakerProxy(string cacheRoot)
+            => _instance = Activator.CreateInstance(CircuitBreakerType, cacheRoot)!;
+
+        public async Task<CacheLeaseProxy> EnterAsync()
+        {
+            object resultTask = EnterAsyncMethod.Invoke(_instance, [CancellationToken.None])!;
+            await (Task)resultTask;
+            object lease = resultTask.GetType().GetProperty("Result")!.GetValue(resultTask)!;
+            return new CacheLeaseProxy(lease);
+        }
+
+        public void Dispose() => ((IDisposable)_instance).Dispose();
+    }
+
+    private sealed class CacheLeaseProxy : IDisposable
+    {
+        private readonly object _instance;
+        private readonly MethodInfo _completeMethod;
+
+        public CacheLeaseProxy(object instance)
+        {
+            _instance = instance;
+            Type leaseType = instance.GetType();
+            _completeMethod = leaseType.GetMethod("Complete")!;
+            ShouldUseCache = (bool)leaseType.GetProperty("ShouldUseCache")!.GetValue(instance)!;
+        }
+
+        public bool ShouldUseCache { get; }
+
+        public void Complete(bool succeeded) => _completeMethod.Invoke(_instance, [succeeded]);
+
+        public void Dispose() => ((IDisposable)_instance).Dispose();
     }
 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -587,6 +587,8 @@ internal sealed class AcceptanceCacheCircuitBreaker : IDisposable
     private const int Disabled = 2;
     private const int SharingViolationHResult = unchecked((int)0x80070020);
     private const int LockViolationHResult = unchecked((int)0x80070021);
+    private const int LinuxWouldBlockHResult = 11;
+    private const int MacOsWouldBlockHResult = 35;
 
     private readonly string _disabledMarkerPath;
     private readonly string _enabledMarkerPath;
@@ -630,7 +632,11 @@ internal sealed class AcceptanceCacheCircuitBreaker : IDisposable
 
                     break;
                 }
-                catch (IOException ex) when (ex.HResult is SharingViolationHResult or LockViolationHResult)
+                catch (IOException ex) when (ex.HResult is
+                    SharingViolationHResult
+                    or LockViolationHResult
+                    or LinuxWouldBlockHResult
+                    or MacOsWouldBlockHResult)
                 {
                     await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
                 }

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/TestAssetFixtureBase.cs
@@ -26,6 +26,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     private const string CacheRootEnvironmentVariable = "TESTFX_ACCEPTANCE_MSBUILD_CACHE_ROOT";
     private const string CacheLogRootEnvironmentVariable = "TESTFX_ACCEPTANCE_MSBUILD_CACHE_LOG_ROOT";
 
+    private static readonly ConcurrentDictionary<string, AcceptanceCacheCircuitBreaker> AcceptanceCacheCircuitBreakers = new(StringComparer.OrdinalIgnoreCase);
     private static int s_cacheBinlogCounter;
 
     private readonly ConcurrentDictionary<string /* asset ID */, TestAsset> _testAssets = new();
@@ -172,6 +173,23 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
                 cancellationToken: cancellationToken);
         }
 
+        AcceptanceCacheCircuitBreaker cacheCircuitBreaker = AcceptanceCacheCircuitBreakers.GetOrAdd(
+            cacheConfiguration.CacheRoot,
+            static cacheRoot => new AcceptanceCacheCircuitBreaker(cacheRoot));
+        using AcceptanceCacheLease cacheLease = await cacheCircuitBreaker.EnterAsync(cancellationToken);
+        if (!cacheLease.ShouldUseCache)
+        {
+            Console.WriteLine(
+                $"Skipping the cached {cacheVariant} build of acceptance asset '{testAsset.AssetId}' because an earlier "
+                + "acceptance MSBuild cache attempt failed; using dotnet build.");
+            return await DotnetCli.RunAsync(
+                dotnetBuildArguments,
+                failIfReturnValueIsNotZero: failIfReturnValueIsNotZero,
+                warnAsError: false,
+                callerMemberName: $"{binlogBaseFileName}_CacheBypass",
+                cancellationToken: cancellationToken);
+        }
+
         string projectPath = ResolveEntryProject(testAsset.TargetAssetPath, testAsset.AssetId);
         int cacheBuildId = Interlocked.Increment(ref s_cacheBinlogCounter);
         string binlogPath = Path.Combine(
@@ -224,6 +242,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
 
         if (exitCode == 0)
         {
+            cacheLease.Complete(succeeded: true);
             ReportCacheStatistics(
                 testAsset.AssetId,
                 cacheVariant,
@@ -259,6 +278,7 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
         // Cache authentication, transport, or plugin failures must not make acceptance validation less
         // reliable. Re-run through the established dotnet build path; a real source failure is then
         // reported exactly as it was before acceptance caching was enabled.
+        cacheLease.Complete(succeeded: false);
         Console.WriteLine(
             $"The cached {cacheVariant} build of acceptance asset '{testAsset.AssetId}' failed with exit code {exitCode}; "
             + $"falling back to dotnet build.{Environment.NewLine}"
@@ -558,4 +578,163 @@ public abstract class TestAssetFixtureBase : ITestAssetFixture
     }
 
     private sealed record CacheConfiguration(string Mode, string CacheRoot, string LogRoot, string AssetKey);
+}
+
+internal sealed class AcceptanceCacheCircuitBreaker : IDisposable
+{
+    private const int Unknown = 0;
+    private const int Enabled = 1;
+    private const int Disabled = 2;
+    private const int SharingViolationHResult = unchecked((int)0x80070020);
+    private const int LockViolationHResult = unchecked((int)0x80070021);
+
+    private readonly string _disabledMarkerPath;
+    private readonly string _enabledMarkerPath;
+    private readonly SemaphoreSlim _initialProbeLock = new(1, 1);
+    private readonly string _probeLockPath;
+    private int _state;
+
+    public AcceptanceCacheCircuitBreaker(string cacheRoot)
+    {
+        string stateDirectory = Path.Combine(cacheRoot, "CircuitBreaker");
+        Directory.CreateDirectory(stateDirectory);
+        _disabledMarkerPath = Path.Combine(stateDirectory, "disabled");
+        _enabledMarkerPath = Path.Combine(stateDirectory, "enabled");
+        _probeLockPath = Path.Combine(stateDirectory, "probe.lock");
+    }
+
+    public async Task<AcceptanceCacheLease> EnterAsync(CancellationToken cancellationToken)
+    {
+        int state = GetState();
+        if (state != Unknown)
+        {
+            return new AcceptanceCacheLease(this, shouldUseCache: state == Enabled);
+        }
+
+        await _initialProbeLock.WaitAsync(cancellationToken);
+        FileStream? probeLock = null;
+        bool ownsProbe = false;
+        try
+        {
+            while ((state = GetState()) == Unknown)
+            {
+                try
+                {
+                    probeLock = new FileStream(_probeLockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                    state = GetState();
+                    if (state == Unknown)
+                    {
+                        ownsProbe = true;
+                        return new AcceptanceCacheLease(this, probeLock);
+                    }
+
+                    break;
+                }
+                catch (IOException ex) when (ex.HResult is SharingViolationHResult or LockViolationHResult)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+                }
+            }
+        }
+        finally
+        {
+            if (!ownsProbe)
+            {
+                probeLock?.Dispose();
+                _initialProbeLock.Release();
+            }
+        }
+
+        return new AcceptanceCacheLease(this, shouldUseCache: state == Enabled);
+    }
+
+    internal void Complete(bool succeeded, FileStream? probeLock)
+    {
+        if (!succeeded)
+        {
+            Interlocked.Exchange(ref _state, Disabled);
+            CreateMarker(_disabledMarkerPath);
+        }
+        else if (probeLock is not null)
+        {
+            Volatile.Write(ref _state, Enabled);
+            CreateMarker(_enabledMarkerPath);
+        }
+
+        if (probeLock is not null)
+        {
+            probeLock.Dispose();
+            _initialProbeLock.Release();
+        }
+    }
+
+    private int GetState()
+    {
+        int state = Volatile.Read(ref _state);
+        if (state == Disabled || File.Exists(_disabledMarkerPath))
+        {
+            Volatile.Write(ref _state, Disabled);
+            return Disabled;
+        }
+
+        if (state == Enabled || File.Exists(_enabledMarkerPath))
+        {
+            Volatile.Write(ref _state, Enabled);
+            return Enabled;
+        }
+
+        return Unknown;
+    }
+
+    private static void CreateMarker(string path)
+    {
+        try
+        {
+            File.WriteAllText(path, string.Empty);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Console.WriteLine($"Could not persist acceptance MSBuild cache circuit-breaker state: {ex.Message}");
+        }
+    }
+
+    public void Dispose() => _initialProbeLock.Dispose();
+}
+
+internal sealed class AcceptanceCacheLease : IDisposable
+{
+    private readonly AcceptanceCacheCircuitBreaker _circuitBreaker;
+    private readonly FileStream? _probeLock;
+    private int _completed;
+
+    public AcceptanceCacheLease(AcceptanceCacheCircuitBreaker circuitBreaker, bool shouldUseCache)
+    {
+        _circuitBreaker = circuitBreaker;
+        ShouldUseCache = shouldUseCache;
+    }
+
+    public AcceptanceCacheLease(AcceptanceCacheCircuitBreaker circuitBreaker, FileStream probeLock)
+    {
+        _circuitBreaker = circuitBreaker;
+        _probeLock = probeLock;
+        ShouldUseCache = true;
+    }
+
+    public bool ShouldUseCache { get; }
+
+    public void Complete(bool succeeded)
+    {
+        if (Interlocked.Exchange(ref _completed, 1) == 0)
+        {
+            _circuitBreaker.Complete(succeeded, _probeLock);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (ShouldUseCache)
+        {
+            Complete(succeeded: false);
+        }
+    }
 }


### PR DESCRIPTION
Intermittent Azure Pipeline Cache authorization failures were making every generated acceptance fixture wait about five minutes before its normal fallback build. Those repeated delays caused unrelated tests to appear slow and eventually exhausted the Windows Release job timeout; increasing the timeout only masked the retry storm.

Add a cache-root-scoped circuit breaker shared across acceptance test processes. The first fixture probes the cache while other fixtures wait. If that probe fails, its diagnostics are preserved and all remaining fixtures bypass the cache and use the established `dotnet build` fallback immediately. Successful probes continue enabling normal concurrent cache use, while any later cache failure trips the breaker. The original 120-minute job timeout remains unchanged so genuine hangs stay visible. File-lock contention is recognized using the precise Windows sharing/lock HRESULTs and Unix `EWOULDBLOCK` errno values.

Validation:
- `build.cmd -pack` succeeds.
- All 26 `TestAssetFixtureBaseTests` pass.
- The four circuit-breaker tests passed in 20 consecutive runs (80/80).
- The first CI run confirmed both Windows jobs complete within the original timeout; its unrelated Linux failure exposed the Unix lock-contention mapping now covered by the same tests.