### PR TITLE
Document experimental API instability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,6 +99,9 @@ When making change to resource files, you MUST:
 - Public API for MSTest and Microsoft.Testing.Platform MUST NOT use `init` accessors.
   - Exception: Existing APIs in Microsoft.Testing.Platform, because changing them right now would be a breaking change. However, we MUST NOT introduce **new** APIs using `init` accessors.
   - IMPORTANT: Make sure to apply this rule strictly both during PR review and when working on code changes.
+- Every API marked with `[Experimental]` MUST include this sentence in its XML documentation `<remarks>`: `This API is experimental. It may change, break, or be removed at any time without notice.` Documentation tooling does not reliably surface the attribute itself.
+  - Add the sentence in a `<para>` when `<remarks>` already contains other text; otherwise, add a new `<remarks>` block.
+  - Apply this rule to experimental members as well as types.
 
 ## Testing Guidelines
 

--- a/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureFoundry/TestApplicationBuilderExtensions.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Testing.Extensions.AzureFoundry;
 /// <summary>
 /// Extension methods for configuring Azure Foundry services.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class TestApplicationBuilderExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.CtrfReport/CtrfReportExtensions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Extensions;
 /// <summary>
 /// Provides extension methods for adding CTRF (Common Test Report Format) report generation to a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class CtrfReportExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportExtensions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Extensions;
 /// <summary>
 /// Provides extension methods for adding HTML report generation to a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class HtmlReportExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.JUnitReport/JUnitReportExtensions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Extensions;
 /// <summary>
 /// Provides extension methods for adding JUnit XML report generation to a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class JUnitReportExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Logging/MicrosoftExtensionsLoggingBuilderExtensions.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Testing.Extensions;
 /// Extension methods on <see cref="ITestApplicationBuilder"/> for forwarding the
 /// Microsoft Testing Platform diagnostic logs to <c>Microsoft.Extensions.Logging</c> providers.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class MicrosoftExtensionsLoggingBuilderExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.VideoRecorder;
