### PR TITLE
Fix cross-assembly source generation accessibility

### DIFF
--- a/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/MetadataRegistryEmitter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.Helpers;
@@ -58,6 +58,7 @@ internal static class MetadataRegistryEmitter
             using (sb.Block("internal sealed class TestMethodReflectionInfo"))
             {
                 sb.AppendLine("public string Name { get; set; } = string.Empty;");
+                sb.AppendLine("public Type DeclaringType { get; set; } = null!;");
                 sb.AppendLine("public bool IsTestMethod { get; set; }");
                 sb.AppendLine("public bool IsStatic { get; set; }");
                 sb.AppendLine("public bool IsAsync { get; set; }");
@@ -243,6 +244,7 @@ internal static class MetadataRegistryEmitter
                 using (sb.Block(null))
                 {
                     sb.AppendLine($"Name = \"{Escape(method.Name)}\",");
+                    sb.AppendLine($"DeclaringType = typeof({method.DeclaringTypeFullyQualifiedName}),");
                     sb.AppendLine($"IsTestMethod = {Bool(method.IsTestMethod)},");
                     sb.AppendLine($"IsStatic = {Bool(method.IsStatic)},");
                     sb.AppendLine($"IsAsync = {Bool(method.IsAsync)},");

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/RuntimeRegistrationEmitter.cs
@@ -192,7 +192,7 @@ internal static class RuntimeRegistrationEmitter
                 // reflection for that one method) rather than throwing out of the [ModuleInitializer],
                 // which would fault registration for the whole assembly.
                 sb.AppendLine("availableMethods ??= type.GetMethods(memberFlags);");
-                sb.AppendLine("MethodInfo? methodInfo = ResolveMethod(availableMethods, method.Name, method.ParameterTypes);");
+                sb.AppendLine("MethodInfo? methodInfo = ResolveMethod(availableMethods, method.DeclaringType, method.Name, method.ParameterTypes);");
                 using (sb.Block("if (methodInfo is not null)"))
                 {
                     sb.AppendLine("methodInvokers[methodInfo] = method.Invoke;");
@@ -280,12 +280,12 @@ internal static class RuntimeRegistrationEmitter
 
     private static void EmitResolveMethodHelper(IndentedStringBuilder sb)
     {
-        sb.AppendLine("private static MethodInfo? ResolveMethod(MethodInfo[] availableMethods, string name, Type[] parameterTypes)");
+        sb.AppendLine("private static MethodInfo? ResolveMethod(MethodInfo[] availableMethods, Type declaringType, string name, Type[] parameterTypes)");
         using (sb.Block(null))
         {
             using (sb.Block("foreach (MethodInfo candidate in availableMethods)"))
             {
-                using (sb.Block("if (candidate.Name != name)"))
+                using (sb.Block("if (candidate.DeclaringType != declaringType || candidate.Name != name)"))
                 {
                     sb.AppendLine("continue;");
                 }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -48,6 +48,7 @@ internal static class TestClassModelBuilder
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         var nonMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
+        var inaccessibleMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
@@ -69,6 +70,7 @@ internal static class TestClassModelBuilder
             bool isLeaf = SymbolEqualityComparer.Default.Equals(current, typeSymbol);
             hasPartialTypeInHierarchy |= IsPartial(current);
             ImmutableArray<ISymbol> currentMembers = current.GetMembers();
+            var inaccessibleMethodNamesInCurrentType = new HashSet<string>(StringComparer.Ordinal);
 
             // Capture each closed, referenceable base type so the runtime registration can root
             // its members (e.g. base-declared [ClassInitialize]/[TestContext]) via [DynamicDependency]
@@ -86,7 +88,8 @@ internal static class TestClassModelBuilder
                     case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
                         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
-                        if (nonMethodNamesInDerivedTypes.Contains(method.Name))
+                        if (nonMethodNamesInDerivedTypes.Contains(method.Name)
+                            || inaccessibleMethodNamesInDerivedTypes.Contains(method.Name))
                         {
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;
@@ -100,6 +103,7 @@ internal static class TestClassModelBuilder
 
                         if (!TestMemberValidationHelper.IsAccessibleFromConsumer(method, consumingAssembly))
                         {
+                            inaccessibleMethodNamesInCurrentType.Add(method.Name);
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;
                         }
@@ -164,6 +168,7 @@ internal static class TestClassModelBuilder
                 }
             }
 
+            inaccessibleMethodNamesInDerivedTypes.UnionWith(inaccessibleMethodNamesInCurrentType);
             foreach (ISymbol member in currentMembers)
             {
                 HashSet<string> names = member is IMethodSymbol { MethodKind: MethodKind.Ordinary }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -90,6 +90,15 @@ internal static class TestClassModelBuilder
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
                         bool hiddenByNonMethod = nonMethodNamesInDerivedTypes.Contains(method.Name);
                         bool hiddenByMethodGroup = methodNamesInDerivedTypes.Contains(method.Name);
+                        bool isAccessible = TestMemberValidationHelper.IsAccessibleFromConsumer(method, consumingAssembly);
+                        if ((hiddenByNonMethod || hiddenByMethodGroup)
+                            && isAccessible
+                            && TestMemberValidationHelper.TryReportUnsupportedMethod(method, leafFqn, diagnostics))
+                        {
+                            hasUnsupportedTestMethod |= isTestMethod;
+                            break;
+                        }
+
                         if (hiddenByNonMethod || hiddenByMethodGroup)
                         {
                             hasUnsupportedTestMethod |= isTestMethod
@@ -100,7 +109,7 @@ internal static class TestClassModelBuilder
                             break;
                         }
 
-                        if (!TestMemberValidationHelper.IsAccessibleFromConsumer(method, consumingAssembly))
+                        if (!isAccessible)
                         {
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -44,8 +44,8 @@ internal static class TestClassModelBuilder
         // Iteration order is derived-first so that an override or `new`-shadowed member
         // on the derived type wins over the base declaration with the same signature.
         // Constructors are NEVER inherited and are taken only from the leaf type.
-        var methodsByKey = new Dictionary<string, TestMethodModel>(StringComparer.Ordinal);
-        var propertiesByName = new Dictionary<string, TestPropertyModel>(StringComparer.Ordinal);
+        var seenMethodKeys = new HashSet<string>(StringComparer.Ordinal);
+        var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
@@ -83,7 +83,13 @@ internal static class TestClassModelBuilder
                     case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
                         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
-                        if (!TestMemberValidationHelper.IsAccessibleFromConsumer(method))
+                        string key = TestMemberValidationHelper.BuildMethodSignatureKey(method);
+                        if (!seenMethodKeys.Add(key))
+                        {
+                            break;
+                        }
+
+                        if (!TestMemberValidationHelper.IsAccessibleFromConsumer(method, consumingAssembly))
                         {
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;
@@ -98,25 +104,17 @@ internal static class TestClassModelBuilder
                             break;
                         }
 
-                        string key = TestMemberValidationHelper.BuildMethodSignatureKey(method);
-                        if (!methodsByKey.ContainsKey(key))
-                        {
-                            TestMethodModel model = BuildMethod(method, consumingAssembly, inheritedAttributes, isTestMethod);
-                            methodsByKey[key] = model;
-                            methods.Add(model);
-                        }
+                        methods.Add(BuildMethod(method, consumingAssembly, inheritedAttributes, isTestMethod));
 
                         break;
                     case IPropertySymbol property:
                         hasUnsupportedTestMethod |= HasTestMethodAttribute(property.GetMethod)
                             || HasTestMethodAttribute(property.SetMethod);
                         if (!property.IsIndexer
-                            && TestMemberValidationHelper.IsAccessibleFromConsumer(property)
-                            && !propertiesByName.ContainsKey(property.Name))
+                            && seenPropertyNames.Add(property.Name)
+                            && TestMemberValidationHelper.IsAccessibleFromConsumer(property, consumingAssembly))
                         {
-                            TestPropertyModel model = BuildProperty(property, consumingAssembly);
-                            propertiesByName[property.Name] = model;
-                            properties.Add(model);
+                            properties.Add(BuildProperty(property, consumingAssembly));
                         }
 
                         break;
@@ -282,15 +280,11 @@ internal static class TestClassModelBuilder
             FullyQualifiedType: property.Type.ToDisplayString(SymbolDisplayFormats.FullyQualified),
             IsStatic: property.IsStatic,
 
-            // The generated registry lives in the consuming assembly, so a getter is reachable
-            // when it is public, internal, or protected-internal. private / protected getters
-            // cannot be read from the generated (non-derived) call site.
-            HasGettableValue: property.GetMethod is
-            {
-                DeclaredAccessibility: Accessibility.Public
-                or Accessibility.Internal
-                or Accessibility.ProtectedOrInternal,
-            },
+            HasGettableValue: property.GetMethod is { } getter
+                && SymbolReferenceabilityHelper.IsMemberAccessibleFrom(
+                    getter.DeclaredAccessibility,
+                    getter.ContainingType,
+                    consumingAssembly),
             // An init-only setter has public DeclaredAccessibility but cannot be assigned outside an
             // object initializer, so emitting `instance.Prop = value` would not compile (CS8852);
             // treat it as non-settable so the adapter falls back to reflection (PropertyInfo.SetValue).

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -48,7 +48,6 @@ internal static class TestClassModelBuilder
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         var nonMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
-        var inaccessibleMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
@@ -70,7 +69,6 @@ internal static class TestClassModelBuilder
             bool isLeaf = SymbolEqualityComparer.Default.Equals(current, typeSymbol);
             hasPartialTypeInHierarchy |= IsPartial(current);
             ImmutableArray<ISymbol> currentMembers = current.GetMembers();
-            var inaccessibleMethodNamesInCurrentType = new HashSet<string>(StringComparer.Ordinal);
 
             // Capture each closed, referenceable base type so the runtime registration can root
             // its members (e.g. base-declared [ClassInitialize]/[TestContext]) via [DynamicDependency]
@@ -89,7 +87,7 @@ internal static class TestClassModelBuilder
                         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
                         if (nonMethodNamesInDerivedTypes.Contains(method.Name)
-                            || inaccessibleMethodNamesInDerivedTypes.Contains(method.Name))
+                            || methodNamesInDerivedTypes.Contains(method.Name))
                         {
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;
@@ -103,7 +101,6 @@ internal static class TestClassModelBuilder
 
                         if (!TestMemberValidationHelper.IsAccessibleFromConsumer(method, consumingAssembly))
                         {
-                            inaccessibleMethodNamesInCurrentType.Add(method.Name);
                             hasUnsupportedTestMethod |= isTestMethod;
                             break;
                         }
@@ -168,7 +165,6 @@ internal static class TestClassModelBuilder
                 }
             }
 
-            inaccessibleMethodNamesInDerivedTypes.UnionWith(inaccessibleMethodNamesInCurrentType);
             foreach (ISymbol member in currentMembers)
             {
                 HashSet<string> names = member is IMethodSymbol { MethodKind: MethodKind.Ordinary }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -43,7 +43,8 @@ internal static class TestClassModelBuilder
         //
         // Iteration order is derived-first. Members declared at a nearer inheritance level
         // hide same-name ancestor members according to C# lookup rules, while overloads
-        // declared together on the same type are preserved.
+        // declared together on the same type are preserved. Indexers are excluded because
+        // their metadata name is not used in C# member access.
         // Constructors are NEVER inherited and are taken only from the leaf type.
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
@@ -161,6 +162,11 @@ internal static class TestClassModelBuilder
 
             foreach (ISymbol member in currentMembers)
             {
+                if (member is IPropertySymbol { IsIndexer: true })
+                {
+                    continue;
+                }
+
                 HashSet<string> names = member is IMethodSymbol { MethodKind: MethodKind.Ordinary }
                     ? methodNamesInDerivedTypes
                     : nonMethodNamesInDerivedTypes;

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -284,6 +284,7 @@ internal static class TestClassModelBuilder
 
         return new TestMethodModel(
             Name: method.Name,
+            DeclaringTypeFullyQualifiedName: method.ContainingType.ToDisplayString(SymbolDisplayFormats.FullyQualified),
             IsStatic: method.IsStatic,
             IsAsync: method.IsAsync,
             ReturnsTask: returnsTask,

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -44,7 +44,6 @@ internal static class TestClassModelBuilder
         // Iteration order is derived-first so that an override or `new`-shadowed member
         // on the derived type wins over the base declaration with the same signature.
         // Constructors are NEVER inherited and are taken only from the leaf type.
-        var seenMethodKeys = new HashSet<string>(StringComparer.Ordinal);
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         var nonMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
@@ -90,12 +89,6 @@ internal static class TestClassModelBuilder
                             || methodNamesInDerivedTypes.Contains(method.Name))
                         {
                             hasUnsupportedTestMethod |= isTestMethod;
-                            break;
-                        }
-
-                        string key = TestMemberValidationHelper.BuildMethodSignatureKey(method);
-                        if (!seenMethodKeys.Add(key))
-                        {
                             break;
                         }
 

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -46,6 +46,8 @@ internal static class TestClassModelBuilder
         // Constructors are NEVER inherited and are taken only from the leaf type.
         var seenMethodKeys = new HashSet<string>(StringComparer.Ordinal);
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
+        var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
+        var nonMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
@@ -66,6 +68,7 @@ internal static class TestClassModelBuilder
         {
             bool isLeaf = SymbolEqualityComparer.Default.Equals(current, typeSymbol);
             hasPartialTypeInHierarchy |= IsPartial(current);
+            ImmutableArray<ISymbol> currentMembers = current.GetMembers();
 
             // Capture each closed, referenceable base type so the runtime registration can root
             // its members (e.g. base-declared [ClassInitialize]/[TestContext]) via [DynamicDependency]
@@ -76,11 +79,16 @@ internal static class TestClassModelBuilder
                 baseTypes.Add(current.ToDisplayString(SymbolDisplayFormats.FullyQualified));
             }
 
-            foreach (ISymbol member in current.GetMembers())
+            foreach (ISymbol member in currentMembers)
             {
                 switch (member)
                 {
                     case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                        if (nonMethodNamesInDerivedTypes.Contains(method.Name))
+                        {
+                            break;
+                        }
+
                         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
                         string key = TestMemberValidationHelper.BuildMethodSignatureKey(method);
@@ -108,6 +116,12 @@ internal static class TestClassModelBuilder
 
                         break;
                     case IPropertySymbol property:
+                        if (methodNamesInDerivedTypes.Contains(property.Name)
+                            || nonMethodNamesInDerivedTypes.Contains(property.Name))
+                        {
+                            break;
+                        }
+
                         hasUnsupportedTestMethod |= HasTestMethodAttribute(property.GetMethod)
                             || HasTestMethodAttribute(property.SetMethod);
                         if (!property.IsIndexer
@@ -147,6 +161,14 @@ internal static class TestClassModelBuilder
                         hasUnsupportedTestMethod |= HasTestMethodAttribute(method);
                         break;
                 }
+            }
+
+            foreach (ISymbol member in currentMembers)
+            {
+                HashSet<string> names = member is IMethodSymbol { MethodKind: MethodKind.Ordinary }
+                    ? methodNamesInDerivedTypes
+                    : nonMethodNamesInDerivedTypes;
+                names.Add(member.Name);
             }
         }
 

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -168,19 +168,19 @@ internal static class TestClassModelBuilder
 
             foreach (ISymbol member in currentMembers)
             {
-                if (member is IPropertySymbol { IsIndexer: true })
+                switch (member)
                 {
-                    continue;
-                }
+                    case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                        methodNamesInDerivedTypes.Add(method.Name);
+                        methodsInDerivedTypes.Add(method);
+                        break;
 
-                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method)
-                {
-                    methodNamesInDerivedTypes.Add(method.Name);
-                    methodsInDerivedTypes.Add(method);
-                }
-                else
-                {
-                    nonMethodNamesInDerivedTypes.Add(member.Name);
+                    case IPropertySymbol { IsIndexer: false }:
+                    case IFieldSymbol:
+                    case IEventSymbol:
+                    case INamedTypeSymbol:
+                        nonMethodNamesInDerivedTypes.Add(member.Name);
+                        break;
                 }
             }
         }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -105,7 +105,7 @@ internal static class TestClassModelBuilder
                                 && (hiddenByNonMethod
                                     || !methodsInDerivedTypes.Any(derivedMethod =>
                                         ReplacesInheritedRuntimeTest(derivedMethod)
-                                        && TestMemberValidationHelper.HaveSameRuntimeSignature(derivedMethod, method)));
+                                        && TestMemberValidationHelper.HaveSameRuntimeDiscoverySignature(derivedMethod, method)));
                             break;
                         }
 

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -49,6 +49,7 @@ internal static class TestClassModelBuilder
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
         var nonMethodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);
