### PR TITLE
Optimize Assert.IsNotEmpty collection checks

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.IsNotEmpty.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.IsNotEmpty.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
@@ -32,7 +32,7 @@ public sealed partial class Assert
         /// <param name="shouldAppend">When this method returns, indicates whether the interpolated string should be evaluated.</param>
         public AssertIsNotEmptyInterpolatedStringHandler(int literalLength, int formattedCount, IEnumerable<TItem> collection, out bool shouldAppend)
         {
-            shouldAppend = !collection.Any();
+            shouldAppend = !IsNotEmptyCore(collection);
             if (shouldAppend)
             {
                 _builder = new StringBuilder(literalLength + formattedCount);
@@ -139,7 +139,7 @@ public sealed partial class Assert
     {
         TelemetryCollector.TrackAssertionCall("Assert.IsNotEmpty");
 
-        if (collection.Any())
+        if (IsNotEmptyCore(collection))
         {
             return;
         }
@@ -160,7 +160,7 @@ public sealed partial class Assert
     {
         TelemetryCollector.TrackAssertionCall("Assert.IsNotEmpty");
 
-        if (collection.Cast<object>().Any())
+        if (IsNotEmptyCore(collection))
         {
             return;
         }
@@ -334,6 +334,16 @@ public sealed partial class Assert
 
 #pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 #pragma warning restore RS0027 // API with optional parameter(s) should have the most parameters amongst its public overloads
+
+    private static bool IsNotEmptyCore<T>(IEnumerable<T> collection)
+        => collection is ICollection<T> genericCollection
+            ? genericCollection.Count != 0
+            : collection.Any();
+
+    private static bool IsNotEmptyCore(IEnumerable collection)
+        => collection is ICollection nonGenericCollection
+            ? nonGenericCollection.Count != 0
+            : collection.Cast<object>().Any();
 
     [DoesNotReturn]
     private static void ReportAssertIsNotEmptyFailed(string? userMessage, string collectionExpression)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -763,6 +763,17 @@ public partial class AssertTests
         collection.EnumerationCount.Should().Be(0);
     }
 
+    public void IsNotEmpty_NonGenericICollection_WhenEmpty_ShouldFailWithoutEnumerating()
+    {
+        CountTrackingCollection collection = new(0);
+
+        Action action = () => Assert.IsNotEmpty(collection);
+
+        action.Should().Throw<Exception>();
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
     public void IsNotEmpty_NonGenericIEnumerable_ShouldEnumerate()
     {
         CountTrackingEnumerable collection = new(1);

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -722,6 +722,47 @@ public partial class AssertTests
         Assert.IsNotEmpty(collection);
     }
 
+    public void IsNotEmpty_GenericICollection_ShouldUseCountWithoutEnumerating()
+    {
+        CountTrackingGenericCollection collection = new(1);
+
+        Assert.IsNotEmpty(collection);
+
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void IsNotEmpty_GenericICollection_InterpolatedString_ShouldUseCountWithoutEnumerating()
+    {
+        CountTrackingGenericCollection collection = new(1);
+        DummyClassTrackingToStringCalls o = new();
+
+        Assert.IsNotEmpty(collection, $"User-provided message: {o}");
+
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+        o.WasToStringCalled.Should().BeFalse();
+    }
+
+    public void IsNotEmpty_NonGenericICollection_ShouldUseCountWithoutEnumerating()
+    {
+        CountTrackingCollection collection = new(1);
+
+        Assert.IsNotEmpty(collection);
+
+        collection.CountAccessCount.Should().Be(1);
+        collection.EnumerationCount.Should().Be(0);
+    }
+
+    public void IsNotEmpty_NonGenericIEnumerable_ShouldEnumerate()
+    {
+        CountTrackingEnumerable collection = new(1);
+
+        Assert.IsNotEmpty(collection);
+
+        collection.EnumerationCount.Should().Be(1);
+    }
+
     public void Any_InterpolatedString_WhenAnyOneItem_ShouldPass()
     {
         DummyClassTrackingToStringCalls o = new();
@@ -769,6 +810,47 @@ public partial class AssertTests
                 Assert.IsNotEmpty(collection)
                 """);
         o.WasToStringCalled.Should().BeTrue();
+    }
+
+    private sealed class CountTrackingGenericCollection(int count) : ICollection<int>
+    {
+        public int Count
+        {
+            get
+            {
+                CountAccessCount++;
+                return count;
+            }
+        }
+
+        public int CountAccessCount { get; private set; }
+
+        public int EnumerationCount { get; private set; }
+
+        public bool IsReadOnly => true;
+
+        public void Add(int item)
+            => throw new NotSupportedException();
+
+        public void Clear()
+            => throw new NotSupportedException();
+
+        public bool Contains(int item)
+            => throw new NotSupportedException();
+
+        public void CopyTo(int[] array, int arrayIndex)
+            => throw new NotSupportedException();
+
+        public bool Remove(int item)
+            => throw new NotSupportedException();
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            EnumerationCount++;
+            throw new InvalidOperationException("The ICollection<T> fast path should not enumerate.");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class CountTrackingCollection(int count) : ICollection

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.Items.cs
@@ -744,6 +744,15 @@ public partial class AssertTests
         o.WasToStringCalled.Should().BeFalse();
     }
 
+    public void IsNotEmpty_GenericIEnumerable_ShouldEnumerate()
+    {
+        CountTrackingGenericEnumerable collection = new(1);
+
+        Assert.IsNotEmpty(collection);
+
+        collection.EnumerationCount.Should().Be(1);
+    }
+
     public void IsNotEmpty_NonGenericICollection_ShouldUseCountWithoutEnumerating()
     {
         CountTrackingCollection collection = new(1);
@@ -848,6 +857,19 @@ public partial class AssertTests
         {
             EnumerationCount++;
             throw new InvalidOperationException("The ICollection<T> fast path should not enumerate.");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class CountTrackingGenericEnumerable(int count) : IEnumerable<int>
+    {
+        public int EnumerationCount { get; private set; }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            EnumerationCount++;
+            return Enumerable.Range(0, count).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();


### PR DESCRIPTION
`Assert.IsNotEmpty` unnecessarily enumerates collection-backed inputs, and the non-generic overload allocates a LINQ wrapper just to determine whether an item exists.

Use `ICollection<T>.Count` and `ICollection.Count` fast paths across the generic, non-generic, and interpolated-string-handler paths. True lazy `IEnumerable` inputs retain the existing `Any()` fallback behavior. Regression tests verify both count fast paths and fallback enumeration.

Tests: full `TestFramework.UnitTests` suite on `net8.0` (1,552 passed).

Fixes #10964