@@ -12,6 +12,9 @@ namespace Microsoft.Testing.Extensions;
 /// <summary>
 /// Provides extension methods to add the video recorder to a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class VideoRecorderExtensions
 {

--- a/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderOptions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VideoRecorder/VideoRecorderOptions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Extensions.VideoRecorder;
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Extensions.VideoRecorder;
 /// <summary>
 /// The output video format produced by the recorder.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum VideoRecorderFormat
 {
@@ -26,6 +29,9 @@ public enum VideoRecorderFormat
 /// <summary>
 /// Controls when a recorded video is persisted (kept and attached to the test session).
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum VideoRecorderPersistenceMode
 {
@@ -45,6 +51,9 @@ public enum VideoRecorderPersistenceMode
 /// <summary>
 /// Controls how recordings are split across a test run.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum VideoCaptureGranularity
 {
@@ -65,6 +74,9 @@ public enum VideoCaptureGranularity
 /// <summary>
 /// What the recorder captures.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum VideoCaptureSource
 {
@@ -83,6 +95,9 @@ public enum VideoCaptureSource
 /// <summary>
 /// Options controlling how the video recorder captures and encodes video.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class VideoRecorderOptions
 {

--- a/src/Platform/Microsoft.Testing.Platform.AI/ChatClientProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.AI/ChatClientProviderExtensions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Platform.AI;
 /// <summary>
 /// Extension methods for chat client provider.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class ChatClientProviderExtensions
 {

--- a/src/Platform/Microsoft.Testing.Platform.AI/IChatClientProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform.AI/IChatClientProvider.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.AI;
 /// <summary>
 /// Provider interface for creating and configuring chat clients.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/experimental")]
 public interface IChatClientProvider
 {

--- a/src/Platform/Microsoft.Testing.Platform/Builder/IArtifactPostProcessingApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/IArtifactPostProcessingApplicationBuilder.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Testing.Platform.Builder;
 /// <summary>
 /// Represents a test application builder that supports registering artifact post-processors and tools.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IArtifactPostProcessingApplicationBuilder : ITestApplicationBuilder
 {

--- a/src/Platform/Microsoft.Testing.Platform/Builder/ITestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/ITestApplicationBuilder.cs
@@ -30,6 +30,9 @@ public interface ITestApplicationBuilder
     /// <summary>
     /// Gets the test host orchestrator manager.
     /// </summary>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     ITestHostOrchestratorManager TestHostOrchestrator { get; }
 
@@ -41,12 +44,18 @@ public interface ITestApplicationBuilder
     /// <summary>
     /// Gets the configuration manager.
     /// </summary>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     IConfigurationManager Configuration { get; }
 
     /// <summary>
     /// Gets the logging manager.
     /// </summary>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     ILoggingManager Logging { get; }
 

--- a/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Builder/TestApplicationBuilder.cs
@@ -57,6 +57,10 @@ internal sealed class TestApplicationBuilder : IArtifactPostProcessingApplicatio
 
     public ITestHostControllersManager TestHostControllers => _testHostBuilder.TestHostControllers;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     ITestHostOrchestratorManager ITestApplicationBuilder.TestHostOrchestrator => _testHostBuilder.TestHostOrchestrator;
 
@@ -65,17 +69,33 @@ internal sealed class TestApplicationBuilder : IArtifactPostProcessingApplicatio
 
     public ICommandLineManager CommandLine => _testHostBuilder.CommandLine;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public IConfigurationManager Configuration => _testHostBuilder.Configuration;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public ILoggingManager Logging => _testHostBuilder.Logging;
 
     internal ITelemetryManager Telemetry => _testHostBuilder.Telemetry;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public IArtifactPostProcessingManager ArtifactPostProcessing => _testHostBuilder.ArtifactPostProcessing;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public IToolsManager Tools => _testHostBuilder.Tools;
 

--- a/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IBannerMessageOwnerCapability.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IBannerMessageOwnerCapability.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Platform.Capabilities.TestFramework;
 /// This capability implementation allows to abstract away the various conditions that the test framework may need to consider
 /// to decide whether or not the banner message should be displayed.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IBannerMessageOwnerCapability : ITestFrameworkCapability
 {

--- a/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IGracefulStopTestExecutionCapability.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/IGracefulStopTestExecutionCapability.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Testing.Platform.Capabilities.TestFramework;
 /// </summary>
 /// <remarks>
 /// Test frameworks can choose to run any needed cleanup when cancellation is requested.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IGracefulStopTestExecutionCapability : ITestFrameworkCapability
@@ -27,6 +30,9 @@ public interface IGracefulStopTestExecutionCapability : ITestFrameworkCapability
 /// <remarks>
 /// Test frameworks should implement this capability when a successful stop request can be a no-op because
 /// execution has already completed.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IGracefulStopTestExecutionResultCapability : IGracefulStopTestExecutionCapability

--- a/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/TestFrameworkCapabilitiesExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Capabilities/TestFramework/TestFrameworkCapabilitiesExtensions.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Capabilities.TestFramework;
 /// <summary>
 /// Provides extension methods for <see cref="ITestFrameworkCapabilities"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class TestFrameworkCapabilitiesExtensions
 {

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderBase.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/CommandLineOptionsProviderBase.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Testing.Platform.CommandLine;
 /// that first-party platform extensions can derive from it across the assembly boundary without an
 /// <c>InternalsVisibleTo</c> grant. Its shape is an implementation detail; do not depend on it from
 /// your own code.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
 [Experimental("TPINTERNAL")]

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ICommandLineManager.cs
@@ -20,6 +20,9 @@ public interface ICommandLineManager
     /// Adds a command line options provider.
     /// </summary>
     /// <param name="commandLineProviderFactory">The factory method for creating the command line options provider, given a service provider.</param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     void AddProvider(Func<IServiceProvider, ICommandLineOptionsProvider> commandLineProviderFactory);
 }

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/OptionRecord.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/OptionRecord.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.CommandLine;
 /// </summary>
 /// <param name="name">The name of the option.</param>
 /// <param name="arguments">The arguments associated to this option.</param>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class CommandLineParseOption(string name, string[] arguments)
 {

--- a/src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs
+++ b/src/Platform/Microsoft.Testing.Platform/CommandLine/ParseResult.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.CommandLine;
 /// <summary>
 /// Represents the result of parsing a command line.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class CommandLineParseResult : IEquatable<CommandLineParseResult>
 {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationManager.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Configurations;
 /// <summary>
 /// Represents a configuration manager.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IConfigurationManager
 {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationProvider.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Configurations;
 /// <summary>
 /// Represents a configuration provider.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IConfigurationProvider
 {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSource.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IConfigurationSource.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Testing.Platform.Configurations;
 /// <summary>
 /// Represents a configuration source.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IConfigurationSource : IExtension
 {

--- a/src/Platform/Microsoft.Testing.Platform/Configurations/IHierarchicalConfigurationProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Configurations/IHierarchicalConfigurationProvider.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Configurations;
 /// <summary>
 /// Represents a configuration provider that exposes hierarchical configuration sections.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IHierarchicalConfigurationProvider : IConfigurationProvider
 {

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessingManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessingManager.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
 /// <summary>
 /// Registers artifact post-processors with a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IArtifactPostProcessingManager
 {

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessor.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/ArtifactPostProcessing/IArtifactPostProcessor.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Extensions.ArtifactPostProcessing;
 /// <summary>
 /// Processes artifacts of one or more well-known kinds after test execution completes.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IArtifactPostProcessor : IExtension
 {
@@ -66,6 +69,9 @@ public interface IArtifactPostProcessor : IExtension
 /// <remarks>
 /// Orchestrators that support this capability advertise that support in the handshake response before a test
 /// session starts. Producers must preserve their standalone behavior when the capability is unavailable.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IArtifactPostProcessorRequiresPostProcessing : IArtifactPostProcessor;
@@ -73,6 +79,9 @@ public interface IArtifactPostProcessorRequiresPostProcessing : IArtifactPostPro
 /// <summary>
 /// Describes the test run that produced artifacts supplied to an <see cref="IArtifactPostProcessor"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class ArtifactPostProcessingContext
 {
@@ -150,6 +159,9 @@ public sealed class ArtifactPostProcessingContext
 /// <summary>
 /// Describes authoritative run-level values supplied by the outer test orchestrator.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class ArtifactPostProcessingRunSummary
 {
@@ -243,6 +255,9 @@ public sealed class ArtifactPostProcessingRunSummary
 /// <summary>
 /// Specifies how the supplied artifacts relate to one another.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum ArtifactPostProcessingMode
 {
@@ -261,6 +276,9 @@ public enum ArtifactPostProcessingMode
 /// <summary>
 /// Specifies why a test run was truncated before every scheduled test module completed.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum ArtifactPostProcessingTruncationReason
 {
@@ -283,6 +301,9 @@ public enum ArtifactPostProcessingTruncationReason
 /// <summary>
 /// Describes an artifact supplied to an <see cref="IArtifactPostProcessor"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class InputArtifact
 {
@@ -339,6 +360,9 @@ public sealed class InputArtifact
 /// <summary>
 /// Describes an artifact produced by an <see cref="IArtifactPostProcessor"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class ProcessedArtifact
 {

--- a/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Extensions/IBlockingDataConsumer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Extensions;
@@ -30,6 +30,9 @@ namespace Microsoft.Testing.Platform.Extensions;
 /// because the message bus skips delivering a producer's data back to that same producer; the deadlock
 /// risk is specifically re-entrant publishing that routes back to this consumer under a
 /// <em>different</em> producer UID.
+/// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/System/IClock.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/System/IClock.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Testing.Platform.Helpers;
 /// <c>InternalsVisibleTo</c> grant (its instances are provided by the platform's service provider,
 /// so it cannot be source-embedded). Its shape is an implementation detail; do not depend on it
 /// from your own code.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [EditorBrowsable(EditorBrowsableState.Never)]
 [Experimental("TPINTERNAL")]

--- a/src/Platform/Microsoft.Testing.Platform/Helpers/TestApplicationBuilderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Helpers/TestApplicationBuilderExtensions.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Testing.Platform.Helpers;
 /// <summary>
 /// A collection of extension methods for <see cref="ITestApplicationBuilder"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public static class TestApplicationBuilderExtensions
 {
@@ -38,6 +41,9 @@ public static class TestApplicationBuilderExtensions
     /// </summary>
     /// <param name="builder">The test application builder.</param>
     /// <param name="extension">The extension owner of the maximum failed tests service.</param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public static void AddMaximumFailedTestsService(this ITestApplicationBuilder builder, IExtension extension)
         => builder.CommandLine.AddProvider(serviceProvider => new MaxFailedTestsCommandLineOptionsProvider(extension, serviceProvider));

--- a/src/Platform/Microsoft.Testing.Platform/Logging/ILoggerProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/ILoggerProvider.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Logging;
 /// <summary>
 /// Represents a logger provider that can be used to create loggers.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ILoggerProvider
 {

--- a/src/Platform/Microsoft.Testing.Platform/Logging/ILoggingManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Logging/ILoggingManager.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Logging;
 /// <summary>
 /// Represents a logging manager that can be used to add logger providers.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ILoggingManager
 {

--- a/src/Platform/Microsoft.Testing.Platform/Messages/FileArtifacts.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Messages/FileArtifacts.cs
@@ -37,6 +37,9 @@ public class FileArtifact : PropertyBagData
     /// the same kind for consolidation. <see langword="null"/> when the producer does not
     /// declare a kind.
     /// </param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public FileArtifact(FileInfo fileInfo, string displayName, string? description, string? kind)
         : base(displayName, description)
@@ -55,6 +58,9 @@ public class FileArtifact : PropertyBagData
     /// (e.g. <c>microsoft.testing.trx</c>), or <see langword="null"/> when the producer
     /// did not declare one.
     /// </summary>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public string? Kind { get; }
 
@@ -129,6 +135,9 @@ public class SessionFileArtifact : DataWithSessionUid
     /// the same kind for consolidation. <see langword="null"/> when the producer does not
     /// declare a kind.
     /// </param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public SessionFileArtifact(SessionUid sessionUid, FileInfo fileInfo, string displayName, string? description, string? kind)
         : base(displayName, description, sessionUid)
@@ -147,6 +156,9 @@ public class SessionFileArtifact : DataWithSessionUid
     /// (e.g. <c>microsoft.testing.trx</c>), or <see langword="null"/> when the producer
     /// did not declare one.
     /// </summary>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public string? Kind { get; }
 

--- a/src/Platform/Microsoft.Testing.Platform/Requests/CompositeTestExecutionFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/CompositeTestExecutionFilter.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Represents an explicit composition of test execution filters.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class CompositeTestExecutionFilter : ITestExecutionFilter
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/IExecuteRequestCompletionNotifier.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/IExecuteRequestCompletionNotifier.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Interface to notify the completion of a request.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IExecuteRequestCompletionNotifier
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/ITestExecutionFilterProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/ITestExecutionFilterProvider.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Provides an additional constraint for a test execution request.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestExecutionFilterProvider : IExtension
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionFilterContext.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionFilterContext.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Describes the request for which a test execution filter provider is being evaluated.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class TestExecutionFilterContext
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionFilterOperator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionFilterOperator.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Specifies how child test execution filters are combined.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum TestExecutionFilterOperator
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionRequestKind.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionRequestKind.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Specifies the kind of test execution request.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum TestExecutionRequestKind
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionRequestOrigin.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TestExecutionRequestOrigin.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// Specifies where a test execution request originated.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public enum TestExecutionRequestOrigin
 {

--- a/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Requests/TreeNodeFilter/TreeNodeFilter.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Platform.Requests;
 /// <summary>
 /// A tree based filter for test execution.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed partial class TreeNodeFilter : ITestExecutionFilter
 {

--- a/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Testing.Platform.Services;
 /// Capabilities are opt-in: unless a client explicitly declares a capability, the platform assumes the
 /// most conservative (default) behavior. This lets a test framework tailor its behavior to how the client
 /// intends to consume the results without having to guess based on the environment or transport.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IClientCapabilities

--- a/src/Platform/Microsoft.Testing.Platform/Services/IClientInfo.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IClientInfo.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Services;
 /// <summary>
 /// Represents the client information.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IClientInfo
 {

--- a/src/Platform/Microsoft.Testing.Platform/Services/IPlatformInformation.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IPlatformInformation.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Services;
 /// <summary>
 /// Provides information about the platform.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IPlatformInformation
 {

--- a/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ServiceProviderExtensions.cs
@@ -120,6 +120,9 @@ public static class ServiceProviderExtensions
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>
     /// <returns>The IClientInfo object.</returns>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public static IClientInfo GetClientInfo(this IServiceProvider serviceProvider)
         => serviceProvider.GetRequiredServiceInternal<IClientInfo>();
@@ -211,6 +214,9 @@ public static class ServiceProviderExtensions
     /// </summary>
     /// <param name="serviceProvider">The service provider.</param>
     /// <returns>The platform <see cref="IClock"/>.</returns>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Experimental("TPINTERNAL")]
     public static IClock GetSystemClock(this IServiceProvider serviceProvider)

--- a/src/Platform/Microsoft.Testing.Platform/TestFramework/ExecuteRequestContext.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestFramework/ExecuteRequestContext.cs
@@ -23,6 +23,9 @@ public sealed class ExecuteRequestContext
     /// <param name="messageBus">The message bus.</param>
     /// <param name="executeRequestCompletionNotifier">The request completion notifier.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     public ExecuteRequestContext(IRequest request, IMessageBus messageBus, IExecuteRequestCompletionNotifier executeRequestCompletionNotifier,
         CancellationToken cancellationToken)

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostControllerConnectionAuthorizer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostControllerConnectionAuthorizer.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
 /// where a sandboxed application is an AppContainer and the values below are its package SID. Elsewhere
 /// the returned values are ignored and the connection is created unchanged.
 /// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostControllerConnectionAuthorizer

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostControllerManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostControllerManager.cs
@@ -44,6 +44,9 @@ public interface ITestHostControllersManager
     /// default <c>Process.Start</c> behavior. At most one launcher can be registered.
     /// </summary>
     /// <param name="testHostLauncherFactory">The factory method that creates the test host launcher.</param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     void AddTestHostLauncher(Func<IServiceProvider, ITestHostLauncher> testHostLauncherFactory);
 
@@ -53,6 +56,9 @@ public interface ITestHostControllersManager
     /// </summary>
     /// <typeparam name="T">The type of the test host launcher.</typeparam>
     /// <param name="compositeServiceFactory">The factory method that creates the composite service.</param>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
     void AddTestHostLauncher<T>(CompositeExtensionFactory<T> compositeServiceFactory)
         where T : class, ITestHostLauncher;

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostHandle.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostHandle.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
@@ -14,6 +14,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
 /// lifetime of the test host and disposes it (via <see cref="IDisposable"/>) once the host has
 /// exited, so implementations should release any OS resources they hold (process objects, sockets,
 /// container clients, …) in <see cref="IDisposable.Dispose"/>.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostHandle : IDisposable

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostLauncher.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/ITestHostLauncher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
@@ -14,6 +14,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
 /// carry extension-specific connection metadata such as Retry. Launchers must forward the supplied context
 /// opaquely rather than require one specific handshake. The launcher does not have to start a local OS
 /// process as long as it returns an <see cref="ITestHostHandle"/> the platform can monitor.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostLauncher : ITestHostControllersExtension

--- a/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostLaunchContext.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostControllers/TestHostLaunchContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
@@ -7,6 +7,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostControllers;
 /// Carries the fully prepared information the platform would have used to start the test host,
 /// passed to an <see cref="ITestHostLauncher"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public sealed class TestHostLaunchContext
 {

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostExecutionOrchestrator.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostExecutionOrchestrator.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostOrchestrator;
 /// <summary>
 /// Represents an extension that orchestrates test host execution.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostExecutionOrchestrator : ITestHostOrchestratorExtension
 {

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorApplicationLifetime.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorApplicationLifetime.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostOrchestrator;
 /// <summary>
 /// Represents the application lifetime for a test host orchestrator.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostOrchestratorApplicationLifetime : ITestHostOrchestratorExtension
 {

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorExtension.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorExtension.cs
@@ -6,5 +6,8 @@ namespace Microsoft.Testing.Platform.Extensions.TestHostOrchestrator;
 /// <summary>
 /// Represents an extension for test host orchestrators.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostOrchestratorExtension : IExtension;

--- a/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/TestHostOrchestrator/ITestHostOrchestratorManager.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.TestHostOrchestrator;
 /// <summary>
 /// Represents a manager for test host orchestrators.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITestHostOrchestratorManager
 {

--- a/src/Platform/Microsoft.Testing.Platform/Tools/ITool.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Tools/ITool.cs
@@ -9,6 +9,9 @@ namespace Microsoft.Testing.Platform.Tools;
 /// Represents a non-test command that can be invoked by passing its <see cref="Name"/>
 /// as the first positional command-line argument.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface ITool : IExtension
 {

--- a/src/Platform/Microsoft.Testing.Platform/Tools/IToolCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Tools/IToolCommandLineOptionsProvider.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Testing.Platform.Tools;
 /// <summary>
 /// Represents command-line options that apply to a specific <see cref="ITool"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IToolCommandLineOptionsProvider : ICommandLineOptionsProvider
 {

--- a/src/Platform/Microsoft.Testing.Platform/Tools/IToolsManager.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Tools/IToolsManager.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Testing.Platform.Tools;
 /// <summary>
 /// Registers tools with a test application.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
 public interface IToolsManager
 {

--- a/src/TestFramework/TestFramework.Extensions/ITestRunInfo.cs
+++ b/src/TestFramework/TestFramework.Extensions/ITestRunInfo.cs
@@ -10,6 +10,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// Unlike <see cref="TestContext"/>, which describes the test currently executing, an
 /// <see cref="ITestRunInfo"/> describes the run as a whole and is queryable from any code reachable
 /// during a test run (for example helpers, fixtures, or <c>[AssemblyInitialize]</c> methods).
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public interface ITestRunInfo

--- a/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
+++ b/src/TestFramework/TestFramework.Extensions/PlannedTest.cs
@@ -12,6 +12,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// They are intended for read-only inspection (for example to decide whether expensive setup is
 /// needed in <c>[AssemblyInitialize]</c>); they do not carry execution-time state such as outcome,
 /// exceptions, or data-driven rows.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public sealed class PlannedTest

--- a/src/TestFramework/TestFramework.Extensions/TestContext.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestContext.cs
@@ -23,6 +23,9 @@ public abstract class TestContext
     /// <remarks>
     /// This property returns the context for the currently executing test. When accessed outside of a test execution,
     /// it returns <see langword="null"/>.
+    /// <para>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </para>
     /// </remarks>
     [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
     public static TestContext? Current

--- a/src/TestFramework/TestFramework.Extensions/TestRun.cs
+++ b/src/TestFramework/TestFramework.Extensions/TestRun.cs
@@ -15,6 +15,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// The information is scoped to the current process and (on .NET Framework) the current
 /// AppDomain. Cross-process or cross-AppDomain test runs each have their own snapshot.
 /// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public static class TestRun

--- a/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.AddValueFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -44,6 +44,9 @@ public sealed partial class Assert
     /// <item><description><c>[ClassInitialize]</c>: all tests in the containing class.</description></item>
     /// <item><description><c>[AssemblyInitialize]</c>: all tests in the containing assembly.</description></item>
     /// </list>
+    /// <para>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </para>
     /// </remarks>
     /// <example>
     /// <code language="csharp">
@@ -97,6 +100,9 @@ public sealed partial class Assert
     /// disposal of other registrations is honored), not just once at registration time. Keep it cheap and
     /// side-effect free; perform any expensive setup outside the factory and have it return a formatter that
     /// closes over the precomputed state.
+    /// </para>
+    /// <para>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
     /// </para>
     /// </remarks>
     [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]

--- a/src/TestFramework/TestFramework/Assertions/Assert.Scope.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.Scope.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,6 +25,9 @@ public sealed partial class Assert
     /// // AssertFailedException is thrown here with all collected failures.
     /// </code>
     /// </example>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
     public static IDisposable Scope() => new AssertScope();
 }

--- a/src/TestFramework/TestFramework/Attributes/Lifecycle/TestFilterProviderAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/Lifecycle/TestFilterProviderAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,6 +32,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// The filter runs <em>before</em> the test type is loaded, before <c>[AssemblyInitialize]</c>,
 /// before <c>[ClassInitialize]</c>, and before the test constructor is invoked, so dropping or
 /// skipping a test through <see cref="ITestFilter"/> avoids paying any of those costs.
+/// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/TestFramework/TestFramework/Attributes/Lifecycle/TestFilterProviderAttributeOfT.cs
+++ b/src/TestFramework/TestFramework/Attributes/Lifecycle/TestFilterProviderAttributeOfT.cs
@@ -46,6 +46,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// #endif
 /// </code>
 /// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryBaseAttribute.cs
@@ -34,6 +34,9 @@ public abstract class RetryBaseAttribute : Attribute
     /// reported, tagged as superseded, so tooling can surface the retry (attempt count, flaky detection,
     /// per-attempt error messages). The VSTest host receives only the final result.
     /// </returns>
+    /// <remarks>
+    /// This API is experimental. It may change, break, or be removed at any time without notice.
+    /// </remarks>
     [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
     protected internal abstract Task<RetryResult> ExecuteAsync(RetryContext retryContext);
 

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryContext.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryContext.cs
@@ -6,6 +6,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// <summary>
 /// Represents the context for a test retry.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public readonly struct RetryContext
 {

--- a/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
+++ b/src/TestFramework/TestFramework/Attributes/TestMethod/RetryResult.cs
@@ -8,6 +8,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// <summary>
 /// The result of a test retry.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public sealed class RetryResult
 {

--- a/src/TestFramework/TestFramework/Filtering/ITestFilter.cs
+++ b/src/TestFramework/TestFramework/Filtering/ITestFilter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -27,6 +27,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// (it requires loading the declaring type, which <see cref="ITestFilter"/> is specifically designed
 /// to avoid). Returning <see cref="TestFilterResult.Run"/> does not override a later
 /// <c>[Ignore]</c>; an ignored test is still ignored.
+/// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]

--- a/src/TestFramework/TestFramework/Filtering/TestFilterAction.cs
+++ b/src/TestFramework/TestFramework/Filtering/TestFilterAction.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +7,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// Indicates how the MSTest adapter should treat a test for which an <see cref="ITestFilter"/>
 /// returned a particular <see cref="TestFilterResult"/>.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public enum TestFilterAction
 {

--- a/src/TestFramework/TestFramework/Filtering/TestFilterContext.cs
+++ b/src/TestFramework/TestFramework/Filtering/TestFilterContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// existing <see cref="ITestFilter"/> implementations or their unit tests. Consumers construct
 /// instances using an object initializer (e.g. <c>new TestFilterContext { FullyQualifiedName = "…" }</c>);
 /// no positional constructor needs to be updated when new properties land.
+/// </para>
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]

--- a/src/TestFramework/TestFramework/Filtering/TestFilterResult.cs
+++ b/src/TestFramework/TestFramework/Filtering/TestFilterResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,6 +11,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// allocation-free. Use the static <see cref="Run"/> / <see cref="Drop"/> properties (one shared
 /// value each) or the parameterized <see cref="Skip(string)"/> factory to create explicit results.
 /// The default value also represents <see cref="Run"/>.
+/// <para>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </para>
 /// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public readonly struct TestFilterResult : IEquatable<TestFilterResult>

--- a/src/TestFramework/TestFramework/Interfaces/ITestDataSourceEmptyDataSourceExceptionInfo.cs
+++ b/src/TestFramework/TestFramework/Interfaces/ITestDataSourceEmptyDataSourceExceptionInfo.cs
@@ -8,6 +8,9 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting;
 /// returns no rows. When a data source implements this interface, MSTest uses the returned member and type names to
 /// build a more actionable exception message instead of the generic <c>GetData returned empty collection</c> message.
 /// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
 [Experimental("MSTESTEXP", UrlFormat = "https://aka.ms/mstest/diagnostics#{0}")]
 public interface ITestDataSourceEmptyDataSourceExceptionInfo
 {


### PR DESCRIPTION
## Summary

- add an explicit instability warning to all 97 APIs marked with `[Experimental]`
- preserve existing remarks and examples while surfacing the warning in generated API documentation
- document the requirement in `.github/copilot-instructions.md` for future experimental APIs

## Validation

- full repository build completed successfully
- verified all 97 experimental declarations have the warning in their associated XML documentation
- verified all changed C# files use UTF-8 with BOM