### PR TITLE
Improve Azure DevOps authentication diagnostics

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsExtensions.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsExtensions.cs
@@ -83,7 +83,7 @@ public static class AzureDevOpsExtensions
                    serviceProvider.GetOutputDevice(),
                    serviceProvider.GetTestApplicationModuleInfo(),
                    serviceProvider.GetTestApplicationProcessExitCode(),
-                   new AzureDevOpsTestResultsClient(serviceProvider.GetTask(), serviceProvider.GetClock()),
+                   new AzureDevOpsTestResultsClient(serviceProvider.GetTask(), serviceProvider.GetClock(), serviceProvider.GetLoggerFactory()),
                    serviceProvider.GetTask(),
                    serviceProvider.GetClock(),
                    serviceProvider.GetLoggerFactory()));
@@ -127,7 +127,7 @@ public static class AzureDevOpsExtensions
                 serviceProvider.GetFileSystem(),
                 serviceProvider.GetOutputDevice(),
                 serviceProvider.GetTestApplicationModuleInfo(),
-                new AzureDevOpsTestResultsClient(serviceProvider.GetTask(), serviceProvider.GetClock()),
+                new AzureDevOpsTestResultsClient(serviceProvider.GetTask(), serviceProvider.GetClock(), serviceProvider.GetLoggerFactory()),
                 serviceProvider.GetTask(),
                 serviceProvider.GetClock(),
                 serviceProvider.GetLoggerFactory()));

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Text.Json;
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
+using Microsoft.Testing.Platform.Logging;
 
 #if !NETCOREAPP
 using Polyfills;
@@ -85,7 +86,7 @@ internal sealed partial class AzureDevOpsTestResultsClient
         using HttpResponseMessage ignoredResponse = await SendCoreAsync(request, requestTimeoutSource.Token, cancellationToken, requestTimeout).ConfigureAwait(false);
     }
 
