### PR TITLE
Narrow source generator DynamicDependency rooting

### DIFF
--- a/docs/source-generator/design.md
+++ b/docs/source-generator/design.md
@@ -31,7 +31,7 @@ The selected mode determines the rest:
   modeled members.
 - **`Rooting` (compatibility mode)** emits member-scoped `DynamicDependency` roots for
   constructors, methods, fields, and properties on each test class and accessible
-  non-generic base type, plus the type/method registry. Nested types are deliberately not
+  closed base type, plus the type/method registry. Nested types are deliberately not
   rooted. Its rich attribute and delegate dictionaries are empty.
 
 Both modes still resolve the `MethodInfo` keys used by the adapter at module

--- a/docs/source-generator/design.md
+++ b/docs/source-generator/design.md
@@ -29,9 +29,10 @@ The selected mode determines the rest:
   assembly, and method attribute arrays; constructor and method invocation delegates; and
   applicable property setter delegates. It also emits direct references that root the
   modeled members.
-- **`Rooting` (compatibility mode)** emits `DynamicDependency(All, typeof(T))` for each
-  test class and accessible non-generic base type, plus the type/method registry. Its rich
-  attribute and delegate dictionaries are empty.
+- **`Rooting` (compatibility mode)** emits member-scoped `DynamicDependency` roots for
+  constructors, methods, fields, and properties on each test class and accessible
+  non-generic base type, plus the type/method registry. Nested types are deliberately not
+  rooted. Its rich attribute and delegate dictionaries are empty.
 
 Both modes still resolve the `MethodInfo` keys used by the adapter at module
 initialization. Reflection-free mode also resolves `PropertyInfo` keys for emitted setters.
@@ -176,9 +177,10 @@ their members. The choices are:
 #### Option 1 — The current source generator
 
 Reflection-free mode emits direct attribute construction and invocation references, which
-root the modeled members, while rooting mode emits
-`[DynamicDependency(All, typeof(MyTests))]` per `[TestClass]` and accessible base type.
-Both preserve test-related types while leaving unrelated code eligible for trimming.
+root the modeled members. Both modes emit member-scoped `[DynamicDependency]` attributes
+for constructors, methods, fields, and properties on each `[TestClass]` and accessible
+base type. Nested types are excluded so unrelated nested fakes and helpers remain eligible
+for trimming and cannot surface trim/AOT warnings through their inherited members.
 Unsupported shapes and missing provider entries can still require reflection-compatible
 preservation (see Category A above).
 
@@ -208,8 +210,8 @@ source generator**. The differences are concrete:
 - `TrimmerRootAssembly Include="$(AssemblyName)"` only preserves *your* assembly. Base
   classes that live in a shared library (a `TestCommon.dll` carrying
   `[AssemblyInitialize]`-bearing fixtures, etc.) are still trimmable. The source
-  generator emits `[DynamicDependency(All, typeof(BaseInOtherAssembly))]` which the
-  trimmer honors across assemblies.
+  generator emits member-scoped `[DynamicDependency]` roots for
+  `BaseInOtherAssembly`, which the trimmer honors across assemblies.
 - `TrimmerRootAssembly` keeps the entire test assembly — helpers, mocks, fixtures, dead
   code. Source generation roots only the test classes and their base chain; everything
   else remains trimmable. Smaller published binary.
@@ -228,8 +230,8 @@ below), but they are not interchangeable.
 
 #### Option 3 — Hand-written `[DynamicDependency]`
 
-The user puts `[DynamicDependency(All, typeof(MyTests))]` on a stub method per test
-class. **Pros:** preserves exactly what's needed. **Cons:** tedious, easy to forget; the
+The user puts member-scoped `[DynamicDependency]` attributes for `MyTests` on a stub
+method per test class. **Pros:** preserves exactly what's needed. **Cons:** tedious, easy to forget; the
 analyzer warning surface to catch missing roots would essentially have to reinvent the
 source generator. Not recommended in practice.
 
@@ -382,7 +384,7 @@ entries.
   necessary and must stay truthful for the explicitly documented fallback paths.
 - **Direct references provide rooting in reflection-free mode.** A static delegate
   `static (instance, args) => ((MyTests)instance).MyTest((int)args[0])` roots its target.