+        var methodsInDerivedTypes = new List<IMethodSymbol>();
         ImmutableArray<TestMethodModel>.Builder methods = ImmutableArray.CreateBuilder<TestMethodModel>();
         ImmutableArray<TestPropertyModel>.Builder properties = ImmutableArray.CreateBuilder<TestPropertyModel>();
         ImmutableArray<TestConstructorModel>.Builder ctors = ImmutableArray.CreateBuilder<TestConstructorModel>();
@@ -87,10 +88,15 @@ internal static class TestClassModelBuilder
                     case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
                         ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
                         bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
-                        if (nonMethodNamesInDerivedTypes.Contains(method.Name)
-                            || methodNamesInDerivedTypes.Contains(method.Name))
+                        bool hiddenByNonMethod = nonMethodNamesInDerivedTypes.Contains(method.Name);
+                        bool hiddenByMethodGroup = methodNamesInDerivedTypes.Contains(method.Name);
+                        if (hiddenByNonMethod || hiddenByMethodGroup)
                         {
-                            hasUnsupportedTestMethod |= isTestMethod;
+                            hasUnsupportedTestMethod |= isTestMethod
+                                && (hiddenByNonMethod
+                                    || !methodsInDerivedTypes.Any(derivedMethod =>
+                                        ReplacesInheritedRuntimeTest(derivedMethod)
+                                        && TestMemberValidationHelper.HaveSameRuntimeSignature(derivedMethod, method)));
                             break;
                         }
 
