### PR TITLE
Add RetryDataConsumer recovery tracking tests

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
@@ -68,11 +68,15 @@ public sealed class RetryDataConsumerTests
 
         await fixture.Consumer.ConsumeAsync(
             null!,
+            CreateUpdate("uid", PassedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.Consumer.ConsumeAsync(
+            null!,
             CreateUpdate("uid", SkippedTestNodeStateProperty.CachedInstance),
             TestContext.CancellationToken);
         await fixture.FinishAsync(TestContext.CancellationToken);
 
-        Assert.AreEqual(0, fixture.Server.TotalTestRan);
+        Assert.AreEqual(1, fixture.Server.TotalTestRan);
         Assert.AreEqual(1, fixture.Server.SkippedTests);
         Assert.IsEmpty(fixture.Server.RecoveredTests);
     }
@@ -136,7 +140,7 @@ public sealed class RetryDataConsumerTests
     }
 
     [TestMethod]
-    public async Task OnTestSessionStartingAsync_NullRetrySet_DoesNotEnableRecoveryTracking()
+    public async Task OnTestSessionStartingAsync_CalledBeforeRetrySetFetched_DoesNotEnableRecoveryTracking()
     {
         using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(
             ["uid"],

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
@@ -113,6 +113,7 @@ public sealed class RetryDataConsumerTests
         await fixture.FinishAsync(TestContext.CancellationToken);
 
         Assert.AreEqual(0, fixture.Server.TotalTestRan);
+        Assert.AreEqual(0, fixture.Server.FailedTestResults);
         Assert.AreEqual(0, fixture.Server.SkippedTests);
         Assert.IsEmpty(fixture.Server.RecoveredTests);
         Assert.IsEmpty(fixture.Server.FailedTests);

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
@@ -1,0 +1,257 @@
+﻿#pragma warning disable IDE0073 // The file header does not match the required text
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
+#pragma warning restore IDE0073 // The file header does not match the required text
+
+using System.Reflection;
+
+using Microsoft.Testing.Extensions.Policy;
+using Microsoft.Testing.Extensions.UnitTests.Helpers;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.Services;
+using Microsoft.Testing.Platform.TestHost;
+
+using Moq;
+
+namespace Microsoft.Testing.Extensions.UnitTests;
+
+[TestClass]
+public sealed class RetryDataConsumerTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task ConsumeAsync_SupersededRetryAttempt_IsIgnored()
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["uid"], TestContext.CancellationToken);
+
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", new FailedTestNodeStateProperty(), new RetryAttemptProperty(1, isSuperseded: true)),
+            TestContext.CancellationToken);
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", PassedTestNodeStateProperty.CachedInstance, new RetryAttemptProperty(2, isSuperseded: false)),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(1, fixture.Server.TotalTestRan);
+        Assert.AreEqual(0, fixture.Server.FailedTestResults);
+        Assert.AreSequenceEqual(["uid"], fixture.Server.RecoveredTests);
+        Assert.IsEmpty(fixture.Server.FailedTests);
+    }
+
+    [DataRow(true)]
+    [DataRow(false)]
+    [TestMethod]
+    public async Task ConsumeAsync_FoldedTestWithPassingAndFailingRows_IsNotRecoveredRegardlessOfOrder(bool passFirst)
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["uid"], TestContext.CancellationToken);
+        TestNodeUpdateMessage passed = CreateUpdate("uid", PassedTestNodeStateProperty.CachedInstance);
+        TestNodeUpdateMessage failed = CreateUpdate("uid", new FailedTestNodeStateProperty());
+
+        await fixture.Consumer.ConsumeAsync(null!, passFirst ? passed : failed, TestContext.CancellationToken);
+        await fixture.Consumer.ConsumeAsync(null!, passFirst ? failed : passed, TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(2, fixture.Server.TotalTestRan);
+        Assert.AreEqual(1, fixture.Server.FailedTestResults);
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
+        Assert.IsTrue(fixture.Server.FailedTests.ContainsKey("uid"));
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_SkippedRetriedTest_IsNotRecovered()
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["uid"], TestContext.CancellationToken);
+
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", SkippedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(0, fixture.Server.TotalTestRan);
+        Assert.AreEqual(1, fixture.Server.SkippedTests);
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_PassedTests_RecoversOnlyTestsFromRetrySet()
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["retried"], TestContext.CancellationToken);
+
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("retried", PassedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("not-retried", PassedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(2, fixture.Server.TotalTestRan);
+        Assert.AreSequenceEqual(["retried"], fixture.Server.RecoveredTests);
+    }
+
+    [TestMethod]
+    public async Task ConsumeAsync_MessagesWithoutFinalOutcome_AreIgnored()
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["uid"], TestContext.CancellationToken);
+
+        await fixture.Consumer.ConsumeAsync(null!, CreateUpdate("uid"), TestContext.CancellationToken);
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", InProgressTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(0, fixture.Server.TotalTestRan);
+        Assert.AreEqual(0, fixture.Server.SkippedTests);
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
+        Assert.IsEmpty(fixture.Server.FailedTests);
+    }
+
+    [DataRow("failed")]
+    [DataRow("error")]
+    [DataRow("timeout")]
+    [DataRow("cancelled")]
+    [TestMethod]
+    public async Task ConsumeAsync_NonPassingState_ReportsFailureAndDoesNotRecover(string state)
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(["uid"], TestContext.CancellationToken);
+
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", CreateNonPassingState(state)),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.AreEqual(1, fixture.Server.TotalTestRan);
+        Assert.AreEqual(1, fixture.Server.FailedTestResults);
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
+        Assert.AreEqual("uid", fixture.Server.FailedTests["uid"]);
+    }
+
+    [TestMethod]
+    public async Task OnTestSessionStartingAsync_NullRetrySet_DoesNotEnableRecoveryTracking()
+    {
+        ServiceProvider serviceProvider = CreateServiceProvider();
+        serviceProvider.AddService(new TestCommandLineOptions(new()
+        {
+            [RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName] = ["unused"],
+        }));
+        var lifecycleCallbacks = new RetryLifecycleCallbacks(serviceProvider);
+        serviceProvider.AddService(lifecycleCallbacks);
+        var consumer = new RetryDataConsumer(serviceProvider);
+        await consumer.InitializeAsync();
+
+        await consumer.OnTestSessionStartingAsync(CreateSessionContext(TestContext.CancellationToken));
+
+        Assert.IsNull(GetTestsBeingRetried(consumer));
+    }
+
+    [TestMethod]
+    public async Task OnTestSessionStartingAsync_EmptyRetrySet_DoesNotEnableRecoveryTracking()
+    {
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync([], TestContext.CancellationToken);
+
+        Assert.IsNull(GetTestsBeingRetried(fixture.Consumer));
+    }
+
+    private static TestNodeUpdateMessage CreateUpdate(string uid, params IProperty[] properties)
+        => new(
+            new SessionUid("session"),
+            new TestNode
+            {
+                Uid = uid,
+                DisplayName = uid,
+                Properties = new PropertyBag(properties),
+            });
+
+    private static TestNodeStateProperty CreateNonPassingState(string state)
+        => state switch
+        {
+            "failed" => new FailedTestNodeStateProperty(),
+            "error" => new ErrorTestNodeStateProperty(),
+            "timeout" => new TimeoutTestNodeStateProperty(),
+#pragma warning disable CS0618, MTP0001 // Type or member is obsolete
+            "cancelled" => new CancelledTestNodeStateProperty(),
+#pragma warning restore CS0618, MTP0001 // Type or member is obsolete
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unexpected test state."),
+        };
+
+    private static HashSet<string>? GetTestsBeingRetried(RetryDataConsumer consumer)
+        => (HashSet<string>?)typeof(RetryDataConsumer)
+            .GetField("_testsBeingRetried", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(consumer);
+
+    private static ITestSessionContext CreateSessionContext(CancellationToken cancellationToken)
+        => Mock.Of<ITestSessionContext>(context => context.CancellationToken == cancellationToken);
+
+    private static ServiceProvider CreateServiceProvider()
+    {
+        ServiceProvider serviceProvider = new();
+        serviceProvider.AddService(new SystemEnvironment());
+        serviceProvider.AddService(new SystemTask());
+        serviceProvider.AddService(Mock.Of<ITestApplicationCancellationTokenSource>(
+            source => source.CancellationToken == CancellationToken.None));
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(factory => factory.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+        serviceProvider.AddService(loggerFactory.Object);
+        return serviceProvider;
+    }
+
+    private sealed class ConnectedConsumer : IDisposable
+    {
+        private readonly RetryLifecycleCallbacks _lifecycleCallbacks;
+
+        private ConnectedConsumer(
+            RetryDataConsumer consumer,
+            RetryLifecycleCallbacks lifecycleCallbacks,
+            RetryFailedTestsPipeServer server)
+        {
+            Consumer = consumer;
+            _lifecycleCallbacks = lifecycleCallbacks;
+            Server = server;
+        }
+
+        public RetryDataConsumer Consumer { get; }
+
+        public RetryFailedTestsPipeServer Server { get; }
+
+        public static async Task<ConnectedConsumer> CreateAsync(string[] retrySet, CancellationToken cancellationToken)
+        {
+            ServiceProvider serviceProvider = CreateServiceProvider();
+            var server = new RetryFailedTestsPipeServer(serviceProvider, retrySet, Mock.Of<ILogger>());
+            serviceProvider.AddService(new TestCommandLineOptions(new()
+            {
+                [RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName] = [server.PipeName],
+            }));
+            var lifecycleCallbacks = new RetryLifecycleCallbacks(serviceProvider);
+            serviceProvider.AddService(lifecycleCallbacks);
+            var consumer = new RetryDataConsumer(serviceProvider);
+            await consumer.InitializeAsync();
+
+            Task connection = server.WaitForConnectionAsync(cancellationToken);
+            await lifecycleCallbacks.BeforeRunAsync(cancellationToken);
+            await connection;
+            await consumer.OnTestSessionStartingAsync(CreateSessionContext(cancellationToken));
+
+            return new ConnectedConsumer(consumer, lifecycleCallbacks, server);
+        }
+
+        public Task FinishAsync(CancellationToken cancellationToken)
+            => Consumer.OnTestSessionFinishingAsync(CreateSessionContext(cancellationToken));
+
+        public void Dispose()
+        {
+            _lifecycleCallbacks.Dispose();
+            Server.Dispose();
+        }
+    }
+}

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
@@ -149,6 +149,7 @@ public sealed class RetryDataConsumerTests
             TestContext.CancellationToken);
         await fixture.FinishAsync(TestContext.CancellationToken);
 
