### PR TITLE
Make client statefulness capability nullable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,7 @@ When making change to resource files, you MUST:
 - Every API marked with `[Experimental]` MUST include this sentence in its XML documentation `<remarks>`: `This API is experimental. It may change, break, or be removed at any time without notice.` Documentation tooling does not reliably surface the attribute itself.
   - Add the sentence in a `<para>` when `<remarks>` already contains other text; otherwise, add a new `<remarks>` block.
   - Apply this rule to experimental members as well as types.
+- When designing a capability API or protocol field, consider clients that predate the capability. Model "unsupported or not declared" separately from an explicit value (for example, with a nullable value or presence-aware representation) unless absence is intentionally equivalent to the default, and document the compatibility behavior.
 
 ## Testing Guidelines
 

--- a/docs/mstest-runner-protocol/001-protocol-intro.md
+++ b/docs/mstest-runner-protocol/001-protocol-intro.md
@@ -257,10 +257,11 @@ interface InitializeParams {
 
             // If true, the client is stateful: it persists an addressable set of test nodes for the
             // whole session and keeps each node in its last-known state until it is explicitly updated
-            // (for example, an IDE test explorer). If false or missing, the client is stateless: it
-            // consumes test updates as a stream and does not retain node state after the run
-            // (for example, `dotnet test`). This is independent of connection lifetime and
-            // experimental_multiRequestSupport. Defaults to false.
+            // (for example, an IDE test explorer). If false, the client explicitly declares that it is
+            // stateless and consumes test updates as a stream without retaining node state after the run
+            // (for example, `dotnet test`). If missing, the client does not support or did not declare
+            // the capability, allowing consumers to apply compatibility behavior for known legacy clients.
+            // This is independent of connection lifetime and experimental_multiRequestSupport.
             isStateful?: boolean,
         },
     }

