### PR TITLE
Fix source-generated constant emission

### DIFF
--- a/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
@@ -30,7 +30,6 @@ internal static class ReflectionMetadataEmitter
         Append(sb, string.Empty);
         Append(sb, "namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Generated");
         Append(sb, "{");
-        Append(sb, "    /// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>");
         Append(sb, $"    internal static class {GeneratedTypeName}");
         Append(sb, "    {");
         Append(sb, "        [ModuleInitializer]");

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -37,7 +37,6 @@ internal static class MetadataRegistryEmitter
 
         using (sb.Block($"namespace {GeneratedNamespace}"))
         {
-            sb.AppendLine("/// <summary>Describes one test class as discovered at compile-time. Mirrors what <c>IReflectionOperations</c> would return at runtime.</summary>");
             using (sb.Block("internal sealed class TestClassReflectionInfo"))
             {
                 // The stored Type flows into the generated Initialize method's direct GetMethods /
@@ -59,7 +58,6 @@ internal static class MetadataRegistryEmitter
             using (sb.Block("internal sealed class TestMethodReflectionInfo"))
             {
                 sb.AppendLine("public string Name { get; set; } = string.Empty;");
-                sb.AppendLine("/// <summary>True when this method is a <c>[TestMethod]</c> (used to populate the test-method roots); false for fixtures and other registered methods.</summary>");
                 sb.AppendLine("public bool IsTestMethod { get; set; }");
                 sb.AppendLine("public bool IsStatic { get; set; }");
                 sb.AppendLine("public bool IsAsync { get; set; }");
@@ -70,14 +68,11 @@ internal static class MetadataRegistryEmitter
                 sb.AppendLine("public Type[] ParameterTypes { get; set; } = Array.Empty<Type>();");
                 sb.AppendLine("public Attribute[] Attributes { get; set; } = Array.Empty<Attribute>();");
                 sb.AppendLine("public bool AreAttributesComplete { get; set; }");
-                sb.AppendLine("/// <summary>Source-generated accessors for this method's <c>[DynamicData]</c> sources (empty when none were resolved), registered with <c>DynamicDataSourceResolver</c> so the data is read without runtime reflection.</summary>");
                 sb.AppendLine("public IReadOnlyList<DynamicDataSourceReflectionInfo> DynamicDataSources { get; set; } = Array.Empty<DynamicDataSourceReflectionInfo>();");
-                sb.AppendLine("/// <summary>Direct invoker — replaces <see cref=\"System.Reflection.MethodInfo.Invoke(object, object[])\" />. Always returns a non-null <see cref=\"Task\" /> so the caller can <c>await</c> regardless of whether the underlying test method is <c>void</c>, <c>Task</c>, <c>Task&lt;T&gt;</c>, <c>ValueTask</c>, or <c>ValueTask&lt;T&gt;</c>; the result value (if any) is discarded.</summary>");
                 sb.AppendLine("public Func<object?, object?[]?, Task> Invoke { get; set; } = static (_, _) => Task.CompletedTask;");
             }
 
             sb.AppendLine();
-            sb.AppendLine("/// <summary>A compile-time-resolved <c>[DynamicData]</c> source: the declaring type, the source name, an accessor that returns the raw data object, and (optionally) a custom display-name accessor.</summary>");
             using (sb.Block("internal sealed class DynamicDataSourceReflectionInfo"))
             {
                 sb.AppendLine("public Type DeclaringType { get; set; } = null!;");
@@ -125,7 +120,6 @@ internal static class MetadataRegistryEmitter
 
         using (sb.Block($"namespace {GeneratedNamespace}"))
         {
-            sb.AppendLine($"/// <summary>Source-generated reflection metadata for assembly <c>{assemblyName}</c>.</summary>");
             using (sb.Block($"internal static class {RegistryClassName}"))
             {
                 sb.AppendLine($"public const string AssemblyName = \"{Escape(assemblyName)}\";");
@@ -529,7 +523,7 @@ internal static class MetadataRegistryEmitter
     {
         string? typeName = constant.FullyQualifiedType;
         string raw = FormatPrimitive(constant.PrimitiveValue);
-        return typeName is null ? raw : $"({typeName}){raw}";
+        return typeName is null ? raw : $"({typeName})({raw})";
     }
 
     private static string BuildArrayLiteral(TypedConstantModel constant)
@@ -551,17 +545,29 @@ internal static class MetadataRegistryEmitter
     }
 
     private static string BuildPrimitiveLiteral(TypedConstantModel constant)
-        => FormatPrimitive(constant.PrimitiveValue);
+    {
+        string literal = FormatPrimitive(constant.PrimitiveValue);
+        return constant.PrimitiveValue is byte or sbyte or short or ushort
+            && constant.FullyQualifiedType is { } typeName
+                ? $"({typeName}){(literal.StartsWith("-", StringComparison.Ordinal) ? $"({literal})" : literal)}"
+                : literal;
+    }
 
     private static string FormatPrimitive(object? value)
         => value switch
         {
             null => "null",
-            string s => $"\"{Escape(s)}\"",
+            string s => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(s, quote: true),
             bool b => Bool(b),
-            char c => $"'{(c == '\'' ? "\\'" : c.ToString())}'",
-            float f => f.ToString("R", CultureInfo.InvariantCulture) + "f",
-            double d => d.ToString("R", CultureInfo.InvariantCulture) + "d",
+            char c => Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(c, quote: true),
+            float f when float.IsNaN(f) => "global::System.Single.NaN",
+            float f when float.IsPositiveInfinity(f) => "global::System.Single.PositiveInfinity",
+            float f when float.IsNegativeInfinity(f) => "global::System.Single.NegativeInfinity",
+            float f => f.ToString("R", CultureInfo.InvariantCulture) + "F",
+            double d when double.IsNaN(d) => "global::System.Double.NaN",
+            double d when double.IsPositiveInfinity(d) => "global::System.Double.PositiveInfinity",
+            double d when double.IsNegativeInfinity(d) => "global::System.Double.NegativeInfinity",
+            double d => d.ToString("R", CultureInfo.InvariantCulture) + "D",
             decimal m => m.ToString(CultureInfo.InvariantCulture) + "m",
             long l => l.ToString(CultureInfo.InvariantCulture) + "L",
             ulong ul => ul.ToString(CultureInfo.InvariantCulture) + "UL",

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
@@ -49,7 +49,6 @@ internal static class RuntimeRegistrationEmitter
 
         using (sb.Block($"namespace {GeneratedNamespace}"))
         {
-            sb.AppendLine("/// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>");
             using (sb.Block($"internal static class {GeneratedTypeName}"))
             {
                 sb.AppendLine("[ModuleInitializer]");

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -63,8 +63,15 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
             public class DataRowAttribute : System.Attribute
             {
-                public DataRowAttribute(object? data1) { }
-                public DataRowAttribute(object? data1, params object?[] moreData) { }
+                public DataRowAttribute(object? data1) { Data = new object?[] { data1 }; }
+                public DataRowAttribute(object? data1, params object?[] moreData)
+                {
+                    Data = new object?[moreData.Length + 1];
+                    Data[0] = data1;
+                    System.Array.Copy(moreData, 0, Data, 1, moreData.Length);
+                }
+
+                public object?[] Data { get; }
             }
 
             public enum DynamicDataSourceType { Property = 0, Method = 1, AutoDetect = 2, Field = 3 }
@@ -1870,6 +1877,168 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_PreservesDataRowConstantTypes()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                internal enum ByteEnum : byte { Max = byte.MaxValue }
+                internal enum SByteEnum : sbyte { Min = sbyte.MinValue }
+                internal enum ShortEnum : short { Min = short.MinValue }
+                internal enum UShortEnum : ushort { Max = ushort.MaxValue }
+                internal enum IntEnum : int { Min = int.MinValue }
+                internal enum UIntEnum : uint { Max = uint.MaxValue }
+                internal enum LongEnum : long { Min = long.MinValue }
+                internal enum ULongEnum : ulong { Max = ulong.MaxValue }
+
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow(false, (byte)0x4D, (sbyte)-1, (short)-2, (ushort)3, uint.MaxValue, ulong.MaxValue, '\n')]
+                    [DataRow(ByteEnum.Max, SByteEnum.Min, ShortEnum.Min, UShortEnum.Max, IntEnum.Min, UIntEnum.Max, LongEnum.Min, ULongEnum.Max)]
+                    public void Test(params object?[] values) { }
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(tree => tree.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain(
+            "DataRowAttribute(false, new object[] { (byte)77, (sbyte)(-1), (short)(-2), (ushort)3, 4294967295U, 18446744073709551615UL, '\\n' })");
+        registry.Should().Contain("(global::Sample.ByteEnum)(255)");
+        registry.Should().Contain("(global::Sample.SByteEnum)(-128)");
+        registry.Should().Contain("(global::Sample.ShortEnum)(-32768)");
+        registry.Should().Contain("(global::Sample.UShortEnum)(65535)");
+        registry.Should().Contain("(global::Sample.IntEnum)(-2147483648)");
+        registry.Should().Contain("(global::Sample.UIntEnum)(4294967295U)");
+        registry.Should().Contain("(global::Sample.LongEnum)(-9223372036854775808L)");
+        registry.Should().Contain("(global::Sample.ULongEnum)(18446744073709551615UL)");
+        Diagnostic[] errors = outputCompilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        errors.Should().BeEmpty(
+            "the typed-constant corpus should compile. Diagnostics: {0}",
+            string.Join(Environment.NewLine, errors.Select(diagnostic => diagnostic.ToString())));
+
+        using var assemblyStream = new MemoryStream();
+        outputCompilation.Emit(assemblyStream).Success.Should().BeTrue();
+        var assembly = System.Reflection.Assembly.Load(assemblyStream.ToArray());
+        Type registryType = assembly.GetType("MSTest.SourceGenerated.MSTestReflectionMetadata")!;
+        var testClasses = (System.Collections.IEnumerable)registryType.GetProperty("TestClasses")!.GetValue(null)!;
+        object testClass = testClasses.Cast<object>().Single();
+        var methods = (System.Collections.IEnumerable)testClass.GetType().GetProperty("Methods")!.GetValue(testClass)!;
+        object method = methods.Cast<object>().Single();
+        var attributes = (Attribute[])method.GetType().GetProperty("Attributes")!.GetValue(method)!;
+        object[][] rows = attributes
+            .Where(attribute => attribute.GetType().Name == "DataRowAttribute")
+            .Select(attribute => (object[])attribute.GetType().GetProperty("Data")!.GetValue(attribute)!)
+            .ToArray();
+
+        rows[0][1].Should().BeOfType<byte>().Which.Should().Be(0x4D);
+        rows[0][2].Should().BeOfType<sbyte>().Which.Should().Be(-1);
+        rows[0][3].Should().BeOfType<short>().Which.Should().Be(-2);
+        rows[0][4].Should().BeOfType<ushort>().Which.Should().Be(3);
+        rows[0][5].Should().BeOfType<uint>().Which.Should().Be(uint.MaxValue);
+        rows[0][6].Should().BeOfType<ulong>().Which.Should().Be(ulong.MaxValue);
+        rows[0][7].Should().BeOfType<char>().Which.Should().Be('\n');
+        rows[1].Select(value => value.GetType().FullName).Should().Equal(
+            "Sample.ByteEnum",
+            "Sample.SByteEnum",
+            "Sample.ShortEnum",
+            "Sample.UShortEnum",
+            "Sample.IntEnum",
+            "Sample.UIntEnum",
+            "Sample.LongEnum",
+            "Sample.ULongEnum");
+    }
+
+    [TestMethod]
+    public void Generator_EscapesDataRowStringAndCharacterLiterals()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+                    [TestMethod]
+                    [DataRow("\tMZXW6\r\n", "\"\\\0\u2028\u2029", '\'', '\\', '\0', '\u2028')]
+                    public void Test(params object?[] values) { }
+                }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(tree => tree.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain("\"\\tMZXW6\\r\\n\"");
+        registry.Should().Contain("\"\\\"\\\\\\0\\u2028\\u2029\"");
+        registry.Should().Contain("'\\''");
+        registry.Should().Contain("'\\\\'");
+        registry.Should().Contain("'\\0'");
+        registry.Should().Contain("'\\u2028'");
+        outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Generator_DeterministicLiteralCorpus_CompilesWithoutGeneratedDiagnostics()
+    {
+        const int seed = 0x5EED;
+        char[] alphabet = ['\0', '\u0001', '\t', '\r', '\n', '"', '\\', '\u2028', '\u2029', '\u2603'];
+        var random = new Random(seed);
+        string[] values = Enumerable.Range(0, 64)
+            .Select(_ => new string(Enumerable.Range(0, random.Next(0, 24))
+                .Select(_ => alphabet[random.Next(alphabet.Length)])
+                .ToArray()))
+            .ToArray();
+        string dataRows = string.Join(
+            Environment.NewLine,
+            values.Select(value => $"        [DataRow({Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true)})]"));
+        string userCode = $$"""
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                [TestClass]
+                public class Tests
+                {
+            {{dataRows}}
+                    [DataRow(float.NaN)]
+                    [DataRow(float.PositiveInfinity)]
+                    [DataRow(float.NegativeInfinity)]
+                    [DataRow(double.NaN)]
+                    [DataRow(double.PositiveInfinity)]
+                    [DataRow(double.NegativeInfinity)]
+                    [DataRow(new int[] { int.MinValue, 0, int.MaxValue })]
+                    [TestMethod]
+                    public void Test(object? value) { }
+                }
+            }
+            """;
+        var parseOptions = new CSharpParseOptions(documentationMode: DocumentationMode.Diagnose);
+        CSharpCompilation compilation = CreateCompilation(parseOptions, MinimalMSTestStub, userCode);
+        GeneratorDriver driver = CreateDriver(compilation);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out _);
+
+        Diagnostic[] generatedDiagnostics = outputCompilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Warning
+                && diagnostic.Location.SourceTree?.FilePath.EndsWith(".g.cs", StringComparison.Ordinal) == true)
+            .ToArray();
+
+        generatedDiagnostics.Should().BeEmpty($"the deterministic literal corpus with seed {seed} should produce clean generated source");
+    }
+
+    [TestMethod]
     public void Generator_HandlesNullValueInDataRow()
     {
         const string userCode = """
@@ -3556,11 +3725,14 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             driverOptions: new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps));
 
     private static CSharpCompilation CreateCompilation(params string[] sources)
+        => CreateCompilation(CSharpParseOptions.Default, sources);
+
+    private static CSharpCompilation CreateCompilation(CSharpParseOptions parseOptions, params string[] sources)
     {
         // Always include the adapter hook stub so the emitted [ModuleInitializer] registration
         // (which calls ReflectionMetadataHook.Register) compiles in the Roslyn test compilation
         // without referencing MSTestAdapter.PlatformServices.
-        IEnumerable<SyntaxTree> trees = sources.Append(RuntimeHookStub).Select(s => CSharpSyntaxTree.ParseText(s));
+        IEnumerable<SyntaxTree> trees = sources.Append(RuntimeHookStub).Select(source => CSharpSyntaxTree.ParseText(source, parseOptions));
         MetadataReference[] references = new[]
         {
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1976,6 +1976,14 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registry.Should().Contain("'\\0'");
         registry.Should().Contain("'\\u2028'");
         outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+
+        object[][] rows = GetMaterializedDataRows(outputCompilation);
+        rows[0][0].Should().Be("\tMZXW6\r\n");
+        rows[0][1].Should().Be("\"\\\0\u2028\u2029");
+        rows[0][2].Should().Be('\'');
+        rows[0][3].Should().Be('\\');
+        rows[0][4].Should().Be('\0');
+        rows[0][5].Should().Be('\u2028');
     }
 
     [TestMethod]
@@ -2065,7 +2073,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         rows[rowIndex++][0].Should().Be(double.MinValue);
         rows[rowIndex++][0].Should().Be(double.MaxValue);
         BitConverter.DoubleToInt64Bits((double)rows[rowIndex++][0]).Should().Be(BitConverter.DoubleToInt64Bits(-0.0D));
-        rows[rowIndex][0].Should().Be(double.Epsilon);
+        rows[rowIndex++][0].Should().Be(double.Epsilon);
+        rows[rowIndex++][0].Should().BeOfType<int[]>().Which.Should().Equal(int.MinValue, 0, int.MaxValue);
+        rowIndex.Should().Be(rows.Length);
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1926,19 +1926,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             "the typed-constant corpus should compile. Diagnostics: {0}",
             string.Join(Environment.NewLine, errors.Select(diagnostic => diagnostic.ToString())));
 
-        using var assemblyStream = new MemoryStream();
-        outputCompilation.Emit(assemblyStream).Success.Should().BeTrue();
-        var assembly = System.Reflection.Assembly.Load(assemblyStream.ToArray());
-        Type registryType = assembly.GetType("MSTest.SourceGenerated.MSTestReflectionMetadata")!;
-        var testClasses = (System.Collections.IEnumerable)registryType.GetProperty("TestClasses")!.GetValue(null)!;
-        object testClass = testClasses.Cast<object>().Single();
-        var methods = (System.Collections.IEnumerable)testClass.GetType().GetProperty("Methods")!.GetValue(testClass)!;
-        object method = methods.Cast<object>().Single();
-        var attributes = (Attribute[])method.GetType().GetProperty("Attributes")!.GetValue(method)!;
-        object[][] rows = attributes
-            .Where(attribute => attribute.GetType().Name == "DataRowAttribute")
-            .Select(attribute => (object[])attribute.GetType().GetProperty("Data")!.GetValue(attribute)!)
-            .ToArray();
+        object[][] rows = GetMaterializedDataRows(outputCompilation);
 
         rows[0][1].Should().BeOfType<byte>().Which.Should().Be(0x4D);
         rows[0][2].Should().BeOfType<sbyte>().Which.Should().Be(-1);
@@ -1994,13 +1982,17 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     public void Generator_DeterministicLiteralCorpus_CompilesWithoutGeneratedDiagnostics()
     {
         const int seed = 0x5EED;
-        char[] alphabet = ['\0', '\u0001', '\t', '\r', '\n', '"', '\\', '\u2028', '\u2029', '\u2603'];
         var random = new Random(seed);
-        string[] values = Enumerable.Range(0, 64)
+        string[] values =
+        [
+            "\uD800",
+            "\uDFFF",
+            "\uD83D\uDE00",
+            .. Enumerable.Range(0, 64)
             .Select(_ => new string(Enumerable.Range(0, random.Next(0, 24))
-                .Select(_ => alphabet[random.Next(alphabet.Length)])
+                .Select(_ => (char)random.Next(char.MinValue, char.MaxValue + 1))
                 .ToArray()))
-            .ToArray();
+        ];
         string dataRows = string.Join(
             Environment.NewLine,
             values.Select(value => $"        [DataRow({Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true)})]"));
@@ -2019,6 +2011,14 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                     [DataRow(double.NaN)]
                     [DataRow(double.PositiveInfinity)]
                     [DataRow(double.NegativeInfinity)]
+                    [DataRow(float.MinValue)]
+                    [DataRow(float.MaxValue)]
+                    [DataRow(-0.0F)]
+                    [DataRow(float.Epsilon)]
+                    [DataRow(double.MinValue)]
+                    [DataRow(double.MaxValue)]
+                    [DataRow(-0.0D)]
+                    [DataRow(double.Epsilon)]
                     [DataRow(new int[] { int.MinValue, 0, int.MaxValue })]
                     [TestMethod]
                     public void Test(object? value) { }
@@ -2032,10 +2032,40 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
         Diagnostic[] generatedDiagnostics = outputCompilation.GetDiagnostics()
             .Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Warning
-                && diagnostic.Location.SourceTree?.FilePath.EndsWith(".g.cs", StringComparison.Ordinal) == true)
+                && diagnostic.Location.SourceTree?.FilePath.EndsWith(".g.cs", StringComparison.Ordinal) is true)
             .ToArray();
 
         generatedDiagnostics.Should().BeEmpty($"the deterministic literal corpus with seed {seed} should produce clean generated source");
+
+        string registry = outputCompilation.SyntaxTrees
+            .Single(tree => tree.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+        registry.Should().Contain("global::System.Single.NaN");
+        registry.Should().Contain("global::System.Single.PositiveInfinity");
+        registry.Should().Contain("global::System.Single.NegativeInfinity");
+        registry.Should().Contain("global::System.Double.NaN");
+        registry.Should().Contain("global::System.Double.PositiveInfinity");
+        registry.Should().Contain("global::System.Double.NegativeInfinity");
+
+        object[][] rows = GetMaterializedDataRows(outputCompilation);
+        string[] actualValues = rows.Take(values.Length).Select(row => (string)row[0]).ToArray();
+        actualValues.Should().Equal(values, $"the deterministic literal corpus with seed {seed} should round-trip");
+
+        int rowIndex = values.Length;
+        float.IsNaN((float)rows[rowIndex++][0]).Should().BeTrue();
+        float.IsPositiveInfinity((float)rows[rowIndex++][0]).Should().BeTrue();
+        float.IsNegativeInfinity((float)rows[rowIndex++][0]).Should().BeTrue();
+        double.IsNaN((double)rows[rowIndex++][0]).Should().BeTrue();
+        double.IsPositiveInfinity((double)rows[rowIndex++][0]).Should().BeTrue();
+        double.IsNegativeInfinity((double)rows[rowIndex++][0]).Should().BeTrue();
+        rows[rowIndex++][0].Should().Be(float.MinValue);
+        rows[rowIndex++][0].Should().Be(float.MaxValue);
+        BitConverter.SingleToInt32Bits((float)rows[rowIndex++][0]).Should().Be(BitConverter.SingleToInt32Bits(-0.0F));
+        rows[rowIndex++][0].Should().Be(float.Epsilon);
+        rows[rowIndex++][0].Should().Be(double.MinValue);
+        rows[rowIndex++][0].Should().Be(double.MaxValue);
+        BitConverter.DoubleToInt64Bits((double)rows[rowIndex++][0]).Should().Be(BitConverter.DoubleToInt64Bits(-0.0D));
+        rows[rowIndex][0].Should().Be(double.Epsilon);
     }
 
     [TestMethod]
@@ -3711,6 +3741,23 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         GeneratorDriver driver = CreateDriver(compilation);
         driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out _);
         return outputCompilation;
+    }
+
+    private static object[][] GetMaterializedDataRows(Compilation outputCompilation)
+    {
+        using var assemblyStream = new MemoryStream();
+        outputCompilation.Emit(assemblyStream).Success.Should().BeTrue();
+        var assembly = System.Reflection.Assembly.Load(assemblyStream.ToArray());
+        Type registryType = assembly.GetType("MSTest.SourceGenerated.MSTestReflectionMetadata")!;
+        var testClasses = (System.Collections.IEnumerable)registryType.GetProperty("TestClasses")!.GetValue(null)!;
+        object testClass = testClasses.Cast<object>().Single();
+        var methods = (System.Collections.IEnumerable)testClass.GetType().GetProperty("Methods")!.GetValue(testClass)!;
+        object method = methods.Cast<object>().Single();
+        var attributes = (Attribute[])method.GetType().GetProperty("Attributes")!.GetValue(method)!;
+        return attributes
+            .Where(attribute => attribute.GetType().Name == "DataRowAttribute")
+            .Select(attribute => (object[])attribute.GetType().GetProperty("Data")!.GetValue(attribute)!)
+            .ToArray();
     }
 
     // Drives the generator in ReflectionFree mode (the mode under test). Without the

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
@@ -78,7 +78,6 @@ public sealed class ReflectionMetadataGeneratorTests
 
             namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Generated
             {
-                /// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>
                 internal static class MSTestSourceGeneratedReflectionMetadata
                 {
                     [ModuleInitializer]


### PR DESCRIPTION
## Summary

- preserve boxed narrow integral and enum types in generated attribute arguments
- use Roslyn C# literal formatting for strings and characters, including control characters
- emit compilable literals for floating-point NaN and infinities
- remove XML documentation from generated implementation details to prevent unresolved `cref` diagnostics
- add deterministic seeded literal-corpus compilation coverage and runtime type round-trip assertions

Fixes #10990
Fixes #10991
Fixes #10992
Fixes #10993