@@ -167,10 +173,15 @@ internal static class TestClassModelBuilder
                     continue;
                 }
 
-                HashSet<string> names = member is IMethodSymbol { MethodKind: MethodKind.Ordinary }
-                    ? methodNamesInDerivedTypes
-                    : nonMethodNamesInDerivedTypes;
-                names.Add(member.Name);
+                if (member is IMethodSymbol { MethodKind: MethodKind.Ordinary } method)
+                {
+                    methodNamesInDerivedTypes.Add(method.Name);
+                    methodsInDerivedTypes.Add(method);
+                }
+                else
+                {
+                    nonMethodNamesInDerivedTypes.Add(member.Name);
+                }
             }
         }
 
@@ -225,6 +236,11 @@ internal static class TestClassModelBuilder
     private static bool HasTestMethodAttribute(IMethodSymbol? method)
         => method is not null
         && TestMemberValidationHelper.IsTestMethodAttributePresent(AttributeMaterializationHelper.CollectInheritedAttributes(method));
+
+    private static bool ReplacesInheritedRuntimeTest(IMethodSymbol method)
+        => method.OverriddenMethod is not null
+        || (method is { DeclaredAccessibility: Accessibility.Public, IsStatic: false }
+            && HasTestMethodAttribute(method));
 
     private static TestMethodModel BuildMethod(
         IMethodSymbol method,

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -84,13 +84,14 @@ internal static class TestClassModelBuilder
                 switch (member)
                 {
                     case IMethodSymbol { MethodKind: MethodKind.Ordinary } method:
+                        ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
+                        bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
                         if (nonMethodNamesInDerivedTypes.Contains(method.Name))
                         {
+                            hasUnsupportedTestMethod |= isTestMethod;
                             break;
                         }
 
-                        ImmutableArray<AttributeData> inheritedAttributes = AttributeMaterializationHelper.CollectInheritedAttributes(method);
-                        bool isTestMethod = TestMemberValidationHelper.IsTestMethodAttributePresent(inheritedAttributes);
                         string key = TestMemberValidationHelper.BuildMethodSignatureKey(method);
                         if (!seenMethodKeys.Add(key))
                         {
@@ -116,14 +117,14 @@ internal static class TestClassModelBuilder
 
                         break;
                     case IPropertySymbol property:
+                        hasUnsupportedTestMethod |= HasTestMethodAttribute(property.GetMethod)
+                            || HasTestMethodAttribute(property.SetMethod);
                         if (methodNamesInDerivedTypes.Contains(property.Name)
                             || nonMethodNamesInDerivedTypes.Contains(property.Name))
                         {
                             break;
                         }
 
-                        hasUnsupportedTestMethod |= HasTestMethodAttribute(property.GetMethod)
-                            || HasTestMethodAttribute(property.SetMethod);
                         if (!property.IsIndexer
                             && seenPropertyNames.Add(property.Name)
                             && TestMemberValidationHelper.IsAccessibleFromConsumer(property, consumingAssembly))

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestClassModelBuilder.cs
@@ -41,8 +41,9 @@ internal static class TestClassModelBuilder
         // [TestMethod], the [TestContext] setter, … — are visible to the consumer
         // without runtime reflection.
         //
-        // Iteration order is derived-first so that an override or `new`-shadowed member
-        // on the derived type wins over the base declaration with the same signature.
+        // Iteration order is derived-first. Members declared at a nearer inheritance level
+        // hide same-name ancestor members according to C# lookup rules, while overloads
+        // declared together on the same type are preserved.
         // Constructors are NEVER inherited and are taken only from the leaf type.
         var seenPropertyNames = new HashSet<string>(StringComparer.Ordinal);
         var methodNamesInDerivedTypes = new HashSet<string>(StringComparer.Ordinal);

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -91,7 +91,7 @@ internal static class TestMemberValidationHelper
             || left.Arity != right.Arity
             || left.Parameters.Length != right.Parameters.Length
             || (left.IsStatic && !right.IsStatic)
-            || !SymbolEqualityComparer.Default.Equals(left.ReturnType, right.ReturnType))
+            || !AreSignatureTypesEquivalent(left.ReturnType, right.ReturnType))
         {
             return false;
         }
@@ -112,6 +112,16 @@ internal static class TestMemberValidationHelper
 
     private static bool AreSignatureTypesEquivalent(ITypeSymbol left, ITypeSymbol right)
     {
+        if (left is IDynamicTypeSymbol)
+        {
+            return right is IDynamicTypeSymbol || right.SpecialType == SpecialType.System_Object;
+        }
+
+        if (right is IDynamicTypeSymbol)
+        {
+            return left.SpecialType == SpecialType.System_Object;
+        }
+
         if (left is ITypeParameterSymbol leftTypeParameter && right is ITypeParameterSymbol rightTypeParameter)
         {
             return leftTypeParameter.TypeParameterKind == rightTypeParameter.TypeParameterKind

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -118,10 +118,48 @@ internal static class TestMemberValidationHelper
                     break;
             }
 
-            sb.Append(p.Type.ToDisplayString(SymbolDisplayFormats.FullyQualified));
+            AppendTypeKey(sb, p.Type);
         }
 
         sb.Append(')');
         return sb.ToString();
+    }
+
+    private static void AppendTypeKey(StringBuilder builder, ITypeSymbol type)
+    {
+        switch (type)
+        {
+            case ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } methodTypeParameter:
+                builder.Append("!!").Append(methodTypeParameter.Ordinal);
+                break;
+            case IDynamicTypeSymbol:
+                builder.Append("object");
+                break;
+            case IArrayTypeSymbol array:
+                AppendTypeKey(builder, array.ElementType);
+                builder.Append('[').Append(array.Rank).Append(']');
+                break;
+            case IPointerTypeSymbol pointer:
+                AppendTypeKey(builder, pointer.PointedAtType);
+                builder.Append('*');
+                break;
+            case INamedTypeSymbol { IsGenericType: true } named:
+                builder.Append(named.OriginalDefinition.ToDisplayString(SymbolDisplayFormats.FullyQualified)).Append('<');
+                for (int i = 0; i < named.TypeArguments.Length; i++)
+                {
+                    if (i > 0)
+                    {
+                        builder.Append(',');
+                    }
+
+                    AppendTypeKey(builder, named.TypeArguments[i]);
+                }
+
+                builder.Append('>');
+                break;
+            default:
+                builder.Append(type.ToDisplayString(SymbolDisplayFormats.FullyQualified));
+                break;
+        }
     }
 }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -85,7 +85,9 @@ internal static class TestMemberValidationHelper
                 && parameters[0].Type.ToDisplayString(SymbolDisplayFormats.FullyQualified) == "global::" + MSTestAttributeNames.UnitTestingNamespace + ".TestContext");
     }
 