--- a/docs/mstest-runner-protocol/server-mode-1.0.schema.json
+++ b/docs/mstest-runner-protocol/server-mode-1.0.schema.json
@@ -129,8 +129,7 @@
               "type": "boolean"
             },
             "isStateful": {
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             }
           },
           "additionalProperties": true

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -84,7 +84,8 @@ internal sealed class MSTestRunSettings : IRunSettings
     private static XDocument Patch(string? runSettingsXml, IConfiguration configuration, IClientInfo client, ICommandLineOptions commandLineOptions)
     {
         // Keep recognizing older Visual Studio clients that predate the statefulness capability.
-        bool isDesignMode = client.Capabilities.IsStateful || client.Id == WellKnownClients.VisualStudio;
+        bool isDesignMode = client.Capabilities.IsStateful
+            ?? client.Id == WellKnownClients.VisualStudio;
         XDocument runSettingsDocument = PatchSettingsWithDefaults(runSettingsXml, isDesignMode, configuration);
         PatchTestRunParameters(runSettingsDocument, commandLineOptions);
         return runSettingsDocument;

--- a/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
+++ b/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/MSTestRunSettings.cs
@@ -84,7 +84,7 @@ internal sealed class MSTestRunSettings : IRunSettings
     private static XDocument Patch(string? runSettingsXml, IConfiguration configuration, IClientInfo client, ICommandLineOptions commandLineOptions)
     {
         // Keep recognizing older Visual Studio clients that predate the statefulness capability.
-        bool isDesignMode = client.Capabilities.IsStateful
+        bool isDesignMode = client.Capabilities.GetIsStateful()
             ?? client.Id == WellKnownClients.VisualStudio;
         XDocument runSettingsDocument = PatchSettingsWithDefaults(runSettingsXml, isDesignMode, configuration);
         PatchTestRunParameters(runSettingsDocument, commandLineOptions);

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
@@ -18,7 +18,8 @@ internal static class RunSettingsPatcher
     public static XDocument Patch(string? runSettingsXml, IConfiguration configuration, IClientInfo client, ICommandLineOptions commandLineOptions)
     {
         // Keep recognizing older Visual Studio clients that predate the statefulness capability.
-        bool isDesignMode = client.Capabilities.IsStateful || client.Id == WellKnownClients.VisualStudio;
+        bool isDesignMode = client.Capabilities.IsStateful
+            ?? client.Id == WellKnownClients.VisualStudio;
         XDocument runSettingsDocument = PatchSettingsWithDefaults(runSettingsXml, isDesignMode, configuration);
         PatchTestRunParameters(runSettingsDocument, commandLineOptions);
 

--- a/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.VSTestBridge/ObjectModel/RunSettingsPatcher.cs
@@ -18,7 +18,7 @@ internal static class RunSettingsPatcher
     public static XDocument Patch(string? runSettingsXml, IConfiguration configuration, IClientInfo client, ICommandLineOptions commandLineOptions)
     {
         // Keep recognizing older Visual Studio clients that predate the statefulness capability.
-        bool isDesignMode = client.Capabilities.IsStateful
+        bool isDesignMode = client.Capabilities.GetIsStateful()
             ?? client.Id == WellKnownClients.VisualStudio;
         XDocument runSettingsDocument = PatchSettingsWithDefaults(runSettingsXml, isDesignMode, configuration);
         PatchTestRunParameters(runSettingsDocument, commandLineOptions);

--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpServerClientOptions.cs
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpServerClientOptions.cs
@@ -38,13 +38,14 @@ internal sealed class MtpServerClientOptions
     /// <summary>
     /// Gets or sets a value indicating whether the client persists an addressable set of test nodes for the
     /// whole session and keeps each node in its last-known state until explicitly updated
-    /// (<c>capabilities.testing.isStateful</c>). Defaults to <see langword="false"/>.
+    /// (<c>capabilities.testing.isStateful</c>). <see langword="null"/> omits the capability from the initialize
+    /// handshake. Defaults to <see langword="null"/>.
     /// </summary>
     /// <remarks>
     /// This capability describes how the client consumes test-node updates. It is independent of connection
     /// lifetime and the server's <c>ServerCapabilities.MultiRequestSupport</c> capability.
     /// </remarks>
-    public bool IsStateful { get; set; }
+    public bool? IsStateful { get; set; }
 
     /// <summary>
     /// Gets or sets how long to wait for the launched test app to connect back to the client's loopback

--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/SerializerUtilities.ClientSerializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/SerializerUtilities.ClientSerializers.cs
@@ -61,13 +61,22 @@ internal static partial class SerializerUtilities
             [JsonRpcStrings.Version] = info.Version,
         });
 
-        Serializers[typeof(ClientCapabilities)] = new ObjectSerializer<ClientCapabilities>(capabilities => new Dictionary<string, object?>
+        Serializers[typeof(ClientCapabilities)] = new ObjectSerializer<ClientCapabilities>(capabilities =>
         {
-            [JsonRpcStrings.Testing] = new Dictionary<string, object?>
+            Dictionary<string, object?> testingCapabilities = new()
             {
                 [JsonRpcStrings.DebuggerProvider] = capabilities.DebuggerProvider,
-                [JsonRpcStrings.IsStateful] = capabilities.IsStateful,
-            },
+            };
+
+            if (capabilities.IsStateful is { } isStateful)
+            {
+                testingCapabilities[JsonRpcStrings.IsStateful] = isStateful;
+            }
+
+            return new Dictionary<string, object?>
+            {
+                [JsonRpcStrings.Testing] = testingCapabilities,
+            };
         });
 
         Serializers[typeof(InitializeRequestArgs)] = new ObjectSerializer<InitializeRequestArgs>(args =>

--- a/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Hosts/ConsoleTestHost.cs
@@ -24,7 +24,7 @@ internal sealed class ConsoleTestHost(
     : CommonHost(serviceProvider)
 {
     private static readonly ClientInfo ClientInfoHost = new("testingplatform-console", PlatformVersion.Version);
-    private static readonly IClientInfo ClientInfoService = new ClientInfoService("testingplatform-console", PlatformVersion.Version, new ClientCapabilitiesService(IsStateful: false));
+    private static readonly IClientInfo ClientInfoService = new ClientInfoService("testingplatform-console", PlatformVersion.Version, new ClientCapabilitiesService(DeclaredIsStateful: false));
 
     private readonly ILogger<ConsoleTestHost> _logger = serviceProvider.GetLoggerFactory().CreateLogger<ConsoleTestHost>();
     private readonly IClock _clock = serviceProvider.GetClock();

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -2,6 +2,18 @@
 [TPEXP]Microsoft.Testing.Platform.CommandLine.CommandLineParseResult.CommandLineParseResult(string? toolName, System.Collections.Generic.IReadOnlyList<Microsoft.Testing.Platform.CommandLine.CommandLineParseOption!>! options, System.Collections.Generic.IReadOnlyList<string!>! errors, System.Collections.Generic.IReadOnlyList<string!>! arguments, System.Collections.Generic.IReadOnlyList<string!>! expandedArguments) -> void
 [TPEXP]Microsoft.Testing.Platform.CommandLine.CommandLineParseResult.ExpandedArguments.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.Testing.Platform.Builder.TestApplicationBuilder.TestApplicationBuilder(Microsoft.Testing.Platform.Logging.ApplicationLoggingState! loggingState, System.DateTimeOffset createBuilderStart, Microsoft.Testing.Platform.Builder.TestApplicationOptions! testApplicationOptions, Microsoft.Testing.Platform.Helpers.IUnhandledExceptionsHandler! unhandledExceptionsHandler, string![]! args, string![]! expandedArgs) -> void
+Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider, bool? IsStateful) -> void
+Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool? IsStateful) -> void
+Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool?
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? IsStateful) -> void
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? IsStateful) -> void
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.get -> bool?
 Microsoft.Testing.Platform.Services.CurrentTestApplicationModuleInfo.CurrentTestApplicationModuleInfo(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Helpers.IProcessHandler! process, string![]? commandLineArguments, string![]? expandedCommandLineArguments) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExecutableInfo(string! filePath, System.Collections.Generic.IEnumerable<string!>! arguments, System.Collections.Generic.IEnumerable<string!>! expandedArguments, string! workspace) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> System.Collections.Generic.IEnumerable<string!>!
+*REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider, bool IsStateful) -> void
+*REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool IsStateful) -> void
+*REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool
+*REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool IsStateful) -> void
+*REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool IsStateful) -> void
+*REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.get -> bool

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -8,6 +8,7 @@ Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool?
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.DeclaredIsStateful.get -> bool?
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.DeclaredIsStateful.init -> void
 Microsoft.Testing.Platform.Services.CurrentTestApplicationModuleInfo.CurrentTestApplicationModuleInfo(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Helpers.IProcessHandler! process, string![]? commandLineArguments, string![]? expandedCommandLineArguments) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExecutableInfo(string! filePath, System.Collections.Generic.IEnumerable<string!>! arguments, System.Collections.Generic.IEnumerable<string!>! expandedArguments, string! workspace) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -16,3 +17,4 @@ Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> Syst
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool IsStateful) -> void
+*REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.init -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Microsoft.Testing.Platform.Builder.TestApplicationBuilder.TestApplicationBuilder
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider, bool? IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool? IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool?
+Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.init -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? DeclaredIsStateful) -> void
 Microsoft.Testing.Platform.Services.ClientCapabilitiesService.DeclaredIsStateful.get -> bool?