-    private async Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, CancellationToken requestCancellationToken, CancellationToken userCancellationToken, TimeSpan attemptTimeout)
+    private async Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, CancellationToken requestCancellationToken, CancellationToken userCancellationToken, TimeSpan attemptTimeout, bool throwOnUnexpectedContentType = true)
     {
         Exception? lastException = null;
 
@@ -106,12 +107,21 @@ internal sealed partial class AzureDevOpsTestResultsClient
                         {
                             int statusCode = (int)response.StatusCode;
                             string contentType = response.Content.Headers.ContentType?.ToString() ?? "text/html";
-                            response.Dispose();
-                            throw new InvalidOperationException(string.Format(
+                            string diagnostic = string.Format(
                                 CultureInfo.InvariantCulture,
                                 AzureDevOpsResources.AzureDevOpsLivePublishingUnexpectedContentType,
                                 statusCode,
-                                contentType));
+                                contentType);
+                            if (throwOnUnexpectedContentType)
+                            {
+                                response.Dispose();
+                                throw new InvalidOperationException(diagnostic);
+                            }
+
+                            if (_logger is not null)
+                            {
+                                await _logger.LogWarningAsync(diagnostic).ConfigureAwait(false);
+                            }
                         }
 
                         return response;

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
@@ -34,7 +34,11 @@ internal sealed partial class AzureDevOpsTestResultsClient
     /// </remarks>
     internal static HttpClientHandler CreateHttpClientHandler()
     {
-        HttpClientHandler handler = new();
+        HttpClientHandler handler = new()
+        {
+            AllowAutoRedirect = false,
+        };
+
         if (ShouldOptInToAutomaticDecompression(handler))
         {
             handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
@@ -97,6 +101,17 @@ internal sealed partial class AzureDevOpsTestResultsClient
                     HttpResponseMessage response = await _httpClient.SendAsync(currentRequest, HttpCompletionOption.ResponseHeadersRead, attemptTimeoutSource.Token).ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
                     {
+                        if (string.Equals(response.Content.Headers.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))
+                        {
+                            string contentType = response.Content.Headers.ContentType?.ToString() ?? "text/html";
+                            response.Dispose();
+                            throw new InvalidOperationException(string.Format(
+                                CultureInfo.InvariantCulture,
+                                AzureDevOpsResources.AzureDevOpsLivePublishingUnexpectedContentType,
+                                (int)response.StatusCode,
+                                contentType));
+                        }
+
                         return response;
                     }
 
@@ -105,6 +120,14 @@ internal sealed partial class AzureDevOpsTestResultsClient
                     {
                         if (!ShouldRetry(response.StatusCode, attempt))
                         {
+                            if (response.StatusCode == HttpStatusCode.Redirect)
+                            {
+                                throw new InvalidOperationException(string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    AzureDevOpsResources.AzureDevOpsLivePublishingAuthenticationRedirect,
+                                    (int)response.StatusCode));
+                            }
+
                             string responseBody = await ReadAsStringAsync(response.Content, requestCancellationToken).ConfigureAwait(false);
                             throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, AzureDevOpsResources.AzureDevOpsLivePublishingHttpError, (int)response.StatusCode, responseBody));
                         }

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
@@ -34,10 +34,11 @@ internal sealed partial class AzureDevOpsTestResultsClient
     /// </remarks>
     internal static HttpClientHandler CreateHttpClientHandler()
     {
-        HttpClientHandler handler = new()
+        HttpClientHandler handler = new();
+        if (!OperatingSystem.IsWasi())
         {
-            AllowAutoRedirect = false,
-        };
+            handler.AllowAutoRedirect = false;
+        }
 
         if (ShouldOptInToAutomaticDecompression(handler))
         {
@@ -103,12 +104,13 @@ internal sealed partial class AzureDevOpsTestResultsClient
                     {
                         if (string.Equals(response.Content.Headers.ContentType?.MediaType, "text/html", StringComparison.OrdinalIgnoreCase))
                         {
+                            int statusCode = (int)response.StatusCode;
                             string contentType = response.Content.Headers.ContentType?.ToString() ?? "text/html";
                             response.Dispose();
                             throw new InvalidOperationException(string.Format(
                                 CultureInfo.InvariantCulture,
                                 AzureDevOpsResources.AzureDevOpsLivePublishingUnexpectedContentType,
-                                (int)response.StatusCode,
+                                statusCode,
                                 contentType));
                         }
 
@@ -120,12 +122,15 @@ internal sealed partial class AzureDevOpsTestResultsClient
                     {
                         if (!ShouldRetry(response.StatusCode, attempt))
                         {
-                            if (response.StatusCode == HttpStatusCode.Redirect)
+                            if (IsAuthenticationFailure(response))
                             {
+                                string status = response.StatusCode == 0
+                                    ? response.ReasonPhrase ?? "opaqueredirect"
+                                    : ((int)response.StatusCode).ToString(CultureInfo.InvariantCulture);
                                 throw new InvalidOperationException(string.Format(
                                     CultureInfo.InvariantCulture,
-                                    AzureDevOpsResources.AzureDevOpsLivePublishingAuthenticationRedirect,
-                                    (int)response.StatusCode));
+                                    AzureDevOpsResources.AzureDevOpsLivePublishingAuthenticationFailure,
+                                    status));
                             }
 
                             string responseBody = await ReadAsStringAsync(response.Content, requestCancellationToken).ConfigureAwait(false);
@@ -161,6 +166,10 @@ internal sealed partial class AzureDevOpsTestResultsClient
 
     private static bool ShouldRetry(HttpStatusCode statusCode, int attempt)
         => attempt < MaxAttempts && ((int)statusCode is >= 500 or 429);
+
+    private static bool IsAuthenticationFailure(HttpResponseMessage response)
+        => response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Redirect
+            || (response.StatusCode == 0 && string.Equals(response.ReasonPhrase, "opaqueredirect", StringComparison.Ordinal));
 
     private static bool ShouldRetry(Exception exception, CancellationToken userCancellationToken, CancellationToken requestCancellationToken, int attempt)
         => attempt < MaxAttempts

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.Http.cs
@@ -118,10 +118,7 @@ internal sealed partial class AzureDevOpsTestResultsClient
                                 throw new InvalidOperationException(diagnostic);
                             }
 
-                            if (_logger is not null)
-                            {
-                                await _logger.LogWarningAsync(diagnostic).ConfigureAwait(false);
-                            }
+                            await TryLogWarningAsync(diagnostic).ConfigureAwait(false);
                         }
 
                         return response;
@@ -180,6 +177,24 @@ internal sealed partial class AzureDevOpsTestResultsClient
     private static bool IsAuthenticationFailure(HttpResponseMessage response)
         => response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Redirect
             || (response.StatusCode == 0 && string.Equals(response.ReasonPhrase, "opaqueredirect", StringComparison.Ordinal));
+
+    private async Task TryLogWarningAsync(string message)
+    {
+        if (_logger is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _logger.LogWarningAsync(message).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // There is nowhere left to report this, and a logger failure must not cause an accepted
+            // non-idempotent publish request to be retried.
+        }
+    }
 
     private static bool ShouldRetry(Exception exception, CancellationToken userCancellationToken, CancellationToken requestCancellationToken, int attempt)
         => attempt < MaxAttempts

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsTestResultsClient.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 
 using Microsoft.Testing.Extensions.AzureDevOpsReport.Resources;
 using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.Logging;
 
 namespace Microsoft.Testing.Extensions.AzureDevOpsReport;
 
@@ -37,17 +38,29 @@ internal sealed partial class AzureDevOpsTestResultsClient : IAzureDevOpsTestRes
     private readonly HttpClient _httpClient;
     private readonly ITask _task;
     private readonly IClock _clock;
+    private readonly ILogger? _logger;
 
     public AzureDevOpsTestResultsClient(ITask task, IClock clock)
-        : this(SharedHttpClient, task, clock)
+        : this(SharedHttpClient, task, clock, logger: null)
+    {
+    }
+
+    public AzureDevOpsTestResultsClient(ITask task, IClock clock, ILoggerFactory loggerFactory)
+        : this(SharedHttpClient, task, clock, loggerFactory.CreateLogger<AzureDevOpsTestResultsClient>())
     {
     }
 
     internal AzureDevOpsTestResultsClient(HttpClient httpClient, ITask task, IClock clock)
+        : this(httpClient, task, clock, logger: null)
+    {
+    }
+
+    internal AzureDevOpsTestResultsClient(HttpClient httpClient, ITask task, IClock clock, ILogger? logger)
     {
         _httpClient = httpClient;
         _task = task;
         _clock = clock;
+        _logger = logger;
     }
 
     public async Task<int> CreateTestRunAsync(AzureDevOpsPublishConfiguration configuration, CancellationToken cancellationToken)
@@ -102,10 +115,11 @@ internal sealed partial class AzureDevOpsTestResultsClient : IAzureDevOpsTestRes
             configuration.AccessToken,
             results);
 
