### PR TITLE
Use native dotnet test for repository test execution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,10 @@ The codebase ships several distinct (but related) products. Knowing which produc
 - `test/Utilities/Microsoft.Testing.TestInfrastructure` — shared helpers for acceptance/integration tests (test asset fixtures, runners, etc.).
 - `eng/` — Arcade-based build infrastructure. Do not hand-edit `eng/common/`: it is mirrored from `dotnet/arcade` and overwritten by automation.
 
-Solution files: `TestFx.slnx` is the full solution; `MSTest.slnf`, `Microsoft.Testing.Platform.slnf`, and `NonWindowsTests.slnf` are filtered views.
+Solution files: `TestFx.slnx` is the full solution; `Tests.slnf`, `UnitTests.slnf`, and `IntegrationTests.slnf` are
+Windows test-only views; `NonWindowsTests.slnf`, `NonWindowsUnitTests.slnf`, and
+`NonWindowsIntegrationTests.slnf` preserve the supported non-Windows test matrix; `MSTest.slnf` and
+`Microsoft.Testing.Platform.slnf` are product-filtered views.
 
 ## Build, test, and debug commands
 
@@ -31,6 +34,9 @@ Always use the repo-local toolchain via the build scripts — they restore the p
 | Unit tests | `.\build.cmd -test` | `./build.sh -test` |
 | Integration + acceptance tests | `.\build.cmd -pack -test -integrationTest` | `./build.sh -pack -test -integrationTest` |
 | Open the solution in VS with the right env | `.\open-vs.cmd` | n/a |
+
+The build scripts use Arcade for SDK bootstrapping and build/pack orchestration, but test execution is always
+delegated to native `dotnet test` with the Microsoft.Testing.Platform runner selected in `global.json`.
 
 Acceptance integration tests (anything under `test/IntegrationTests/*.Acceptance.IntegrationTests`) consume the packed NuGets from `artifacts/packages/<Configuration>/Shipping`, so you **must** run `-pack` (and rerun it after every source change you want to test) before invoking them. Plain unit tests do not need `-pack`.
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -107,7 +107,8 @@
 
   <!-- Test config -->
   <PropertyGroup>
-    <!-- Needs to be setup globally so that arcade doesn't bring xUnit to playground and other test projects -->
+    <!-- Arcade remains the build SDK and defaults test-project evaluation to its xUnit runner.
+         Keep evaluation on MTP, while all repository test execution goes through native dotnet test. -->
     <TestRunnerName>Microsoft.Testing.Platform</TestRunnerName>
   </PropertyGroup>
 

--- a/IntegrationTests.slnf
+++ b/IntegrationTests.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\IntegrationTests\\MSTest.Acceptance.IntegrationTests\\MSTest.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\PlatformServices.Desktop.IntegrationTests\\PlatformServices.Desktop.IntegrationTests.csproj"
+    ]
+  }
+}

--- a/MSTestProductTests.slnf
+++ b/MSTestProductTests.slnf
@@ -1,0 +1,14 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\IntegrationTests\\MSTest.Acceptance.IntegrationTests\\MSTest.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\PlatformServices.Desktop.IntegrationTests\\PlatformServices.Desktop.IntegrationTests.csproj",
+      "test\\UnitTests\\MSTest.Analyzers.UnitTests\\MSTest.Analyzers.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SelfRealExamples.UnitTests\\MSTest.SelfRealExamples.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.PlatformServices.UnitTests\\MSTestAdapter.PlatformServices.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.UnitTests\\MSTestAdapter.UnitTests.csproj",
+      "test\\UnitTests\\TestFramework.UnitTests\\TestFramework.UnitTests.csproj"
+    ]
+  }
+}

--- a/MicrosoftTestingPlatformProductTests.slnf
+++ b/MicrosoftTestingPlatformProductTests.slnf
@@ -1,0 +1,13 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.UnitTests\\Microsoft.Testing.Extensions.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.UnitTests\\Microsoft.Testing.Platform.UnitTests.csproj"
+    ]
+  }
+}

--- a/NonWindowsIntegrationTests.slnf
+++ b/NonWindowsIntegrationTests.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\IntegrationTests\\MSTest.Acceptance.IntegrationTests\\MSTest.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj"
+    ]
+  }
+}

--- a/NonWindowsUnitTests.slnf
+++ b/NonWindowsUnitTests.slnf
@@ -1,0 +1,13 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\UnitTests\\MSTest.Analyzers.UnitTests\\MSTest.Analyzers.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.UnitTests\\Microsoft.Testing.Extensions.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.UnitTests\\Microsoft.Testing.Platform.UnitTests.csproj"
+    ]
+  }
+}

--- a/Tests.slnf
+++ b/Tests.slnf
@@ -1,0 +1,23 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\IntegrationTests\\MSTest.Acceptance.IntegrationTests\\MSTest.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests\\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj",
+      "test\\IntegrationTests\\PlatformServices.Desktop.IntegrationTests\\PlatformServices.Desktop.IntegrationTests.csproj",
+      "test\\UnitTests\\MSTest.Analyzers.UnitTests\\MSTest.Analyzers.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SelfRealExamples.UnitTests\\MSTest.SelfRealExamples.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SourceGeneration.UnitTests\\MSTest.SourceGeneration.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.PlatformServices.UnitTests\\MSTestAdapter.PlatformServices.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.UnitTests\\MSTestAdapter.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.UnitTests\\Microsoft.Testing.Extensions.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests\\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.TerminalReporterContract.UnitTests\\Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.UnitTests\\Microsoft.Testing.Platform.UnitTests.csproj",
+      "test\\UnitTests\\TestFramework.UnitTests\\TestFramework.UnitTests.csproj"
+    ]
+  }
+}

