### PR TITLE
Stabilize concurrent MTP client disposal test

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientInProcessTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientInProcessTests.cs
@@ -419,23 +419,34 @@ public sealed class MtpServerClientInProcessTests
     [TestMethod]
     public async Task Dispose_WhileShutdownAsyncIsInFlight_WaitsForTheSameTeardown()
     {
-        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var server = new InProcessServerFixture(onDisconnected: () => release.Task.GetAwaiter().GetResult());
+        using var release = new ManualResetEventSlim();
+        using var callbackBlocked = new ManualResetEventSlim();
+        using var disposeEntered = new ManualResetEventSlim();
+        using var disposeReturned = new ManualResetEventSlim();
+        using var server = new InProcessServerFixture(
+            onDisconnected: () =>
+            {
+                callbackBlocked.Set();
+                release.Wait(TestContext.CancellationToken);
+            },
+            waitForDisconnectSynchronously: true);
 
         MtpServerClient client = await LaunchAsync(server);
         _ = await WithTimeoutAsync(client.InitializeAsync(TestContext.CancellationToken));
 
         Task shutdown = client.ShutdownAsync();
+        Task? dispose = null;
         try
         {
+            Assert.IsTrue(
+                callbackBlocked.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken),
+                "The callback must be blocked before testing the concurrent Dispose.");
             Assert.IsFalse(shutdown.IsCompleted, "ShutdownAsync must remain incomplete while the callback is blocked.");
 
             // A Dispose that races an in-flight ShutdownAsync must join it, not report success while the
             // application is still stopping. Keep the probe off the thread pool: under net462 contention an
             // awaited probe can resume only after the bounded teardown abandons the callback.
-            using var disposeEntered = new ManualResetEventSlim();
-            using var disposeReturned = new ManualResetEventSlim();
-            Task dispose = Task.Factory.StartNew(
+            dispose = Task.Factory.StartNew(
                 () =>
                 {
                     disposeEntered.Set();
@@ -452,17 +463,18 @@ public sealed class MtpServerClientInProcessTests
             Assert.IsFalse(
                 disposeReturned.Wait(TimeSpan.FromMilliseconds(100), TestContext.CancellationToken),
                 "Dispose must not return while the shared teardown is still running.");
-
-            _ = release.TrySetResult(true);
-
-            await WithTimeoutAsync(shutdown);
-            await WithTimeoutAsync(dispose);
-            Assert.AreEqual(1, server.CompletionCount, "Both entry points must share one teardown.");
         }
         finally
         {
-            _ = release.TrySetResult(true);
+            release.Set();
+            await WithTimeoutAsync(shutdown);
+            if (dispose is not null)
+            {
+                await WithTimeoutAsync(dispose);
+            }
         }
+
+        Assert.AreEqual(1, server.CompletionCount, "Both entry points must share one teardown.");
     }
 
     [TestMethod]
@@ -839,6 +851,7 @@ public sealed class MtpServerClientInProcessTests
     {
         private readonly Action? _onDisconnected;
         private readonly int _exitCode;
+        private readonly bool _waitForDisconnectSynchronously;
         private readonly TaskCompletionSource<int> _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<FakeMtpServer> _connected = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly StringBuilder _log = new();
@@ -848,10 +861,14 @@ public sealed class MtpServerClientInProcessTests
         private int _completionCount;
         private int _transportClosedCount;
 
-        public InProcessServerFixture(Action? onDisconnected = null, int exitCode = 0)
+        public InProcessServerFixture(
+            Action? onDisconnected = null,
+            int exitCode = 0,
+            bool waitForDisconnectSynchronously = false)
         {
             _onDisconnected = onDisconnected;
             _exitCode = exitCode;
+            _waitForDisconnectSynchronously = waitForDisconnectSynchronously;
         }
 
         /// <summary>Gets the argument array the client generated for the callback (empty before it ran).</summary>
@@ -915,7 +932,17 @@ public sealed class MtpServerClientInProcessTests
             {
                 // A real server-mode application runs until its session ends, which is what closing the
                 // client's end of the transport produces.
-                await server.Disconnected.ConfigureAwait(false);
+                if (_waitForDisconnectSynchronously)
+                {
+                    // This test-only path keeps the post-disconnect callback on the host's dedicated invocation
+                    // instead of depending on a thread-pool continuation while testing thread-pool contention.
+                    server.Disconnected.GetAwaiter().GetResult();
+                }
+                else
+                {
+                    await server.Disconnected.ConfigureAwait(false);
+                }
+
                 _ = Interlocked.Increment(ref _transportClosedCount);
                 _onDisconnected?.Invoke();
                 _ = Interlocked.Increment(ref _completionCount);

--- a/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientInProcessTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientInProcessTests.cs
@@ -420,12 +420,7 @@ public sealed class MtpServerClientInProcessTests
     public async Task Dispose_WhileShutdownAsyncIsInFlight_WaitsForTheSameTeardown()
     {
         var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var callbackBlocked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var server = new InProcessServerFixture(onDisconnected: () =>
-        {
-            callbackBlocked.TrySetResult(true);
-            release.Task.GetAwaiter().GetResult();
-        });
+        using var server = new InProcessServerFixture(onDisconnected: () => release.Task.GetAwaiter().GetResult());
 
         MtpServerClient client = await LaunchAsync(server);
         _ = await WithTimeoutAsync(client.InitializeAsync(TestContext.CancellationToken));
@@ -433,27 +428,30 @@ public sealed class MtpServerClientInProcessTests
         Task shutdown = client.ShutdownAsync();
         try
         {
-            await WithTimeoutAsync(callbackBlocked.Task);
             Assert.IsFalse(shutdown.IsCompleted, "ShutdownAsync must remain incomplete while the callback is blocked.");
 
             // A Dispose that races an in-flight ShutdownAsync must join it, not report success while the
-            // application is still stopping.
-            var disposeEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var dispose = Task.Run(
+            // application is still stopping. Keep the probe off the thread pool: under net462 contention an
+            // awaited probe can resume only after the bounded teardown abandons the callback.
+            using var disposeEntered = new ManualResetEventSlim();
+            using var disposeReturned = new ManualResetEventSlim();
+            Task dispose = Task.Factory.StartNew(
                 () =>
                 {
-                    disposeEntered.TrySetResult(true);
+                    disposeEntered.Set();
                     client.Dispose();
+                    disposeReturned.Set();
                 },
-                TestContext.CancellationToken);
-            await WithTimeoutAsync(disposeEntered.Task);
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
 
-            for (int attempt = 0; attempt < 10 && !dispose.IsCompleted; attempt++)
-            {
-                _ = await Task.WhenAny(dispose, Task.Delay(10, TestContext.CancellationToken));
-            }
-
-            Assert.IsFalse(dispose.IsCompleted, "Dispose must not return while the shared teardown is still running.");
+            Assert.IsTrue(
+                disposeEntered.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken),
+                "The dedicated Dispose thread must start.");
+            Assert.IsFalse(
+                disposeReturned.Wait(TimeSpan.FromMilliseconds(100), TestContext.CancellationToken),
+                "Dispose must not return while the shared teardown is still running.");
 
             _ = release.TrySetResult(true);
 


### PR DESCRIPTION
The net462 test could exhaust the in-process host's bounded teardown window while its assertion continuation waited for a contended thread pool, causing a false failure.

Run the concurrent `Dispose` probe on a dedicated thread and coordinate it with synchronous rendezvous signals so the test verifies shared teardown behavior independently of thread-pool scheduling.