+        Assert.AreEqual(1, fixture.Server.TotalTestRan);
         Assert.IsEmpty(fixture.Server.RecoveredTests);
     }
 
@@ -163,6 +164,7 @@ public sealed class RetryDataConsumerTests
             TestContext.CancellationToken);
         await fixture.FinishAsync(TestContext.CancellationToken);
 
+        Assert.AreEqual(1, fixture.Server.TotalTestRan);
         Assert.IsEmpty(fixture.Server.RecoveredTests);
     }
 

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/RetryDataConsumerTests.cs
@@ -3,8 +3,6 @@
 // Licensed under dual-license. See LICENSE.PLATFORMTOOLS.txt file in the project root for full license information.
 #pragma warning restore IDE0073 // The file header does not match the required text
 
-using System.Reflection;
-
 using Microsoft.Testing.Extensions.Policy;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
 using Microsoft.Testing.Platform.Extensions.Messages;
@@ -140,19 +138,18 @@ public sealed class RetryDataConsumerTests
     [TestMethod]
     public async Task OnTestSessionStartingAsync_NullRetrySet_DoesNotEnableRecoveryTracking()
     {
-        ServiceProvider serviceProvider = CreateServiceProvider();
-        serviceProvider.AddService(new TestCommandLineOptions(new()
-        {
-            [RetryCommandLineOptionsProvider.RetryFailedTestsPipeNameOptionName] = ["unused"],
-        }));
-        var lifecycleCallbacks = new RetryLifecycleCallbacks(serviceProvider);
-        serviceProvider.AddService(lifecycleCallbacks);
-        var consumer = new RetryDataConsumer(serviceProvider);
-        await consumer.InitializeAsync();
+        using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync(
+            ["uid"],
+            TestContext.CancellationToken,
+            startSessionBeforeConnecting: true);
 
-        await consumer.OnTestSessionStartingAsync(CreateSessionContext(TestContext.CancellationToken));
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", PassedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
 
-        Assert.IsNull(GetTestsBeingRetried(consumer));
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
     }
 
     [TestMethod]