--- a/UnitTests.slnf
+++ b/UnitTests.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "TestFx.slnx",
+    "projects": [
+      "test\\UnitTests\\MSTest.Analyzers.UnitTests\\MSTest.Analyzers.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SelfRealExamples.UnitTests\\MSTest.SelfRealExamples.UnitTests.csproj",
+      "test\\UnitTests\\MSTest.SourceGeneration.UnitTests\\MSTest.SourceGeneration.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.PlatformServices.UnitTests\\MSTestAdapter.PlatformServices.UnitTests.csproj",
+      "test\\UnitTests\\MSTestAdapter.UnitTests\\MSTestAdapter.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.UnitTests\\Microsoft.Testing.Extensions.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests\\Microsoft.Testing.Extensions.VSTestBridge.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests\\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests\\Microsoft.Testing.Platform.MSBuild.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests\\Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.TerminalReporterContract.UnitTests\\Microsoft.Testing.Platform.TerminalReporterContract.UnitTests.csproj",
+      "test\\UnitTests\\Microsoft.Testing.Platform.UnitTests\\Microsoft.Testing.Platform.UnitTests.csproj",
+      "test\\UnitTests\\TestFramework.UnitTests\\TestFramework.UnitTests.csproj"
+    ]
+  }
+}

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -148,17 +148,13 @@ extends:
                 DOTNET_HOST_PATH: '$(Build.SourcesDirectory)/.dotnet/dotnet.exe'
 
             - ${{ if eq(parameters.SkipTests, False) }}:
-              # -ci is allowing to import some environment variables and some required configurations
-              - script: Test.cmd
-                  -configuration $(_BuildConfig)
-                  -ci
-                  -nobl
-                  /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog
+              - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe test --solution Tests.slnf --configuration $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:TestingPlatformCaptureOutput=false
                 name: Test
                 displayName: Test
                 env:
                   TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT: 5m
                   DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+                  NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
                   # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
                   # flaky-history injected by test/Directory.Build.targets) can query this pipeline's own
                   # test-result history. Secret variables are not auto-exposed to scripts, so the explicit
@@ -285,15 +281,13 @@ extends:
               displayName: Build
 
             - ${{ if eq(parameters.SkipTests, False) }}:
-              # -ci is allowing to import some environment variables and some required configurations
-              - script: |
-                  chmod +x ./test.sh
-                  ./test.sh --configuration $(_BuildConfig) --ci --test --integrationTest --nobl /bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog
+              - script: $(Build.SourcesDirectory)/.dotnet/dotnet test --solution NonWindowsTests.slnf --configuration $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:TestingPlatformCaptureOutput=false
                 name: Test
                 displayName: Tests
                 env:
                   TESTINGPLATFORM_DEFAULT_HANG_TIMEOUT: 5m
                   DOTNET_ROOT: $(Build.SourcesDirectory)/.dotnet
+                  NUGET_PACKAGES: $(Build.SourcesDirectory)/.packages
                   # Expose the build's OAuth token so the report-azdo history options (slow-test-history /
                   # flaky-history injected by test/Directory.Build.targets) can query this pipeline's own
                   # test-result history. Secret variables are not auto-exposed to scripts, so the explicit

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -56,6 +56,14 @@ variables:
     value: Release
   - name: _Products
     value: ${{parameters.products}}
+  - name: _WindowsTestSolution
+    value: Tests.slnf
+  - ${{ if eq(parameters.products, 'mstest') }}:
+    - name: _WindowsTestSolution
+      value: MSTestProductTests.slnf
+  - ${{ if eq(parameters.products, 'testing-platform') }}:
+    - name: _WindowsTestSolution
+      value: MicrosoftTestingPlatformProductTests.slnf
   # _SignType and _Sign are required for signing even if not used directly here
   - name: _SignType
     value: real
@@ -148,7 +156,7 @@ extends:
                 DOTNET_HOST_PATH: '$(Build.SourcesDirectory)/.dotnet/dotnet.exe'
 
             - ${{ if eq(parameters.SkipTests, False) }}:
-              - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe test --solution Tests.slnf --configuration $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:TestingPlatformCaptureOutput=false
+              - script: $(Build.SourcesDirectory)\.dotnet\dotnet.exe test --solution $(_WindowsTestSolution) --configuration $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:TestingPlatformCaptureOutput=false
                 name: Test
                 displayName: Test
                 env:

