### PR TITLE
Optimize data-driven test display names

### DIFF
--- a/src/TestFramework/TestFramework/Internal/TestDataSourceUtilities.cs
+++ b/src/TestFramework/TestFramework/Internal/TestDataSourceUtilities.cs
@@ -5,6 +5,21 @@ namespace Microsoft.VisualStudio.TestTools.UnitTesting.Internal;
 
 internal static class TestDataSourceUtilities
 {
+    private const int MaxCachedBuilderCapacity = 360;
+
+#pragma warning disable IDE0028 // ConditionalWeakTable is not collection-expression-constructible on .NET Framework (CS9174).
+    private static readonly ConditionalWeakTable<MethodInfo, MethodData> MethodDataCache = new();
+#pragma warning restore IDE0028
+
+    [ThreadStatic]
+    private static StringBuilder? s_cachedBuilder;
+
+    [ThreadStatic]
+    private static CultureInfo? s_cachedResourceCulture;
+
+    [ThreadStatic]
+    private static string? s_cachedDisplayNameFormat;
+
     public static string? ComputeDefaultDisplayName(MethodInfo methodInfo, object?[]? data)
     {
         if (data is null)
@@ -12,15 +27,15 @@ internal static class TestDataSourceUtilities
             return null;
         }
 
-        ParameterInfo[] parameters = methodInfo.GetParameters();
+        MethodData methodData = MethodDataCache.GetValue(methodInfo, static method => new(method));
         string methodDisplayName = methodInfo is ReflectionTestMethodInfo reflectionTestMethodInfo
             ? reflectionTestMethodInfo.DisplayName
             : methodInfo.Name;
         CultureInfo currentCulture = CultureInfo.CurrentCulture;
-        string displayNameFormat = FrameworkMessages.DataDrivenResultDisplayName;
+        string displayNameFormat = GetDisplayNameFormat();
 
-        var argumentsBuilder = new StringBuilder();
-        if (parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]))
+        StringBuilder argumentsBuilder = AcquireBuilder();
+        if (methodData.HasSingleObjectArrayParameter)
         {
             AppendHumanizedArgument(argumentsBuilder, data);
         }
@@ -29,11 +44,64 @@ internal static class TestDataSourceUtilities
             AppendHumanizedArguments(argumentsBuilder, data);
         }
 
+        string arguments = GetStringAndReleaseBuilder(argumentsBuilder);
         return string.Format(
             currentCulture,
             displayNameFormat,
             methodDisplayName,
-            argumentsBuilder.ToString());
+            arguments);
+    }
+
+    private static string GetDisplayNameFormat()
+    {
+        CultureInfo resourceCulture = FrameworkMessages.Culture ?? CultureInfo.CurrentUICulture;
+        if (!resourceCulture.Equals(s_cachedResourceCulture))
+        {
+            s_cachedResourceCulture = resourceCulture;
+            s_cachedDisplayNameFormat = FrameworkMessages.DataDrivenResultDisplayName;
+        }
+
+        return s_cachedDisplayNameFormat!;
+    }
+
+    private static StringBuilder AcquireBuilder()
+    {
+        StringBuilder? builder = s_cachedBuilder;
+        if (builder is null)
+        {
+            return new StringBuilder();
+        }
+
+        s_cachedBuilder = null;
+        builder.Clear();
+        return builder;
+    }
+
+    private static string GetStringAndReleaseBuilder(StringBuilder builder)
+    {
+        string result = builder.ToString();
+        if (builder.Capacity <= MaxCachedBuilderCapacity)
+        {
+            s_cachedBuilder = builder;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Appends a collection of objects using their display-name representation.
+    /// </summary>
+    private static void AppendHumanizedArguments(StringBuilder builder, object?[] data)
+    {
+        for (int i = 0; i < data.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(',');
+            }
+
+            AppendHumanizedArgument(builder, data[i]);
+        }
     }
 
     /// <summary>
@@ -73,6 +141,12 @@ internal static class TestDataSourceUtilities
                 builder.Append('\'').Append(value).Append('\'');
                 break;
 
+            case object?[] values:
+                builder.Append('[');
+                AppendHumanizedArguments(builder, values);
+                builder.Append(']');
+                break;
+
             case Array:
                 builder.Append('[');
                 AppendHumanizedArguments(builder, (IEnumerable)data);
@@ -83,5 +157,16 @@ internal static class TestDataSourceUtilities
                 builder.Append(data.ToString());
                 break;
         }
+    }
+
+    private sealed class MethodData
+    {
+        public MethodData(MethodInfo method)
+        {
+            ParameterInfo[] parameters = method.GetParameters();
+            HasSingleObjectArrayParameter = parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]);
+        }
+
+        public bool HasSingleObjectArrayParameter { get; }
     }
 }

--- a/test/UnitTests/TestFramework.UnitTests/Attributes/DataRowAttributeTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Attributes/DataRowAttributeTests.cs
@@ -261,6 +261,26 @@ public class DataRowAttributeTests : TestContainer
         }
     }
 
+    public void GetDisplayNameRefreshesLocalizedFormatWhenUICultureChanges()
+    {
+        CultureInfo previousUICulture = CultureInfo.CurrentUICulture;
+        try
+        {
+            MethodInfo methodInfo = typeof(DummyTestClass).GetMethod(nameof(DummyTestClass.DataRowTestMethod))!;
+            var attribute = new DataRowAttribute();
+
+            CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+            attribute.GetDisplayName(methodInfo, ["value"]).Should().Be("DataRowTestMethod (\"value\")");
+
+            CultureInfo.CurrentUICulture = new CultureInfo("ko-KR");
+            attribute.GetDisplayName(methodInfo, ["value"]).Should().Be("DataRowTestMethod(\"value\")");
+        }
+        finally
+        {
+            CultureInfo.CurrentUICulture = previousUICulture;
+        }
+    }
+
     private class DummyDataRowAttribute : DataRowAttribute
     {
         public override string GetDisplayName(MethodInfo methodInfo, object?[]? data) => "Overridden DisplayName";


### PR DESCRIPTION
Filtrace analysis identified repeated reflection, resource lookup locking, StringBuilder growth, and array enumeration as hotspots when generating data-driven test display names.

Cache immutable method metadata and localized formats, reuse bounded thread-local StringBuilder instances, and iterate object arrays directly while preserving culture-sensitive behavior.

BenchmarkDotNet MediumRun results:
- Mixed arguments: 423.0 ns / 768 B to 254.3 ns / 328 B
- Object-array argument: 451.6 ns / 792 B to 245.6 ns / 352 B

TestFramework unit tests pass on net48, net8.0, net8.0-windows, and net9.0.