@@ -15,6 +16,7 @@ Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> Syst
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider, bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool
+*REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.init -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.init -> void

--- a/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/InternalAPI/InternalAPI.Unshipped.txt
@@ -5,9 +5,9 @@ Microsoft.Testing.Platform.Builder.TestApplicationBuilder.TestApplicationBuilder
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.ClientCapabilities(bool DebuggerProvider, bool? IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.Deconstruct(out bool DebuggerProvider, out bool? IsStateful) -> void
 Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool?
-Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? IsStateful) -> void
-Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? IsStateful) -> void
-Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.get -> bool?
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool? DeclaredIsStateful) -> void
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool? DeclaredIsStateful) -> void
+Microsoft.Testing.Platform.Services.ClientCapabilitiesService.DeclaredIsStateful.get -> bool?
 Microsoft.Testing.Platform.Services.CurrentTestApplicationModuleInfo.CurrentTestApplicationModuleInfo(Microsoft.Testing.Platform.Helpers.IEnvironment! environment, Microsoft.Testing.Platform.Helpers.IProcessHandler! process, string![]? commandLineArguments, string![]? expandedCommandLineArguments) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExecutableInfo(string! filePath, System.Collections.Generic.IEnumerable<string!>! arguments, System.Collections.Generic.IEnumerable<string!>! expandedArguments, string! workspace) -> void
 Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> System.Collections.Generic.IEnumerable<string!>!
@@ -16,4 +16,3 @@ Microsoft.Testing.Platform.Services.ExecutableInfo.ExpandedArguments.get -> Syst
 *REMOVED*Microsoft.Testing.Platform.ServerMode.ClientCapabilities.IsStateful.get -> bool
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.ClientCapabilitiesService(bool IsStateful) -> void
 *REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.Deconstruct(out bool IsStateful) -> void
