### PR TITLE
Bump CodeCoverage to 18.11.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup Label="MSTest prod dependencies - darc updated">
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26451.4</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftTestingExtensionsCodeCoverageVersion>18.11.0-preview.26451.4</MicrosoftTestingExtensionsCodeCoverageVersion>
+    <MicrosoftTestingExtensionsCodeCoverageVersion>18.11.0</MicrosoftTestingExtensionsCodeCoverageVersion>
     <!-- empty line to avoid merge conflicts for darc PRs to update CC and MSTest+MTP -->
     <MSTestVersion>4.4.0-preview.26451.11</MSTestVersion>
     <MicrosoftTestingPlatformVersion>2.4.0-preview.26451.10</MicrosoftTestingPlatformVersion>


### PR DESCRIPTION
Updates `Microsoft.Testing.Extensions.CodeCoverage` from `18.11.0-preview.26451.4` to the stable `18.11.0` release.