### PR TITLE
Fix timing-sensitive platform tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -716,6 +716,7 @@ public sealed class AsynchronousMessageBusTests
     }
 
     [TestMethod]
+    [DoNotParallelize]
     public async Task DisableAsync_WithManyCanceledConsumersIgnoringTheToken_ShouldNotMultiplyTheBudget()
     {
         using CTRLPlusCCancellationTokenSource cancellationTokenSource = new();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterTests.cs
@@ -897,11 +897,11 @@ public sealed class TerminalTestReporterTests
     }
 
     [TestMethod]
-    public void TestProgressStateAwareTerminal_RenderFailure_LogsAndSuppressesLoggerFailure()
+    public async Task TestProgressStateAwareTerminal_RenderFailure_LogsAndSuppressesLoggerFailure()
     {
         var terminal = new RecordingTerminal();
         var renderer = new ThrowingProgressRenderer();
-        using var logAttempted = new ManualResetEventSlim();
+        var logAttempted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         Mock<ILogger> logger = new();
         logger
             .Setup(x => x.Log(LogLevel.Debug, It.IsAny<string>(), null, LoggingExtensions.Formatter))
@@ -909,14 +909,15 @@ public sealed class TerminalTestReporterTests
                 (_, message, _, _) =>
                 {
                     Assert.Contains(nameof(InvalidOperationException), message);
-                    logAttempted.Set();
+                    logAttempted.TrySetResult(true);
                 })
             .Throws(new IOException("Logging failed."));
         using var progressAwareTerminal = new TestProgressStateAwareTerminal(terminal, () => true, renderer, logger.Object);
 
         progressAwareTerminal.StartShowingProgress(workerCount: 1);
 
-        Assert.IsTrue(logAttempted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken), "Expected the render failure to be logged.");
+        Task completedTask = await Task.WhenAny(logAttempted.Task, Task.Delay(TimeSpan.FromSeconds(5), TestContext.CancellationToken));
+        Assert.AreSame(logAttempted.Task, completedTask, "Expected the render failure to be logged.");
         progressAwareTerminal.StopShowingProgress();
         Assert.Contains("EraseProgress", terminal.Events);
     }


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Windows Release build 1579346 exposed two timing-sensitive tests during a ThreadPool-starvation window. This change removes the test-side scheduling hazards without changing production behavior.

- Run the message-bus wall-clock budget test without parallel test contention, preserving its strict regression threshold.
- Replace the terminal logger test's blocking wait with an asynchronous completion signal so it does not occupy a ThreadPool worker while waiting for queued logging work.

Validation: the full Microsoft.Testing.Platform.UnitTests net8.0 suite passed four consecutive runs with 32-worker method-level parallelism.

Related pipeline: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1579346&view=results