-*REMOVED*Microsoft.Testing.Platform.Services.ClientCapabilitiesService.IsStateful.get -> bool

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+[TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool?
+*REMOVED*[TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool

--- a/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Platform/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-[TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool?
-*REMOVED*[TPEXP]Microsoft.Testing.Platform.Services.IClientCapabilities.IsStateful.get -> bool
+[TPEXP]Microsoft.Testing.Platform.Services.ClientCapabilitiesExtensions
+[TPEXP]static Microsoft.Testing.Platform.Services.ClientCapabilitiesExtensions.GetIsStateful(this Microsoft.Testing.Platform.Services.IClientCapabilities! capabilities) -> bool?

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Deserializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Deserializers.cs
@@ -189,9 +189,16 @@ internal sealed partial class Json
         {
             jsonElement.TryGetProperty(JsonRpcStrings.Testing, out JsonElement testing);
 
-            bool isStateful = testing.ValueKind == JsonValueKind.Object
-                && testing.TryGetProperty(JsonRpcStrings.IsStateful, out JsonElement statefulElement)
-                && statefulElement.ValueKind == JsonValueKind.True;
+            bool? isStateful = testing.ValueKind != JsonValueKind.Object
+                || !testing.TryGetProperty(JsonRpcStrings.IsStateful, out JsonElement statefulElement)
+                ? null
+                : statefulElement.ValueKind switch
+                {
+                    JsonValueKind.Null => null,
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    _ => throw new MessageFormatException($"'{JsonRpcStrings.IsStateful}' field has wrong type (expected {nameof(Boolean)})"),
+                };
 
             return new ClientCapabilities(
                     DebuggerProvider: json.Bind<bool>(testing, JsonRpcStrings.DebuggerProvider),

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Deserializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/Json/Json.Deserializers.cs
@@ -194,7 +194,6 @@ internal sealed partial class Json
                 ? null
                 : statefulElement.ValueKind switch
                 {
-                    JsonValueKind.Null => null,
                     JsonValueKind.True => true,
                     JsonValueKind.False => false,
                     _ => throw new MessageFormatException($"'{JsonRpcStrings.IsStateful}' field has wrong type (expected {nameof(Boolean)})"),

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/RpcMessages.cs
@@ -108,7 +108,7 @@ internal sealed record InvalidRequestParamsArgs(int ErrorCode, string ErrorMessa
 
 internal sealed record ClientInfo(string Name, string Version);
 
-internal sealed record ClientCapabilities(bool DebuggerProvider, bool IsStateful);
+internal sealed record ClientCapabilities(bool DebuggerProvider, bool? IsStateful);
 
 internal sealed record ServerInfo(string Name, string Version);
 

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.Deserializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.Deserializers.cs
@@ -146,7 +146,12 @@ internal static partial class SerializerUtilities
             IDictionary<string, object?> capabilities = GetRequiredPropertyFromJson<IDictionary<string, object?>>(properties, JsonRpcStrings.Capabilities);
             IDictionary<string, object?> testingCapabilities = GetRequiredPropertyFromJson<IDictionary<string, object?>>(capabilities, JsonRpcStrings.Testing);
             bool debuggerProvider = GetRequiredPropertyFromJson<bool>(testingCapabilities, JsonRpcStrings.DebuggerProvider);
-            bool isStateful = GetOptionalPropertyFromJson(testingCapabilities, JsonRpcStrings.IsStateful) as bool? ?? false;
+            bool? isStateful = GetOptionalPropertyFromJson(testingCapabilities, JsonRpcStrings.IsStateful) switch
+            {
+                null => null,
+                bool value => value,
+                _ => throw new MessageFormatException($"'{JsonRpcStrings.IsStateful}' field has wrong type (expected {nameof(Boolean)})"),
+            };
 
             return new ClientCapabilities(debuggerProvider, isStateful);
         });

--- a/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.Deserializers.cs
+++ b/src/Platform/Microsoft.Testing.Platform/ServerMode/JsonRpc/SerializerUtilities.Deserializers.cs
@@ -146,12 +146,11 @@ internal static partial class SerializerUtilities
             IDictionary<string, object?> capabilities = GetRequiredPropertyFromJson<IDictionary<string, object?>>(properties, JsonRpcStrings.Capabilities);
             IDictionary<string, object?> testingCapabilities = GetRequiredPropertyFromJson<IDictionary<string, object?>>(capabilities, JsonRpcStrings.Testing);
             bool debuggerProvider = GetRequiredPropertyFromJson<bool>(testingCapabilities, JsonRpcStrings.DebuggerProvider);
-            bool? isStateful = GetOptionalPropertyFromJson(testingCapabilities, JsonRpcStrings.IsStateful) switch
-            {
-                null => null,
-                bool value => value,
-                _ => throw new MessageFormatException($"'{JsonRpcStrings.IsStateful}' field has wrong type (expected {nameof(Boolean)})"),
-            };
+            bool? isStateful = testingCapabilities.TryGetValue(JsonRpcStrings.IsStateful, out object? isStatefulValue)
+                ? isStatefulValue is bool value
+                    ? value
+                    : throw new MessageFormatException($"'{JsonRpcStrings.IsStateful}' field has wrong type (expected {nameof(Boolean)})")
+                : null;
 
             return new ClientCapabilities(debuggerProvider, isStateful);
         });

--- a/src/Platform/Microsoft.Testing.Platform/Services/ClientCapabilitiesService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ClientCapabilitiesService.cs
@@ -3,4 +3,7 @@
 
 namespace Microsoft.Testing.Platform.Services;
 
-internal sealed record ClientCapabilitiesService(bool? IsStateful) : IClientCapabilities;
+internal sealed record ClientCapabilitiesService(bool? DeclaredIsStateful) : IClientCapabilities
+{
+    public bool IsStateful => DeclaredIsStateful ?? false;
+}

--- a/src/Platform/Microsoft.Testing.Platform/Services/ClientCapabilitiesService.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/ClientCapabilitiesService.cs
@@ -3,4 +3,4 @@
 
 namespace Microsoft.Testing.Platform.Services;
 
-internal sealed record ClientCapabilitiesService(bool IsStateful) : IClientCapabilities;
+internal sealed record ClientCapabilitiesService(bool? IsStateful) : IClientCapabilities;

--- a/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
@@ -7,8 +7,9 @@ namespace Microsoft.Testing.Platform.Services;
 /// Represents the capabilities declared by the client that is driving the test host.
 /// </summary>
 /// <remarks>
-/// Capabilities are opt-in. The platform preserves whether a client omitted a capability so a test framework
-/// can distinguish an explicit value from a legacy client that does not support the capability.
+/// Capabilities are opt-in: unless a client explicitly declares a capability, the platform assumes the
+/// most conservative (default) behavior. Use <see cref="ClientCapabilitiesExtensions.GetIsStateful"/>
+/// when the distinction between an explicitly stateless client and an undeclared capability is required.
 /// <para>
 /// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
@@ -17,16 +18,38 @@ namespace Microsoft.Testing.Platform.Services;
 public interface IClientCapabilities
 {
     /// <summary>
-    /// Gets a value indicating whether the client is stateful, or <see langword="null"/> when the client
-    /// did not declare the capability.
+    /// Gets a value indicating whether the client is stateful.
     /// </summary>
     /// <remarks>
     /// A stateful client persists an addressable set of test nodes for the whole session and keeps each node in
     /// its last-known state until it is explicitly updated (for example, an IDE test explorer). A stateless client
     /// consumes updates as a stream and does not retain node state after the run (for example, <c>dotnet test</c>).
-    /// <see langword="null"/> means that the client does not support or did not declare this capability. Consumers
-    /// can use compatibility behavior for known legacy clients only in that case.
+    /// The default is <see langword="false"/> (stateless); a client opts into stateful behavior.
     /// This capability is independent of connection lifetime and multi-request support.
     /// </remarks>
-    bool? IsStateful { get; }
+    bool IsStateful { get; }
+}
+
+/// <summary>
+/// Provides extension methods for <see cref="IClientCapabilities"/>.
+/// </summary>
+/// <remarks>
+/// This API is experimental. It may change, break, or be removed at any time without notice.
+/// </remarks>
+[Experimental("TPEXP", UrlFormat = "https://aka.ms/testingplatform/diagnostics#{0}")]
+public static class ClientCapabilitiesExtensions
+{
+    /// <summary>
+    /// Gets a value indicating whether the client is stateful, or <see langword="null"/> when the client
+    /// did not declare the capability.
+    /// </summary>
+    /// <param name="capabilities">The client capabilities.</param>
+    /// <returns>
+    /// <see langword="true"/> for a stateful client, <see langword="false"/> for a client that explicitly declares
+    /// itself stateless, or <see langword="null"/> when the capability was not declared.
+    /// </returns>
+    public static bool? GetIsStateful(this IClientCapabilities capabilities)
+        => capabilities is ClientCapabilitiesService clientCapabilities
+            ? clientCapabilities.DeclaredIsStateful
+            : capabilities.IsStateful;
 }

--- a/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
+++ b/src/Platform/Microsoft.Testing.Platform/Services/IClientCapabilities.cs
@@ -7,9 +7,8 @@ namespace Microsoft.Testing.Platform.Services;
 /// Represents the capabilities declared by the client that is driving the test host.
 /// </summary>
 /// <remarks>
-/// Capabilities are opt-in: unless a client explicitly declares a capability, the platform assumes the
-/// most conservative (default) behavior. This lets a test framework tailor its behavior to how the client
-/// intends to consume the results without having to guess based on the environment or transport.
+/// Capabilities are opt-in. The platform preserves whether a client omitted a capability so a test framework
+/// can distinguish an explicit value from a legacy client that does not support the capability.
 /// <para>
 /// This API is experimental. It may change, break, or be removed at any time without notice.
 /// </para>
@@ -18,14 +17,16 @@ namespace Microsoft.Testing.Platform.Services;
 public interface IClientCapabilities
 {
     /// <summary>
-    /// Gets a value indicating whether the client is stateful.
+    /// Gets a value indicating whether the client is stateful, or <see langword="null"/> when the client
+    /// did not declare the capability.
     /// </summary>
     /// <remarks>
     /// A stateful client persists an addressable set of test nodes for the whole session and keeps each node in
     /// its last-known state until it is explicitly updated (for example, an IDE test explorer). A stateless client
     /// consumes updates as a stream and does not retain node state after the run (for example, <c>dotnet test</c>).
-    /// The default is <see langword="false"/> (stateless); a client opts into stateful behavior.
+    /// <see langword="null"/> means that the client does not support or did not declare this capability. Consumers
+    /// can use compatibility behavior for known legacy clients only in that case.
     /// This capability is independent of connection lifetime and multi-request support.
     /// </remarks>
-    bool IsStateful { get; }
+    bool? IsStateful { get; }
 }

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ServerMode/v1.0.0/ClientCapabilities.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/ServerMode/v1.0.0/ClientCapabilities.cs
@@ -13,5 +13,5 @@ public sealed record ClientTestingCapabilities(
     [property: JsonProperty("debuggerProvider")]
     bool DebuggerProvider,
 
-    [property: JsonProperty("isStateful")]
-    bool IsStateful = false);
+    [property: JsonProperty("isStateful", NullValueHandling = NullValueHandling.Ignore)]
+    bool? IsStateful = null);

--- a/test/UnitTests/MSTestAdapter.UnitTests/MSTestRunSettingsTests.cs
+++ b/test/UnitTests/MSTestAdapter.UnitTests/MSTestRunSettingsTests.cs
@@ -26,10 +26,16 @@ public sealed class MSTestRunSettingsTests : TestContainer
     public void StatelessNonVisualStudioClientDoesNotSetDesignMode()
         => GetDesignMode("custom-client", isStateful: false).Should().BeFalse();
 
-    public void StatelessVisualStudioClientSetsDesignModeForBackwardCompatibility()
-        => GetDesignMode(WellKnownClients.VisualStudio, isStateful: false).Should().BeTrue();
+    public void UndeclaredNonVisualStudioClientDoesNotSetDesignMode()
+        => GetDesignMode("custom-client", isStateful: null).Should().BeFalse();
 
-    private static bool GetDesignMode(string clientId, bool isStateful)
+    public void UndeclaredVisualStudioClientSetsDesignModeForBackwardCompatibility()
+        => GetDesignMode(WellKnownClients.VisualStudio, isStateful: null).Should().BeTrue();
+
+    public void StatelessVisualStudioClientDoesNotSetDesignMode()
+        => GetDesignMode(WellKnownClients.VisualStudio, isStateful: false).Should().BeFalse();
+
+    private static bool GetDesignMode(string clientId, bool? isStateful)
     {
         const string RunSettingsFilePath = "settings.runsettings";
         string[]? runSettingsFilePaths = [RunSettingsFilePath];

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/ObjectModelConvertersTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Testing.Extensions.VSTestBridge.UnitTests.ObjectModel;
 [TestClass]
 public sealed class ObjectModelConvertersTests
 {
-    private static readonly IClientInfo ClientInfo = new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: false));
+    private static readonly IClientInfo ClientInfo = new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: false));
     private static readonly TestProperty OriginalExecutorUriProperty = TestProperty.Register(
         VSTestTestNodeProperties.OriginalExecutorUriPropertyName,
         VSTestTestNodeProperties.OriginalExecutorUriPropertyName,

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/RunSettingsPatcherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/RunSettingsPatcherTests.cs
@@ -47,7 +47,35 @@ public class RunSettingsPatcherTests
     }
 
     [TestMethod]
