### PR TITLE
Persist skipped test visibility for solution runs

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProvider.cs
@@ -113,14 +113,15 @@ internal sealed class TerminalTestReporterCommandLineOptionsProvider : CommandLi
             || ShowOutputNoneArgument.Equals(argument, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Resolves <c>--show-test-results</c>, returning <see langword="null"/> when the option is absent so the
-    /// caller (<c>TerminalOutputDevice.InitializeAsync</c>) can fall back to its <c>--output</c>-based default.
+    /// Resolves <c>--show-test-results</c> or its passive configuration default, returning <see langword="null"/>
+    /// when neither is present so the caller (<c>TerminalOutputDevice.InitializeAsync</c>) can fall back to its
+    /// <c>--output</c>-based default.
     /// Arguments are already guaranteed valid by <see cref="ValidateOptionArgumentsAsync"/> by the time a real run
     /// reaches this method; an unexpected parse failure therefore indicates that command-line validation was
     /// bypassed and is reported as an invalid application state.
     /// </summary>
     internal static TestResultVisibility? GetShowTestResultsVisibility(ICommandLineOptions commandLineOptions)
-        => !commandLineOptions.TryGetOptionArgumentList(ShowTestResultsOption, out string[]? arguments)
+        => !commandLineOptions.TryGetOptionArgumentListOrDefault(ShowTestResultsOption, out string[]? arguments)
             ? null
             : TryParseShowTestResultsArguments(arguments ?? [], out TestResultVisibility visibility, out _)
             ? visibility

--- a/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.Initialization.cs
+++ b/src/Platform/Microsoft.Testing.Platform/OutputDevice/TerminalOutputDevice.Initialization.cs
@@ -206,18 +206,17 @@ internal sealed partial class TerminalOutputDevice
             }
             : isLLMEnvironment ? OutputShowMode.Failed : OutputShowMode.All;
 
-    // Resolves which per-test terminal blocks are rendered. An explicit --show-test-results always wins over
-    // --output, regardless of the order the two options appear on the command line (only --show-test-results is
-    // consulted for the override, via TerminalTestReporterCommandLineOptionsProvider.GetShowTestResultsVisibility).
-    // Absent --show-test-results, 'minimal' shows only failed results, 'detailed' shows every outcome, and
-    // everything else (including no --output at all) shows failed and skipped results (passed tests stay hidden).
+    // Resolves which per-test terminal blocks are rendered. An explicit --show-test-results value or its passive
+    // configuration default wins over --output; an explicit value wins over the passive default. When neither is
+    // present, 'minimal' shows only failed results, 'detailed' shows every outcome, and everything else (including
+    // no --output at all) shows failed and skipped results (passed tests stay hidden).
     // Internal for unit testing the parse seam that feeds
     // TerminalTestReporterOptions.ShowTestResults.
     internal static TestResultVisibility GetShowTestResultsVisibility(ICommandLineOptions commandLineOptions)
     {
-        if (TerminalTestReporterCommandLineOptionsProvider.GetShowTestResultsVisibility(commandLineOptions) is { } explicitVisibility)
+        if (TerminalTestReporterCommandLineOptionsProvider.GetShowTestResultsVisibility(commandLineOptions) is { } configuredVisibility)
         {
-            return explicitVisibility;
+            return configuredVisibility;
         }
 
         string? outputArgument = commandLineOptions.TryGetOptionArgumentList(TerminalTestReporterCommandLineOptionsProvider.OutputOption, out string[]? outputArguments)

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,9 +16,6 @@
     <TestingPlatformCommandLineArguments Condition=" '$([MSBuild]::GetTargetFrameworkIdentifier($(TargetFramework)))' == '.NETCoreApp' ">$(TestingPlatformCommandLineArguments) --crashdump</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --hangdump --hangdump-timeout 15m</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-azdo</TestingPlatformCommandLineArguments>
-    <!-- Keep test output focused on actionable per-test results. Skipped tests remain included in summaries
-         and report files; only their terminal result blocks are suppressed. -->
-    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --show-test-results failed</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-ctrf --report-ctrf-filename $(MSBuildProjectName)_$(TargetFramework).ctrf.json</TestingPlatformCommandLineArguments>
     <!-- The report-azdo-summary option implements ITestSessionLifetimeHandler and emits a warning on the
          output device when TF_BUILD is not 'true', unlike the silent report-azdo. Gate it on $(TF_BUILD)
@@ -50,6 +47,12 @@
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Persist this preference into each test host so direct solution and test-module runs also honor it.
+         Explicit command-line values can still override the default. Skipped tests remain in summaries and reports. -->
+    <TestingPlatformCommandLineOptionDefault Include="show-test-results" Value="failed" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(UsingDotNetTest)'=='true'">
     <!-- By default, Arcade already adds report-trx, report-trx-filename, and results-directory -->

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TestCommandLineOptions.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Helpers/TestCommandLineOptions.cs
@@ -5,13 +5,26 @@ using Microsoft.Testing.Platform.CommandLine;
 
 namespace Microsoft.Testing.Platform.UnitTests.Helpers;
 
-internal class TestCommandLineOptions : ICommandLineOptions
+internal class TestCommandLineOptions : ICommandLineOptions, ICommandLineOptionsWithDefaults
 {
     private readonly Dictionary<string, string[]> _options;
+    private readonly Dictionary<string, string[]> _defaults;
 
-    public TestCommandLineOptions(Dictionary<string, string[]> options) => _options = options;
+    public TestCommandLineOptions(Dictionary<string, string[]> options)
+        : this(options, [])
+    {
+    }
+
+    public TestCommandLineOptions(Dictionary<string, string[]> options, Dictionary<string, string[]> defaults)
+    {
+        _options = options;
+        _defaults = defaults;
+    }
 
     public bool IsOptionSet(string optionName) => _options.ContainsKey(optionName);
 
     public bool TryGetOptionArgumentList(string optionName, [NotNullWhen(true)] out string[]? arguments) => _options.TryGetValue(optionName, out arguments);
+
+    bool ICommandLineOptionsWithDefaults.TryGetOptionArgumentListOrDefault(string optionName, [NotNullWhen(true)] out string[]? arguments)
+        => _options.TryGetValue(optionName, out arguments) || _defaults.TryGetValue(optionName, out arguments);
 }

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProviderTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/OutputDevice/Terminal/TerminalTestReporterCommandLineOptionsProviderTests.cs
@@ -426,6 +426,35 @@ public sealed class TerminalTestReporterCommandLineOptionsProviderTests
     }
 
     [TestMethod]