-        // Transport/HTTP failures throw from SendCoreAsync — caller retries.
+        // Do not throw for an unexpected 2xx content type: Azure DevOps may have accepted this
+        // non-idempotent POST, and retrying it could create duplicate result rows.
         using var requestTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         requestTimeoutSource.CancelAfter(RequestTimeout);
-        using HttpResponseMessage response = await SendCoreAsync(request, requestTimeoutSource.Token, cancellationToken, AttemptTimeout).ConfigureAwait(false);
+        using HttpResponseMessage response = await SendCoreAsync(request, requestTimeoutSource.Token, cancellationToken, AttemptTimeout, throwOnUnexpectedContentType: false).ConfigureAwait(false);
 
         // From this point on the AzDO server has accepted the results. Failing to parse the response
         // must not cause the caller to retry the publish (that would duplicate result rows).

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsClient.AzureDevOpsTestResultsClient(Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Logging.ILoggerFactory! loggerFactory) -> void
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsClient.AzureDevOpsTestResultsClient(System.Net.Http.HttpClient! httpClient, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Logging.ILogger? logger) -> void

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -149,6 +149,10 @@
     <value>'--report-azdo-groups' requires '--report-azdo' to be enabled</value>
     <comment>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</comment>
   </data>
+  <data name="AzureDevOpsLivePublishingAuthenticationRedirect" xml:space="preserve">
+    <value>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</value>
+    <comment>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</comment>
+  </data>
   <data name="AzureDevOpsLivePublishingAttachmentsDropped" xml:space="preserve">
     <value>Azure DevOps live publishing could not upload {0} attachment(s); they will be missing from the Azure DevOps test run.</value>
     <comment>{0} is the number of attachments that could not be uploaded.</comment>
