### PR TITLE
Update MSTest 4.4 and Platform 2.4 changelogs

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -60,6 +60,7 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Label Azure DevOps retry sub-results as `Attempt# <n> - <test>` and upload each retry attempt's artifacts to the sub-result that produced them, by @Evangelink in [#10704](https://github.com/microsoft/testfx/pull/10704) and [#10723](https://github.com/microsoft/testfx/pull/10723)
 * Harden server-mode JSON-RPC lifecycle and error handling, add independent protocol-version negotiation, align the System.Text.Json and Jsonite serializers, and publish a versioned JSON Schema, by @Evangelink in [#10779](https://github.com/microsoft/testfx/pull/10779)
 * Use controller-backed TRX recovery by default whenever the platform supports a test-host controller, while retaining the in-process compatibility path on browser, WASI, iOS and tvOS, by @Evangelink in [#10808](https://github.com/microsoft/testfx/pull/10808)
+* Include concise descriptions for known non-success Microsoft.Testing.Platform exit codes in run and discovery summaries, by @Evangelink in [#10882](https://github.com/microsoft/testfx/pull/10882)
 
 ### Fixed
 
@@ -91,6 +92,8 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Publish each Azure DevOps retry sub-result exactly once and retain stable attachment targets across retry processes, by @Evangelink in [#10795](https://github.com/microsoft/testfx/pull/10795)
 * Publish superseded in-process MSTest retry attempts to Azure DevOps as ordered rerun sub-results with their durations and attachments, by @Evangelink in [#10845](https://github.com/microsoft/testfx/pull/10845)
 * Authorize TRX, HangDump and Retry extension pipes for sandboxed test-host identities supplied by a custom launcher, by @Evangelink in [#10842](https://github.com/microsoft/testfx/pull/10842)
+* Recover partial HTML, JUnit and CTRF reports after an abnormal test-host termination on platforms with a test-host controller, by @Evangelink in [#10894](https://github.com/microsoft/testfx/pull/10894)
+* Use wall-clock elapsed time instead of the sum of individual test durations for HTML report summaries, so parallel test runs report an accurate duration, by @Evangelink in [#10944](https://github.com/microsoft/testfx/pull/10944)
 
 ## <a name="2.3.3" />[2.3.3] - 2026-07-28
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -31,6 +31,7 @@ See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4
 * Emit OpenTelemetry spans for MSTest tests and fixture methods as part of the expanded testing semantic conventions by @Evangelink in [#10358](https://github.com/microsoft/testfx/pull/10358)
 * Add MSTEST0082 to detect lifecycle and test members inherited from a base class compiled against a different major MSTest framework version, where the assembly rename between v3 and v4 would otherwise make those members silently undiscoverable, by @nohwnd and @Evangelink in [#10508](https://github.com/microsoft/testfx/pull/10508) and [#10637](https://github.com/microsoft/testfx/pull/10637)
 * Add MSTEST0083 and a code fix to replace executable-file guards before matching `Process.Start` calls with `[ExecutableCondition]`, by @Evangelink in [#10634](https://github.com/microsoft/testfx/pull/10634)
+* Add exhaustive combinatorial test data through `CombinatorialData`, with explicit, inferred, range and random parameter-value providers, by @AArnott in [#10896](https://github.com/microsoft/testfx/pull/10896)
 
 ### Changed
 
@@ -1285,7 +1286,7 @@ See full log [of v3.6.0...v3.6.1](https://github.com/microsoft/testfx/compare/v3
 * Microsoft.Testing.Extensions.Retry: [1.4.1](https://www.nuget.org/packages/Microsoft.Testing.Extensions.Retry/1.4.1)
 * Microsoft.Testing.Extensions.TrxReport: [1.4.1](https://www.nuget.org/packages/Microsoft.Testing.Extensions.TrxReport/1.4.1)
 
-## <a name="3.6.1" />[3.6.0] - 2024-09-11
+## <a name="3.6.0" />[3.6.0] - 2024-09-11
 
 See full log [of v3.5.2...v3.6.0](https://github.com/microsoft/testfx/compare/v3.5.2...v3.6.0)
 

--- a/eng/generate-changelog-release.ps1
+++ b/eng/generate-changelog-release.ps1
@@ -142,7 +142,7 @@ $($issues.fix.text -join "`n")
 Testing Platform Version: $PlatformVersion
 -------------------------------
 
-See the release notes [here](https://github.com/microsoft/testfx/blob/main/docs/Changelog-TestingPlatform.md#$PlatformVersion).
+See the release notes [here](https://github.com/microsoft/testfx/blob/main/docs/Changelog-Platform.md#$PlatformVersion).
 
 -------------------------------
 


### PR DESCRIPTION
The unreleased MSTest 4.4 and Microsoft.Testing.Platform 2.4 changelogs were missing several user-visible changes merged after the last full refresh.

This adds the missing combinatorial data, exit-code summary, crash-resilient report, and HTML duration entries. It also fixes the duplicate 3.6.0 anchor and updates the release-note generator to link to the current Platform changelog filename.