--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,66 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/common/build.sh" --build --restore $@
+
+run_unit_tests=false
+run_integration_tests=false
+configuration=Debug
+projects=''
+ci=false
+terminal_build_action=false
+build_arguments=()
+test_properties=()
+
+while [[ $# -gt 0 ]]; do
+  opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -test|-t)
+      run_unit_tests=true
+      ;;
+    -integrationtest)
+      run_integration_tests=true
+      ;;
+    -configuration|-c)
+      configuration=$2
+      build_arguments+=("$1" "$2")
+      shift
+      ;;
+    -projects)
+      projects=$2
+      build_arguments+=("$1" "$2")
+      shift
+      ;;
+    -ci)
+      ci=true
+      build_arguments+=("$1")
+      ;;
+    -clean|-help|-h)
+      terminal_build_action=true
+      build_arguments+=("$1")
+      ;;
+    *)
+      build_arguments+=("$1")
+      if [[ "$1" == /p:* || "$1" == -p:* || "$1" == /bl:* || "$1" == -bl:* ]]; then
+        test_properties+=("$1")
+      fi
+      ;;
+  esac
+
+  shift
+done
+
+"$scriptroot/eng/common/build.sh" --build --restore "${build_arguments[@]}"
+exit_code=$?
+if [[ $exit_code -ne 0 || "$terminal_build_action" == true ||
+      ("$run_unit_tests" != true && "$run_integration_tests" != true) ]]; then
+  exit $exit_code
+fi
+
+test_arguments=(--configuration "$configuration")
+[[ "$run_unit_tests" == true ]] && test_arguments+=(--unit)
+[[ "$run_integration_tests" == true ]] && test_arguments+=(--integration)
+[[ "$ci" == true ]] && test_arguments+=(--ci)
+[[ -n "$projects" ]] && test_arguments+=(--projects "$projects")
+test_arguments+=(-- "${test_properties[@]}")
+
+bash "$scriptroot/eng/run-tests.sh" "${test_arguments[@]}"

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -146,7 +146,11 @@ MSTest uses the following 3 kinds of tests:
 - Performance tests
   - Focused tests that ensure the performance of specific workflows of the application
 
-The easiest way to run the tests is to call
+The repository uses the native .NET `dotnet test` Microsoft.Testing.Platform experience. The build scripts still
+bootstrap the pinned SDK, build, and pack through Arcade, but their test switches delegate test execution to
+`dotnet test`.
+
+The easiest way to build, pack, and run all tests is to call
 
 For Windows:
 
@@ -160,7 +164,21 @@ For Linux and macOS:
 ./build.sh -pack -test -integrationTest
 ```
 
-Note that `-test` allows to run the unit tests and `-integrationTest` allows to run the two kinds of integration tests. Acceptance integration tests require the NuGet packages to have been produced hence the `-pack` flag.
+The `-test` switch runs `UnitTests.slnf` (or `NonWindowsUnitTests.slnf`) and `-integrationTest` runs
+`IntegrationTests.slnf` (or `NonWindowsIntegrationTests.slnf`). Acceptance integration tests require the NuGet
+packages in `artifacts/packages/<Configuration>/Shipping`, hence the `-pack` flag.
+
+After building, the equivalent direct commands are:
+
+```powershell
+.\.dotnet\dotnet.exe test --solution UnitTests.slnf --configuration Debug --no-build
+.\.dotnet\dotnet.exe test --solution IntegrationTests.slnf --configuration Debug --no-build
+```
+
+```shell
+./.dotnet/dotnet test --solution NonWindowsUnitTests.slnf --configuration Debug --no-build
+./.dotnet/dotnet test --solution NonWindowsIntegrationTests.slnf --configuration Debug --no-build
+```
 
 ### Mutation testing
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -82,4 +82,59 @@ if ($installWindowsSdk) {
 $null = $PSBoundParameters.Remove("vs")
 $null = $PSBoundParameters.Remove("installWindowsSdk")
 
+$runUnitTests = $test.IsPresent
+$runIntegrationTests = $integrationTest.IsPresent
+
+if (($runUnitTests -or $runIntegrationTests) -and -not $clean -and -not $help) {
+    $childBuildArguments = [System.Collections.Generic.List[string]]::new()
+    foreach ($parameter in $PSBoundParameters.GetEnumerator()) {
+        if ($parameter.Key -in "test", "integrationTest") {
+            continue
+        }
+
+        if ($parameter.Key -eq "properties") {
+            foreach ($property in $parameter.Value) {
+                $childBuildArguments.Add($property)
+            }
+
+            continue
+        }
+
+        if ($parameter.Value -is [System.Management.Automation.SwitchParameter]) {
+            if ($parameter.Value.IsPresent) {
+                $childBuildArguments.Add("-$($parameter.Key)")
+            }
+
+            continue
+        }
+
+        if ($parameter.Value -is [bool]) {
+            $childBuildArguments.Add("-$($parameter.Key):`$$($parameter.Value.ToString().ToLowerInvariant())")
+            continue
+        }
+
+        if ($null -ne $parameter.Value) {
+            $childBuildArguments.Add("-$($parameter.Key)")
+            $childBuildArguments.Add([string]$parameter.Value)
+        }
+    }
+
+    # Arcade still bootstraps the pinned SDK and performs build/pack/sign work, but it no longer
+    # receives either test switch. Test execution is delegated to the native dotnet test command.
+    $powerShellPath = (Get-Process -Id $PID).Path
+    & $powerShellPath -ExecutionPolicy ByPass -NoProfile -File $PSCommandPath @childBuildArguments
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    & $PSScriptRoot\run-tests.ps1 `
+        -configuration $configuration `
+        -unit:$runUnitTests `
+        -integration:$runIntegrationTests `
+        -ci:$ci.IsPresent `
+        -projects $projects `
+        -properties $properties
+    exit $LASTEXITCODE
+}
+
 & $PSScriptRoot\common\Build.ps1 @PSBoundParameters

--- a/eng/pipelines/steps/test-non-windows.yml
+++ b/eng/pipelines/steps/test-non-windows.yml
@@ -31,7 +31,7 @@ steps:
 # by Microsoft.Testing.Platform actually reaches the live build log; with the default (true), the
 # output is buffered into a per-module .log file and only surfaced on failure, so no live progress
 # is visible during long-running test sessions.
-- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false ${{ parameters.testFailureTrailer }}
+- script: dotnet test --solution NonWindowsTests.slnf -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)/artifacts/TestResults/$(_BuildConfig)/TestStep.binlog -p:TestingPlatformCaptureOutput=false ${{ parameters.testFailureTrailer }}
   name: Test
   displayName: Test
   condition: and(succeeded(), eq(variables._BuildConfig, 'Release'))

--- a/eng/pipelines/steps/test-windows-app-model.yml
+++ b/eng/pipelines/steps/test-windows-app-model.yml
@@ -23,10 +23,10 @@ steps:
 - script: dotnet build test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-incremental -bl:artifacts\log\$(_BuildConfig)\PackagedWinUI.binlog
   displayName: 'Build packaged WinUI acceptance tests'
 
-- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:UsingDotNetTest=true -p:ArtifactsTestResultsDir=$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\WindowsApplicationModelPackageContracts
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "FullyQualifiedName~WindowsApplicationModelPackageTests" -p:ArtifactsTestResultsDir=$(Build.SourcesDirectory)\artifacts\TestResults\$(_BuildConfig)\WindowsApplicationModelPackageContracts
   displayName: 'Test packed Windows application-model contracts'
 
-- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+- script: dotnet test test\IntegrationTests\MSTest.Acceptance.IntegrationTests\MSTest.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel"
   displayName: 'Test real Modern and classic UWP applications'
   env:
     TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1
@@ -60,7 +60,7 @@ steps:
   env:
     WINAPP_CLI_TELEMETRY_OPTOUT: 1
 
-- script: dotnet test test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel" -p:UsingDotNetTest=true
+- script: dotnet test test\IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests\Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj -c $(_BuildConfig) --no-build --filter "TestCategory=WindowsApplicationModel"
   displayName: 'Test packaged WinUI and WinApp CLI interoperability'
   env:
     TESTFX_RUN_WINDOWS_APP_MODEL_TESTS: 1

--- a/eng/pipelines/steps/test-windows-configuration-tests.yml
+++ b/eng/pipelines/steps/test-windows-configuration-tests.yml
@@ -27,7 +27,7 @@ steps:
 - ${{ if eq(parameters.enableAffectedTests, false) }}:
   - script: |
       echo ##vso[task.setvariable variable=PublishCoverageReport]true
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:SkipNonTestPlaygrounds=true -p:TestingPlatformCaptureOutput=false
     name: Test
     displayName: Test
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
@@ -52,7 +52,7 @@ steps:
 
   - script: |
       echo ##vso[task.setvariable variable=PublishCoverageReport]true
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --collect-test-map
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:SkipNonTestPlaygrounds=true -p:TestingPlatformCaptureOutput=false --collect-test-map
     name: Test
     displayName: Test and collect affected-test map
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'))
@@ -72,7 +72,7 @@ steps:
     condition: and(succeeded(), eq(variables._BuildConfig, 'Release'), ne(variables._XmlDocsOnly, 'true'), eq(variables['Build.Reason'], 'PullRequest'))
 
   - pwsh: |
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false --affected-tests
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:SkipNonTestPlaygrounds=true -p:TestingPlatformCaptureOutput=false --affected-tests
       $exitCode = $LASTEXITCODE
       if ($exitCode -eq 0) {
         Write-Host "##vso[task.setvariable variable=AffectedTestsSucceeded]true"
@@ -104,7 +104,7 @@ steps:
           Remove-Item -Force
       }
 
-      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:UsingDotNetTest=true -p:TestingPlatformCaptureOutput=false
+      dotnet test -c $(_BuildConfig) --no-build -bl:$(BUILD.SOURCESDIRECTORY)\artifacts\TestResults\$(_BuildConfig)\TestStep.binlog -p:SkipNonTestPlaygrounds=true -p:TestingPlatformCaptureOutput=false
       exit $LASTEXITCODE
     name: Test
     displayName: Test (affected-test fallback)