@@ -160,7 +157,13 @@ public sealed class RetryDataConsumerTests
     {
         using ConnectedConsumer fixture = await ConnectedConsumer.CreateAsync([], TestContext.CancellationToken);
 
-        Assert.IsNull(GetTestsBeingRetried(fixture.Consumer));
+        await fixture.Consumer.ConsumeAsync(
+            null!,
+            CreateUpdate("uid", PassedTestNodeStateProperty.CachedInstance),
+            TestContext.CancellationToken);
+        await fixture.FinishAsync(TestContext.CancellationToken);
+
+        Assert.IsEmpty(fixture.Server.RecoveredTests);
     }
 
     private static TestNodeUpdateMessage CreateUpdate(string uid, params IProperty[] properties)
@@ -184,11 +187,6 @@ public sealed class RetryDataConsumerTests
 #pragma warning restore CS0618, MTP0001 // Type or member is obsolete
             _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Unexpected test state."),
         };
-
-    private static HashSet<string>? GetTestsBeingRetried(RetryDataConsumer consumer)
-        => (HashSet<string>?)typeof(RetryDataConsumer)
-            .GetField("_testsBeingRetried", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(consumer);
 
     private static ITestSessionContext CreateSessionContext(CancellationToken cancellationToken)
         => Mock.Of<ITestSessionContext>(context => context.CancellationToken == cancellationToken);
@@ -224,7 +222,10 @@ public sealed class RetryDataConsumerTests
 
         public RetryFailedTestsPipeServer Server { get; }
 
-        public static async Task<ConnectedConsumer> CreateAsync(string[] retrySet, CancellationToken cancellationToken)
+        public static async Task<ConnectedConsumer> CreateAsync(
+            string[] retrySet,
+            CancellationToken cancellationToken,
+            bool startSessionBeforeConnecting = false)
         {
             ServiceProvider serviceProvider = CreateServiceProvider();
             var server = new RetryFailedTestsPipeServer(serviceProvider, retrySet, Mock.Of<ILogger>());
@@ -237,10 +238,18 @@ public sealed class RetryDataConsumerTests
             var consumer = new RetryDataConsumer(serviceProvider);
             await consumer.InitializeAsync();
 
+            if (startSessionBeforeConnecting)
+            {
+                await consumer.OnTestSessionStartingAsync(CreateSessionContext(cancellationToken));
+            }
+
             Task connection = server.WaitForConnectionAsync(cancellationToken);
             await lifecycleCallbacks.BeforeRunAsync(cancellationToken);
             await connection;
-            await consumer.OnTestSessionStartingAsync(CreateSessionContext(cancellationToken));
+            if (!startSessionBeforeConnecting)
+            {
+                await consumer.OnTestSessionStartingAsync(CreateSessionContext(cancellationToken));
+            }
 
             return new ConnectedConsumer(consumer, lifecycleCallbacks, server);
         }


### PR DESCRIPTION
## Summary

`RetryDataConsumer` recovery bookkeeping had no direct unit coverage despite relying on ordering-sensitive behavior for folded data-driven tests and composition with in-process retries.

Add end-to-end unit tests that use the real retry pipe protocol to cover superseded attempts, pass/fail arrival ordering, skipped retries, every non-passing state, retry-set filtering, non-final messages, and null or empty retry sets. This keeps the production implementation unchanged while validating the counts and recovered UIDs observed by the orchestrator.

## Testing

- Built `Microsoft.Testing.Extensions.UnitTests` for `net462`, `net472`, `net8.0`, and `net9.0`.
- Ran all 12 new cases successfully on each target framework.

Closes #10965