### PR TITLE
Prevent .NET Framework telemetry consumer starvation

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.Telemetry/AppInsightsProvider.cs
@@ -120,12 +120,16 @@ internal sealed partial class AppInsightsProvider :
 #endif
 
         // On single-threaded wasm runtimes (browser-wasm / wasi-wasm) there is no thread pool, so the
-        // background ingest loop (started via Task.Run) would never run and Dispose's blocking
+        // background ingest loop would never run and Dispose's blocking
         // _telemetryTask.Wait(...) would throw PlatformNotSupportedException. Telemetry requires a
         // background sender, so skip the loop entirely there and keep Dispose non-blocking by leaving
         // the task completed. LogEventAsync short-circuits in this mode, so no events are queued.
         _telemetryTask = RuntimeFeatureHelper.IsMultiThreaded
+#if NETCOREAPP
             ? task.Run(IngestLoopAsync, _testApplicationCancellationTokenSource.CancellationToken)
+#else
+            ? task.RunLongRunning(IngestLoopAsync, "AppInsights telemetry ingest", _testApplicationCancellationTokenSource.CancellationToken)
+#endif
             : Task.CompletedTask;
         _logger = loggerFactory.CreateLogger<AppInsightsProvider>();
     }
@@ -139,14 +143,24 @@ internal sealed partial class AppInsightsProvider :
         }
 
         DateTimeOffset? lastLoggedError = null;
+#if NETCOREAPP
         _testApplicationCancellationTokenSource.CancellationToken.Register(_flushTimeoutOrStop.Cancel);
+#else
+        _testApplicationCancellationTokenSource.CancellationToken.Register(() =>
+        {
+            _flushTimeoutOrStop.Cancel();
+            _payloads.Complete();
+        });
+#endif
 
         try
         {
 #if NETCOREAPP
             while (await _payloads.Reader.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
 #else
-            while (await _payloads.WaitToReadAsync(_flushTimeoutOrStop.Token).ConfigureAwait(false))
+#pragma warning disable VSTHRD103 // The consumer runs on a dedicated thread; synchronous waiting prevents thread-pool starvation.
+            while (_payloads.WaitToRead())
+#pragma warning restore VSTHRD103
 #endif
             {
                 if (_client is null)

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AppInsightsProviderTests.cs
@@ -36,6 +36,34 @@ public sealed class AppInsightsProviderTests
         telemetryClient.Verify(x => x.Flush(), Times.Never);
     }
 
+#if !NETCOREAPP
+    [TestMethod]
+    public void Constructor_StartsTelemetryConsumerOnDedicatedThread()
+    {
+        Mock<ITask> task = new();
+        task.Setup(x => x.RunLongRunning(It.IsAny<Func<Task>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _ = new AppInsightsProvider(
+            new Mock<IEnvironment>().Object,
+            new Mock<ITestApplicationCancellationTokenSource>().Object,
+            task.Object,
+            new Mock<ILoggerFactory>().Object,
+            new Mock<IClock>().Object,
+            new Mock<IConfiguration>().Object,
+            new Mock<ITelemetryInformation>().Object,
+            new Mock<ITelemetryClientFactory>().Object,
+            "sessionId");
+
+        task.Verify(
+            x => x.RunLongRunning(It.IsAny<Func<Task>>(), "AppInsights telemetry ingest", It.IsAny<CancellationToken>()),
+            Times.Once);
+        task.Verify(
+            x => x.Run(It.IsAny<Func<Task>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+#endif
+
     [TestMethod]
     public async Task FirstPayload_InitializesTelemetryClientOnce()
     {


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Windows CI build 3065109 timed out in six .NET Framework telemetry tests because the AppInsights ingest loop could be starved when scheduled on the thread pool.

Run the .NET Framework consumer on a named dedicated thread and synchronously wait for channel data, while preserving the existing asynchronous thread-pool path on modern .NET. Complete the framework channel during cancellation so the dedicated consumer exits cleanly. Regression coverage verifies the dedicated scheduling path.

Validated with the Microsoft.Testing.Extensions unit tests on net462, net472, and net8.0.