### PR TITLE
Respect SatelliteResourceLanguages for adapter resources

### DIFF
--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -57,15 +57,25 @@
     <!--
       MTP scenario (EnableMSTestRunner): the UI language is chosen at runtime (for example via
       TESTINGPLATFORM_UI_LANGUAGE / DOTNET_CLI_UI_LANGUAGE), so the build-machine culture is irrelevant.
-      Every localized satellite must be copied to the output directory so any culture can be resolved at run time.
+      Every requested localized satellite must be copied to the output directory so any selected culture can be resolved at run time.
       -->
     <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' ">
-      <MSTestV2Files Include="$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\_localization'))\**\*.dll" />
+      <_MSTestSatelliteResourceLanguages Include="$(SatelliteResourceLanguages)" />
+      <_MSTestV2Files Include="$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\_localization'))\**\*.dll" />
       <!-- Set UICulture from the satellite's culture folder. This is done via Update (not inline on Include) because
            the well-known %(RecursiveDir) metadata is only available on items after they have been created. -->
-      <MSTestV2Files Update="@(MSTestV2Files)">
+      <_MSTestV2Files Update="@(_MSTestV2Files)">
         <UICulture>%(RecursiveDir)</UICulture>
-      </MSTestV2Files>
+        <Culture>$([System.String]::Copy('%(RecursiveDir)').TrimEnd('\').TrimEnd('/').ToLowerInvariant())</Culture>
+      </_MSTestV2Files>
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(EnableMSTestRunner)' == 'true' AND '$(SatelliteResourceLanguages)' != '' ">
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>;@(_MSTestSatelliteResourceLanguages);</_MSTestSatelliteResourceLanguagesWithDelimiters>
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>$([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').ToLowerInvariant())</_MSTestSatelliteResourceLanguagesWithDelimiters>
+    </PropertyGroup>
+    <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' ">
+      <MSTestV2Files Include="@(_MSTestV2Files)"
+                     Condition=" '$(SatelliteResourceLanguages)' == '' OR $([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').Contains(';%(_MSTestV2Files.Culture);')) " />
     </ItemGroup>
 
     <!--

--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/common/MSTest.TestAdapter.targets
@@ -54,6 +54,14 @@
   </PropertyGroup>
 
   <Target Name="GetMSTestV2CultureHierarchy" Returns="@(MSTestV2Files)">
+    <ItemGroup>
+      <_MSTestSatelliteResourceLanguages Include="$(SatelliteResourceLanguages)" />
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(SatelliteResourceLanguages)' != '' ">
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>;@(_MSTestSatelliteResourceLanguages);</_MSTestSatelliteResourceLanguagesWithDelimiters>
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>$([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').ToLowerInvariant())</_MSTestSatelliteResourceLanguagesWithDelimiters>
+    </PropertyGroup>
+
     <!--
       MTP scenario (EnableMSTestRunner): the UI language is chosen at runtime (for example via
       TESTINGPLATFORM_UI_LANGUAGE / DOTNET_CLI_UI_LANGUAGE), so the build-machine culture is irrelevant.
@@ -68,14 +76,6 @@
         <UICulture>%(RecursiveDir)</UICulture>
         <Culture>$([System.String]::Copy('%(RecursiveDir)').TrimEnd('\').TrimEnd('/').ToLowerInvariant())</Culture>
       </_MSTestV2Files>
-    </ItemGroup>
-    <PropertyGroup Condition=" '$(EnableMSTestRunner)' == 'true' AND '$(SatelliteResourceLanguages)' != '' ">
-      <_MSTestSatelliteResourceLanguagesWithDelimiters>;@(_MSTestSatelliteResourceLanguages);</_MSTestSatelliteResourceLanguagesWithDelimiters>
-      <_MSTestSatelliteResourceLanguagesWithDelimiters>$([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').ToLowerInvariant())</_MSTestSatelliteResourceLanguagesWithDelimiters>
-    </PropertyGroup>
-    <ItemGroup Condition=" '$(EnableMSTestRunner)' == 'true' ">
-      <MSTestV2Files Include="@(_MSTestV2Files)"
-                     Condition=" '$(SatelliteResourceLanguages)' == '' OR $([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').Contains(';%(_MSTestV2Files.Culture);')) " />
     </ItemGroup>
 
     <!--
@@ -101,9 +101,15 @@
       Inputs/Outputs of CopyMSTestV2Resources are evaluated for incremental build.
     -->
     <ItemGroup Condition=" '$(EnableMSTestRunner)' != 'true' ">
-      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
+      <_MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
         <UICulture>%(CurrentUICultureHierarchy.Identity)\</UICulture>
-      </MSTestV2Files>
+        <Culture>$([System.String]::Copy('%(CurrentUICultureHierarchy.Identity)').ToLowerInvariant())</Culture>
+      </_MSTestV2Files>
+    </ItemGroup>
+
+    <ItemGroup>
+      <MSTestV2Files Include="@(_MSTestV2Files)"
+                     Condition=" '$(SatelliteResourceLanguages)' == '' OR $([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').Contains(';%(_MSTestV2Files.Culture);')) " />
     </ItemGroup>
   </Target>
 

--- a/src/Adapter/MSTest.TestAdapter/buildTransitive/uwp/MSTest.TestAdapter.targets
+++ b/src/Adapter/MSTest.TestAdapter/buildTransitive/uwp/MSTest.TestAdapter.targets
@@ -14,6 +14,14 @@
   </ItemGroup>
 
   <Target Name="GetMSTestV2CultureHierarchy" Returns="@(MSTestV2Files)">
+    <ItemGroup>
+      <_MSTestSatelliteResourceLanguages Include="$(SatelliteResourceLanguages)" />
+    </ItemGroup>
+    <PropertyGroup Condition=" '$(SatelliteResourceLanguages)' != '' ">
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>;@(_MSTestSatelliteResourceLanguages);</_MSTestSatelliteResourceLanguagesWithDelimiters>
+      <_MSTestSatelliteResourceLanguagesWithDelimiters>$([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').ToLowerInvariant())</_MSTestSatelliteResourceLanguagesWithDelimiters>
+    </PropertyGroup>
+
     <!--
       Only traversing 5 levels in the culture hierarchy. This is the maximum length for all cultures and should be sufficient
       to get to a culture name that maps to a resource folder we package.
@@ -35,9 +43,12 @@
       Inputs/Outputs of CopyMSTestV2Resources are evaluated for incremental build.
     -->
     <ItemGroup>
-      <MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
+      <_MSTestV2Files Include="$(MSBuildThisFileDirectory)..\_localization\%(CurrentUICultureHierarchy.Identity)\*.dll">
         <UICulture>%(CurrentUICultureHierarchy.Identity)</UICulture>
-      </MSTestV2Files>
+        <Culture>$([System.String]::Copy('%(CurrentUICultureHierarchy.Identity)').ToLowerInvariant())</Culture>
+      </_MSTestV2Files>
+      <MSTestV2Files Include="@(_MSTestV2Files)"
+                     Condition=" '$(SatelliteResourceLanguages)' == '' OR $([System.String]::Copy('$(_MSTestSatelliteResourceLanguagesWithDelimiters)').Contains(';%(_MSTestV2Files.Culture);')) " />
     </ItemGroup>
   </Target>
 

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -145,26 +145,39 @@ namespace MSTestSdkTest
     }
 
     [TestMethod]
-    [DataRow("Unset", "", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
-    [DataRow("Empty", "<SatelliteResourceLanguages />", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
-    [DataRow("SingleLanguage", "<SatelliteResourceLanguages>fr</SatelliteResourceLanguages>", "fr")]
-    [DataRow("CaseInsensitiveLanguage", "<SatelliteResourceLanguages>FR</SatelliteResourceLanguages>", "fr")]
-    [DataRow("MultipleLanguages", "<SatelliteResourceLanguages>fr;ja</SatelliteResourceLanguages>", "fr;ja")]
-    [DataRow("NeutralLanguageOnly", "<NeutralLanguage>en-US</NeutralLanguage>", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
-    [DataRow("NeutralLanguageFilter", "<NeutralLanguage>en-US</NeutralLanguage><SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>", "")]
-    public async Task SatelliteResourceLanguages_FiltersAdapterResources(string scenario, string properties, string expectedCultures)
+    [DataRow("MTP", "Unset", "", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("MTP", "Empty", "<SatelliteResourceLanguages />", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("MTP", "SingleLanguage", "<SatelliteResourceLanguages>fr</SatelliteResourceLanguages>", "fr")]
+    [DataRow("MTP", "CaseInsensitiveLanguage", "<SatelliteResourceLanguages>FR</SatelliteResourceLanguages>", "fr")]
+    [DataRow("MTP", "MultipleLanguages", "<SatelliteResourceLanguages>fr;ja</SatelliteResourceLanguages>", "fr;ja")]
+    [DataRow("MTP", "SpecificCultureDoesNotMatchParent", "<SatelliteResourceLanguages>fr-FR</SatelliteResourceLanguages>", "")]
+    [DataRow("MTP", "ParentCultureDoesNotMatchSpecific", "<SatelliteResourceLanguages>pt</SatelliteResourceLanguages>", "")]
+    [DataRow("MTP", "NeutralLanguageOnly", "<NeutralLanguage>en-US</NeutralLanguage>", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("MTP", "NeutralLanguageFilter", "<NeutralLanguage>en-US</NeutralLanguage><SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>", "")]
+    [DataRow("VSTest", "Unset", "", "fr")]
+    [DataRow("VSTest", "Empty", "<SatelliteResourceLanguages />", "fr")]
+    [DataRow("VSTest", "SingleLanguage", "<SatelliteResourceLanguages>fr</SatelliteResourceLanguages>", "fr")]
+    [DataRow("VSTest", "CaseInsensitiveLanguage", "<SatelliteResourceLanguages>FR</SatelliteResourceLanguages>", "fr")]
+    [DataRow("VSTest", "MultipleLanguages", "<SatelliteResourceLanguages>fr;ja</SatelliteResourceLanguages>", "fr")]
+    [DataRow("VSTest", "DifferentLanguage", "<SatelliteResourceLanguages>ja</SatelliteResourceLanguages>", "")]
+    [DataRow("VSTest", "SpecificCultureDoesNotMatchParent", "<SatelliteResourceLanguages>fr-FR</SatelliteResourceLanguages>", "")]
+    [DataRow("VSTest", "NeutralLanguageOnly", "<NeutralLanguage>en-US</NeutralLanguage>", "fr")]
+    [DataRow("VSTest", "NeutralLanguageFilter", "<NeutralLanguage>en-US</NeutralLanguage><SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>", "")]
+    public async Task SatelliteResourceLanguages_FiltersAdapterResources(string runner, string scenario, string properties, string expectedCultures)
     {
-        string assetName = $"{AssetName}Satellites{scenario}";
+        string assetName = $"{AssetName}{runner}Satellites{scenario}";
+        string runnerProperties = runner == "VSTest" ? "<UseVSTest>true</UseVSTest>" : string.Empty;
         using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
             assetName,
             SingleTestSourceCode
                 .PatchCodeWithReplace("MSTestSdk.csproj", $"{assetName}.csproj")
                 .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
                 .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
-                .PatchCodeWithReplace("$ExtraProperties$", properties));
+                .PatchCodeWithReplace("$ExtraProperties$", runnerProperties + properties));
 
         DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
             $"build -c {BuildConfiguration.Release} {testAsset.TargetAssetPath}",
+            environmentVariables: new() { ["DOTNET_CLI_UI_LANGUAGE"] = "fr" },
             cancellationToken: TestContext.CancellationToken);
         compilationResult.AssertExitCodeIs(0);
 
@@ -173,6 +186,53 @@ namespace MSTestSdkTest
 
         AssertSatelliteCultures(outputDirectory, "MSTest.TestAdapter.resources.dll", expected);
         AssertSatelliteCultures(outputDirectory, "MSTestAdapter.PlatformServices.resources.dll", expected);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows, IgnoreMessage = "Classic UWP package assets are produced only on Windows.")]
+    [DataRow("Unset", "", "fr;fr")]
+    [DataRow("Empty", "<SatelliteResourceLanguages />", "fr;fr")]
+    [DataRow("MatchingLanguage", "<SatelliteResourceLanguages>fr</SatelliteResourceLanguages>", "fr;fr")]
+    [DataRow("CaseInsensitiveLanguage", "<SatelliteResourceLanguages>FR</SatelliteResourceLanguages>", "fr;fr")]
+    [DataRow("DifferentLanguage", "<SatelliteResourceLanguages>ja</SatelliteResourceLanguages>", "")]
+    [DataRow("SpecificCultureDoesNotMatchParent", "<SatelliteResourceLanguages>fr-FR</SatelliteResourceLanguages>", "")]
+    public async Task SatelliteResourceLanguages_FiltersClassicUwpAdapterResources(string scenario, string properties, string expectedCultures)
+    {
+        const string Source = """
+            #file ClassicUwpSatelliteResources.csproj
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>$TargetFramework$</TargetFramework>
+                $Properties$
+              </PropertyGroup>
+
+              <ItemGroup>
+                <PackageReference Include="MSTest.TestAdapter" Version="$MSTestVersion$" GeneratePathProperty="true" ExcludeAssets="all" />
+              </ItemGroup>
+
+              <Import Project="$(PkgMSTest_TestAdapter)\buildTransitive\uap10.0\MSTest.TestAdapter.targets"
+                      Condition=" '$(PkgMSTest_TestAdapter)' != '' " />
+
+              <Target Name="PrintSatelliteCultures" DependsOnTargets="GetMSTestV2CultureHierarchy">
+                <Message Text="SatelliteCultures=[@(MSTestV2Files->'%(UICulture)')]" Importance="High" />
+              </Target>
+            </Project>
+            """;
+
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            $"{AssetName}ClassicUwpSatellites{scenario}",
+            Source
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+                .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$Properties$", properties));
+
+        DotnetMuxerResult result = await DotnetCli.RunAsync(
+            $"msbuild {testAsset.TargetAssetPath} -restore -t:PrintSatelliteCultures",
+            environmentVariables: new() { ["DOTNET_CLI_UI_LANGUAGE"] = "fr" },
+            cancellationToken: TestContext.CancellationToken);
+
+        result.AssertExitCodeIs(0);
+        result.AssertOutputContains($"SatelliteCultures=[{expectedCultures}]");
     }
 
     [TestMethod]

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SdkTests.cs
@@ -145,6 +145,37 @@ namespace MSTestSdkTest
     }
 
     [TestMethod]
+    [DataRow("Unset", "", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("Empty", "<SatelliteResourceLanguages />", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("SingleLanguage", "<SatelliteResourceLanguages>fr</SatelliteResourceLanguages>", "fr")]
+    [DataRow("CaseInsensitiveLanguage", "<SatelliteResourceLanguages>FR</SatelliteResourceLanguages>", "fr")]
+    [DataRow("MultipleLanguages", "<SatelliteResourceLanguages>fr;ja</SatelliteResourceLanguages>", "fr;ja")]
+    [DataRow("NeutralLanguageOnly", "<NeutralLanguage>en-US</NeutralLanguage>", "cs;de;es;fr;it;ja;ko;pl;pt-BR;ru;tr;zh-Hans;zh-Hant")]
+    [DataRow("NeutralLanguageFilter", "<NeutralLanguage>en-US</NeutralLanguage><SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>", "")]
+    public async Task SatelliteResourceLanguages_FiltersAdapterResources(string scenario, string properties, string expectedCultures)
+    {
+        string assetName = $"{AssetName}Satellites{scenario}";
+        using TestAsset testAsset = await TestAsset.GenerateAssetAsync(
+            assetName,
+            SingleTestSourceCode
+                .PatchCodeWithReplace("MSTestSdk.csproj", $"{assetName}.csproj")
+                .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion)
+                .PatchCodeWithReplace("$TargetFramework$", TargetFrameworks.NetCurrent)
+                .PatchCodeWithReplace("$ExtraProperties$", properties));
+
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync(
+            $"build -c {BuildConfiguration.Release} {testAsset.TargetAssetPath}",
+            cancellationToken: TestContext.CancellationToken);
+        compilationResult.AssertExitCodeIs(0);
+
+        string outputDirectory = Path.Combine(testAsset.TargetAssetPath, "bin", BuildConfiguration.Release.ToString(), TargetFrameworks.NetCurrent);
+        string[] expected = expectedCultures.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+        AssertSatelliteCultures(outputDirectory, "MSTest.TestAdapter.resources.dll", expected);
+        AssertSatelliteCultures(outputDirectory, "MSTestAdapter.PlatformServices.resources.dll", expected);
+    }
+
+    [TestMethod]
     [DynamicData(nameof(GetBuildMatrixMultiTfmFoldedBuildConfiguration), typeof(AcceptanceTestBase<NopAssetFixture>))]
     public async Task RunTests_With_CentralPackageManagement_Standalone(string multiTfm, BuildConfiguration buildConfiguration)
     {
@@ -962,6 +993,20 @@ namespace MSTestWebTest
 
         result.AssertOutputContains("WindowsTestContract:UseVSTest=false;GenerateEntryPoint=true;GenerateHelper=true;PackagedApp=false");
         result.AssertOutputContains("OutputType=Exe");
+    }
+
+    private static void AssertSatelliteCultures(string outputDirectory, string resourceAssemblyName, string[] expectedCultures)
+    {
+        string[] actualCultures = Directory.GetFiles(outputDirectory, resourceAssemblyName, SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(outputDirectory, Path.GetDirectoryName(path)!))
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        string[] expected = expectedCultures.Order(StringComparer.OrdinalIgnoreCase).ToArray();
+
+        CollectionAssert.AreEqual(
+            expected,
+            actualCultures,
+            $"Unexpected cultures for {resourceAssemblyName}. Expected: '{string.Join(";", expected)}'. Actual: '{string.Join(";", actualCultures)}'.");
     }
 
     private async Task<DotnetMuxerResult> EvaluateWindowsApplicationModelAsync(


### PR DESCRIPTION
MSTest.Sdk 4.4.0 started copying every localized adapter satellite into MTP test outputs, even when a project constrained `SatelliteResourceLanguages`. This produced unwanted locale directories and bypassed the behavior users get from normal .NET SDK package resource assets.

## Root cause

PR #9748 intentionally changed the MTP path from copying the build machine's UI-culture hierarchy to globbing every DLL under `buildTransitive/_localization`. MTP can choose its UI language at runtime through `TESTINGPLATFORM_UI_LANGUAGE` or `DOTNET_CLI_UI_LANGUAGE`, so all cultures are required when the project does not specify a filter.

The adapter satellites are manually injected as `Content` with `CopyToOutputDirectory`, rather than flowing through `ResolvePackageAssets`. The .NET SDK therefore never gets a chance to apply `SatelliteResourceLanguages`, and the new all-culture glob copied both `MSTest.TestAdapter.resources.dll` and `MSTestAdapter.PlatformServices.resources.dll` for all 13 packaged cultures.

We missed the regression because the localization tests verified that French and Italian execution worked, but did not assert the consuming project's output layout or exercise `SatelliteResourceLanguages`. Package verification only checked that the satellites were present in the nupkg. Before 4.4, an English build happened to copy no adapter satellites because the package has no `en-US` satellite; that incidental result masked the missing property support.

## Fix

Filter the adapter's custom localization items against `SatelliteResourceLanguages` using case-insensitive, exact culture matching. Unset and explicitly empty values preserve existing behavior. `NeutralLanguage` by itself does not filter satellites, matching .NET SDK semantics.

The same manual-copy pattern also existed in the classic VSTest and classic UWP branches. This PR now applies the filter consistently to all three paths: MTP, VSTest, and classic UWP.

## Regression coverage

Generated consuming projects assert exact output sets for both adapter resource assemblies across:

- unset and explicitly empty values
- single and multiple languages
- case-insensitive matching
- exact matching without parent/specific culture prefix collisions
- `NeutralLanguage` alone
- `NeutralLanguage=en-US` with `SatelliteResourceLanguages=en-US`, the reported reproduction
- MTP and VSTest host selection
- classic UWP package-target selection on Windows

The reported `en-US` case fails if any locale directory is present, so the original regression cannot pass the test silently.

## Related audit

All shipping packages were scanned for satellites outside normal `lib`, `runtimes`, `analyzers`, or `tools` layouts. MSTest.TestAdapter was the only consumer-output package using this custom `_localization` copy path. WinUI and modern UWP use the corrected common target; normal `lib/<tfm>/<culture>` assets remain filtered by the .NET SDK. MSBuild-task and analyzer satellites are internal tool assets and are not copied to test application output.

## Validation

- Full Debug package build succeeded.
- Focused acceptance coverage passed 24/24 scenarios.
- An independent final MSBuild/code review found no remaining correctness issues or equivalent custom copy paths.

Fixes #10972