@@ -231,6 +235,10 @@
   <data name="AzureDevOpsLivePublishingTimeoutErrorMessageWithReason" xml:space="preserve">
     <value>Timeout: {0}</value>
     <comment>{0} is the timeout reason.</comment>
+  </data>
+  <data name="AzureDevOpsLivePublishingUnexpectedContentType" xml:space="preserve">
+    <value>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</value>
+    <comment>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</comment>
   </data>
   <data name="AzureDevOpsLivePublishingWarningDisplayFailed" xml:space="preserve">
     <value>Azure DevOps live publishing could not display a warning on the output device.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -154,8 +154,8 @@
     <comment>{0} is the number of attachments that could not be uploaded.</comment>
   </data>
   <data name="AzureDevOpsLivePublishingAuthenticationFailure" xml:space="preserve">
-    <value>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</value>
-    <comment>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</comment>
+    <value>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</value>
+    <comment>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</comment>
   </data>
   <data name="AzureDevOpsLivePublishingCompleteRunFailed" xml:space="preserve">
     <value>Azure DevOps live publishing failed to complete the test run.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/AzureDevOpsResources.resx
@@ -149,13 +149,13 @@
     <value>'--report-azdo-groups' requires '--report-azdo' to be enabled</value>
     <comment>{Locked="--report-azdo-groups"}{Locked="--report-azdo"}</comment>
   </data>
-  <data name="AzureDevOpsLivePublishingAuthenticationRedirect" xml:space="preserve">
-    <value>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</value>
-    <comment>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</comment>
-  </data>
   <data name="AzureDevOpsLivePublishingAttachmentsDropped" xml:space="preserve">
     <value>Azure DevOps live publishing could not upload {0} attachment(s); they will be missing from the Azure DevOps test run.</value>
     <comment>{0} is the number of attachments that could not be uploaded.</comment>
+  </data>
+  <data name="AzureDevOpsLivePublishingAuthenticationFailure" xml:space="preserve">
+    <value>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</value>
+    <comment>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</comment>
   </data>
   <data name="AzureDevOpsLivePublishingCompleteRunFailed" xml:space="preserve">
     <value>Azure DevOps live publishing failed to complete the test run.</value>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Živé publikování v Azure DevOps nemohlo nahrát přílohy ({0}); v testovacím běhu Azure DevOps budou chybět.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Živému publikování Azure DevOps se nepodařilo dokončit testovací běh.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Časový limit: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.cs.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Živé publikování v Azure DevOps nemohlo nahrát přílohy ({0}); v testovacím běhu Azure DevOps budou chybět.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Bei der Azure DevOps-Liveveröffentlichung konnten {0} Anlagen nicht hochgeladen werden. Sie fehlen im Azure DevOps-Testlauf.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Die Azure DevOps Liveveröffentlichung konnte den Testlauf nicht abschließen.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Zeitüberschreitung: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.de.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Bei der Azure DevOps-Liveveröffentlichung konnten {0} Anlagen nicht hochgeladen werden. Sie fehlen im Azure DevOps-Testlauf.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">La publicación en vivo de Azure DevOps no pudo cargar {0} los datos adjuntos; faltarán en la serie de pruebas Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">La publicación en directo de Azure DevOps no pudo completar la ejecución de pruebas.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Tiempo de espera: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -47,10 +47,10 @@
         <target state="translated">La publicación en vivo de Azure DevOps no pudo cargar {0} los datos adjuntos; faltarán en la serie de pruebas Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.es.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">La publication en direct Azure DevOps n’a pas pu charger {0} pièces jointes. Elles seront absentes de l’exécution de test Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Nous n’avons pas pu effectuer la publication en direct d’Azure DevOps pour effectuer l’exécution de tests.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Délai d’expiration : {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.fr.xlf
