### PR TITLE
Set release dates for MSTest 4.4 and MTP 2.4

### DIFF
--- a/docs/Changelog-Platform.md
+++ b/docs/Changelog-Platform.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## <a name="2.4.0" />[2.4.0] - UNRELEASED
+## <a name="2.4.0" />[2.4.0] - 2026-09-02
 
 See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...main)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## <a name="4.4.0" />[4.4.0] - UNRELEASED
+## <a name="4.4.0" />[4.4.0] - 2026-09-02
 
 See full log [of v4.3.3...v4.4.0](https://github.com/microsoft/testfx/compare/v4.3.3...main)
 


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Sets September 2, 2026 as the release date for MSTest 4.4.0 and Microsoft.Testing.Platform 2.4.0 in their changelogs.