-    internal static bool HaveSameRuntimeSignature(IMethodSymbol left, IMethodSymbol right)
+    // Mirrors TypeEnumerator's MethodInfo.ToString()-based discovery identity. In particular,
+    // generic parameter names remain significant because reflection formats them into that string.
+    internal static bool HaveSameRuntimeDiscoverySignature(IMethodSymbol left, IMethodSymbol right)
     {
         if (!string.Equals(left.Name, right.Name, StringComparison.Ordinal)
             || left.Arity != right.Arity

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -19,13 +19,13 @@ internal static class TestMemberValidationHelper
     // Restricted to accessibilities the emitted helper class (a separate static type
     // declared in MSTest.SourceGenerated, not a derived type) can legally call.
     // 'protected' and 'private protected' members require the caller to be a derived
-    // type, so they are excluded; 'protected internal' is included because the internal
-    // half is satisfied (the generated helper lives in the same assembly).
-    internal static bool IsAccessibleFromConsumer(ISymbol symbol)
-        => symbol.DeclaredAccessibility is
-            Accessibility.Public
-            or Accessibility.Internal
-            or Accessibility.ProtectedOrInternal;
+    // type, so they are excluded. Internal access is available only for members declared
+    // in the consuming assembly.
+    internal static bool IsAccessibleFromConsumer(ISymbol symbol, IAssemblySymbol consumingAssembly)
+        => SymbolReferenceabilityHelper.IsMemberAccessibleFrom(
+            symbol.DeclaredAccessibility,
+            symbol.ContainingAssembly,
+            consumingAssembly);
 
     internal static bool IsTestMethodAttributePresent(ImmutableArray<AttributeData> attributes)
     {

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -134,10 +134,13 @@ internal static class TestMemberValidationHelper
                 && AreSignatureTypesEquivalent(leftArray.ElementType, rightArray.ElementType);
         }
 
-        if (left is INamedTypeSymbol leftNamed && right is INamedTypeSymbol rightNamed && !leftNamed.TypeArguments.IsEmpty)
+        if (left is INamedTypeSymbol leftNamed && right is INamedTypeSymbol rightNamed)
         {
             if (leftNamed.TypeArguments.Length != rightNamed.TypeArguments.Length
-                || !SymbolEqualityComparer.Default.Equals(leftNamed.OriginalDefinition, rightNamed.OriginalDefinition))
+                || !SymbolEqualityComparer.Default.Equals(leftNamed.OriginalDefinition, rightNamed.OriginalDefinition)
+                || (leftNamed.ContainingType is null) != (rightNamed.ContainingType is null)
+                || (leftNamed.ContainingType is not null
+                    && !AreSignatureTypesEquivalent(leftNamed.ContainingType, rightNamed.ContainingType!)))
             {
                 return false;
             }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
@@ -83,83 +83,5 @@ internal static class TestMemberValidationHelper
         return parameters.Length == 0
             || (parameters.Length == 1
                 && parameters[0].Type.ToDisplayString(SymbolDisplayFormats.FullyQualified) == "global::" + MSTestAttributeNames.UnitTestingNamespace + ".TestContext");
-    }
-
-    internal static string BuildMethodSignatureKey(IMethodSymbol method)
-    {
-        var sb = new StringBuilder();
-        sb.Append(method.Name);
-        if (method.Arity > 0)
-        {
-            sb.Append('`');
-            sb.Append(method.Arity);
-        }
-
-        sb.Append('(');
-        bool first = true;
-        foreach (IParameterSymbol p in method.Parameters)
-        {
-            if (!first)
-            {
-                sb.Append(',');
-            }
-
-            first = false;
-            switch (p.RefKind)
-            {
-                case RefKind.Ref:
-                    sb.Append("ref ");
-                    break;
-                case RefKind.Out:
-                    sb.Append("out ");
-                    break;
-                case RefKind.In:
-                    sb.Append("in ");
-                    break;
-            }
-
-            AppendTypeKey(sb, p.Type);
-        }
-
-        sb.Append(')');
-        return sb.ToString();
-    }
-
-    private static void AppendTypeKey(StringBuilder builder, ITypeSymbol type)
-    {
-        switch (type)
-        {
-            case ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } methodTypeParameter:
-                builder.Append("!!").Append(methodTypeParameter.Ordinal);
-                break;
-            case IDynamicTypeSymbol:
-                builder.Append("object");
-                break;
-            case IArrayTypeSymbol array:
-                AppendTypeKey(builder, array.ElementType);
-                builder.Append('[').Append(array.Rank).Append(']');
-                break;
-            case IPointerTypeSymbol pointer:
-                AppendTypeKey(builder, pointer.PointedAtType);
-                builder.Append('*');
-                break;
-            case INamedTypeSymbol { IsGenericType: true } named:
-                builder.Append(named.OriginalDefinition.ToDisplayString(SymbolDisplayFormats.FullyQualified)).Append('<');
-                for (int i = 0; i < named.TypeArguments.Length; i++)
-                {
-                    if (i > 0)
-                    {
-                        builder.Append(',');
-                    }
-
-                    AppendTypeKey(builder, named.TypeArguments[i]);
-                }
-
-                builder.Append('>');
-                break;
-            default:
-                builder.Append(type.ToDisplayString(SymbolDisplayFormats.FullyQualified));
-                break;
-        }
     }
 }

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -88,7 +88,6 @@ internal static class TestMemberValidationHelper
     internal static string BuildMethodSignatureKey(IMethodSymbol method)
     {
         var sb = new StringBuilder();
-        sb.Append(method.IsStatic ? "S:" : "I:");
         sb.Append(method.Name);
         if (method.Arity > 0)
         {

--- a/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Generators/TestMemberValidationHelper.cs
@@ -84,4 +84,65 @@ internal static class TestMemberValidationHelper
             || (parameters.Length == 1
                 && parameters[0].Type.ToDisplayString(SymbolDisplayFormats.FullyQualified) == "global::" + MSTestAttributeNames.UnitTestingNamespace + ".TestContext");
     }
+
+    internal static bool HaveSameRuntimeSignature(IMethodSymbol left, IMethodSymbol right)
+    {
+        if (!string.Equals(left.Name, right.Name, StringComparison.Ordinal)
+            || left.Arity != right.Arity
+            || left.Parameters.Length != right.Parameters.Length
+            || (left.IsStatic && !right.IsStatic)
+            || !SymbolEqualityComparer.Default.Equals(left.ReturnType, right.ReturnType))
+        {
+            return false;
+        }
+
+        for (int index = 0; index < left.Parameters.Length; index++)
+        {
+            IParameterSymbol leftParameter = left.Parameters[index];
+            IParameterSymbol rightParameter = right.Parameters[index];
+            if ((leftParameter.RefKind == RefKind.None) != (rightParameter.RefKind == RefKind.None)
+                || !AreSignatureTypesEquivalent(leftParameter.Type, rightParameter.Type))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool AreSignatureTypesEquivalent(ITypeSymbol left, ITypeSymbol right)
+    {
+        if (left is ITypeParameterSymbol leftTypeParameter && right is ITypeParameterSymbol rightTypeParameter)
+        {
+            return leftTypeParameter.TypeParameterKind == rightTypeParameter.TypeParameterKind
+                && string.Equals(leftTypeParameter.Name, rightTypeParameter.Name, StringComparison.Ordinal);
+        }
+
+        if (left is IArrayTypeSymbol leftArray && right is IArrayTypeSymbol rightArray)
+        {
+            return leftArray.Rank == rightArray.Rank
+                && AreSignatureTypesEquivalent(leftArray.ElementType, rightArray.ElementType);
+        }
+
+        if (left is INamedTypeSymbol leftNamed && right is INamedTypeSymbol rightNamed && !leftNamed.TypeArguments.IsEmpty)
+        {
+            if (leftNamed.TypeArguments.Length != rightNamed.TypeArguments.Length
+                || !SymbolEqualityComparer.Default.Equals(leftNamed.OriginalDefinition, rightNamed.OriginalDefinition))
+            {
+                return false;
+            }
+
+            for (int index = 0; index < leftNamed.TypeArguments.Length; index++)
+            {
+                if (!AreSignatureTypesEquivalent(leftNamed.TypeArguments[index], rightNamed.TypeArguments[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(left, right);
+    }
 }

--- a/src/Analyzers/MSTest.SourceGeneration/Models/TestClassModel.cs
+++ b/src/Analyzers/MSTest.SourceGeneration/Models/TestClassModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using MSTest.Analyzers.Shared;
@@ -65,6 +65,7 @@ internal sealed record DynamicDataSourceModel(
 
 internal sealed record TestMethodModel(
     string Name,
+    string DeclaringTypeFullyQualifiedName,
     bool IsStatic,
     bool IsAsync,
     bool ReturnsTask,

--- a/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SourceGenerationNonAotTests.cs
+++ b/test/IntegrationTests/MSTest.Acceptance.IntegrationTests/SourceGenerationNonAotTests.cs
@@ -190,7 +190,7 @@ public class UnitTest1
 
         string registration = File.ReadAllText(generatedFiles.Single(path => path.EndsWith("MSTestReflectionMetadata.Registration.g.cs", StringComparison.Ordinal)));
         StringAssert.Contains(registration, "availableMethods ??= type.GetMethods(memberFlags)");
-        StringAssert.Contains(registration, "ResolveMethod(availableMethods, method.Name, method.ParameterTypes)");
+        StringAssert.Contains(registration, "ResolveMethod(availableMethods, method.DeclaringType, method.Name, method.ParameterTypes)");
         StringAssert.Contains(registration, "methodInfo.GetCustomAttributes(typeof(AsyncStateMachineAttribute), inherit: false)");
         StringAssert.Contains(registration, "methodInfo.GetCustomAttributes(typeof(DebuggerStepThroughAttribute), inherit: false)");
         StringAssert.Contains(registration, "descriptorTestMethods[type] = descriptorMethodRoots.ToArray()");

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1776,6 +1776,28 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void RuntimeSignature_DifferentlyNamedMethodTypeParameters_AreNotEquivalent()
+    {
+        const string userCode = """
+            public class First
+            {
+                public void Method<T>(T value) { }
+            }
+
+            public class Second
+            {
+                public void Method<U>(U value) { }
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(userCode);
+        var firstMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("First")!.GetMembers("Method").Single();
+        var secondMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("Second")!.GetMembers("Method").Single();
+
+        TestMemberValidationHelper.HaveSameRuntimeSignature(firstMethod, secondMethod).Should().BeFalse();
+    }
+
+    [TestMethod]
     public void Generator_NestedGenericContainingTypeSubstitutions_HaveDistinctRuntimeSignatures()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1285,6 +1285,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             public class BaseTests : GrandparentTests
             {
                 [TestMethod]
+                public void PublicInheritedTest() { }
+
+                [TestMethod]
                 protected internal void InheritedTest() { }
 
                 [TestMethod]
@@ -1297,6 +1300,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 protected internal static new void StaticHidesInstance() { }
 
                 protected internal void InaccessibleOverloadHidesMethodGroup(string value) { }
+
+                [TestContext]
+                public int PublicContext { get; set; }
 
                 [TestContext]
                 protected internal int InaccessibleContext { get; set; }
@@ -1339,8 +1345,10 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
         registry.Should().NotContain("Name = \"InheritedTest\"");
         registry.Should().NotContain("Name = \"InternalTest\"");
+        registry.Should().Contain("Name = \"PublicInheritedTest\"");
         registry.Should().NotContain("Name = \"InaccessibleContext\"");
         registry.Should().NotContain("Name = \"InternalContext\"");
+        registry.Should().Contain("Name = \"PublicContext\"");
         registry.Should().NotContain("Name = \"HiddenTest\"");
         registry.Should().NotContain("Name = \"HiddenContext\"");
         registry.Should().NotContain("Name = \"PropertyHidesMethod\"");

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1743,7 +1743,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         var dynamicMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("DynamicReturn")!.GetMembers("Method").Single();
         var objectMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("ObjectReturn")!.GetMembers("Method").Single();
 
-        TestMemberValidationHelper.HaveSameRuntimeSignature(dynamicMethod, objectMethod).Should().BeTrue();
+        TestMemberValidationHelper.HaveSameRuntimeDiscoverySignature(dynamicMethod, objectMethod).Should().BeTrue();
     }
 
     [TestMethod]
@@ -1770,7 +1770,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         var baseMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("BaseTests")!.GetMembers("Hidden").Single();
         var derivedMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("DerivedTests")!.GetMembers("Hidden").Single();
 
-        TestMemberValidationHelper.HaveSameRuntimeSignature(derivedMethod, baseMethod).Should().BeFalse();
+        TestMemberValidationHelper.HaveSameRuntimeDiscoverySignature(derivedMethod, baseMethod).Should().BeFalse();
         GetRegistry(RunGenerator(MinimalMSTestStub, userCode))
             .Should().Contain("AreGeneratedDescriptorsComplete = false");
     }
@@ -1794,7 +1794,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         var firstMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("First")!.GetMembers("Method").Single();
         var secondMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("Second")!.GetMembers("Method").Single();
 
-        TestMemberValidationHelper.HaveSameRuntimeSignature(firstMethod, secondMethod).Should().BeFalse();
+        TestMemberValidationHelper.HaveSameRuntimeDiscoverySignature(firstMethod, secondMethod).Should().BeFalse();
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1376,6 +1376,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
 
         registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+        registry.Should().NotContain("((global::DerivedTests)instance!).Hidden();");
     }
 
     [TestMethod]
@@ -1399,31 +1400,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
 
         registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
-    }
-
-    [TestMethod]
-    public void Generator_DynamicAndObjectParameters_HaveSameSignatureKey()
-    {
-        const string userCode = """
-            using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-            public class BaseTests
-            {
-                [TestMethod]
-                public void Hidden(object value) { }
-            }
-
-            [TestClass]
-            public class DerivedTests : BaseTests
-            {
-                public new void Hidden(dynamic value) { }
-            }
-            """;
-
-        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
-
-        int hiddenEntries = registry.Split(["Name = \"Hidden\""], StringSplitOptions.None).Length - 1;
-        hiddenEntries.Should().Be(1);
+        registry.Should().NotContain("PropertyType = typeof(int)");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1389,6 +1389,50 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_NonMethodMembersHideBaseMethods()
+    {
+        const string userCode = """
+            using System;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void FieldHidden() { }
+
+                [TestMethod]
+                public void EventHidden() { }
+
+                [TestMethod]
+                public void TypeHidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public int FieldHidden;
+
+                public event Action? EventHidden;
+
+                public class TypeHidden { }
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+        registry.Should().NotContain("((global::DerivedTests)instance!).FieldHidden();");
+        registry.Should().NotContain("((global::DerivedTests)instance!).EventHidden();");
+        registry.Should().NotContain("((global::DerivedTests)instance!).TypeHidden();");
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+    }
+
+    [TestMethod]
     public void Generator_MethodHidingTestAttributedPropertyAccessor_MarksDescriptorsIncomplete()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1575,6 +1575,37 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_DerivedIndexer_DoesNotHideBaseItemMethod()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Item() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public int this[int index] => index;
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
+        registry.Should().Contain("((global::DerivedTests)instance!).Item();");
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+    }
+
+    [TestMethod]
     public void Generator_IncludesPropertiesFromBaseType()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1267,8 +1267,17 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 [TestMethod]
                 public void HiddenTest() { }
 
+                [TestMethod]
+                public void PropertyHidesMethod() { }
+
+                [TestMethod]
+                public void StaticHidesInstance() { }
+
                 [TestContext]
                 public int HiddenContext { get; set; }
+
+                [TestContext]
+                public int MethodHidesProperty { get; set; }
             }
 
             public class BaseTests : GrandparentTests
@@ -1276,14 +1285,28 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 [TestMethod]
                 protected internal void InheritedTest() { }
 
+                [TestMethod]
+                internal void InternalTest() { }
+
                 protected internal new void HiddenTest() { }
+
+                protected internal int PropertyHidesMethod { get; set; }
+
+                protected internal static new void StaticHidesInstance() { }
 
                 [TestContext]
                 protected internal int InaccessibleContext { get; set; }
 
+                [TestContext]
+                internal int InternalContext { get; set; }
+
                 protected internal new int HiddenContext { get; set; }
 
+                protected internal void MethodHidesProperty() { }
+
                 public int ContextWithInaccessibleGetter { protected internal get; set; }
+
+                public int ContextWithInternalGetter { internal get; set; }
             }
             """;
 
@@ -1300,7 +1323,10 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             public class DerivedTests : BaseTests { }
             """;
 
-        CSharpCompilation consumerCompilation = CreateCompilation(consumerCode).AddReferences(baseReference);
+        CSharpCompilation consumerCompilation = CreateCompilation(consumerCode);
+        consumerCompilation = consumerCompilation
+            .WithOptions(consumerCompilation.Options.WithMetadataImportOptions(MetadataImportOptions.All))
+            .AddReferences(baseReference);
         GeneratorDriver driver = CreateDriver(consumerCompilation);
         driver.RunGeneratorsAndUpdateCompilation(consumerCompilation, out Compilation outputCompilation, out _);
         string registry = outputCompilation.SyntaxTrees
@@ -1308,10 +1334,16 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             .ToString();
 
         registry.Should().NotContain("Name = \"InheritedTest\"");
+        registry.Should().NotContain("Name = \"InternalTest\"");
         registry.Should().NotContain("Name = \"InaccessibleContext\"");
+        registry.Should().NotContain("Name = \"InternalContext\"");
         registry.Should().NotContain("Name = \"HiddenTest\"");
         registry.Should().NotContain("Name = \"HiddenContext\"");
+        registry.Should().NotContain("Name = \"PropertyHidesMethod\"");
+        registry.Should().NotContain("Name = \"StaticHidesInstance\"");
+        registry.Should().NotContain("Name = \"MethodHidesProperty\"");
         registry.Should().Contain("Property 'ContextWithInaccessibleGetter' has no accessible getter.");
+        registry.Should().Contain("Property 'ContextWithInternalGetter' has no accessible getter.");
         outputCompilation.GetDiagnostics()
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .Should().BeEmpty();

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1692,6 +1692,37 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_DerivedPropertyAccessor_DoesNotHideBaseAccessorNamedMethod()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void get_Value() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public int Value => 1;
+            }
+            """;
+
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
+        registry.Should().Contain("((global::DerivedTests)instance!).get_Value();");
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+    }
+
+    [TestMethod]
     public void Generator_IncludesPropertiesFromBaseType()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1276,8 +1276,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 [TestContext]
                 public int HiddenContext { get; set; }
 
-                [TestContext]
-                public int MethodHidesProperty { get; set; }
+                public int MethodHidesProperty { [TestMethod] get; set; }
             }
 
             public class BaseTests : GrandparentTests
@@ -1347,6 +1346,53 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         outputCompilation.GetDiagnostics()
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Generator_PropertyHidingTestMethod_MarksDescriptorsIncomplete()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public new int Hidden { get; set; }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+    }
+
+    [TestMethod]
+    public void Generator_MethodHidingTestAttributedPropertyAccessor_MarksDescriptorsIncomplete()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                public int Hidden { [TestMethod] get; set; }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public new void Hidden() { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1703,6 +1703,41 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_NestedGenericContainingTypeSubstitutions_HaveDistinctRuntimeSignatures()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class Outer<T>
+            {
+                public class Middle<U>
+                {
+                    public class Inner { }
+                }
+            }
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden(Outer<int>.Middle<string>.Inner value) { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                [TestMethod]
+                public new void Hidden(Outer<long>.Middle<string>.Inner value) { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+        registry.Should().Contain("typeof(global::Outer<long>.Middle<string>.Inner)");
+        registry.Should().NotContain("typeof(global::Outer<int>.Middle<string>.Inner)");
+    }
+
+    [TestMethod]
     public void Generator_DerivedMethodGroup_HidesBaseOverloads()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1257,6 +1257,67 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_ExcludesInaccessibleMembersFromBaseTypeInAnotherAssembly()
+    {
+        const string baseCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class GrandparentTests
+            {
+                [TestMethod]
+                public void HiddenTest() { }
+
+                [TestContext]
+                public int HiddenContext { get; set; }
+            }
+
+            public class BaseTests : GrandparentTests
+            {
+                [TestMethod]
+                protected internal void InheritedTest() { }
+
+                protected internal new void HiddenTest() { }
+
+                [TestContext]
+                protected internal int InaccessibleContext { get; set; }
+
+                protected internal new int HiddenContext { get; set; }
+
+                public int ContextWithInaccessibleGetter { protected internal get; set; }
+            }
+            """;
+
+        CSharpCompilation baseCompilation = CreateCompilation(MinimalMSTestStub, baseCode)
+            .WithAssemblyName("BaseAssembly");
+        using var stream = new MemoryStream();
+        baseCompilation.Emit(stream).Success.Should().BeTrue();
+        MetadataReference baseReference = MetadataReference.CreateFromImage(stream.ToArray());
+
+        const string consumerCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class DerivedTests : BaseTests { }
+            """;
+
+        CSharpCompilation consumerCompilation = CreateCompilation(consumerCode).AddReferences(baseReference);
+        GeneratorDriver driver = CreateDriver(consumerCompilation);
+        driver.RunGeneratorsAndUpdateCompilation(consumerCompilation, out Compilation outputCompilation, out _);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
+
+        registry.Should().NotContain("Name = \"InheritedTest\"");
+        registry.Should().NotContain("Name = \"InaccessibleContext\"");
+        registry.Should().NotContain("Name = \"HiddenTest\"");
+        registry.Should().NotContain("Name = \"HiddenContext\"");
+        registry.Should().Contain("Property 'ContextWithInaccessibleGetter' has no accessible getter.");
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+    }
+
+    [TestMethod]
     public void Generator_IncludesMethodsFromMultiLevelInheritance()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1476,6 +1476,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         runEntries.Should().Be(1, "the derived override must replace the base entry (not duplicate it)");
         registry.Should().Contain("((global::Sample.DerivedTests)instance!).Run();");
         registry.Should().NotContain("((global::Sample.BaseTests)instance!).Run();");
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
 
         // TestMethodAttribute is not inherited, so the override should not pick up the base attribute.
         registry.Should().NotContain("global::Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute");
@@ -1543,6 +1544,83 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         int hiddenEntries = registry.Split(["Name = \"Hidden\""], System.StringSplitOptions.None).Length - 1;
         hiddenEntries.Should().Be(1, "members with the same name and signature must be de-duplicated; derived wins");
         registry.Should().Contain("((global::Sample.DerivedTests)instance!).Hidden();");
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
+    }
+
+    [TestMethod]
+    public void Generator_PrivateSameSignatureMethod_DoesNotReplaceInheritedTest()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                private new void Hidden() { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+        registry.Should().NotContain("((global::DerivedTests)instance!).Hidden();");
+    }
+
+    [TestMethod]
+    public void Generator_PublicNonTestSameSignatureMethod_DoesNotReplaceInheritedTest()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public new void Hidden() { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+        registry.Should().Contain("((global::DerivedTests)instance!).Hidden();");
+    }
+
+    [TestMethod]
+    public void Generator_InstanceTestMethod_ReplacesStaticAncestor()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public static void Hidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                [TestMethod]
+                public new void Hidden() { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
+        registry.Should().Contain("((global::DerivedTests)instance!).Hidden();");
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1412,6 +1412,36 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_HiddenUnsupportedInheritedMethods_ReportDiagnostics()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void GenericHidden<T>() { }
+
+                [TestMethod]
+                public void ByRefHidden(ref int value) { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public int GenericHidden { get; set; }
+
+                public int ByRefHidden { get; set; }
+            }
+            """;
+
+        GeneratorRunResult result = RunGenerator(MinimalMSTestStub, userCode);
+
+        result.Diagnostics.Should().ContainSingle(d => d.Id == "AOTSG0004");
+        result.Diagnostics.Should().ContainSingle(d => d.Id == "AOTSG0005");
+    }
+
+    [TestMethod]
     public void Generator_IncludesMethodsFromMultiLevelInheritance()
     {
         const string userCode = """

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -114,11 +114,12 @@ public sealed class MSTestReflectionMetadataGeneratorTests
 
             public static class ReflectionMetadataHook
             {
+                public static System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]>? RegisteredTestMethods { get; private set; }
                 public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods) { }
                 public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Attribute[]> typeAttributes, object[] assemblyAttributes) { }
                 public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Attribute[]> typeAttributes, object[] assemblyAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Func<object, object[], object>> methodInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Type, ConstructorInvokerInfo[]> constructorInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.PropertyInfo, System.Action<object, object>> propertySetters) { }
                 public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Attribute[]> typeAttributes, object[] assemblyAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Attribute[]> methodAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Func<object, object[], object>> methodInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Type, ConstructorInvokerInfo[]> constructorInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.PropertyInfo, System.Action<object, object>> propertySetters) { }
-                public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Attribute[]> typeAttributes, object[] assemblyAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Attribute[]> methodAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Func<object, object[], object>> methodInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Type, ConstructorInvokerInfo[]> constructorInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.PropertyInfo, System.Action<object, object>> propertySetters, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> descriptorTestMethods, System.Type[] descriptorCompleteTypes) { }
+                public static void Register(System.Reflection.Assembly assembly, System.Type[] types, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> testMethods, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Attribute[]> typeAttributes, object[] assemblyAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Attribute[]> methodAttributes, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.MethodInfo, System.Func<object, object[], object>> methodInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Type, ConstructorInvokerInfo[]> constructorInvokers, System.Collections.Generic.IReadOnlyDictionary<System.Reflection.PropertyInfo, System.Action<object, object>> propertySetters, System.Collections.Generic.IReadOnlyDictionary<System.Type, System.Reflection.MethodInfo[]> descriptorTestMethods, System.Type[] descriptorCompleteTypes) { RegisteredTestMethods = testMethods; }
             }
         }
         """;
@@ -1654,6 +1655,54 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void Generator_DynamicTestMethod_ReplacesObjectAncestor()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden(object value) { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                [TestMethod]
+                public new void Hidden(dynamic value) { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = true");
+        registry.Should().Contain("((global::DerivedTests)instance!).Hidden((dynamic)args![0]!);");
+    }
+
+    [TestMethod]
+    public void RuntimeSignature_DynamicAndObjectReturnTypes_AreEquivalent()
+    {
+        const string userCode = """
+            public class DynamicReturn
+            {
+                public dynamic Method() => new object();
+            }
+
+            public class ObjectReturn
+            {
+                public object Method() => new object();
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(userCode);
+        var dynamicMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("DynamicReturn")!.GetMembers("Method").Single();
+        var objectMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("ObjectReturn")!.GetMembers("Method").Single();
+
+        TestMemberValidationHelper.HaveSameRuntimeSignature(dynamicMethod, objectMethod).Should().BeTrue();
+    }
+
+    [TestMethod]
     public void Generator_DerivedMethodGroup_HidesBaseOverloads()
     {
         const string userCode = """
@@ -1750,6 +1799,17 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         outputCompilation.GetDiagnostics()
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .Should().BeEmpty();
+
+        using var assemblyStream = new MemoryStream();
+        outputCompilation.Emit(assemblyStream).Success.Should().BeTrue();
+        var assembly = System.Reflection.Assembly.Load(assemblyStream.ToArray());
+        Type hookType = assembly.GetType("Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.SourceGeneration.ReflectionMetadataHook")!;
+        var registeredTestMethods = (IReadOnlyDictionary<Type, System.Reflection.MethodInfo[]>)hookType
+            .GetProperty("RegisteredTestMethods")!
+            .GetValue(null)!;
+        System.Reflection.MethodInfo registeredMethod = registeredTestMethods.Values.SelectMany(static methods => methods).Single();
+        registeredMethod.DeclaringType!.Name.Should().Be("BaseTests");
+        registeredMethod.ReturnType.Should().Be(typeof(void));
     }
 
     [TestMethod]
@@ -3357,8 +3417,8 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         // matching and unresolved-member fallback over those cached arrays.
         registration.Should().Contain("MethodInfo[]? availableMethods = null;");
         registration.Should().Contain("availableMethods ??= type.GetMethods(memberFlags);");
-        registration.Should().Contain("ResolveMethod(availableMethods, method.Name, method.ParameterTypes)");
-        registration.Should().Contain("private static MethodInfo? ResolveMethod(MethodInfo[] availableMethods");
+        registration.Should().Contain("ResolveMethod(availableMethods, method.DeclaringType, method.Name, method.ParameterTypes)");
+        registration.Should().Contain("private static MethodInfo? ResolveMethod(MethodInfo[] availableMethods, Type declaringType");
         registration.Should().Contain("availableProperties ??= type.GetProperties(memberFlags);");
         registration.Should().Contain("private static PropertyInfo? ResolveProperty(PropertyInfo[] availableProperties");
         registration.Should().NotContain("type.GetMethods(flags)");

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1561,7 +1561,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
-    public void Generator_OverloadsWithDifferentSignatures_AreAllPreserved()
+    public void Generator_DerivedMethodGroup_HidesBaseOverloads()
     {
         const string userCode = """
             using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1583,13 +1583,18 @@ public sealed class MSTestReflectionMetadataGeneratorTests
             }
             """;
 
-        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+        Compilation outputCompilation = RunGeneratorAndGetCompilation(MinimalMSTestStub, userCode);
+        string registry = outputCompilation.SyntaxTrees
+            .Single(t => t.FilePath.EndsWith("MSTestReflectionMetadata.Registry.g.cs", StringComparison.Ordinal))
+            .ToString();
 
-        // Both overloads survive — they have different signatures.
         int opEntries = registry.Split(["Name = \"Op\""], System.StringSplitOptions.None).Length - 1;
-        opEntries.Should().Be(2);
-        registry.Should().Contain("typeof(int)");
+        opEntries.Should().Be(1);
+        registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
         registry.Should().Contain("typeof(string)");
+        outputCompilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1273,6 +1273,9 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 [TestMethod]
                 public void StaticHidesInstance() { }
 
+                [TestMethod]
+                public void InaccessibleOverloadHidesMethodGroup(int value) { }
+
                 [TestContext]
                 public int HiddenContext { get; set; }
 
@@ -1292,6 +1295,8 @@ public sealed class MSTestReflectionMetadataGeneratorTests
                 protected internal int PropertyHidesMethod { get; set; }
 
                 protected internal static new void StaticHidesInstance() { }
+
+                protected internal void InaccessibleOverloadHidesMethodGroup(string value) { }
 
                 [TestContext]
                 protected internal int InaccessibleContext { get; set; }
@@ -1340,6 +1345,7 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         registry.Should().NotContain("Name = \"HiddenContext\"");
         registry.Should().NotContain("Name = \"PropertyHidesMethod\"");
         registry.Should().NotContain("Name = \"StaticHidesInstance\"");
+        registry.Should().NotContain("Name = \"InaccessibleOverloadHidesMethodGroup\"");
         registry.Should().NotContain("Name = \"MethodHidesProperty\"");
         registry.Should().Contain("Property 'ContextWithInaccessibleGetter' has no accessible getter.");
         registry.Should().Contain("Property 'ContextWithInternalGetter' has no accessible getter.");
@@ -1393,6 +1399,31 @@ public sealed class MSTestReflectionMetadataGeneratorTests
         string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
 
         registry.Should().Contain("AreGeneratedDescriptorsComplete = false");
+    }
+
+    [TestMethod]
+    public void Generator_DynamicAndObjectParameters_HaveSameSignatureKey()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden(object value) { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                public new void Hidden(dynamic value) { }
+            }
+            """;
+
+        string registry = GetRegistry(RunGenerator(MinimalMSTestStub, userCode));
+
+        int hiddenEntries = registry.Split(["Name = \"Hidden\""], StringSplitOptions.None).Length - 1;
+        hiddenEntries.Should().Be(1);
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
+++ b/test/UnitTests/MSTest.SourceGeneration.UnitTests/MSTestReflectionMetadataGeneratorTests.cs
@@ -1703,6 +1703,35 @@ public sealed class MSTestReflectionMetadataGeneratorTests
     }
 
     [TestMethod]
+    public void RuntimeSignature_DifferentReturnTypes_AreNotEquivalent()
+    {
+        const string userCode = """
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            public class BaseTests
+            {
+                [TestMethod]
+                public void Hidden() { }
+            }
+
+            [TestClass]
+            public class DerivedTests : BaseTests
+            {
+                [TestMethod]
+                public new int Hidden() => 1;
+            }
+            """;
+
+        CSharpCompilation compilation = CreateCompilation(userCode);
+        var baseMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("BaseTests")!.GetMembers("Hidden").Single();
+        var derivedMethod = (IMethodSymbol)compilation.GetTypeByMetadataName("DerivedTests")!.GetMembers("Hidden").Single();
+
+        TestMemberValidationHelper.HaveSameRuntimeSignature(derivedMethod, baseMethod).Should().BeFalse();
+        GetRegistry(RunGenerator(MinimalMSTestStub, userCode))
+            .Should().Contain("AreGeneratedDescriptorsComplete = false");
+    }
+
+    [TestMethod]
     public void Generator_NestedGenericContainingTypeSubstitutions_HaveDistinctRuntimeSignatures()
     {
         const string userCode = """


### PR DESCRIPTION
## Summary

- make reflection-free member accessibility checks account for the declaring assembly
- prevent inaccessible nearer members from exposing hidden ancestor members during model construction
- add two-assembly regression coverage for inherited methods and properties

## Testing

- `build.cmd -test -projects test\UnitTests\MSTest.SourceGeneration.UnitTests\MSTest.SourceGeneration.UnitTests.csproj -bl`