@@ -47,10 +47,10 @@
         <target state="translated">La publication en direct Azure DevOps n’a pas pu charger {0} pièces jointes. Elles seront absentes de l’exécution de test Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">La pubblicazione live di Azure DevOps non è riuscita a caricare {0} allegato/i; non saranno presenti nell'esecuzione dei test di Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">La pubblicazione live di Azure DevOps non è riuscita a completare l'esecuzione dei test.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Timeout: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.it.xlf
@@ -47,10 +47,10 @@
         <target state="translated">La pubblicazione live di Azure DevOps non è riuscita a caricare {0} allegato/i; non saranno presenti nell'esecuzione dei test di Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Azure DevOps ライブ パブリッシングでは {0} 件の添付ファイルをアップロードできませんでした。これらは Azure DevOps のテスト実行に含まれません。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps ライブ公開でテスト実行を完了できませんでした。</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">タイムアウト: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ja.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Azure DevOps ライブ パブリッシングでは {0} 件の添付ファイルをアップロードできませんでした。これらは Azure DevOps のテスト実行に含まれません。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Azure DevOps 라이브 게시에서 {0} 첨부 파일을 업로드할 수 없습니다. 해당 첨부 파일은 Azure DevOps 테스트 실행에서 누락됩니다.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps 라이브 게시에서 테스트 실행을 완료하지 못했습니다.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">시간 제한: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ko.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Azure DevOps 라이브 게시에서 {0} 첨부 파일을 업로드할 수 없습니다. 해당 첨부 파일은 Azure DevOps 테스트 실행에서 누락됩니다.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Publikowanie na żywo w usłudze Azure DevOps nie może przekazać {0} załączników. Nie będzie ich w przebiegu testu usługi Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Publikowanie na żywo w usłudze Azure DevOps nie może ukończyć przebiegu testu.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Limit czasu: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Publikowanie na żywo w usłudze Azure DevOps nie może przekazać {0} załączników. Nie będzie ich w przebiegu testu usługi Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pl.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -47,10 +47,10 @@
         <target state="translated">A publicação ao vivo do Azure DevOps não pôde carregar {0} anexos; eles ficarão ausentes da execução de teste do Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">A publicação ao vivo do Azure DevOps não pôde carregar {0} anexos; eles ficarão ausentes da execução de teste do Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">A publicação ao vivo do Azure DevOps falhou ao concluir a execução de teste.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Tempo limite: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.pt-BR.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Динамической публикации Azure DevOps не удалось отправить несколько ({0}) вложений; они будут отсутствовать в тестовом запуске Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Динамической публикации Azure DevOps не удалось отправить несколько ({0}) вложений; они будут отсутствовать в тестовом запуске Azure DevOps.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps: не удалось выполнить тестовый запуск при публикации в реальном времени.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Превышено время ожидания: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.ru.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Azure DevOps canlı yayımlama {0} eki karşıya yükleyemedi; bu ekler Azure DevOps test çalıştırmasında eksik olacak.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps canlı yayımlama test çalıştırmasını tamamlayamadı.</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">Zaman aşımı: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Azure DevOps canlı yayımlama {0} eki karşıya yükleyemedi; bu ekler Azure DevOps test çalıştırmasında eksik olacak.</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.tr.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Azure DevOps 实时发布无法上传 {0} 个附件；它们将在 Azure DevOps 测试运行中缺失。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps 实时发布未能完成测试运行。</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">超时: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hans.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Azure DevOps 实时发布无法上传 {0} 个附件；它们将在 Azure DevOps 测试运行中缺失。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -48,9 +48,9 @@
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
-        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, do not expose secrets to untrusted fork code; publish results from a separate trusted pipeline context or disable Azure DevOps live publishing.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -47,10 +47,10 @@
         <target state="translated">Azure DevOps 即時發佈無法上傳 {0} 個附件; 這些附件將不會出現在 Azure DevOps 測試執行中。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
