### PR TITLE
Fix Retry extension warning under Native AOT

### DIFF
--- a/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
+++ b/src/Package/MSTest.Sdk/Sdk/Runner/NativeAOT.targets
@@ -23,7 +23,7 @@
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsCrashDump)' == 'true' " Text="Crash dump extension might not be working well under Native AOT." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsHangDump)' == 'true' " Text="Hang dump extension might not be working well under Native AOT." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsHotReload)' == 'true' " Text="Hot reload extension might not be working well under Native AOT." />
-    <Warning Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' == 'true' " Text="Hot reload extension might not be working well under Native AOT." />
+    <Warning Condition=" '$(EnableMicrosoftTestingExtensionsRetry)' == 'true' " Text="Retry extension might not be working well under Native AOT." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsAzureDevOpsReport)' == 'true' " Text="Azure DevOps report extension is not supported in NativeAOT mode." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsGitHubActionsReport)' == 'true' " Text="GitHub Actions report extension is not supported in NativeAOT mode." />
     <Warning Condition=" '$(EnableMicrosoftTestingExtensionsJUnitReport)' == 'true' " Text="JUnit report extension is not supported in NativeAOT mode." />


### PR DESCRIPTION
Enabling the Retry extension in an MSTest.Sdk Native AOT project currently emits a misleading warning about Hot Reload. Update the validation warning to identify the Retry extension while leaving the Hot Reload warning unchanged.

Fixes #10970