-    public void Patch_StatelessVisualStudioClient_SetsDesignModeForBackwardCompatibility()
+    public void Patch_UndeclaredNonVisualStudioClient_DoesNotSetDesignMode()
+    {
+        _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
+
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(
+            null,
+            _configuration.Object,
+            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(IsStateful: null)),
+            _commandLineOptions.Object);
+
+        Assert.IsFalse(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
+    }
+
+    [TestMethod]
+    public void Patch_UndeclaredVisualStudioClient_SetsDesignModeForBackwardCompatibility()
+    {
+        _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
+
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(
+            null,
+            _configuration.Object,
+            new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: null)),
+            _commandLineOptions.Object);
+
+        Assert.IsTrue(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
+    }
+
+    [TestMethod]
+    public void Patch_StatelessVisualStudioClient_DoesNotSetDesignMode()
     {
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
 
@@ -57,7 +85,7 @@ public class RunSettingsPatcherTests
             new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: false)),
             _commandLineOptions.Object);
 
-        Assert.IsTrue(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
+        Assert.IsFalse(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/RunSettingsPatcherTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.VSTestBridge.UnitTests/ObjectModel/RunSettingsPatcherTests.cs
@@ -26,7 +26,7 @@ public class RunSettingsPatcherTests
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(
             null,
             _configuration.Object,
-            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(IsStateful: true)),
+            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: true)),
             _commandLineOptions.Object);
 
         Assert.IsTrue(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
@@ -40,7 +40,7 @@ public class RunSettingsPatcherTests
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(
             null,
             _configuration.Object,
-            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(IsStateful: false)),
+            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: false)),
             _commandLineOptions.Object);
 
         Assert.IsFalse(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
@@ -54,7 +54,7 @@ public class RunSettingsPatcherTests
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(
             null,
             _configuration.Object,
-            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(IsStateful: null)),
+            new ClientInfoService("custom-client", "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: null)),
             _commandLineOptions.Object);
 
         Assert.IsFalse(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
@@ -68,7 +68,7 @@ public class RunSettingsPatcherTests
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(
             null,
             _configuration.Object,
-            new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: null)),
+            new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: null)),
             _commandLineOptions.Object);
 
         Assert.IsTrue(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
@@ -82,7 +82,7 @@ public class RunSettingsPatcherTests
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(
             null,
             _configuration.Object,
-            new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(IsStateful: false)),
+            new ClientInfoService(WellKnownClients.VisualStudio, "1.0.0", new ClientCapabilitiesService(DeclaredIsStateful: false)),
             _commandLineOptions.Object);
 
         Assert.IsFalse(bool.Parse(runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/DesignMode")!.Value));
@@ -93,7 +93,7 @@ public class RunSettingsPatcherTests
     {
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
         XDocument runSettingsDocument = RunSettingsPatcher.Patch(null, _configuration.Object,
-            new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(IsStateful: false)), _commandLineOptions.Object);
+            new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(DeclaredIsStateful: false)), _commandLineOptions.Object);
         Assert.AreEqual(
             "/PlatformResultDirectory",
             runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/ResultsDirectory")!.Value);
@@ -112,7 +112,7 @@ public class RunSettingsPatcherTests
 
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
 
-        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(IsStateful: false)), _commandLineOptions.Object);
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(DeclaredIsStateful: false)), _commandLineOptions.Object);
         Assert.AreEqual(
             "/PlatformResultDirectory",
             runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/ResultsDirectory")!.Value);
@@ -133,7 +133,7 @@ public class RunSettingsPatcherTests
 """;
 
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
-        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(IsStateful: false)), _commandLineOptions.Object);
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(DeclaredIsStateful: false)), _commandLineOptions.Object);
         Assert.AreEqual(
             "/PlatformResultDirectoryFromFile",
             runSettingsDocument.XPathSelectElement("RunSettings/RunConfiguration/ResultsDirectory")!.Value);
@@ -162,7 +162,7 @@ public class RunSettingsPatcherTests
             });
 
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
-        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(IsStateful: false)),
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(runSettings, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(DeclaredIsStateful: false)),
             _commandLineOptions.Object);
 
         XElement[] testRunParameters = [.. runSettingsDocument.XPathSelectElements("RunSettings/TestRunParameters/Parameter")];
@@ -186,7 +186,7 @@ public class RunSettingsPatcherTests
             });
 
         _configuration.Setup(x => x[PlatformConfigurationConstants.PlatformResultDirectory]).Returns("/PlatformResultDirectory");
-        XDocument runSettingsDocument = RunSettingsPatcher.Patch(null, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(IsStateful: false)),
+        XDocument runSettingsDocument = RunSettingsPatcher.Patch(null, _configuration.Object, new ClientInfoService(string.Empty, string.Empty, new ClientCapabilitiesService(DeclaredIsStateful: false)),
             _commandLineOptions.Object);
 
         XElement[] testRunParameters = [.. runSettingsDocument.XPathSelectElements("RunSettings/TestRunParameters/Parameter")];

--- a/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientTests.cs
@@ -52,6 +52,18 @@ public sealed class MtpServerClientTests
     }
 
     [TestMethod]
+    public async Task InitializeAsync_DefaultOptions_LeaveStatefulnessUndeclared()
+    {
+        using FakeMtpServer server = new();
+        using MtpServerClient client = server.ConnectClient();
+
+        _ = await WithTimeoutAsync(client.InitializeAsync(TestContext.CancellationToken)).ConfigureAwait(false);
+
+        InitializeRequestArgs initializeArgs = GetSingleRequestParams<InitializeRequestArgs>(server, JsonRpcMethods.Initialize);
+        Assert.IsNull(initializeArgs.Capabilities.IsStateful);
+    }
+
+    [TestMethod]
     public void SerializeClientCapabilities_UndeclaredStatefulness_OmitsProperty()
     {
         IDictionary<string, object?> serialized = SerializerUtilities.Serialize(

--- a/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests/MtpServerClientTests.cs
@@ -52,6 +52,28 @@ public sealed class MtpServerClientTests
     }
 
     [TestMethod]
+    public void SerializeClientCapabilities_UndeclaredStatefulness_OmitsProperty()
+    {
+        IDictionary<string, object?> serialized = SerializerUtilities.Serialize(
+            new ClientCapabilities(DebuggerProvider: false, IsStateful: null));
+        var testingCapabilities = (IDictionary<string, object?>)serialized[JsonRpcStrings.Testing]!;
+
+        Assert.IsFalse(testingCapabilities.ContainsKey(JsonRpcStrings.IsStateful));
+    }
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void SerializeClientCapabilities_DeclaredStatefulness_IncludesProperty(bool isStateful)
+    {
+        IDictionary<string, object?> serialized = SerializerUtilities.Serialize(
+            new ClientCapabilities(DebuggerProvider: false, IsStateful: isStateful));
+        var testingCapabilities = (IDictionary<string, object?>)serialized[JsonRpcStrings.Testing]!;
+
+        Assert.AreEqual(isStateful, testingCapabilities[JsonRpcStrings.IsStateful]);
+    }
+
+    [TestMethod]
     public async Task InitializeAsync_LegacyServerWithoutProtocolVersion_Succeeds()
     {
         using FakeMtpServer server = new();

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
@@ -223,7 +223,27 @@ public sealed class JsonTests
     }
 
     [TestMethod]
-    public void Deserialize_InitializeRequest_WithoutIsStateful_StjPath_DefaultsToStateless()
+    public void Deserialize_InitializeRequest_WithIsStatefulFalse_StjPath_SurfacesStatelessClient()
+    {
+        // Arrange
+        Json json = new();
+        const string initializeParams = """
+            {
+                "processId": 1,
+                "clientInfo": { "name": "client", "version": "1.0.0" },
+                "capabilities": { "testing": { "debuggerProvider": true, "isStateful": false } }
+            }
+            """;
+
+        // Act
+        InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory());
+
+        // Assert
+        Assert.IsFalse(args.Capabilities.IsStateful);
+    }
+
+    [TestMethod]
+    public void Deserialize_InitializeRequest_WithoutIsStateful_StjPath_LeavesCapabilityUndeclared()
     {
         // Arrange
         Json json = new();
@@ -239,7 +259,28 @@ public sealed class JsonTests
         InitializeRequestArgs args = json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory());
 
         // Assert
-        Assert.IsFalse(args.Capabilities.IsStateful);
+        Assert.IsNull(args.Capabilities.IsStateful);
+    }
+
+    [TestMethod]
+    public void Deserialize_InitializeRequest_WithInvalidIsStateful_StjPath_Throws()
+    {
+        // Arrange
+        Json json = new();
+        const string initializeParams = """
+            {
+                "processId": 1,
+                "clientInfo": { "name": "client", "version": "1.0.0" },
+                "capabilities": { "testing": { "debuggerProvider": true, "isStateful": "false" } }
+            }
+            """;
+
+        // Act
+        MessageFormatException exception = Assert.ThrowsExactly<MessageFormatException>(
+            () => json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory()));
+
+        // Assert
+        Assert.Contains(JsonRpcStrings.IsStateful, exception.Message);
     }
 
     [TestMethod]
@@ -266,7 +307,30 @@ public sealed class JsonTests
     }
 
     [TestMethod]
-    public void Deserialize_ClientCapabilities_WithoutIsStateful_JsonitePath_DefaultsToStateless()
+    public void Deserialize_ClientCapabilities_WithIsStatefulFalse_JsonitePath_SurfacesStatelessClient()
+    {
+        // Arrange
+        Dictionary<string, object?> properties = new()
+        {
+            ["capabilities"] = new Dictionary<string, object?>
+            {
+                ["testing"] = new Dictionary<string, object?>
+                {
+                    ["debuggerProvider"] = true,
+                    ["isStateful"] = false,
+                },
+            },
+        };
+
+        // Act
+        ClientCapabilities capabilities = SerializerUtilities.Deserialize<ClientCapabilities>(properties);
+
+        // Assert
+        Assert.IsFalse(capabilities.IsStateful);
+    }
+
+    [TestMethod]
+    public void Deserialize_ClientCapabilities_WithoutIsStateful_JsonitePath_LeavesCapabilityUndeclared()
     {
         // Arrange
         Dictionary<string, object?> properties = new()
@@ -284,7 +348,31 @@ public sealed class JsonTests
         ClientCapabilities capabilities = SerializerUtilities.Deserialize<ClientCapabilities>(properties);
 
         // Assert
-        Assert.IsFalse(capabilities.IsStateful);
+        Assert.IsNull(capabilities.IsStateful);
+    }
+
+    [TestMethod]
+    public void Deserialize_ClientCapabilities_WithInvalidIsStateful_JsonitePath_Throws()
+    {
+        // Arrange
+        Dictionary<string, object?> properties = new()
+        {
+            ["capabilities"] = new Dictionary<string, object?>
+            {
+                ["testing"] = new Dictionary<string, object?>
+                {
+                    ["debuggerProvider"] = true,
+                    ["isStateful"] = "false",
+                },
+            },
+        };
+
+        // Act
+        MessageFormatException exception = Assert.ThrowsExactly<MessageFormatException>(
+            () => SerializerUtilities.Deserialize<ClientCapabilities>(properties));
+
+        // Assert
+        Assert.Contains(JsonRpcStrings.IsStateful, exception.Message);
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/ServerMode/JsonTests.cs
@@ -284,6 +284,27 @@ public sealed class JsonTests
     }
 
     [TestMethod]
+    public void Deserialize_InitializeRequest_WithNullIsStateful_StjPath_Throws()
+    {
+        // Arrange
+        Json json = new();
+        const string initializeParams = """
+            {
+                "processId": 1,
+                "clientInfo": { "name": "client", "version": "1.0.0" },
+                "capabilities": { "testing": { "debuggerProvider": true, "isStateful": null } }
+            }
+            """;
+
+        // Act
+        MessageFormatException exception = Assert.ThrowsExactly<MessageFormatException>(
+            () => json.Deserialize<InitializeRequestArgs>(Encoding.UTF8.GetBytes(initializeParams).AsMemory()));
+
+        // Assert
+        Assert.Contains(JsonRpcStrings.IsStateful, exception.Message);
+    }
+
+    [TestMethod]
     public void Deserialize_ClientCapabilities_WithIsStatefulTrue_JsonitePath_SurfacesStatefulClient()
     {
         // Arrange
@@ -363,6 +384,30 @@ public sealed class JsonTests
                 {
                     ["debuggerProvider"] = true,
                     ["isStateful"] = "false",
+                },
+            },
+        };
+
+        // Act
+        MessageFormatException exception = Assert.ThrowsExactly<MessageFormatException>(
+            () => SerializerUtilities.Deserialize<ClientCapabilities>(properties));
+
+        // Assert
+        Assert.Contains(JsonRpcStrings.IsStateful, exception.Message);
+    }
+
+    [TestMethod]
+    public void Deserialize_ClientCapabilities_WithNullIsStateful_JsonitePath_Throws()
+    {
+        // Arrange
+        Dictionary<string, object?> properties = new()
+        {
+            ["capabilities"] = new Dictionary<string, object?>
+            {
+                ["testing"] = new Dictionary<string, object?>
+                {
+                    ["debuggerProvider"] = true,
+                    ["isStateful"] = null,
                 },
             },
         };

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ClientCapabilitiesExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ClientCapabilitiesExtensionsTests.cs
@@ -10,6 +10,14 @@ namespace Microsoft.Testing.Platform.UnitTests;
 public sealed class ClientCapabilitiesExtensionsTests
 {
     [TestMethod]
+    public void IsStateful_UndeclaredCapability_DefaultsToFalse()
+    {
+        IClientCapabilities capabilities = new ClientCapabilitiesService(DeclaredIsStateful: null);
+
+        Assert.IsFalse(capabilities.IsStateful);
+    }
+
+    [TestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public void GetIsStateful_ForwardsCustomImplementation(bool isStateful)

--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ClientCapabilitiesExtensionsTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Services/ClientCapabilitiesExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Testing.Platform.Services;
+
+namespace Microsoft.Testing.Platform.UnitTests;
+
+#pragma warning disable TPEXP // IClientCapabilities and ClientCapabilitiesExtensions are experimental.
+[TestClass]
+public sealed class ClientCapabilitiesExtensionsTests
+{
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void GetIsStateful_ForwardsCustomImplementation(bool isStateful)
+    {
+        IClientCapabilities capabilities = new CustomClientCapabilities(isStateful);
+
+        Assert.AreEqual(isStateful, capabilities.GetIsStateful());
+    }
+
+    private sealed class CustomClientCapabilities(bool isStateful) : IClientCapabilities
+    {
+        public bool IsStateful { get; } = isStateful;
+    }
+}
+#pragma warning restore TPEXP


### PR DESCRIPTION
## Summary

- add `IClientCapabilities.GetIsStateful()` so frameworks can distinguish stateful, explicitly stateless, and undeclared clients while preserving the shipped `bool IsStateful` getter for binary compatibility
- omit `capabilities.testing.isStateful` from the server-mode client handshake when it is undeclared and reject malformed values consistently across serializers
- apply the legacy Visual Studio compatibility fallback only when the capability is undeclared
- document the protocol semantics and add capability-design guidance for future APIs

Follow-up to #6494.

## Validation

- `build.cmd -pack -c Release -bl`
- `Microsoft.Testing.Extensions.VSTestBridge.UnitTests` `RunSettingsPatcherTests` pass in Debug and Release (10/10)
- `MSTestAdapter.UnitTests` pass on `net8.0` (90/90)
- the Windows application-model acceptance host now starts and discovers both tests without the previous `MissingMethodException`; local packaged-app activation remains unavailable in this workspace