--- a/eng/run-tests.ps1
+++ b/eng/run-tests.ps1
@@ -32,9 +32,18 @@ $forwardedProperties = @($properties | Where-Object { $_ -notmatch '^(?:-|/)bl(?
 $requestedBinaryLog = $properties | Where-Object { $_ -match '^(?:-|/)bl:' } | Select-Object -Last 1
 $requestedBinaryLog = if ($requestedBinaryLog) { $requestedBinaryLog.Substring($requestedBinaryLog.IndexOf(':') + 1).Trim('"') } else { $null }
 
-function Invoke-NativeTest([string]$selectionOption, [string]$selection, [string]$binaryLogName) {
+function Invoke-NativeTest([string]$selectionOption, [string]$selection, [string]$binaryLogName, [bool]$useUniqueBinaryLog = $false) {
     $binaryLog = if ($requestedBinaryLog) {
-        $requestedBinaryLog
+        if ($useUniqueBinaryLog) {
+            $directory = [System.IO.Path]::GetDirectoryName($requestedBinaryLog)
+            $fileName = [System.IO.Path]::GetFileNameWithoutExtension($requestedBinaryLog)
+            $extension = [System.IO.Path]::GetExtension($requestedBinaryLog)
+            $selectionName = [System.IO.Path]::GetFileNameWithoutExtension($binaryLogName)
+            $uniqueFileName = "$fileName.$selectionName$extension"
+            if ($directory) { Join-Path $directory $uniqueFileName } else { $uniqueFileName }
+        } else {
+            $requestedBinaryLog
+        }
     } else {
         Join-Path $testResultsDirectory $binaryLogName
     }
@@ -52,15 +61,23 @@ function Invoke-NativeTest([string]$selectionOption, [string]$selection, [string
 
 if ($projects) {
     $selectedProjects = $projects.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
-    foreach ($project in $selectedProjects) {
+    $useUniqueBinaryLog = $selectedProjects.Count -gt 1
+    for ($index = 0; $index -lt $selectedProjects.Count; $index++) {
+        $project = $selectedProjects[$index]
         $projectPath = if ([System.IO.Path]::IsPathRooted($project)) { $project } else { Join-Path $repoRoot $project }
         $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath)
+        $binaryLogName = if ($useUniqueBinaryLog) { "{0:D2}.$projectName.binlog" -f ($index + 1) } else { "$projectName.binlog" }
+        if ([System.IO.Path]::GetExtension($projectPath) -in ".sln", ".slnf", ".slnx") {
+            Invoke-NativeTest "--solution" $projectPath $binaryLogName $useUniqueBinaryLog
+            continue
+        }
+
         $isIntegrationTest = $projectName.EndsWith(".IntegrationTests", [System.StringComparison]::OrdinalIgnoreCase)
         $isUnitTest = -not $isIntegrationTest -and
             ($projectName.EndsWith(".UnitTests", [System.StringComparison]::OrdinalIgnoreCase) -or
              $projectName.EndsWith(".Tests", [System.StringComparison]::OrdinalIgnoreCase))
         if (($unit -and $isUnitTest) -or ($integration -and $isIntegrationTest)) {
-            Invoke-NativeTest "--project" $projectPath "$projectName.binlog"
+            Invoke-NativeTest "--project" $projectPath $binaryLogName $useUniqueBinaryLog
         }
     }
 

--- a/eng/run-tests.ps1
+++ b/eng/run-tests.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding(PositionalBinding=$false)]
+param(
+    [string][Alias('c')]$configuration = "Debug",
+    [switch]$unit,
+    [switch]$integration,
+    [switch]$ci,
+    [string]$projects,
+    [string[]]$properties
+)
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$dotnet = Join-Path $repoRoot ".dotnet\dotnet.exe"
+if (-not (Test-Path -LiteralPath $dotnet -PathType Leaf)) {
+    Write-Error "The repository-local .NET SDK was not found. Run build.cmd before running tests."
+    exit 1
+}
+
+if ($ci) {
+    $env:DOTNET_ROOT = Join-Path $repoRoot ".dotnet"
+    $env:NUGET_PACKAGES = Join-Path $repoRoot ".packages"
+}
+
+if (-not $unit -and -not $integration) {
+    Write-Error "Specify -unit, -integration, or both."
+    exit 1
+}
+
+$testResultsDirectory = Join-Path $repoRoot "artifacts\TestResults\$configuration"
+New-Item -Path $testResultsDirectory -ItemType Directory -Force | Out-Null
+
+$forwardedProperties = @($properties | Where-Object { $_ -notmatch '^(?:-|/)bl(?::|$)' })
+$requestedBinaryLog = $properties | Where-Object { $_ -match '^(?:-|/)bl:' } | Select-Object -Last 1
+$requestedBinaryLog = if ($requestedBinaryLog) { $requestedBinaryLog.Substring($requestedBinaryLog.IndexOf(':') + 1).Trim('"') } else { $null }
+
+function Invoke-NativeTest([string]$selectionOption, [string]$selection, [string]$binaryLogName) {
+    $binaryLog = if ($requestedBinaryLog) {
+        $requestedBinaryLog
+    } else {
+        Join-Path $testResultsDirectory $binaryLogName
+    }
+
+    & $dotnet test $selectionOption $selection `
+        --configuration $configuration `
+        --no-build `
+        "-bl:$binaryLog" `
+        @forwardedProperties
+
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+if ($projects) {
+    $selectedProjects = $projects.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
+    foreach ($project in $selectedProjects) {
+        $projectPath = if ([System.IO.Path]::IsPathRooted($project)) { $project } else { Join-Path $repoRoot $project }
+        $projectName = [System.IO.Path]::GetFileNameWithoutExtension($projectPath)
+        $isIntegrationTest = $projectName.EndsWith(".IntegrationTests", [System.StringComparison]::OrdinalIgnoreCase)
+        $isUnitTest = -not $isIntegrationTest -and
+            ($projectName.EndsWith(".UnitTests", [System.StringComparison]::OrdinalIgnoreCase) -or
+             $projectName.EndsWith(".Tests", [System.StringComparison]::OrdinalIgnoreCase))
+        if (($unit -and $isUnitTest) -or ($integration -and $isIntegrationTest)) {
+            Invoke-NativeTest "--project" $projectPath "$projectName.binlog"
+        }
+    }
+
+    exit 0
+}
+
+$solution = if ($IsWindows -or $env:OS -eq "Windows_NT") {
+    if ($unit -and $integration) { "Tests.slnf" }
+    elseif ($unit) { "UnitTests.slnf" }
+    else { "IntegrationTests.slnf" }
+} else {
+    if ($unit -and $integration) { "NonWindowsTests.slnf" }
+    elseif ($unit) { "NonWindowsUnitTests.slnf" }
+    else { "NonWindowsIntegrationTests.slnf" }
+}
+
+$solutionPath = Join-Path $repoRoot $solution
+Invoke-NativeTest "--solution" $solutionPath "TestStep.binlog"
+exit 0

--- a/eng/run-tests.sh
+++ b/eng/run-tests.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -u
+
+scriptroot="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$scriptroot/.." && pwd)"
+configuration=Debug
+run_unit_tests=false
+run_integration_tests=false
+ci=false
+projects=''
+properties=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --configuration|-c)
+      configuration=$2
+      shift 2
+      ;;
+    --unit)
+      run_unit_tests=true
+      shift
+      ;;
+    --integration)
+      run_integration_tests=true
+      shift
+      ;;
+    --ci)
+      ci=true
+      shift
+      ;;
+    --projects)
+      projects=$2
+      shift 2
+      ;;
+    --)
+      shift
+      properties+=("$@")
+      break
+      ;;
+    *)
+      echo "Unknown test-runner argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$run_unit_tests" != true && "$run_integration_tests" != true ]]; then
+  echo "Specify --unit, --integration, or both." >&2
+  exit 1
+fi
+
+dotnet="$repo_root/.dotnet/dotnet"
+if [[ ! -x "$dotnet" ]]; then
+  echo "The repository-local .NET SDK was not found. Run ./build.sh before running tests." >&2
+  exit 1
+fi
+
+if [[ "$ci" == true ]]; then
+  export DOTNET_ROOT="$repo_root/.dotnet"
+  export NUGET_PACKAGES="$repo_root/.packages"
+fi
+
+test_results_directory="$repo_root/artifacts/TestResults/$configuration"
+mkdir -p "$test_results_directory"
+
+forwarded_properties=()
+requested_binary_log=''
+for property in "${properties[@]}"; do
+  case "$property" in
+    /bl:*|-bl:*)
+      requested_binary_log="${property#*:}"
+      requested_binary_log="${requested_binary_log%\"}"
+      requested_binary_log="${requested_binary_log#\"}"
+      ;;
+    /bl|-bl)
+      ;;
+    *)
+      forwarded_properties+=("$property")
+      ;;
+  esac
+done
+
+run_native_test() {
+  local selection_option=$1
+  local selection=$2
+  local binary_log_name=$3
+  local binary_log="${requested_binary_log:-$test_results_directory/$binary_log_name}"
+
+  "$dotnet" test "$selection_option" "$selection" \
+    --configuration "$configuration" \
+    --no-build \
+    "-bl:$binary_log" \
+    "${forwarded_properties[@]}"
+}
+
+if [[ -n "$projects" ]]; then
+  IFS=';' read -ra selected_projects <<< "$projects"
+  for project in "${selected_projects[@]}"; do
+    if [[ "$project" != /* ]]; then
+      project="$repo_root/$project"
+    fi
+    project_file="${project##*[\\/]}"
+    project_name="${project_file%.*}"
+    is_unit_test=false
+    is_integration_test=false
+    [[ "$project_name" == *.IntegrationTests ]] && is_integration_test=true
+    [[ "$is_integration_test" != true && ("$project_name" == *.UnitTests || "$project_name" == *.Tests) ]] && is_unit_test=true
+    if { [[ "$run_unit_tests" == true && "$is_unit_test" == true ]]; } ||
+       { [[ "$run_integration_tests" == true && "$is_integration_test" == true ]]; }; then
+      run_native_test --project "$project" "$project_name.binlog" || exit $?
+    fi
+  done
+
+  exit 0
+fi
+
+if [[ "$run_unit_tests" == true && "$run_integration_tests" == true ]]; then
+  solution=NonWindowsTests.slnf
+elif [[ "$run_unit_tests" == true ]]; then
+  solution=NonWindowsUnitTests.slnf
+else
+  solution=NonWindowsIntegrationTests.slnf
+fi
+
+run_native_test --solution "$repo_root/$solution" TestStep.binlog

--- a/eng/run-tests.sh
+++ b/eng/run-tests.sh
@@ -85,7 +85,20 @@ run_native_test() {
   local selection_option=$1
   local selection=$2
   local binary_log_name=$3
+  local use_unique_binary_log=${4:-false}
   local binary_log="${requested_binary_log:-$test_results_directory/$binary_log_name}"
+  if [[ -n "$requested_binary_log" && "$use_unique_binary_log" == true ]]; then
+    local requested_directory requested_file requested_stem requested_extension selection_name unique_file
+    requested_directory="$(dirname "$requested_binary_log")"
+    requested_file="$(basename "$requested_binary_log")"
+    requested_stem="${requested_file%.*}"
+    requested_extension=''
+    [[ "$requested_file" == *.* ]] && requested_extension=".${requested_file##*.}"
+    selection_name="${binary_log_name%.*}"
+    unique_file="$requested_stem.$selection_name$requested_extension"
+    binary_log="$unique_file"
+    [[ "$requested_directory" != "." ]] && binary_log="$requested_directory/$unique_file"
+  fi
 
   "$dotnet" test "$selection_option" "$selection" \
     --configuration "$configuration" \
@@ -96,19 +109,33 @@ run_native_test() {
 
 if [[ -n "$projects" ]]; then
   IFS=';' read -ra selected_projects <<< "$projects"
-  for project in "${selected_projects[@]}"; do
+  use_unique_binary_log=false
+  [[ ${#selected_projects[@]} -gt 1 ]] && use_unique_binary_log=true
+  for index in "${!selected_projects[@]}"; do
+    project="${selected_projects[$index]}"
     if [[ "$project" != /* ]]; then
       project="$repo_root/$project"
     fi
     project_file="${project##*[\\/]}"
     project_name="${project_file%.*}"
+    binary_log_name="$project_name.binlog"
+    if [[ "$use_unique_binary_log" == true ]]; then
+      printf -v binary_log_name '%02d.%s.binlog' "$((index + 1))" "$project_name"
+    fi
+    case "$project" in
+      *.sln|*.slnf|*.slnx)
+        run_native_test --solution "$project" "$binary_log_name" "$use_unique_binary_log" || exit $?
+        continue
+        ;;
+    esac
+
     is_unit_test=false
     is_integration_test=false
     [[ "$project_name" == *.IntegrationTests ]] && is_integration_test=true
     [[ "$is_integration_test" != true && ("$project_name" == *.UnitTests || "$project_name" == *.Tests) ]] && is_unit_test=true
     if { [[ "$run_unit_tests" == true && "$is_unit_test" == true ]]; } ||
        { [[ "$run_integration_tests" == true && "$is_integration_test" == true ]]; }; then
-      run_native_test --project "$project" "$project_name.binlog" || exit $?
+      run_native_test --project "$project" "$binary_log_name" "$use_unique_binary_log" || exit $?
     fi
   done
 

--- a/samples/BrowserPlayground/BrowserPlayground.csproj
+++ b/samples/BrowserPlayground/BrowserPlayground.csproj
@@ -24,13 +24,12 @@
     <Nullable>enable</Nullable>
     <!--
       Marks this as a Microsoft.Testing.Platform application. It is intentionally NOT set
-      when running under 'dotnet test' (CI's Debug Test step on TestFx.slnx passes
-      -p:UsingDotNetTest=true): the browser-wasm output can only be launched through a JS
+      during repository-wide test runs: the browser-wasm output can only be launched through a JS
       host (a browser or node importing dotnet.js), which is not wired into 'dotnet test'.
       The entry point is this sample's own Program.cs (top-level statements), not an
       MTP-generated one.
     -->
-    <IsTestingPlatformApplication Condition=" '$(UsingDotNetTest)' != 'true' ">true</IsTestingPlatformApplication>
+    <IsTestingPlatformApplication Condition=" '$(SkipNonTestPlaygrounds)' != 'true' ">true</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/CtrfPlayground/Mtp/Mtp.csproj
+++ b/samples/CtrfPlayground/Mtp/Mtp.csproj
@@ -7,14 +7,13 @@
     <NoWarn>$(NoWarn);NETSDK1023;SA0001;EnableGenerateDocumentationFile;TPEXP</NoWarn>
 
     <!--
-      IsTestingPlatformApplication is intentionally NOT set when running under
-      'dotnet test' (CI's Debug Test step on TestFx.slnx passes -p:UsingDotNetTest=true).
+      IsTestingPlatformApplication is intentionally NOT set during repository-wide test runs.
       This playground intentionally contains failing, throwing and skipped tests so the
       user can compare the produced CTRF report against xunit.v3's built-in CTRF output
       (see ../README.md). We don't want those intentional failures to break CI's test step.
       During a normal build the property stays true so the project still wires MTP correctly.
     -->
-    <IsTestingPlatformApplication Condition=" '$(UsingDotNetTest)' != 'true' ">true</IsTestingPlatformApplication>
+    <IsTestingPlatformApplication Condition=" '$(SkipNonTestPlaygrounds)' != 'true' ">true</IsTestingPlatformApplication>
     <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/samples/CtrfPlayground/XunitMtp/XunitMtp.csproj
+++ b/samples/CtrfPlayground/XunitMtp/XunitMtp.csproj
@@ -8,13 +8,13 @@
     <NoWarn>$(NoWarn);NETSDK1023;SA0001;EnableGenerateDocumentationFile</NoWarn>
 
     <!--
-      Mirror Mtp.csproj: opt this project out of the CI 'dotnet test' run, which passes
-      -p:UsingDotNetTest=true. The playground intentionally contains failing/throwing/skipped
+      Mirror Mtp.csproj: opt this project out of repository-wide test runs. The playground
+      intentionally contains failing/throwing/skipped
       tests so users can diff the CTRF output against the in-repo extension; those failures
       must not break CI. A normal build still enables MTP so 'dotnet run' works as documented.
     -->
-    <UseMicrosoftTestingPlatformRunner Condition=" '$(UsingDotNetTest)' != 'true' ">true</UseMicrosoftTestingPlatformRunner>
-    <IsTestingPlatformApplication Condition=" '$(UsingDotNetTest)' == 'true' ">false</IsTestingPlatformApplication>
+    <UseMicrosoftTestingPlatformRunner Condition=" '$(SkipNonTestPlaygrounds)' != 'true' ">true</UseMicrosoftTestingPlatformRunner>
+    <IsTestingPlatformApplication Condition=" '$(SkipNonTestPlaygrounds)' == 'true' ">false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test.sh
+++ b/test.sh
@@ -13,4 +13,58 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/common/build.sh" --test --integrationTest $@
+
+configuration=Debug
+projects=''
+ci=false
+terminal_build_action=false
+build_arguments=()
+test_properties=()
+
+while [[ $# -gt 0 ]]; do
+  opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -test|-t|-integrationtest)
+      ;;
+    -configuration|-c)
+      configuration=$2
+      build_arguments+=("$1" "$2")
+      shift
+      ;;
+    -projects)
+      projects=$2
+      build_arguments+=("$1" "$2")
+      shift
+      ;;
+    -ci)
+      ci=true
+      build_arguments+=("$1")
+      ;;
+    -clean|-help|-h)
+      terminal_build_action=true
+      build_arguments+=("$1")
+      ;;
+    *)
+      build_arguments+=("$1")
+      if [[ "$1" == /p:* || "$1" == -p:* || "$1" == /bl:* || "$1" == -bl:* ]]; then
+        test_properties+=("$1")
+      fi
+      ;;
+  esac
+
+  shift
+done
+
+# Bootstrap the pinned SDK and apply Arcade's build environment without asking Arcade to run tests.
+"$scriptroot/eng/common/build.sh" "${build_arguments[@]}"
+exit_code=$?
+if [[ $exit_code -ne 0 || "$terminal_build_action" == true ]]; then
+  exit $exit_code
+fi
+
+test_arguments=(--configuration "$configuration" --unit --integration)
+[[ "$ci" == true ]] && test_arguments+=(--ci)
+[[ -n "$projects" ]] && test_arguments+=(--projects "$projects")
+test_arguments+=(-- "${test_properties[@]}")
+
+bash "$scriptroot/eng/run-tests.sh" "${test_arguments[@]}"

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -44,20 +44,11 @@
          token, so gate it on $(TF_BUILD). -->
     <TestingPlatformCommandLineArguments Condition=" '$(TF_BUILD)' == 'true' ">$(TestingPlatformCommandLineArguments) --report-azdo-flaky-history 30</TestingPlatformCommandLineArguments>
     <!-- Dogfood the JUnit report extension (Microsoft.Testing.Extensions.JUnitReport). The .xml files end up in
-         $(ResultsDirectory) (Arcade default) alongside the TRX files so they are picked up by the AzDO
+         $(ResultsDirectory) alongside the TRX files so they are picked up by the AzDO
          PublishTestResults task and any external JUnit consumer. -->
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-junit</TestingPlatformCommandLineArguments>
     <TestingPlatformCommandLineArguments Condition=" '$(EnableCodeCoverage)' == 'True' ">$(TestingPlatformCommandLineArguments) --coverage --coverage-settings $(RepoRoot)test/coverage.config --coverage-output $(ModuleName).coverage</TestingPlatformCommandLineArguments>
 
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(UsingDotNetTest)'=='true'">
-    <!-- By default, Arcade already adds report-trx, report-trx-filename, and results-directory -->
-    <!-- However, when we run with dotnet test, we need to add these options, but still don't duplicate them on Arcade -->
-    <!-- So we detect when running with dotnet test and only add them there. That's unfortunate because any invocation of dotnet test will need to be done with -p:UsingDotNetTest=true -->
-    <!-- An alternative is that we always add those options here, and introduce a property in Arcade so that Arcade doesn't add the options again -->
-
-    <!-- This usage is bad. See https://github.com/dotnet/arcade/issues/16003 -->
     <_TestArchitecture>$(PlatformTarget)</_TestArchitecture>
     <_TestArchitecture Condition="'$(PlatformTarget)' == '' or '$(PlatformTarget)' == 'AnyCpu'">x64</_TestArchitecture>
     <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --report-trx --report-trx-filename $(MSBuildProjectName)_$(TargetFramework)_$(_TestArchitecture).trx --results-directory $(ArtifactsTestResultsDir)</TestingPlatformCommandLineArguments>

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
-    <TestRunnerAdditionalArguments>$(TestRunnerAdditionalArguments) --retry-failed-tests 3</TestRunnerAdditionalArguments>
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --retry-failed-tests 3</TestingPlatformCommandLineArguments>
     <!-- Retry attempts emit Azure DevOps annotations before the retry orchestrator knows the final outcome.
          Keep those annotations visible as warnings; the final process exit code and published TRX still fail
          the step and Tests tab when all retry attempts are exhausted. -->


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

## Summary

Contributors and official CI still reached Arcade-specific test targets even though testfx uses Microsoft.Testing.Platform and the .NET 11 native `dotnet test` experience. This moves repository test execution to native `dotnet test` while retaining Arcade for SDK bootstrap, build, packaging, signing, publishing, and Helix infrastructure.

- Route the existing build and test entry points through repository-owned native test dispatchers.
- Add unit, integration, Windows, and non-Windows solution filters so test selection and platform coverage remain unchanged.
- Preserve diagnostics, TRX, JUnit, CTRF, coverage, Azure DevOps reporting, retry arguments, forwarded MSBuild properties, and exit codes.
- Update official CI to invoke the repo-local SDK directly and remove the obsolete Arcade runner compatibility switches.
- Document the native test workflow and the remaining build-only Arcade boundary.

## Testing

- `pwsh -NoProfile -File eng\run-tests.ps1 -configuration Debug -unit -projects test\UnitTests\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj` (75 passed across net462, net8.0, and net9.0)
- `test.cmd -projects test\UnitTests\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests\Microsoft.Testing.Platform.DotnetTestProtocolContract.UnitTests.csproj -configuration Debug` (75 passed)
- PowerShell parser validation for the Windows scripts
- `bash -n build.sh test.sh eng/run-tests.sh`
- Solution-filter membership and unit/integration classification checks
- `git diff --check`

## Notes

`Microsoft.DotNet.Arcade.Sdk`, `eng/common`, and the Helix/post-build templates remain intentionally unchanged because they provide build and infrastructure services rather than repository test execution. The validated build binlog contains no Arcade `RunTests` target.