+    public void GetShowTestResultsVisibility_WhenPassiveDefaultPresent_ReturnsParsedFlags()
+    {
+        var options = new Helpers.TestCommandLineOptions(
+            [],
+            new Dictionary<string, string[]>
+            {
+                [TerminalTestReporterCommandLineOptionsProvider.ShowTestResultsOption] = ["failed"],
+            });
+
+        Assert.AreEqual(TestResultVisibility.Failed, TerminalTestReporterCommandLineOptionsProvider.GetShowTestResultsVisibility(options));
+    }
+
+    [TestMethod]
+    public void GetShowTestResultsVisibility_WhenOptionAndPassiveDefaultPresent_OptionWins()
+    {
+        var options = new Helpers.TestCommandLineOptions(
+            new Dictionary<string, string[]>
+            {
+                [TerminalTestReporterCommandLineOptionsProvider.ShowTestResultsOption] = ["skipped"],
+            },
+            new Dictionary<string, string[]>
+            {
+                [TerminalTestReporterCommandLineOptionsProvider.ShowTestResultsOption] = ["failed"],
+            });
+
+        Assert.AreEqual(TestResultVisibility.Skipped, TerminalTestReporterCommandLineOptionsProvider.GetShowTestResultsVisibility(options));
+    }
+
+    [TestMethod]
     public void GetShowTestResultsVisibility_WhenPresentValueWasNotValidated_Throws()
     {
         var options = new Helpers.TestCommandLineOptions(new Dictionary<string, string[]>
@@ -438,10 +467,10 @@ public sealed class TerminalTestReporterCommandLineOptionsProviderTests
         Assert.AreEqual("The --show-test-results option was not validated.", exception.Message);
     }
 
-    // TerminalOutputDevice.GetShowTestResultsVisibility resolution/precedence: an explicit --show-test-results
-    // always wins over --output; absent it, --output's 'Minimal' maps to 'failed', 'Detailed' maps to 'all', and
-    // everything else (including no --output at all) maps to 'failed'+'skipped'. Since both options are read independently by name from the
-    // same options bag, the resolution cannot depend on which one a user typed first on the command line.
+    // TerminalOutputDevice.GetShowTestResultsVisibility resolution/precedence: an explicit or passive-default
+    // --show-test-results value wins over --output; absent both, --output's 'Minimal' maps to 'failed', 'Detailed'
+    // maps to 'all', and everything else (including no --output at all) maps to 'failed'+'skipped'. Since both
+    // options are read independently by name from the same options bag, resolution cannot depend on CLI order.
     //
     // Comparisons cast to int: TerminalOutputDevice itself is not compiled into this test project (only the
     // OutputDevice\Terminal folder is, via the Compile Include in the .csproj), so its return value is the


### PR DESCRIPTION
<!--
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

## Summary

Repository solution and module test runs launch built test hosts directly, so the existing `TestingPlatformCommandLineArguments` setting did not reach them and skipped-test details remained visible.

- persist `show-test-results=failed` in each test host as a passive default
- make the terminal reporter consume passive defaults while preserving explicit command-line precedence
- cover passive-default resolution and explicit override behavior

## Validation

- `Microsoft.Testing.Platform.UnitTests`: 2515 passed
- generated test-host configuration contains `show-test-results: failed`
- default execution hides per-test result blocks, while explicit `--show-test-results all` restores them

Fixes #11009