-  Rooting mode continues to emit the explicit `[DynamicDependency]` base chain.
+  Both modes also emit the explicit, member-scoped `[DynamicDependency]` base chain.
 - **Compile-time validation of attribute shapes becomes possible.** Reading
   `[DataRow]` / `[DataSource]` / `[ExpectedException]` etc. at compile time to bake them
   also lets the generator surface analyzer diagnostics for:

--- a/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
+++ b/src/Adapter/MSTestAdapter.PlatformServices/SourceGeneration/SourceGeneratedReflectionOperations.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Helpers;
@@ -72,9 +72,10 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Sou
 /// </list>
 /// <para>
 /// <b>Trim/AOT safety.</b> Reflection-free mode directly references modeled attributes and
-/// invocation targets; rooting mode uses <c>[DynamicDependency(All, typeof(T))]</c> for each
-/// <c>[TestClass]</c> and accessible base type. Reflection fallback remains for unsupported,
-/// unresolved, cross-assembly, and general enumeration operations.
+/// invocation targets; both modes use member-scoped <c>[DynamicDependency]</c> roots for each
+/// <c>[TestClass]</c> and accessible base type. Nested types are deliberately excluded from those
+/// roots. Reflection fallback remains for unsupported, unresolved, cross-assembly, and general
+/// enumeration operations.
 /// </para>
 /// <para>
 /// <b>Adding a new fallback?</b> Mark the method with a <c>// Category A/B/C</c> comment and

--- a/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
@@ -45,7 +45,7 @@ internal static class ReflectionMetadataEmitter
             Append(sb, $"        [DynamicDependency(TestClassMemberTypes, typeof({cls.FullyQualifiedName}))]");
         }
 
-        // Emit a [DynamicDependency] for every accessible non-generic base type of every
+        // Emit a [DynamicDependency] for every closed, referenceable base type of every
         // discovered [TestClass]. This roots members declared on the abstract base — most
         // importantly [ClassInitialize] / [ClassCleanup] / [AssemblyInitialize] / [AssemblyCleanup]
         // and any [TestContext] property — so the trimmer / Native AOT does not remove them.

--- a/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Emitters/ReflectionMetadataEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Helpers;
@@ -33,17 +33,16 @@ internal static class ReflectionMetadataEmitter
         Append(sb, "    /// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>");
         Append(sb, $"    internal static class {GeneratedTypeName}");
         Append(sb, "    {");
+        EmitTestClassMemberTypes(sb);
+        Append(sb, string.Empty);
         Append(sb, "        [ModuleInitializer]");
         var emittedBaseTypeDependencies = new HashSet<string>(StringComparer.Ordinal);
         foreach (TestClassMetadata cls in metadata.Classes)
         {
-            // Preserve the test class members at runtime even when the assembly is published with
-            // Native AOT / IL trimming. MSTest's adapter still needs to call GetConstructors,
-            // GetProperties and other reflection APIs on the class (the source generator only
-            // populates TypeMethods; constructors, properties, etc. fall back to runtime reflection).
-            // Without this hint the trimmer removes those members and discovery fails with
-            // "Cannot find a valid constructor for test class".
-            Append(sb, $"        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof({cls.FullyQualifiedName}))]");
+            // Preserve the member kinds that MSTest reflects over at runtime, while deliberately
+            // excluding nested types. Rooting nested types recursively preserves unrelated fakes and
+            // helpers and can surface IL2026 / IL3050 from their base-class members.
+            Append(sb, $"        [DynamicDependency(TestClassMemberTypes, typeof({cls.FullyQualifiedName}))]");
         }
 
         // Emit a [DynamicDependency] for every accessible non-generic base type of every
@@ -57,7 +56,7 @@ internal static class ReflectionMetadataEmitter
             {
                 if (emittedBaseTypeDependencies.Add(baseTypeName))
                 {
-                    Append(sb, $"        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof({baseTypeName}))]");
+                    Append(sb, $"        [DynamicDependency(TestClassMemberTypes, typeof({baseTypeName}))]");
                 }
             }
         }
@@ -110,6 +109,19 @@ internal static class ReflectionMetadataEmitter
         Append(sb, "}");
 
         return sb.ToString();
