### PR TITLE
Split report generator journal logic into a partial class

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/Microsoft.Testing.Extensions.CtrfReport.csproj
@@ -59,6 +59,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportFileNameSanitizer.cs" Link="Helpers\ReportFileNameSanitizer.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.Journal.cs" Link="Helpers\ReportGeneratorBase.Journal.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/Microsoft.Testing.Extensions.HtmlReport.csproj
@@ -61,6 +61,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ArtifactPostProcessingHelper.cs" Link="Helpers\ArtifactPostProcessingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.Journal.cs" Link="Helpers\ReportGeneratorBase.Journal.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/Microsoft.Testing.Extensions.JUnitReport.csproj
@@ -59,6 +59,7 @@ $(CommonProductDescription)]]></PackageDescription>
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ArtifactPostProcessingHelper.cs" Link="Helpers\ArtifactPostProcessingHelper.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportEngineBase.cs" Link="Helpers\ReportEngineBase.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.cs" Link="Helpers\ReportGeneratorBase.cs" />
+    <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorBase.Journal.cs" Link="Helpers\ReportGeneratorBase.Journal.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportProviderRegistration.cs" Link="Helpers\ReportProviderRegistration.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportRecovery.cs" Link="Helpers\ReportRecovery.cs" />
     <Compile Include="$(RepoRoot)src\Platform\SharedExtensionHelpers\ReportGeneratorCommandLineBase.cs" Link="Helpers\ReportGeneratorCommandLineBase.cs" />

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.Journal.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.Journal.cs
@@ -1,0 +1,367 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+
+namespace Microsoft.Testing.Extensions;
+
+#pragma warning disable RS0051 // Reporter lifecycle internals are shared-source implementation detail, not package API.
+#pragma warning disable CA1416 // BlockingCollection is unreachable on single-threaded browser/WASI runtimes.
+
+internal abstract partial class ReportGeneratorBase<TGenerator, TCapturedTestResult>
+    where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
+    where TCapturedTestResult : class
+{
+    private const int JournalBatchSize = 64;
+    private const int JournalCompletionReserveBytes = 64 * 1024;
+    private const int JournalFlushIntervalMilliseconds = 500;
+    private const int JournalQueueCapacity = 4096;
+    private static readonly TimeSpan JournalShutdownTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly string? _journalPath;
+
+    private IFileStream? _journalStream;
+    private BlockingCollection<ReportJournalRecord<TCapturedTestResult>>? _journalQueue;
+    private Task? _journalWriterTask;
+    private volatile bool _journalFailed;
+    private volatile bool _journalBudgetExceeded;
+    private volatile bool _journalCompletionTimedOut;
+    private volatile bool _writeCompletionRecord;
+    private string? _completedReportFileName;
+    private long _journalBytesWritten;
+    private int _journalRecordsWritten;
+    private int _droppedJournalRecords;
+    private bool _disposed;
+
+    internal async Task<(string FileName, string? Warning)> GenerateRecoveredReportAsync(
+        ReportJournalReadResult<TCapturedTestResult> journal,
+        int exitCode,
+        CancellationToken cancellationToken)
+    {
+        foreach (ReportJournalParentEntry parent in journal.Parents)
+        {
+            RestoreParentEntry(parent);
+        }
+
+        return await GenerateReportAsync(
+            [.. journal.Results],
+            journal.Metadata.StartTime,
+            exitCode,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private void StartJournalWriter()
+    {
+#pragma warning disable IDE0028 // Explicit ConcurrentQueue documents FIFO ordering.
+        _journalQueue = new(new ConcurrentQueue<ReportJournalRecord<TCapturedTestResult>>(), JournalQueueCapacity);
+#pragma warning restore IDE0028
+        _journalWriterTask = _task.RunLongRunning(WriteJournalLoopAsync, $"{DisplayName} recovery journal writer", CancellationToken.None);
+    }
+
+    private void EnqueueJournalRecord(
+        ReportJournalRecord<TCapturedTestResult> record,
+        bool inlineAlreadyWritten = false)
+    {
+        if (inlineAlreadyWritten || _journalFailed)
+        {
+            return;
+        }
+
+        if (_journalBudgetExceeded)
+        {
+            RecordDroppedJournalRecords(1, "its configured size or record limit was reached");
+            return;
+        }
+
+        if (_journalQueue is null)
+        {
+            TryWriteJournalBatch([record]);
+            return;
+        }
+
+        try
+        {
+            if (_journalQueue.IsAddingCompleted || !_journalQueue.TryAdd(record))
+            {
+                RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
+        }
+        catch (InvalidOperationException)
+        {
+            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
+        }
+    }
+
+    private void RecordDroppedJournalRecords(int count, string reason)
+    {
+        if (Interlocked.Add(ref _droppedJournalRecords, count) == count)
+        {
+            _logger.LogWarning(
+                $"Report recovery journal '{_journalPath}' dropped records because {reason}. Normal report generation is unaffected; crash recovery may be partial.");
+        }
+    }
+
+    private async Task WriteJournalLoopAsync()
+    {
+        ApplicationStateGuard.Ensure(_journalQueue is not null);
+        var batch = new List<ReportJournalRecord<TCapturedTestResult>>(JournalBatchSize);
+        try
+        {
+            while (!_journalQueue.IsCompleted)
+            {
+                if (!_journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? first, JournalFlushIntervalMilliseconds))
+                {
+                    continue;
+                }
+
+                batch.Add(first);
+                while (batch.Count < JournalBatchSize
+                    && _journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? next))
+                {
+                    batch.Add(next);
+                }
+
+                await WriteJournalBatchAsync(batch).ConfigureAwait(false);
+                batch.Clear();
+            }
+
+            if (_writeCompletionRecord)
+            {
+                ApplicationStateGuard.Ensure(_completedReportFileName is not null);
+                await WriteJournalBatchAsync(
+                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
+                        _completedReportFileName,
+                        Volatile.Read(ref _droppedJournalRecords))],
+                    isCompletion: true).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _journalFailed = true;
+            int dropped = batch.Count + DrainJournalQueue();
+            Interlocked.Add(ref _droppedJournalRecords, dropped);
+            await LogJournalFailureAsync(ex).ConfigureAwait(false);
+        }
+        finally
+        {
+            DisposeJournalStream();
+        }
+    }
+
+    private void TryWriteJournalBatch(
+        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
+        bool isCompletion = false)
+    {
+        try
+        {
+            WriteJournalBatchAsync(records, isCompletion).GetAwaiter().GetResult();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _journalFailed = true;
+            _ = LogJournalFailureAsync(ex);
+            DisposeJournalStream();
+        }
+    }
+
+    private async Task WriteJournalBatchAsync(
+        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
+        bool isCompletion = false)
+    {
+        _journalStream ??= FileSystem.NewFileStream(
+            _journalPath!,
+            FileMode.Append,
+            FileAccess.Write,
+            FileShare.ReadWrite);
+
+        var batch = new StringBuilder();
+        int accepted = 0;
+        long maxBytes = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalBytes
+            - (isCompletion ? 0 : JournalCompletionReserveBytes);
+        int maxRecords = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordCount
+            - (isCompletion ? 0 : 1);
+        foreach (ReportJournalRecord<TCapturedTestResult> record in records)
+        {
+            string serializedRecord = SerializeJournalRecord(record);
+            int recordBytes = Encoding.UTF8.GetByteCount(serializedRecord) + 1;
+            if (recordBytes > ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordBytes
+                || _journalBytesWritten + recordBytes > maxBytes
+                || _journalRecordsWritten >= maxRecords)
+            {
+                _journalBudgetExceeded = true;
+                RecordDroppedJournalRecords(records.Count - accepted, "its configured size or record limit was reached");
+                break;
+            }
+
+            batch.Append(serializedRecord).Append('\n');
+            _journalBytesWritten += recordBytes;
+            _journalRecordsWritten++;
+            accepted++;
+        }
+
+        if (batch.Length == 0)
+        {
+            return;
+        }
+
+        byte[] bytes = Encoding.UTF8.GetBytes(batch.ToString());
+#if NETCOREAPP
+        await _journalStream.Stream.WriteAsync(bytes.AsMemory(), CancellationToken.None).ConfigureAwait(false);
+#else
+        await _journalStream.Stream.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None).ConfigureAwait(false);
+#endif
+        await _journalStream.Stream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private async Task CompleteJournalAsync(
+        bool writeCompletionRecord,
+        string? reportFileName,
+        CancellationToken cancellationToken)
+    {
+        if (_journalPath is null || _journalCompletionTimedOut)
+        {
+            return;
+        }
+
+        if (_journalQueue is null)
+        {
+            if (writeCompletionRecord && !_journalFailed)
+            {
+                ApplicationStateGuard.Ensure(reportFileName is not null);
+                TryWriteJournalBatch(
+                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
+                        reportFileName,
+                        Volatile.Read(ref _droppedJournalRecords))],
+                    isCompletion: true);
+            }
+
+            DisposeJournalStream();
+            return;
+        }
+
+        if (!_journalQueue.IsAddingCompleted)
+        {
+            _writeCompletionRecord = writeCompletionRecord;
+            _completedReportFileName = reportFileName;
+            _journalQueue.CompleteAdding();
+        }
+
+        if (_journalWriterTask is not null)
+        {
+            Task timeout = _task.Delay(JournalShutdownTimeout, cancellationToken);
+            Task completed = await Task.WhenAny(_journalWriterTask, timeout).ConfigureAwait(false);
+            if (completed != _journalWriterTask)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _journalCompletionTimedOut = true;
+                await _logger.LogWarningAsync(
+                    $"Report recovery journal '{_journalPath}' writer did not drain within the hang timeout. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
+                return;
+            }
+
+            await _journalWriterTask.ConfigureAwait(false);
+        }
+
+        int dropped = Volatile.Read(ref _droppedJournalRecords);
+        if (dropped > 0)
+        {
+            await _logger.LogWarningAsync(
+                $"Report recovery journal '{_journalPath}' dropped {dropped} record(s) because its bounded writer queue was full or unavailable, or its safety limits were reached. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
+        }
+    }
+
+    private int DrainJournalQueue()
+    {
+        if (_journalQueue is null)
+        {
+            return 0;
+        }
+
+        if (!_journalQueue.IsAddingCompleted)
+        {
+            _journalQueue.CompleteAdding();
+        }
+
+        int count = 0;
+        while (_journalQueue.TryTake(out _))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private Task LogJournalFailureAsync(Exception exception)
+        => _logger.LogWarningAsync(
+            $"Report recovery journal '{_journalPath}' could not be written. The report will still be generated in process, but it might not be recoverable after a crash. Reason: {exception.Message}");
+
+    private void DisposeJournalStream()
+    {
+        IFileStream? stream = Interlocked.Exchange(ref _journalStream, null);
+        try
+        {
+            stream?.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug($"Failed to close report recovery journal '{_journalPath}': {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_journalQueue is not null)
+        {
+            if (!_journalQueue.IsAddingCompleted)
+            {
+                _journalQueue.CompleteAdding();
+            }
+
+            if (_journalCompletionTimedOut)
+            {
+                _disposed = true;
+                return;
+            }
+
+            try
+            {
+                if (_journalWriterTask is not null
+                    && !_journalWriterTask.Wait(JournalShutdownTimeout))
+                {
+                    _journalCompletionTimedOut = true;
+                    _logger.LogWarning(
+                        $"Report recovery journal '{_journalPath}' writer did not stop within the hang timeout during disposal. The writer will be abandoned until process exit.");
+                    _disposed = true;
+                    return;
+                }
+
+                _journalWriterTask?.GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug($"Failed to drain report recovery journal '{_journalPath}' during disposal: {ex.Message}");
+            }
+
+            _journalQueue.Dispose();
+        }
+        else
+        {
+            DisposeJournalStream();
+        }
+
+        _disposed = true;
+    }
+}
+
+#pragma warning restore RS0051
+#pragma warning restore CA1416

--- a/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
+++ b/src/Platform/SharedExtensionHelpers/ReportGeneratorBase.cs
@@ -17,9 +17,8 @@ using Microsoft.Testing.Platform.Services;
 namespace Microsoft.Testing.Extensions;
 
 #pragma warning disable RS0051 // Reporter lifecycle internals are shared-source implementation detail, not package API.
-#pragma warning disable CA1416 // BlockingCollection is unreachable on single-threaded browser/WASI runtimes.
 
-internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
+internal abstract partial class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     IDataConsumer,
     ITestSessionLifetimeHandler,
     IDataProducer,
@@ -28,12 +27,6 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     where TGenerator : ReportGeneratorBase<TGenerator, TCapturedTestResult>
     where TCapturedTestResult : class
 {
-    private const int JournalBatchSize = 64;
-    private const int JournalCompletionReserveBytes = 64 * 1024;
-    private const int JournalFlushIntervalMilliseconds = 500;
-    private const int JournalQueueCapacity = 4096;
-    private static readonly TimeSpan JournalShutdownTimeout = TimeSpan.FromSeconds(30);
-
     // MTP guarantees that ConsumeAsync is called sequentially (never concurrently)
     // for a given consumer instance, so List<T> is safe here without locking.
     private readonly List<TCapturedTestResult> _tests = [];
@@ -43,23 +36,10 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     private readonly ILogger<TGenerator> _logger;
     private readonly ITask _task;
     private readonly bool _isEnabled;
-    private readonly string? _journalPath;
     private readonly int? _recoveredProcessId;
     private readonly bool _isRecoveredReportIncomplete;
 
     private DateTimeOffset? _testStartTime;
-    private IFileStream? _journalStream;
-    private BlockingCollection<ReportJournalRecord<TCapturedTestResult>>? _journalQueue;
-    private Task? _journalWriterTask;
-    private volatile bool _journalFailed;
-    private volatile bool _journalBudgetExceeded;
-    private volatile bool _journalCompletionTimedOut;
-    private volatile bool _writeCompletionRecord;
-    private string? _completedReportFileName;
-    private long _journalBytesWritten;
-    private int _journalRecordsWritten;
-    private int _droppedJournalRecords;
-    private bool _disposed;
 
     protected ReportGeneratorBase(IServiceProvider serviceProvider, string optionName)
         : this(serviceProvider, optionName, journalEnvironmentVariableName: string.Empty)
@@ -347,339 +327,11 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
     {
     }
 
-    internal async Task<(string FileName, string? Warning)> GenerateRecoveredReportAsync(
-        ReportJournalReadResult<TCapturedTestResult> journal,
-        int exitCode,
-        CancellationToken cancellationToken)
-    {
-        foreach (ReportJournalParentEntry parent in journal.Parents)
-        {
-            RestoreParentEntry(parent);
-        }
-
-        return await GenerateReportAsync(
-            [.. journal.Results],
-            journal.Metadata.StartTime,
-            exitCode,
-            cancellationToken).ConfigureAwait(false);
-    }
-
     internal string RecoveredArtifactDisplayName => ArtifactDisplayName;
 
     internal string RecoveredArtifactDescription => ArtifactDescription;
 
     internal string? RecoveredArtifactKind => ArtifactKind;
-
-    private void StartJournalWriter()
-    {
-#pragma warning disable IDE0028 // Explicit ConcurrentQueue documents FIFO ordering.
-        _journalQueue = new(new ConcurrentQueue<ReportJournalRecord<TCapturedTestResult>>(), JournalQueueCapacity);
-#pragma warning restore IDE0028
-        _journalWriterTask = _task.RunLongRunning(WriteJournalLoopAsync, $"{DisplayName} recovery journal writer", CancellationToken.None);
-    }
-
-    private void EnqueueJournalRecord(
-        ReportJournalRecord<TCapturedTestResult> record,
-        bool inlineAlreadyWritten = false)
-    {
-        if (inlineAlreadyWritten || _journalFailed)
-        {
-            return;
-        }
-
-        if (_journalBudgetExceeded)
-        {
-            RecordDroppedJournalRecords(1, "its configured size or record limit was reached");
-            return;
-        }
-
-        if (_journalQueue is null)
-        {
-            TryWriteJournalBatch([record]);
-            return;
-        }
-
-        try
-        {
-            if (_journalQueue.IsAddingCompleted || !_journalQueue.TryAdd(record))
-            {
-                RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
-            }
-        }
-        catch (ObjectDisposedException)
-        {
-            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
-        }
-        catch (InvalidOperationException)
-        {
-            RecordDroppedJournalRecords(1, "its writer queue is full or unavailable");
-        }
-    }
-
-    private void RecordDroppedJournalRecords(int count, string reason)
-    {
-        if (Interlocked.Add(ref _droppedJournalRecords, count) == count)
-        {
-            _logger.LogWarning(
-                $"Report recovery journal '{_journalPath}' dropped records because {reason}. Normal report generation is unaffected; crash recovery may be partial.");
-        }
-    }
-
-    private async Task WriteJournalLoopAsync()
-    {
-        ApplicationStateGuard.Ensure(_journalQueue is not null);
-        var batch = new List<ReportJournalRecord<TCapturedTestResult>>(JournalBatchSize);
-        try
-        {
-            while (!_journalQueue.IsCompleted)
-            {
-                if (!_journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? first, JournalFlushIntervalMilliseconds))
-                {
-                    continue;
-                }
-
-                batch.Add(first);
-                while (batch.Count < JournalBatchSize
-                    && _journalQueue.TryTake(out ReportJournalRecord<TCapturedTestResult>? next))
-                {
-                    batch.Add(next);
-                }
-
-                await WriteJournalBatchAsync(batch).ConfigureAwait(false);
-                batch.Clear();
-            }
-
-            if (_writeCompletionRecord)
-            {
-                ApplicationStateGuard.Ensure(_completedReportFileName is not null);
-                await WriteJournalBatchAsync(
-                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
-                        _completedReportFileName,
-                        Volatile.Read(ref _droppedJournalRecords))],
-                    isCompletion: true).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _journalFailed = true;
-            int dropped = batch.Count + DrainJournalQueue();
-            Interlocked.Add(ref _droppedJournalRecords, dropped);
-            await LogJournalFailureAsync(ex).ConfigureAwait(false);
-        }
-        finally
-        {
-            DisposeJournalStream();
-        }
-    }
-
-    private void TryWriteJournalBatch(
-        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
-        bool isCompletion = false)
-    {
-        try
-        {
-            WriteJournalBatchAsync(records, isCompletion).GetAwaiter().GetResult();
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _journalFailed = true;
-            _ = LogJournalFailureAsync(ex);
-            DisposeJournalStream();
-        }
-    }
-
-    private async Task WriteJournalBatchAsync(
-        IReadOnlyList<ReportJournalRecord<TCapturedTestResult>> records,
-        bool isCompletion = false)
-    {
-        _journalStream ??= FileSystem.NewFileStream(
-            _journalPath!,
-            FileMode.Append,
-            FileAccess.Write,
-            FileShare.ReadWrite);
-
-        var batch = new StringBuilder();
-        int accepted = 0;
-        long maxBytes = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalBytes
-            - (isCompletion ? 0 : JournalCompletionReserveBytes);
-        int maxRecords = ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordCount
-            - (isCompletion ? 0 : 1);
-        foreach (ReportJournalRecord<TCapturedTestResult> record in records)
-        {
-            string serializedRecord = SerializeJournalRecord(record);
-            int recordBytes = Encoding.UTF8.GetByteCount(serializedRecord) + 1;
-            if (recordBytes > ReportProcessLifetimeHandler<TGenerator, TCapturedTestResult>.MaxJournalRecordBytes
-                || _journalBytesWritten + recordBytes > maxBytes
-                || _journalRecordsWritten >= maxRecords)
-            {
-                _journalBudgetExceeded = true;
-                RecordDroppedJournalRecords(records.Count - accepted, "its configured size or record limit was reached");
-                break;
-            }
-
-            batch.Append(serializedRecord).Append('\n');
-            _journalBytesWritten += recordBytes;
-            _journalRecordsWritten++;
-            accepted++;
-        }
-
-        if (batch.Length == 0)
-        {
-            return;
-        }
-
-        byte[] bytes = Encoding.UTF8.GetBytes(batch.ToString());
-#if NETCOREAPP
-        await _journalStream.Stream.WriteAsync(bytes.AsMemory(), CancellationToken.None).ConfigureAwait(false);
-#else
-        await _journalStream.Stream.WriteAsync(bytes, 0, bytes.Length, CancellationToken.None).ConfigureAwait(false);
-#endif
-        await _journalStream.Stream.FlushAsync(CancellationToken.None).ConfigureAwait(false);
-    }
-
-    private async Task CompleteJournalAsync(
-        bool writeCompletionRecord,
-        string? reportFileName,
-        CancellationToken cancellationToken)
-    {
-        if (_journalPath is null || _journalCompletionTimedOut)
-        {
-            return;
-        }
-
-        if (_journalQueue is null)
-        {
-            if (writeCompletionRecord && !_journalFailed)
-            {
-                ApplicationStateGuard.Ensure(reportFileName is not null);
-                TryWriteJournalBatch(
-                    [ReportJournalRecord<TCapturedTestResult>.CreateCompletion(
-                        reportFileName,
-                        Volatile.Read(ref _droppedJournalRecords))],
-                    isCompletion: true);
-            }
-
-            DisposeJournalStream();
-            return;
-        }
-
-        if (!_journalQueue.IsAddingCompleted)
-        {
-            _writeCompletionRecord = writeCompletionRecord;
-            _completedReportFileName = reportFileName;
-            _journalQueue.CompleteAdding();
-        }
-
-        if (_journalWriterTask is not null)
-        {
-            Task timeout = _task.Delay(JournalShutdownTimeout, cancellationToken);
-            Task completed = await Task.WhenAny(_journalWriterTask, timeout).ConfigureAwait(false);
-            if (completed != _journalWriterTask)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                _journalCompletionTimedOut = true;
-                await _logger.LogWarningAsync(
-                    $"Report recovery journal '{_journalPath}' writer did not drain within the hang timeout. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
-                return;
-            }
-
-            await _journalWriterTask.ConfigureAwait(false);
-        }
-
-        int dropped = Volatile.Read(ref _droppedJournalRecords);
-        if (dropped > 0)
-        {
-            await _logger.LogWarningAsync(
-                $"Report recovery journal '{_journalPath}' dropped {dropped} record(s) because its bounded writer queue was full or unavailable, or its safety limits were reached. Normal report generation is unaffected, but crash recovery may be partial.").ConfigureAwait(false);
-        }
-    }
-
-    private int DrainJournalQueue()
-    {
-        if (_journalQueue is null)
-        {
-            return 0;
-        }
-
-        if (!_journalQueue.IsAddingCompleted)
-        {
-            _journalQueue.CompleteAdding();
-        }
-
-        int count = 0;
-        while (_journalQueue.TryTake(out _))
-        {
-            count++;
-        }
-
-        return count;
-    }
-
-    private Task LogJournalFailureAsync(Exception exception)
-        => _logger.LogWarningAsync(
-            $"Report recovery journal '{_journalPath}' could not be written. The report will still be generated in process, but it might not be recoverable after a crash. Reason: {exception.Message}");
-
-    private void DisposeJournalStream()
-    {
-        IFileStream? stream = Interlocked.Exchange(ref _journalStream, null);
-        try
-        {
-            stream?.Dispose();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug($"Failed to close report recovery journal '{_journalPath}': {ex.Message}");
-        }
-    }
-
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        if (_journalQueue is not null)
-        {
-            if (!_journalQueue.IsAddingCompleted)
-            {
-                _journalQueue.CompleteAdding();
-            }
-
-            if (_journalCompletionTimedOut)
-            {
-                _disposed = true;
-                return;
-            }
-
-            try
-            {
-                if (_journalWriterTask is not null
-                    && !_journalWriterTask.Wait(JournalShutdownTimeout))
-                {
-                    _journalCompletionTimedOut = true;
-                    _logger.LogWarning(
-                        $"Report recovery journal '{_journalPath}' writer did not stop within the hang timeout during disposal. The writer will be abandoned until process exit.");
-                    _disposed = true;
-                    return;
-                }
-
-                _journalWriterTask?.GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug($"Failed to drain report recovery journal '{_journalPath}' during disposal: {ex.Message}");
-            }
-
-            _journalQueue.Dispose();
-        }
-        else
-        {
-            DisposeJournalStream();
-        }
-
-        _disposed = true;
-    }
 
     protected abstract string ArtifactDisplayName { get; }
 
@@ -707,4 +359,3 @@ internal abstract class ReportGeneratorBase<TGenerator, TCapturedTestResult> :
 }
 
 #pragma warning restore RS0051
-#pragma warning restore CA1416


### PR DESCRIPTION
`ReportGeneratorBase` mixed report lifecycle orchestration with a large crash-recovery journal subsystem, making the shared base difficult to navigate and maintain.

This change moves journal state, recovery generation, background batching, safety limits, completion, and disposal into a focused `ReportGeneratorBase.Journal.cs` partial class. The CTRF, HTML, and JUnit projects explicitly link the new shared file. Both partial files are now under 400 lines, with no API or behavior changes.

The three report generator projects build cleanly across `netstandard2.0`, `net8.0`, and `net9.0`. Broader unit and acceptance setup is currently blocked by unrelated existing RS0051 errors in `Microsoft.Testing.Extensions.GitHubActionsReport`, which prevent the repository pack step from producing the required packages.

Fixes #10954