-      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
-        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
-        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
-        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationFailure">
+        <source>Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API authentication failed or was redirected to sign-in (status: {0}), which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code or browser redirect reason. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/Resources/xlf/AzureDevOpsResources.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Azure DevOps 即時發佈無法上傳 {0} 個附件; 這些附件將不會出現在 Azure DevOps 測試執行中。</target>
         <note>{0} is the number of attachments that could not be uploaded.</note>
       </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingAuthenticationRedirect">
+        <source>Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</source>
+        <target state="new">Azure DevOps REST API request was redirected to sign-in with status code {0}, which indicates that SYSTEM_ACCESSTOKEN is invalid or unavailable. For fork pull request validation builds, enable 'Make secrets available to builds of forks' in the pipeline settings.</target>
+        <note>{0} is the HTTP status code. {Locked="REST API"}{Locked="SYSTEM_ACCESSTOKEN"}{Locked="'Make secrets available to builds of forks'"}</note>
+      </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingCompleteRunFailed">
         <source>Azure DevOps live publishing failed to complete the test run.</source>
         <target state="translated">Azure DevOps 即時發佈無法完成測試執行。</target>
@@ -161,6 +166,11 @@
         <source>Timeout: {0}</source>
         <target state="translated">逾時: {0}</target>
         <note>{0} is the timeout reason.</note>
+      </trans-unit>
+      <trans-unit id="AzureDevOpsLivePublishingUnexpectedContentType">
+        <source>Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</source>
+        <target state="new">Azure DevOps REST API returned an unexpected successful response with status code {0} and content type '{1}'.</target>
+        <note>{0} is the HTTP status code. {1} is the response content type. {Locked="REST API"}</note>
       </trans-unit>
       <trans-unit id="AzureDevOpsLivePublishingWarningDisplayFailed">
         <source>Azure DevOps live publishing could not display a warning on the output device.</source>

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -672,10 +672,12 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
-    public async Task AzureDevOpsTestResultsClient_AuthenticationRedirect_ReportsInvalidAccessTokenGuidance()
+    [DataRow(HttpStatusCode.Redirect, "302")]
+    [DataRow(HttpStatusCode.Unauthorized, "401")]
+    public async Task AzureDevOpsTestResultsClient_AuthenticationFailure_ReportsInvalidAccessTokenGuidance(HttpStatusCode statusCode, string expectedStatus)
     {
         QueueHttpMessageHandler handler = new(
-            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Redirect)));
+            (_, _) => Task.FromResult(new HttpResponseMessage(statusCode)));
         using HttpClient httpClient = new(handler)
         {
             Timeout = Timeout.InfiniteTimeSpan,
@@ -686,7 +688,30 @@ public sealed class AzureDevOpsLivePublishingTests
         InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
             () => client.CreateTestRunAsync(configuration, CancellationToken.None));
 
