### PR TITLE
Enable multithreaded MSBuild in acceptance tests

### DIFF
--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSBuildRunnerTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/MSBuildRunnerTests.cs
@@ -6,6 +6,8 @@ using Microsoft.Testing.Platform.Acceptance.IntegrationTests.Helpers;
 
 namespace MSTest.Acceptance.IntegrationTests;
 
+// InvokeTestingPlatformTask does not yet preserve its terminal summary and artifacts in -mt's
+// out-of-process TaskHost, so tests that exercise the MSBuild Test target must opt out.
 [TestClass]
 public class MSBuildRunnerTests : AcceptanceTestBase<NopAssetFixture>
 {
@@ -46,7 +48,7 @@ public class MSBuildRunnerTests : AcceptanceTestBase<NopAssetFixture>
         DotnetMuxerResult restoreResult = await DotnetCli.RunAsync($"restore {solution.SolutionFile} --configfile {nugetFile}", cancellationToken: TestContext.CancellationToken);
         restoreResult.AssertOutputDoesNotContain("An approximate best match of");
 
-        DotnetMuxerResult testResult = await DotnetCli.RunAsync($"build --no-restore /t:Test {solution.SolutionFile}", workingDirectory: generator.TargetAssetPath, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult testResult = await DotnetCli.RunAsync($"build --no-restore /t:Test {solution.SolutionFile}", workingDirectory: generator.TargetAssetPath, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         if (isMultiTfm)
         {

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/PublishAotNonNativeTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/PublishAotNonNativeTests.cs
@@ -9,6 +9,8 @@ namespace MSTest.Acceptance.IntegrationTests;
 /// <summary>
 /// When PublishAOT=true is set on a project, it will set IsDynamicCodeSupported to false, but the code will still run as managed
 /// and VSTest is still able to find tests in the dll.
+/// InvokeTestingPlatformTask does not yet preserve its terminal summary and artifacts in -mt's out-of-process
+/// TaskHost, so tests that exercise the MSBuild Test target must opt out.
 /// </summary>
 [TestClass]
 public sealed class PublishAotNonNativeTests : AcceptanceTestBase<NopAssetFixture>
@@ -24,7 +26,7 @@ public sealed class PublishAotNonNativeTests : AcceptanceTestBase<NopAssetFixtur
             .PatchCodeWithReplace("$TargetFramework$", $"<TargetFramework>{TargetFrameworks.NetCurrent}</TargetFramework>")
             .PatchCodeWithReplace("$MSTestVersion$", MSTestVersion));
 
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"build -t:Test -c Debug {generator.TargetAssetPath}", workingDirectory: generator.TargetAssetPath, failIfReturnValueIsNotZero: false, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"build -t:Test -c Debug {generator.TargetAssetPath}", workingDirectory: generator.TargetAssetPath, failIfReturnValueIsNotZero: false, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         // In the real-world issue, access to path C:\Program Files\dotnet\ is denied, but we run this from a local .dotnet folder, where we have write access.
         // So instead of relying on the test run failing because of AccessDenied, we check the output, and see where TestResults were placed.

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BrowserWasmExecutionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BrowserWasmExecutionTests.cs
@@ -892,12 +892,14 @@ internal sealed class WarningFramework : ITestFramework, IDataProducer, IOutputD
 
         // Only a missing 'wasm-tools' workload is an acceptable skip; any other build failure (compiler
         // error, a broken generated MTP entry point) is a real regression and must fail the test.
+        // The browser-WASM SDK's JsonToItemsTaskFactory cannot run in the out-of-process TaskHost used by -mt.
         DotnetMuxerResult buildResult = await DotnetCli.RunAsync(
             $"build {generator.TargetAssetPath} -f {TargetFramework} -r {WasmRuntime.BrowserRid} -c Release",
             // Trimming/wasm builds can emit non-actionable warnings; we only assert on the build
             // succeeding and the entry point being generated, not on a warning-clean build.
             warnAsError: false,
             failIfReturnValueIsNotZero: false,
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         if (buildResult.ExitCode != 0)

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceFixture.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Helpers/AcceptanceFixture.cs
@@ -11,6 +11,7 @@ public static class AcceptanceFixture
     [AssemblyInitialize]
     public static void AssemblyInitialize(TestContext context)
     {
+        DotnetCli.UseMultithreadedMSBuild = true;
         Environment.SetEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1");
 
         s_directoryToCleanup = Path.Combine(TempDirectory.TestSuiteDirectory, RandomId.Next());

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Solution.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Solution.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
+// InvokeTestingPlatformTask does not yet preserve its terminal summary and artifacts in -mt's
+// out-of-process TaskHost, so tests that exercise the MSBuild Test target must opt out.
 [TestClass]
 public class MSBuildTests_Solution : AcceptanceTestBase<NopAssetFixture>
 {
@@ -47,7 +49,7 @@ public class MSBuildTests_Solution : AcceptanceTestBase<NopAssetFixture>
         // Build the solution
         DotnetMuxerResult restoreResult = await DotnetCli.RunAsync($"restore {solution.SolutionFile} --configfile {nugetFile}", cancellationToken: TestContext.CancellationToken);
         restoreResult.AssertOutputDoesNotContain("An approximate best match of");
-        DotnetMuxerResult testResult = await DotnetCli.RunAsync($"build --no-restore -t:Test -p:UseMSBuildTestInfrastructure=true {solution.SolutionFile}", workingDirectory: solution.FolderPath, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult testResult = await DotnetCli.RunAsync($"build --no-restore -t:Test -p:UseMSBuildTestInfrastructure=true {solution.SolutionFile}", workingDirectory: solution.FolderPath, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         if (isMultiTfm)
         {

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/MSBuildTests.Test.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Testing.Platform.Acceptance.IntegrationTests;
 
+// InvokeTestingPlatformTask does not yet preserve its terminal summary and artifacts in -mt's
+// out-of-process TaskHost, so tests that exercise the MSBuild Test target must opt out.
 [TestClass]
 public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
 {
@@ -53,7 +55,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             .PatchCodeWithReplace("$AssertValue$", testSucceeded.ToString().ToLowerInvariant())
             .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
         string testResultFolder = Path.Combine(testAsset.TargetAssetPath, Guid.NewGuid().ToString("N"));
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformCommandLineArguments=\"--results-directory %22{testResultFolder}%22\" -p:Configuration={compilationMode} \"{testAsset.TargetAssetPath}\"", workingDirectory: testAsset.TargetAssetPath, failIfReturnValueIsNotZero: false, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformCommandLineArguments=\"--results-directory %22{testResultFolder}%22\" -p:Configuration={compilationMode} \"{testAsset.TargetAssetPath}\"", workingDirectory: testAsset.TargetAssetPath, failIfReturnValueIsNotZero: false, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         foreach (string tfmToAssert in tfmsToAssert)
         {
@@ -85,10 +87,10 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
         DotnetMuxerResult compilationResult = testCommand.StartsWith("test", StringComparison.OrdinalIgnoreCase)
             ? await DotnetCli.RunAsync(
                 $"{testCommand} -p:Configuration={compilationMode} \"{testAsset.TargetAssetPath}\" -- --treenode-filter <whatever> --results-directory \"{testResultFolder}\"",
-                workingDirectory: testAsset.TargetAssetPath, cancellationToken: TestContext.CancellationToken)
+                workingDirectory: testAsset.TargetAssetPath, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken)
             : await DotnetCli.RunAsync(
                 $"{testCommand} -p:TestingPlatformCommandLineArguments=\"--treenode-filter <whatever> --results-directory \"{testResultFolder}\"\" -p:Configuration={compilationMode} \"{testAsset.TargetAssetPath}\"",
-                workingDirectory: testAsset.TargetAssetPath, cancellationToken: TestContext.CancellationToken);
+                workingDirectory: testAsset.TargetAssetPath, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         foreach (string tfmToAssert in tfmsToAssert)
         {
@@ -145,6 +147,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             workingDirectory: testAsset.TargetAssetPath,
             environmentVariables: dotnetRootX86,
             failIfReturnValueIsNotZero: false,
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         string[] outputLogFiles = Directory.GetFiles(testAsset.TargetAssetPath, $"MSBuild Tests_{TargetFrameworks.NetCurrent}_x86.log", SearchOption.AllDirectories);
@@ -178,6 +181,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             $"build -t:Test --arch {incompatibleArchitecture} \"{testAsset.TargetAssetPath}\"",
             workingDirectory: testAsset.TargetAssetPath,
             failIfReturnValueIsNotZero: false,
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         // The build should fail and the failure should mention the incompatible target architecture
@@ -262,6 +266,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             workingDirectory: testAsset.TargetAssetPath,
             environmentVariables: dotnetHostPathEnvVar,
             failIfReturnValueIsNotZero: false,
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         string[] outputLogFiles = Directory.GetFiles(testAsset.TargetAssetPath, $"MSBuild Tests_{TargetFrameworks.NetCurrent}_x64.log", SearchOption.AllDirectories);
@@ -315,7 +320,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             .PatchCodeWithReplace("$TargetFrameworks$", $"<targetFramework>{tfm}</targetFramework>")
             .PatchCodeWithReplace("$AssertValue$", testSucceeded.ToString().ToLowerInvariant())
             .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformShowTestsFailure=True -p:TestingPlatformCaptureOutput=False -p:Configuration={compilationMode} {testAsset.TargetAssetPath}", workingDirectory: testAsset.TargetAssetPath, failIfReturnValueIsNotZero: false, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"{testCommand} -p:TestingPlatformShowTestsFailure=True -p:TestingPlatformCaptureOutput=False -p:Configuration={compilationMode} {testAsset.TargetAssetPath}", workingDirectory: testAsset.TargetAssetPath, failIfReturnValueIsNotZero: false, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         compilationResult.AssertOutputContains("error test failed: Test2 (");
         compilationResult.AssertOutputContains("FAILED: Expected 'true', but got 'false'.");
@@ -332,7 +337,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             .PatchCodeWithReplace("$TargetFrameworks$", $"<targetFramework>{TargetFrameworks.NetCurrent}</targetFramework>")
             .PatchCodeWithReplace("$AssertValue$", "true")
             .PatchCodeWithReplace("$MicrosoftTestingPlatformVersion$", MicrosoftTestingPlatformVersion));
-        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -p:TestingPlatformDisableCustomTestTarget=true -p:ImportUserDefinedTestTarget=true -t:\"Build;Test\"", failIfReturnValueIsNotZero: false, cancellationToken: TestContext.CancellationToken);
+        DotnetMuxerResult compilationResult = await DotnetCli.RunAsync($"build {testAsset.TargetAssetPath} -p:TestingPlatformDisableCustomTestTarget=true -p:ImportUserDefinedTestTarget=true -t:\"Build;Test\"", failIfReturnValueIsNotZero: false, useMultithreadedMSBuild: false, cancellationToken: TestContext.CancellationToken);
 
         compilationResult.AssertOutputContains("Error from UserDefinedTestTarget.targets");
     }
@@ -359,6 +364,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
                 // process by inheritance from the MSBuild process.
                 ["MTP_ENV_INHERITED"] = "inherited-value",
             },
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         compilationResult.AssertOutputContains("[env] MTP_ENV_SIMPLE=simple-value");
@@ -397,6 +403,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             $"build -t:Test -p:TestingPlatformCaptureOutput=False \"{testAsset.TargetAssetPath}\"",
             workingDirectory: testAsset.TargetAssetPath,
             environmentVariables: CreateEnvironmentVariables(),
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         string dotnetRootOutputPrefix = $"[env] {dotnetRootVariableName}=";
@@ -420,6 +427,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
                 // existing directory without a dotnet installation to prove the explicit item clears this override.
                 [dotnetRootVariableName] = Path.GetTempPath(),
             },
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         explicitResult.AssertOutputContains($"[env] DOTNET_ROOT={dotnetRoot}");
@@ -429,6 +437,7 @@ public class MSBuildTests_Test : AcceptanceTestBase<NopAssetFixture>
             $"build -t:Test -p:TestingPlatformCaptureOutput=False -p:TestingPlatformDisableAppHostDotnetRoot=true \"{testAsset.TargetAssetPath}\"",
             workingDirectory: testAsset.TargetAssetPath,
             environmentVariables: CreateEnvironmentVariables(),
+            useMultithreadedMSBuild: false,
             cancellationToken: TestContext.CancellationToken);
 
         disabledResult.AssertOutputContains($"[env] {dotnetRootVariableName}=");

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -37,6 +37,7 @@ public static class DotnetCli
         "--solution",
         "--test-adapter-path",
         "--timeout",
+        "--verbosity",
         "-a",
         "-c",
         "-e",

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -55,6 +55,7 @@ public static class DotnetCli
         bool disableCodeCoverage = true,
         bool warnAsError = true,
         bool suppressPreviewDotNetMessage = true,
+        bool useMultithreadedMSBuild = true,
         [CallerMemberName] string callerMemberName = "",
         CancellationToken cancellationToken = default)
     {
@@ -92,14 +93,16 @@ public static class DotnetCli
                 environmentVariables.Add("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
             }
 
-            bool useMultithreadedMSBuild = UseMultithreadedMSBuild && IsMSBuildBackedBuildOrTest(args);
-            if (useMultithreadedMSBuild && IsCommand(args, "test"))
+            bool shouldUseMultithreadedMSBuild = UseMultithreadedMSBuild
+                && useMultithreadedMSBuild
+                && IsMSBuildBackedBuildOrTest(args);
+            if (shouldUseMultithreadedMSBuild && IsCommand(args, "test"))
             {
                 // The Microsoft.Testing.Platform mode of 'dotnet test' does not accept MSBuild's -mt switch.
-                environmentVariables["MSBUILDFORCEMULTITHREADED"] = "1";
+                environmentVariables["MSBUILDENABLEMULTITHREADED"] = "1";
             }
 
-            string extraArgs = useMultithreadedMSBuild && IsCommand(args, "build") ? " -mt" : string.Empty;
+            string extraArgs = shouldUseMultithreadedMSBuild && IsCommand(args, "build") ? " -mt" : string.Empty;
             extraArgs += warnAsError ? " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true" : string.Empty;
             extraArgs += suppressPreviewDotNetMessage ? " -p:SuppressNETCoreSdkPreviewMessage=true" : string.Empty;
             if (args.IndexOf("-- ", StringComparison.Ordinal) is int platformArgsIndex && platformArgsIndex > 0)

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -44,6 +44,8 @@ public static class DotnetCli
         }
     }
 
+    public static bool UseMultithreadedMSBuild { get; set; }
+
     public static async Task<DotnetMuxerResult> RunAsync(
         string args,
         string? workingDirectory = null,
@@ -90,7 +92,15 @@ public static class DotnetCli
                 environmentVariables.Add("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
             }
 
-            string extraArgs = warnAsError ? " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true" : string.Empty;
+            bool useMultithreadedMSBuild = UseMultithreadedMSBuild && IsMSBuildBackedBuildOrTest(args);
+            if (useMultithreadedMSBuild && IsCommand(args, "test"))
+            {
+                // The Microsoft.Testing.Platform mode of 'dotnet test' does not accept MSBuild's -mt switch.
+                environmentVariables["MSBUILDFORCEMULTITHREADED"] = "1";
+            }
+
+            string extraArgs = useMultithreadedMSBuild && IsCommand(args, "build") ? " -mt" : string.Empty;
+            extraArgs += warnAsError ? " -p:MSBuildTreatWarningsAsErrors=true -p:TreatWarningsAsErrors=true" : string.Empty;
             extraArgs += suppressPreviewDotNetMessage ? " -p:SuppressNETCoreSdkPreviewMessage=true" : string.Empty;
             if (args.IndexOf("-- ", StringComparison.Ordinal) is int platformArgsIndex && platformArgsIndex > 0)
             {
@@ -109,8 +119,18 @@ public static class DotnetCli
         }
     }
 
+    private static bool IsMSBuildBackedBuildOrTest(string args)
+        => IsCommand(args, "build")
+            || (IsCommand(args, "test") && !IsDotNetTestWithExeOrDll(args));
+
+    private static bool IsCommand(string args, string command)
+        => args.StartsWith(command, StringComparison.OrdinalIgnoreCase)
+            && (args.Length == command.Length || char.IsWhiteSpace(args[command.Length]));
+
     private static bool IsDotNetTestWithExeOrDll(string args)
-        => args.StartsWith("test ", StringComparison.Ordinal) && (args.Contains(".dll") || args.Contains(".exe"));
+        => IsCommand(args, "test")
+            && (args.Contains(".dll", StringComparison.OrdinalIgnoreCase)
+                || args.Contains(".exe", StringComparison.OrdinalIgnoreCase));
 
     private static async Task<DotnetMuxerResult> CallTheMuxerAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, bool failIfReturnValueIsNotZero, string binlogBaseFileName, CancellationToken cancellationToken)
         => await Policy

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -172,13 +172,13 @@ public static class DotnetCli
 
     private static bool IsMSBuildBackedBuildOrTest(string args)
         => IsCommand(args, "build")
-            || (IsCommand(args, "test") && !IsDotNetTestWithExeOrDll(args));
+            || (IsCommand(args, "test") && !IsDirectDotNetTestInvocation(args));
 
     private static bool IsCommand(string args, string command)
         => args.StartsWith(command, StringComparison.OrdinalIgnoreCase)
             && (args.Length == command.Length || char.IsWhiteSpace(args[command.Length]));
 
-    private static bool IsDotNetTestWithExeOrDll(string args)
+    private static bool IsDirectDotNetTestInvocation(string args)
     {
         string[] tokens = TokenizeArguments(args);
         if (tokens.Length == 0 || !string.Equals(tokens[0], "test", StringComparison.OrdinalIgnoreCase))
@@ -195,6 +195,11 @@ public static class DotnetCli
             }
 
             string optionName = token.Split(['=', ':'], 2)[0];
+            if (string.Equals(optionName, "--test-modules", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             if (string.Equals(optionName, "--project", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
@@ -283,7 +288,7 @@ public static class DotnetCli
         }
 
         string? binlogFullPath = null;
-        if (!args.Contains("-bl:") && !IsDotNetTestWithExeOrDll(args))
+        if (!args.Contains("-bl:") && !IsDirectDotNetTestInvocation(args))
         {
             // We do this here rather than in the caller so that different retries produce different binlog file names.
             binlogFullPath = Path.Combine(TempDirectory.TestSuiteDirectory, $"{binlogBaseFileName}-{Interlocked.Increment(ref s_binlogCounter)}.binlog");

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -24,7 +24,6 @@ public static class DotnetCli
         "--filter",
         "--framework",
         "--logger",
-        "--list-tests",
         "--max-parallel-test-modules",
         "--maximum-failed-tests",
         "--minimum-expected-tests",
@@ -203,6 +202,19 @@ public static class DotnetCli
             if (string.Equals(optionName, "--project", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
+            }
+
+            if (string.Equals(optionName, "--list-tests", StringComparison.OrdinalIgnoreCase))
+            {
+                if (token.Length == optionName.Length
+                    && i + 1 < tokens.Length
+                    && (string.Equals(tokens[i + 1], "text", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(tokens[i + 1], "json", StringComparison.OrdinalIgnoreCase)))
+                {
+                    i++;
+                }
+
+                continue;
             }
 
             if (token.StartsWith('-'))

--- a/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
+++ b/test/Utilities/Microsoft.Testing.TestInfrastructure/DotnetCli.cs
@@ -7,6 +7,48 @@ namespace Microsoft.Testing.TestInfrastructure;
 
 public static class DotnetCli
 {
+    private static readonly string[] DotNetTestOptionsWithValues =
+    [
+        "--arch",
+        "--artifacts-path",
+        "--blame-crash-dump-type",
+        "--blame-hang-dump-type",
+        "--blame-hang-timeout",
+        "--collect",
+        "--config-file",
+        "--configuration",
+        "--device",
+        "--diag",
+        "--diagnostic-output-directory",
+        "--environment",
+        "--filter",
+        "--framework",
+        "--logger",
+        "--list-tests",
+        "--max-parallel-test-modules",
+        "--maximum-failed-tests",
+        "--minimum-expected-tests",
+        "--os",
+        "--output",
+        "--results-directory",
+        "--results-directory-layout",
+        "--root-directory",
+        "--runtime",
+        "--settings",
+        "--solution",
+        "--test-adapter-path",
+        "--timeout",
+        "-a",
+        "-c",
+        "-e",
+        "-f",
+        "-l",
+        "-r",
+        "-s",
+        "-v",
+        "-verbosity",
+    ];
+
     private static readonly string[] CodeCoverageEnvironmentVariables =
     [
         "MicrosoftInstrumentationEngine_ConfigPath32_VanguardInstrumentationProfiler",
@@ -93,6 +135,12 @@ public static class DotnetCli
                 environmentVariables.Add("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
             }
 
+            if (!useMultithreadedMSBuild)
+            {
+                RemoveEnvironmentVariable(environmentVariables, "MSBUILDENABLEMULTITHREADED");
+                RemoveEnvironmentVariable(environmentVariables, "MSBUILDFORCEMULTITHREADED");
+            }
+
             bool shouldUseMultithreadedMSBuild = UseMultithreadedMSBuild
                 && useMultithreadedMSBuild
                 && IsMSBuildBackedBuildOrTest(args);
@@ -131,9 +179,85 @@ public static class DotnetCli
             && (args.Length == command.Length || char.IsWhiteSpace(args[command.Length]));
 
     private static bool IsDotNetTestWithExeOrDll(string args)
-        => IsCommand(args, "test")
-            && (args.Contains(".dll", StringComparison.OrdinalIgnoreCase)
-                || args.Contains(".exe", StringComparison.OrdinalIgnoreCase));
+    {
+        string[] tokens = TokenizeArguments(args);
+        if (tokens.Length == 0 || !string.Equals(tokens[0], "test", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        for (int i = 1; i < tokens.Length; i++)
+        {
+            string token = tokens[i];
+            if (token == "--")
+            {
+                break;
+            }
+
+            string optionName = token.Split(['=', ':'], 2)[0];
+            if (string.Equals(optionName, "--project", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (token.StartsWith('-'))
+            {
+                if (token.Length == optionName.Length && DotNetTestOptionsWithValues.Contains(optionName, StringComparer.OrdinalIgnoreCase))
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            string extension = Path.GetExtension(token);
+            return string.Equals(extension, ".dll", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(extension, ".exe", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    private static string[] TokenizeArguments(string args)
+    {
+        List<string> tokens = [];
+        StringBuilder currentToken = new();
+        bool inQuotes = false;
+        foreach (char character in args)
+        {
+            if (character == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (char.IsWhiteSpace(character) && !inQuotes)
+            {
+                if (currentToken.Length > 0)
+                {
+                    tokens.Add(currentToken.ToString());
+                    currentToken.Clear();
+                }
+            }
+            else
+            {
+                currentToken.Append(character);
+            }
+        }
+
+        if (currentToken.Length > 0)
+        {
+            tokens.Add(currentToken.ToString());
+        }
+
+        return [.. tokens];
+    }
+
+    private static void RemoveEnvironmentVariable(Dictionary<string, string?> environmentVariables, string variableName)
+    {
+        foreach (string key in environmentVariables.Keys.Where(key => string.Equals(key, variableName, StringComparison.OrdinalIgnoreCase)).ToArray())
+        {
+            environmentVariables.Remove(key);
+        }
+    }
 
     private static async Task<DotnetMuxerResult> CallTheMuxerAsync(string args, Dictionary<string, string?> environmentVariables, string? workingDirectory, bool failIfReturnValueIsNotZero, string binlogBaseFileName, CancellationToken cancellationToken)
         => await Policy


### PR DESCRIPTION
## Summary
- enable multithreaded MSBuild for ordinary acceptance-test `dotnet build` calls with `-mt`
- enable the equivalent mode for project-based `dotnet test` through `MSBUILDENABLEMULTITHREADED=1`
- opt out browser-WASM builds and MSBuild `Test` target scenarios whose tasks do not support multithreaded execution yet
- leave assembly-based `dotnet test` execution unchanged because it bypasses MSBuild

## Local performance report

**Environment:** Windows 11 Enterprise 10.0.26200; AMD Ryzen AI Max+ 395 (16 cores/32 logical processors); 47.8 GB RAM; .NET SDK 11.0.100-rc.2.26425.121; MSBuild 18.11.0.42621.

The benchmark used generated, multi-targeted MSTest acceptance assets (`net10.0`, `net8.0`, and `net462`). Acceptance tests ran with 32 method-level workers and a fresh randomized NuGet package directory per test-assembly invocation.

| Benchmark scenario | Without multithreaded MSBuild | With multithreaded MSBuild | Change |
| --- | ---: | ---: | ---: |
| Four-case scenario, median of 3 | 19.421s | 17.874s | **8.0% faster** |
| Broader 32-case scenario | 2m 30.221s | 1m 42.742s | **31.6% faster** |

Four-case samples were 19.420s, 20.570s, and 13.990s without multithreading versus 18.210s, 17.320s, and 17.870s with multithreading. All measured tests passed. The smaller sample is noisy, but both scenarios showed improvement and the larger concurrent scenario showed the strongest gain.

### Integration findings

The Microsoft.Testing.Platform mode of `dotnet test` does not accept the raw MSBuild `-mt` switch; it treats it as an unmatched platform option and test applications fail their handshake. This change therefore passes `-mt` directly to `dotnet build`, while project-based `dotnet test` uses MSBuild's equivalent `MSBUILDENABLEMULTITHREADED=1` environment input.

Two task paths currently need explicit opt-outs:

- The browser-WASM SDK's `JsonToItemsTaskFactory` cannot run in the out-of-process TaskHost selected by `-mt`.
- `InvokeTestingPlatformTask` does not yet preserve its terminal summary and output artifacts in that TaskHost, so acceptance scenarios that directly exercise `build -t:Test` remain single-process.

## Validation
- `build.cmd -pack -bl`
- targeted four-case scenario, three runs per variant
- broader 32-case acceptance scenario
- all 52 MTP acceptance cases covering the failed `build -t:Test` matrix and browser-WASM build
- 8 MSBuild solution acceptance cases
- 12 MSTest acceptance cases covering MSBuild `Test` target opt-outs and ordinary multithreaded build/test paths