### PR TITLE
Fix retry launcher unit test race

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -1236,25 +1236,75 @@ public class RetryTests
             int pipeNameIndex = context.Arguments.ToList().IndexOf($"--{RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName}") + 1;
             var pipeClient = new NamedPipeClientStream(".", context.Arguments[pipeNameIndex], PipeDirection.InOut, PipeOptions.Asynchronous);
             await pipeClient.ConnectAsync(5_000, cancellationToken);
-            return new ConnectedTestHostHandle(pipeClient);
+            return new ConnectedTestHostHandle(pipeClient, new GetListOfFailedTestsRequestSerializer().Id);
         }
     }
 
-    private sealed class ConnectedTestHostHandle(NamedPipeClientStream pipeClient) : ITestHostHandle
+    private sealed class ConnectedTestHostHandle : ITestHostHandle
     {
+        private readonly NamedPipeClientStream _pipeClient;
+        private readonly Task _exitTask;
+        private readonly int _requestSerializerId;
+
+        public ConnectedTestHostHandle(NamedPipeClientStream pipeClient, int requestSerializerId)
+        {
+            _pipeClient = pipeClient;
+            _requestSerializerId = requestSerializerId;
+            _exitTask = CompleteRunAsync();
+        }
+
         public string Identifier => nameof(ConnectedTestHostHandle);
 
         public int ExitCode => 0;
 
-        public bool HasExited => true;
+        public bool HasExited => _exitTask.IsCompleted;
 
-        public Task WaitForExitAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task WaitForExitAsync(CancellationToken cancellationToken)
+            => _exitTask.WithCancellationAsync(cancellationToken);
 
         public void Terminate()
         {
         }
 
-        public void Dispose() => pipeClient.Dispose();
+        public void Dispose() => _pipeClient.Dispose();
+
+        private async Task CompleteRunAsync()
+        {
+            await Task.Yield();
+
+            // Complete a retry-protocol round trip before reporting exit so the server has accepted the connection.
+            byte[] request = new byte[2 * sizeof(int)];
+            BitConverter.GetBytes(sizeof(int)).CopyTo(request, 0);
+            BitConverter.GetBytes(_requestSerializerId).CopyTo(request, sizeof(int));
+            await _pipeClient.WriteAsync(request, 0, request.Length, CancellationToken.None);
+            await _pipeClient.FlushAsync(CancellationToken.None);
+
+            byte[] responseSizeBuffer = new byte[sizeof(int)];
+            await ReadExactlyAsync(responseSizeBuffer);
+            int responseSize = BitConverter.ToInt32(responseSizeBuffer, 0);
+            if (responseSize < sizeof(int))
+            {
+                throw new InvalidDataException($"Invalid retry pipe response size: {responseSize}.");
+            }
+
+            await ReadExactlyAsync(new byte[responseSize]);
+            _pipeClient.Dispose();
+        }
+
+        private async Task ReadExactlyAsync(byte[] buffer)
+        {
+            int bytesRead = 0;
+            while (bytesRead < buffer.Length)
+            {
+                int read = await _pipeClient.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead, CancellationToken.None);
+                if (read == 0)
+                {
+                    throw new EndOfStreamException("The retry pipe closed before the response was complete.");
+                }
+
+                bytesRead += read;
+            }
+        }
     }
 
     private sealed class AlreadyExitedTestHostLauncher(int exitCode) : ITestHostLauncher

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -1242,6 +1242,8 @@ public class RetryTests
 
     private sealed class ConnectedTestHostHandle : ITestHostHandle
     {
+        private static readonly TimeSpan RetryPipeRoundTripTimeout = TimeSpan.FromSeconds(30);
+
         private readonly NamedPipeClientStream _pipeClient;
         private readonly Task _exitTask;
         private readonly int _requestSerializerId;
@@ -1272,31 +1274,32 @@ public class RetryTests
         {
             await Task.Yield();
 
+            using var timeout = new CancellationTokenSource(RetryPipeRoundTripTimeout);
+
             // Complete a retry-protocol round trip before reporting exit so the server has accepted the connection.
             byte[] request = new byte[2 * sizeof(int)];
             BitConverter.GetBytes(sizeof(int)).CopyTo(request, 0);
             BitConverter.GetBytes(_requestSerializerId).CopyTo(request, sizeof(int));
-            await _pipeClient.WriteAsync(request, 0, request.Length, CancellationToken.None);
-            await _pipeClient.FlushAsync(CancellationToken.None);
+            await _pipeClient.WriteAsync(request, 0, request.Length, timeout.Token);
+            await _pipeClient.FlushAsync(timeout.Token);
 
             byte[] responseSizeBuffer = new byte[sizeof(int)];
-            await ReadExactlyAsync(responseSizeBuffer);
+            await ReadExactlyAsync(responseSizeBuffer, timeout.Token);
             int responseSize = BitConverter.ToInt32(responseSizeBuffer, 0);
             if (responseSize < sizeof(int))
             {
                 throw new InvalidDataException($"Invalid retry pipe response size: {responseSize}.");
             }
 
-            await ReadExactlyAsync(new byte[responseSize]);
-            _pipeClient.Dispose();
+            await ReadExactlyAsync(new byte[responseSize], timeout.Token);
         }
 
-        private async Task ReadExactlyAsync(byte[] buffer)
+        private async Task ReadExactlyAsync(byte[] buffer, CancellationToken cancellationToken)
         {
             int bytesRead = 0;
             while (bytesRead < buffer.Length)
             {
-                int read = await _pipeClient.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead, CancellationToken.None);
+                int read = await _pipeClient.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead, cancellationToken);
                 if (read == 0)
                 {
                     throw new EndOfStreamException("The retry pipe closed before the response was complete.");

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryTests.cs
@@ -1299,7 +1299,8 @@ public class RetryTests
             int bytesRead = 0;
             while (bytesRead < buffer.Length)
             {
-                int read = await _pipeClient.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead, cancellationToken);
+                int read = await _pipeClient.ReadAsync(buffer, bytesRead, buffer.Length - bytesRead, cancellationToken)
+                    .WithCancellationAsync(cancellationToken);
                 if (read == 0)
                 {
                     throw new EndOfStreamException("The retry pipe closed before the response was complete.");


### PR DESCRIPTION
## Summary

- keep the fake custom test host alive until it completes a retry-pipe request/response
- report the handle as exited only after the server has accepted and processed the connection
- preserve the `ExitedBeforeConnect` assertion and production failure handling

## Root cause

The test launcher connected its named-pipe client and immediately returned a handle with `HasExited == true` while the pipe was still open. On .NET Framework under CI thread-pool pressure, that synthetic exit could win before the server-side `WaitForConnectionAsync` callback ran; the existing one-second settling period then expired and produced `ExitedBeforeConnect == true` despite the client connection.

## Validation

- `Microsoft.Testing.Extensions.UnitTests.csproj` Debug build (all target frameworks)
- all 64 `RetryTests` on `net462`
- repeated launcher test runs on `net462`
- launcher test on `net472`, `net8.0`, and `net9.0`