-        Assert.Contains("status code 302", exception.Message);
+        Assert.Contains($"(status: {expectedStatus})", exception.Message);
+        Assert.Contains("SYSTEM_ACCESSTOKEN is invalid or unavailable", exception.Message);
+        Assert.Contains("Make secrets available to builds of forks", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_BrowserOpaqueRedirect_ReportsInvalidAccessTokenGuidance()
+    {
+        QueueHttpMessageHandler handler = new(
+            (_, _) => Task.FromResult(new HttpResponseMessage(0)
+            {
+                ReasonPhrase = "opaqueredirect",
+            }));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock());
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 1, "run", "tests.dll", "results");
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => client.CreateTestRunAsync(configuration, CancellationToken.None));
+
+        Assert.Contains("(status: opaqueredirect)", exception.Message);
         Assert.Contains("SYSTEM_ACCESSTOKEN is invalid or unavailable", exception.Message);
         Assert.Contains("Make secrets available to builds of forks", exception.Message);
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -672,6 +672,48 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_AuthenticationRedirect_ReportsInvalidAccessTokenGuidance()
+    {
+        QueueHttpMessageHandler handler = new(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.Redirect)));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock());
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 1, "run", "tests.dll", "results");
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => client.CreateTestRunAsync(configuration, CancellationToken.None));
+
+        Assert.Contains("status code 302", exception.Message);
+        Assert.Contains("SYSTEM_ACCESSTOKEN is invalid or unavailable", exception.Message);
+        Assert.Contains("Make secrets available to builds of forks", exception.Message);
+    }
+
+    [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_SuccessfulHtmlResponse_ReportsStatusAndContentType()
+    {
+        QueueHttpMessageHandler handler = new(
+            (_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<!DOCTYPE html><html></html>", Encoding.UTF8, "text/html"),
+            }));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock());
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 1, "run", "tests.dll", "results");
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => client.CreateTestRunAsync(configuration, CancellationToken.None));
+
+        Assert.Contains("status code 200", exception.Message);
+        Assert.Contains("content type 'text/html; charset=utf-8'", exception.Message);
+    }
+
+    [TestMethod]
     public async Task ConsumeAsync_PublishFailureLogsWarningAndDoesNotThrow()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -739,6 +739,31 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_PublishTestResults_SuccessfulHtmlResponseReturnsNullAndReportsDiagnostic()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<!DOCTYPE html><html></html>", Encoding.UTF8, "text/html"),
+        };
+        QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        CollectingLogger logger = new();
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock(), logger);
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 1, "run", "tests.dll", "results");
+        AzureDevOpsTestCaseResult result = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 5, null, null, null, null);
+
+        IReadOnlyList<AzureDevOpsPublishedTestResult>? publishedResults =
+            await client.PublishTestResultsWithSubResultsAsync(configuration, runId: 42, [result], CancellationToken.None);
+
+        Assert.IsNull(publishedResults);
+        Assert.Contains("status code 200", string.Join(Environment.NewLine, logger.Logs));
+        Assert.Contains("content type 'text/html; charset=utf-8'", string.Join(Environment.NewLine, logger.Logs));
+    }
+
+    [TestMethod]
     public async Task ConsumeAsync_PublishFailureLogsWarningAndDoesNotThrow()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -764,6 +764,29 @@ public sealed class AzureDevOpsLivePublishingTests
     }
 
     [TestMethod]