+    }
+
+    private static void EmitTestClassMemberTypes(StringBuilder sb)
+    {
+        Append(sb, "        private const DynamicallyAccessedMemberTypes TestClassMemberTypes =");
+        Append(sb, "            DynamicallyAccessedMemberTypes.PublicConstructors |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.NonPublicConstructors |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.PublicMethods |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.NonPublicMethods |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.PublicFields |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.NonPublicFields |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.PublicProperties |");
+        Append(sb, "            DynamicallyAccessedMemberTypes.NonPublicProperties;");
     }
 
     private static string EmitTypesExpression(TestAssemblyMetadata metadata)

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
@@ -112,7 +112,7 @@ public sealed class ReflectionMetadataGenerator : IIncrementalGenerator
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Capture every base type that the generated module initializer can reference, so we
+            // Capture every closed base type that the generated module initializer can reference, so we
             // can root its members (ClassInitialize / ClassCleanup / AssemblyInitialize /
             // AssemblyCleanup / TestContext setter) via [DynamicDependency] under trimming or
             // Native AOT. Without this, those members live on the abstract base only and the
@@ -120,8 +120,7 @@ public sealed class ReflectionMetadataGenerator : IIncrementalGenerator
             // We intentionally do NOT add the base to types[] or
             // testMethods{}; runtime discovery still flows through the concrete [TestClass].
             if (!SymbolEqualityComparer.Default.Equals(currentType, typeSymbol)
-                && !currentType.IsGenericType
-                && SymbolAccessibilityHelper.IsAccessibleFromGeneratedCode(currentType))
+                && SymbolReferenceabilityHelper.IsClosedReferenceableType(currentType, typeSymbol.ContainingAssembly))
             {
                 baseTypes.Add(currentType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
             }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/ReflectionMetadataGenerator.cs
@@ -116,8 +116,8 @@ public sealed class ReflectionMetadataGenerator : IIncrementalGenerator
             // can root its members (ClassInitialize / ClassCleanup / AssemblyInitialize /
             // AssemblyCleanup / TestContext setter) via [DynamicDependency] under trimming or
             // Native AOT. Without this, those members live on the abstract base only and the
-            // trimmer removes them because [DynamicDependency(All, typeof(Concrete))] does not
-            // preserve base-type members. We intentionally do NOT add the base to types[] or
+            // test-class member roots on the concrete type do not preserve base-type members.
+            // We intentionally do NOT add the base to types[] or
             // testMethods{}; runtime discovery still flows through the concrete [TestClass].
             if (!SymbolEqualityComparer.Default.Equals(currentType, typeSymbol)
                 && !currentType.IsGenericType

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Helpers;
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Sou
 /// <c>Activator.CreateInstance</c> / <c>PropertyInfo.SetValue</c>). The reflection objects that
 /// the adapter still keys on (<see cref="System.Reflection.MethodInfo"/>,
 /// <see cref="System.Reflection.PropertyInfo"/>) are resolved once at module-load time under the
-/// <c>[DynamicDependency(All)]</c> roots emitted below.
+/// member-scoped <c>[DynamicDependency]</c> roots emitted below.
 /// </para>
 /// </summary>
 internal static class RuntimeRegistrationEmitter
@@ -52,6 +52,8 @@ internal static class RuntimeRegistrationEmitter
             sb.AppendLine("/// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>");
             using (sb.Block($"internal static class {GeneratedTypeName}"))
             {
+                EmitTestClassMemberTypes(sb);
+                sb.AppendLine();
                 sb.AppendLine("[ModuleInitializer]");
                 EmitDynamicDependencies(sb, testClasses);
 
@@ -70,12 +72,27 @@ internal static class RuntimeRegistrationEmitter
         return sb.ToString();
     }
 
+    private static void EmitTestClassMemberTypes(IndentedStringBuilder sb)
+    {
+        sb.AppendLine("private const DynamicallyAccessedMemberTypes TestClassMemberTypes =");
+        sb.IndentationLevel++;
+        sb.AppendLine("DynamicallyAccessedMemberTypes.PublicConstructors |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.NonPublicConstructors |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.PublicMethods |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.NonPublicMethods |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.PublicFields |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.NonPublicFields |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.PublicProperties |");
+        sb.AppendLine("DynamicallyAccessedMemberTypes.NonPublicProperties;");
+        sb.IndentationLevel--;
+    }
+
     private static void EmitDynamicDependencies(IndentedStringBuilder sb, IReadOnlyList<TestClassModel> testClasses)
     {
         var emittedBases = new HashSet<string>(StringComparer.Ordinal);
         foreach (TestClassModel cls in testClasses)
         {
-            sb.AppendLine($"[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof({cls.FullyQualifiedTypeName}))]");
+            sb.AppendLine($"[DynamicDependency(TestClassMemberTypes, typeof({cls.FullyQualifiedTypeName}))]");
         }
 
         foreach (TestClassModel cls in testClasses)
@@ -84,7 +101,7 @@ internal static class RuntimeRegistrationEmitter
             {
                 if (emittedBases.Add(baseType))
                 {
-                    sb.AppendLine($"[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof({baseType}))]");
+                    sb.AppendLine($"[DynamicDependency(TestClassMemberTypes, typeof({baseType}))]");
                 }
             }
         }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -67,11 +67,11 @@ internal static class TestClassModelBuilder
             bool isLeaf = SymbolEqualityComparer.Default.Equals(current, typeSymbol);
             hasPartialTypeInHierarchy |= IsPartial(current);
 
-            // Capture each accessible, non-generic base type so the runtime registration can root
+            // Capture each closed, referenceable base type so the runtime registration can root
             // its members (e.g. base-declared [ClassInitialize]/[TestContext]) via [DynamicDependency]
             // under trimming / Native AOT. Members are folded into the leaf model, but the trimmer
             // only keeps members of the concrete type unless the base is rooted explicitly too.
-            if (!isLeaf && !current.IsGenericType && SymbolAccessibilityHelper.IsAccessibleFromGeneratedCode(current))
+            if (!isLeaf && SymbolReferenceabilityHelper.IsClosedReferenceableType(current, consumingAssembly))
             {
                 baseTypes.Add(current.ToDisplayString(SymbolDisplayFormats.FullyQualified));
             }

--- a/src/TestFramework/TestFramework/Attributes/DataSource/DynamicDataOperations.cs
+++ b/src/TestFramework/TestFramework/Attributes/DataSource/DynamicDataOperations.cs
@@ -18,11 +18,9 @@ internal static class DynamicDataOperations
     /// <see cref="DynamicDataAttribute"/> can resolve the source by name at runtime.
     /// </summary>
     /// <remarks>
-    /// This mirrors the <c>[DynamicDependency(DynamicallyAccessedMemberTypes.All, ...)]</c> that
-    /// <c>MSTest.SourceGeneration</c> already emits for every discovered test class and its base types. It over-preserves
-    /// (constructors, events, instance members, and so on) because there is no static-only or member-kind-scoped variant
-    /// that also walks the base hierarchy; this is intentional and unavoidable to keep the inherited-source scenario
-    /// trim-safe.
+    /// <c>MSTest.SourceGeneration</c> emits explicit method, field, and property roots for every discovered test class
+    /// and its base types. This broader annotation remains necessary for reflection-only callers because there is no
+    /// static-only or member-kind-scoped variant that also walks the base hierarchy.
     /// </remarks>
     internal const DynamicallyAccessedMemberTypes RequiredMemberTypes = DynamicallyAccessedMemberTypes.All;
 
@@ -30,8 +28,9 @@ internal static class DynamicDataOperations
     {
         // Check if the declaring type of test data is passed in. If not, default to test method's class type.
         // In the supported trimming/NativeAOT configuration the test class (and its base types) are rooted by the
-        // [DynamicDependency(All)] that MSTest.SourceGeneration emits, so MethodInfo.DeclaringType stays trim-safe even
-        // though it is not statically annotated with DynamicallyAccessedMembersAttribute (see GetTestMethodDeclaringType).
+        // member-scoped [DynamicDependency] attributes that MSTest.SourceGeneration emits, so
+        // MethodInfo.DeclaringType stays trim-safe even though it is not statically annotated with
+        // DynamicallyAccessedMembersAttribute (see GetTestMethodDeclaringType).
         dynamicDataDeclaringType ??= GetTestMethodDeclaringType(methodInfo);
         DebugEx.Assert(dynamicDataDeclaringType is not null, "Declaring type of test data cannot be null.");
 
@@ -199,7 +198,7 @@ internal static class DynamicDataOperations
     }
 
     [return: DynamicallyAccessedMembers(RequiredMemberTypes)]
-    [UnconditionalSuppressMessage("Trimming", "IL2073:Value returned does not have matching annotations", Justification = "In the supported trimming/NativeAOT configuration, test classes are source-generated: MSTest.SourceGeneration emits [DynamicDependency(DynamicallyAccessedMemberTypes.All, ...)] for every discovered test class and its base types, so MethodInfo.DeclaringType and its members are already rooted. This fallback only runs for the test method's own declaring type; it does not claim safety for unsupported reflection-only trimmed callers that discover tests without the source generator.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2073:Value returned does not have matching annotations", Justification = "In the supported trimming/NativeAOT configuration, test classes are source-generated: MSTest.SourceGeneration emits explicit constructor, method, field, and property roots for every discovered test class and its base types, so MethodInfo.DeclaringType and the members DynamicData reflects over are already rooted. This fallback only runs for the test method's own declaring type; it does not claim safety for unsupported reflection-only trimmed callers that discover tests without the source generator.")]
     internal static Type? GetTestMethodDeclaringType(MethodInfo methodInfo)
         => methodInfo.DeclaringType;
 }

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -58,6 +58,12 @@ public sealed class RunAllFilter : ITestFilter
 [TestClass]
 public class UnitTest1
 {
+    // These ordinary nested helper shapes used to be recursively rooted by
+    // DynamicDependency(All), surfacing IL2026 and IL3050 from their base types.
+    private sealed class NestedStream : MemoryStream { }
+    private sealed class NestedException : Exception { }
+    private enum ScenarioState { Ready }
+
     [TestMethod]
     public void TestMethod1()
     {

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/NativeAotTests.cs
@@ -50,13 +50,22 @@ using Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial;
 
 namespace MyTests;
 
+public abstract class GenericBase<T>
+{
+    protected static IEnumerable<object[]> GenericData { get; }
+        = new[]
+        {
+            new object[] { 2, 3 }
+        };
+}
+
 public sealed class RunAllFilter : ITestFilter
 {
     public TestFilterResult Filter(TestFilterContext context) => TestFilterResult.Run;
 }
 
 [TestClass]
-public class UnitTest1
+public class UnitTest1 : GenericBase<int>
 {
     // These ordinary nested helper shapes used to be recursively rooted by
     // DynamicDependency(All), surfacing IL2026 and IL3050 from their base types.
@@ -106,6 +115,16 @@ public class UnitTest1
         {
            new object[] { 1, 2 }
         };
+
+    // The protected source cannot be called by generated code, so this exercises the reflection
+    // fallback and requires the closed generic base's non-public properties to remain rooted.
+    [TestMethod]
+    [DynamicData(nameof(GenericData))]
+    public void TestMethodFromGenericBase(int a, int b)
+    {
+        Assert.AreEqual(2, a);
+        Assert.AreEqual(3, b);
+    }
 
     [TestMethod]
     [CombinatorialData]
@@ -197,7 +216,7 @@ public sealed class AsyncVoidTests
         var testHost = TestHost.LocateFrom(generator.TargetAssetPath, "MSTestNativeAotTests", tfm, RID, Verb.publish);
 
         TestHostResult result = await testHost.ExecuteAsync(cancellationToken: TestContext.CancellationToken);
-        result.AssertOutputContainsSummary(failed: 0, passed: 8, skipped: 0);
+        result.AssertOutputContainsSummary(failed: 0, passed: 9, skipped: 0);
         result.AssertExitCodeIs(0);
 
         TestHostResult asyncGeneratedResult = await testHost.ExecuteAsync(

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -2635,6 +2635,63 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_DynamicDependenciesDoNotRootNestedTypes()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    private sealed class NestedException : System.Exception { }
+
+                    [TestMethod]
+                    public void InheritedTest() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    private sealed class NestedStream : System.IO.MemoryStream { }
+                    private enum ScenarioState { Ready }
+
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registration = result.GeneratedSources
+            .Single(s => s.HintName == "MSTestReflectionMetadata.Registration.g.cs")
+            .SourceText.ToString();
+
+        registration.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.DerivedTests))]");
+        registration.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.BaseTests))]");
+        foreach (string memberType in new[]
+        {
+            "PublicConstructors",
+            "NonPublicConstructors",
+            "PublicMethods",
+            "NonPublicMethods",
+            "PublicFields",
+            "NonPublicFields",
+            "PublicProperties",
+            "NonPublicProperties",
+        })
+        {
+            registration.Should().Contain($"DynamicallyAccessedMemberTypes.{memberType}");
+        }
+
+        registration.Should().NotContain("DynamicallyAccessedMemberTypes.All");
+        registration.Should().NotContain("DynamicallyAccessedMemberTypes.PublicNestedTypes");
+        registration.Should().NotContain("DynamicallyAccessedMemberTypes.NonPublicNestedTypes");
+    }
+
+    [TestMethod]
     public void Generator_PreservesNullableEnumTestMethodParametersForNativeAot()
     {
         const string userCode = """
@@ -2702,7 +2759,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             .SourceText.ToString();
 
         registration.Should().Contain("[ModuleInitializer]");
-        registration.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.MyTests))]");
+        registration.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.MyTests))]");
 
         // The initializer consumes the MSTestReflectionMetadata registry (no more dead code) and
         // publishes the delegate-based invokers via the richer Register overload so the adapter

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -2692,6 +2692,43 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_RootsClosedGenericBaseForDynamicDataReflectionFallback()
+    {
+        const string userCode = """
+            using System.Collections.Generic;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public abstract class GenericBase<T>
+                {
+                    protected static IEnumerable<object[]> Data => new[] { new object[] { 1 } };
+                }
+
+                [TestClass]
+                public class DerivedTests : GenericBase<int>
+                {
+                    [TestMethod]
+                    [DynamicData(nameof(Data))]
+                    public void Test(int value) { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string registration = result.GeneratedSources
+            .Single(s => s.HintName == "MSTestReflectionMetadata.Registration.g.cs")
+            .SourceText.ToString();
+        string registry = GetRegistry(result);
+
+        registration.Should().Contain(
+            "[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.GenericBase<int>))]");
+        registry.Should().Contain("DynamicDataSources = Array.Empty<DynamicDataSourceReflectionInfo>()");
+    }
+
+    [TestMethod]
     public void Generator_PreservesNullableEnumTestMethodParametersForNativeAot()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AwesomeAssertions;
@@ -81,8 +81,18 @@ public sealed class ReflectionMetadataGeneratorTests
                 /// <summary>Source-generated MSTest reflection metadata hook for this test assembly.</summary>
                 internal static class MSTestSourceGeneratedReflectionMetadata
                 {
+                    private const DynamicallyAccessedMemberTypes TestClassMemberTypes =
+                        DynamicallyAccessedMemberTypes.PublicConstructors |
+                        DynamicallyAccessedMemberTypes.NonPublicConstructors |
+                        DynamicallyAccessedMemberTypes.PublicMethods |
+                        DynamicallyAccessedMemberTypes.NonPublicMethods |
+                        DynamicallyAccessedMemberTypes.PublicFields |
+                        DynamicallyAccessedMemberTypes.NonPublicFields |
+                        DynamicallyAccessedMemberTypes.PublicProperties |
+                        DynamicallyAccessedMemberTypes.NonPublicProperties;
+
                     [ModuleInitializer]
-                    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.MyTests))]
+                    [DynamicDependency(TestClassMemberTypes, typeof(global::Sample.MyTests))]
                     internal static void Initialize()
                     {
                         var assembly = typeof(MSTestSourceGeneratedReflectionMetadata).Assembly;
@@ -141,6 +151,54 @@ public sealed class ReflectionMetadataGeneratorTests
             """;
 
         generated.Should().Be(NormalizeNewlines(expected));
+    }
+
+    [TestMethod]
+    public void Generator_DynamicDependenciesDoNotRootNestedTypes()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            namespace Sample
+            {
+                public class BaseTests
+                {
+                    private sealed class NestedException : System.Exception { }
+
+                    [TestMethod]
+                    public void InheritedTest() { }
+                }
+
+                [TestClass]
+                public class DerivedTests : BaseTests
+                {
+                    private sealed class NestedStream : System.IO.MemoryStream { }
+                    private enum ScenarioState { Ready }
+
+                    [TestMethod]
+                    public void Test() { }
+                }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().BeEmpty();
+        string generated = result.GeneratedSources.Single().SourceText.ToString();
+
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.DerivedTests))]");
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.BaseTests))]");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.PublicConstructors");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.NonPublicConstructors");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.PublicMethods");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.NonPublicMethods");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.PublicFields");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.NonPublicFields");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.PublicProperties");
+        generated.Should().Contain("DynamicallyAccessedMemberTypes.NonPublicProperties");
+        generated.Should().NotContain("DynamicallyAccessedMemberTypes.All");
+        generated.Should().NotContain("DynamicallyAccessedMemberTypes.PublicNestedTypes");
+        generated.Should().NotContain("DynamicallyAccessedMemberTypes.NonPublicNestedTypes");
     }
 
     [TestMethod]
@@ -301,9 +359,9 @@ public sealed class ReflectionMetadataGeneratorTests
         // generated module initializer so that members declared on it ([ClassInitialize],
         // [ClassCleanup], [AssemblyInitialize], [AssemblyCleanup], TestContext setter) are
         // preserved by the IL trimmer / Native AOT. Without this hint those members live only
-        // on the abstract base and are trimmed because [DynamicDependency(All, typeof(Concrete))]
+        // on the abstract base and are trimmed because preserving the concrete type's members
         // does not preserve base-type members.
-        generated.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.AbstractTests))]");
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.AbstractTests))]");
     }
 
     [TestMethod]
@@ -618,8 +676,8 @@ public sealed class ReflectionMetadataGeneratorTests
         // two [DynamicDependency] attributes on Initialize. We assert each block as a
         // contiguous snippet so the per-class layout is locked in.
         const string expectedDynamicDependencies = """
-                [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.AlphaTests))]
-                [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.BetaTests))]
+                [DynamicDependency(TestClassMemberTypes, typeof(global::Sample.AlphaTests))]
+                [DynamicDependency(TestClassMemberTypes, typeof(global::Sample.BetaTests))]
         """;
         generated.Should().Contain(NormalizeNewlines(expectedDynamicDependencies));
 
@@ -790,9 +848,9 @@ public sealed class ReflectionMetadataGeneratorTests
         // trimmer keeps members like [AssemblyInitialize] (declared on GrandparentTests) and
         // [ClassInitialize] (declared on ParentTests). The concrete [TestClass] still owns the
         // discovery entry, but the trimmer roots are emitted per type.
-        generated.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.Derived))]");
-        generated.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.ParentTests))]");
-        generated.Should().Contain("[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.GrandparentTests))]");
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.Derived))]");
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.ParentTests))]");
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.GrandparentTests))]");
 
         // Bases must NOT appear in the types[] array or the testMethods{} dictionary — they are
         // not runnable test classes; discovery still goes through the concrete [TestClass].
@@ -842,7 +900,7 @@ public sealed class ReflectionMetadataGeneratorTests
         // be emitted N times for N derived classes, bloating the generated source.
         int sharedBaseCount = CountOccurrences(
             generated,
-            "[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(global::Sample.SharedBase))]");
+            "[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.SharedBase))]");
         sharedBaseCount.Should().Be(1);
     }
 

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/ReflectionMetadataGeneratorTests.cs
@@ -972,7 +972,7 @@ public sealed class ReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
-    public void Generator_DoesNotEmitDynamicDependencyForGenericBase()
+    public void Generator_EmitsDynamicDependencyForClosedGenericBase()
     {
         const string userCode = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -999,12 +999,9 @@ public sealed class ReflectionMetadataGeneratorTests
         result.Diagnostics.Should().BeEmpty();
         string generated = result.GeneratedSources[0].SourceText.ToString();
 
-        // For this conservative iteration we skip generic base types from [DynamicDependency]
-        // emission — emitting `typeof(GenericBase<int>)` is technically valid but adds edge
-        // cases (open vs. closed, type-parameter capture) that the rest of the generator does
-        // not exercise. The derived class itself is still emitted, and the inherited test
-        // method is still surfaced through the base-walk in the methods collection.
-        generated.Should().NotContain("typeof(global::Sample.GenericBase");
+        // A non-generic test class can inherit a closed generic base. Root that constructed
+        // base explicitly so inherited non-public members used by reflection survive trimming.
+        generated.Should().Contain("[DynamicDependency(TestClassMemberTypes, typeof(global::Sample.GenericBase<int>))]");
         generated.Should().Contain("typeof(global::Sample.Derived)");
         generated.Should().Contain("ResolveMethod(typeof(global::Sample.Derived), \"InheritedTest\", Type.EmptyTypes)");
     }


### PR DESCRIPTION
## Summary

- replace `DynamicallyAccessedMemberTypes.All` roots with explicit constructor, method, field, and property roots in both source-generator modes
- keep accessible base-type members rooted without recursively preserving unrelated nested helpers
- add unit coverage for nested stream, exception, and enum shapes, plus Native AOT publish coverage

## Validation

- `MSTest.SourceGeneration.UnitTests`: 135 passed
- `build.cmd -pack -bl`: succeeded with 0 warnings and 0 errors
- `NativeAotTests_WillRunWithExitCodeZero`: passed for net8.0 and net10.0 with no publish warnings

Fixes #10994