+    public async Task AzureDevOpsTestResultsClient_PublishTestResults_LoggerFailureDoesNotReplaySuccessfulHtmlResponse()
+    {
+        using HttpResponseMessage response = new(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<!DOCTYPE html><html></html>", Encoding.UTF8, "text/html"),
+        };
+        QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
+        using HttpClient httpClient = new(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        CollectingLogger logger = new() { ThrowOnLog = true };
+        AzureDevOpsTestResultsClient client = new(httpClient, new FakeTask(), new FakeClock(), logger);
+        AzureDevOpsPublishConfiguration configuration = new("https://dev.azure.com/org/", "project", "token", 1, "run", "tests.dll", "results");
+        AzureDevOpsTestCaseResult result = new("MyTest", "tests", "MyTest", AzureDevOpsLivePublishingConstants.PassedTestOutcome, 5, null, null, null, null);
+
+        IReadOnlyList<AzureDevOpsPublishedTestResult>? publishedResults =
+            await client.PublishTestResultsWithSubResultsAsync(configuration, runId: 42, [result], CancellationToken.None);
+
+        Assert.IsNull(publishedResults);
+    }
+
+    [TestMethod]
     public async Task ConsumeAsync_PublishFailureLogsWarningAndDoesNotThrow()
     {
         using TestDirectory directory = CreateTestDirectory();

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -690,7 +690,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.Contains($"(status: {expectedStatus})", exception.Message);
         Assert.Contains("SYSTEM_ACCESSTOKEN is invalid or unavailable", exception.Message);
-        Assert.Contains("Make secrets available to builds of forks", exception.Message);
+        Assert.Contains("do not expose secrets to untrusted fork code", exception.Message);
+        Assert.Contains("separate trusted pipeline context", exception.Message);
     }
 
     [TestMethod]
@@ -713,7 +714,8 @@ public sealed class AzureDevOpsLivePublishingTests
 
         Assert.Contains("(status: opaqueredirect)", exception.Message);
         Assert.Contains("SYSTEM_ACCESSTOKEN is invalid or unavailable", exception.Message);
-        Assert.Contains("Make secrets available to builds of forks", exception.Message);
+        Assert.Contains("do not expose secrets to untrusted fork code", exception.Message);
+        Assert.Contains("separate trusted pipeline context", exception.Message);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -770,7 +770,13 @@ public sealed class AzureDevOpsLivePublishingTests
         {
             Content = new StringContent("<!DOCTYPE html><html></html>", Encoding.UTF8, "text/html"),
         };
-        QueueHttpMessageHandler handler = new((_, _) => Task.FromResult(response));
+        int sendCount = 0;
+        QueueHttpMessageHandler handler = new(
+            (_, _) =>
+            {
+                sendCount++;
+                return Task.FromResult(response);
+            });
         using HttpClient httpClient = new(handler)
         {
             Timeout = Timeout.InfiniteTimeSpan,
@@ -784,6 +790,7 @@ public sealed class AzureDevOpsLivePublishingTests
             await client.PublishTestResultsWithSubResultsAsync(configuration, runId: 42, [result], CancellationToken.None);
 
         Assert.IsNull(publishedResults);
+        Assert.AreEqual(1, sendCount);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestResultsClientHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestResultsClientHandlerTests.cs
@@ -23,12 +23,13 @@ namespace Microsoft.Testing.Extensions.UnitTests;
 public sealed class AzureDevOpsTestResultsClientHandlerTests
 {
     [TestMethod]
-    public void CreateHttpClientHandler_WhenPlatformSupportsDecompression_OptsIntoGZipAndDeflate()
+    public void CreateHttpClientHandler_WhenPlatformSupportsDecompression_DisablesRedirectsAndOptsIntoGZipAndDeflate()
     {
         Assert.IsFalse(OperatingSystem.IsBrowser(), "The unit test host is expected to run outside the browser sandbox.");
 
         using HttpClientHandler handler = AzureDevOpsTestResultsClient.CreateHttpClientHandler();
 
+        Assert.IsFalse(handler.AllowAutoRedirect);
         Assert.IsTrue(handler.SupportsAutomaticDecompression, "This platform is expected to support automatic decompression.");
         Assert.AreEqual(DecompressionMethods.Deflate | DecompressionMethods.GZip, handler.AutomaticDecompression);
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestResultsClientHandlerTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsTestResultsClientHandlerTests.cs
@@ -29,6 +29,7 @@ public sealed class AzureDevOpsTestResultsClientHandlerTests
 
         using HttpClientHandler handler = AzureDevOpsTestResultsClient.CreateHttpClientHandler();
 
+        Assert.IsFalse(OperatingSystem.IsWasi(), "The unit test host is expected to support redirect configuration.");
         Assert.IsFalse(handler.AllowAutoRedirect);
         Assert.IsTrue(handler.SupportsAutomaticDecompression, "This platform is expected to support automatic decompression.");
         Assert.AreEqual(DecompressionMethods.Deflate | DecompressionMethods.GZip, handler.AutomaticDecompression);


### PR DESCRIPTION
## Summary

- disable automatic redirects for Azure DevOps REST requests on supported transports
- report actionable `SYSTEM_ACCESSTOKEN` guidance for `401`, `302`, and browser `opaqueredirect` responses
- preserve WASI compatibility and report successful HTML responses by status/content type instead of surfacing JSON parse failures
- add localized diagnostics and regression coverage

## Validation

- `build.cmd -projects test\UnitTests\Microsoft.Testing.Extensions.UnitTests\Microsoft.Testing.Extensions.UnitTests.csproj -binaryLog`
- 151 focused Azure DevOps publishing tests passed on `net8.0`

Fixes #10983