### PR TITLE
Add HangDump disposal path tests

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Testing.Extensions.Diagnostics.Resources;
+#if NETCOREAPP
 using Microsoft.Testing.Platform.Helpers;
+#endif
 using Microsoft.Testing.Platform.OutputDevice;
 
 namespace Microsoft.Testing.Extensions.Diagnostics;
@@ -18,7 +20,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
             bool waitResult;
             try
             {
-                waitResult = activityIndicatorTask.Wait(TimeoutHelper.DefaultHangTimeSpanTimeout);
+                waitResult = activityIndicatorTask.Wait(_disposeTimeout);
             }
             catch (Exception e)
             {
@@ -28,7 +30,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
 
             if (!waitResult)
             {
-                throw new InvalidOperationException($"_activityIndicatorTask didn't exit in {TimeoutHelper.DefaultHangTimeSpanTimeout} seconds");
+                throw new InvalidOperationException($"_activityIndicatorTask didn't exit in {_disposeTimeout} seconds");
             }
         }
 
@@ -46,7 +48,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
         {
             try
             {
-                await activityIndicatorTask.TimeoutAfterAsync(TimeoutHelper.DefaultHangTimeSpanTimeout).ConfigureAwait(false);
+                await activityIndicatorTask.TimeoutAfterAsync(_disposeTimeout).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.Disposal.cs
@@ -30,7 +30,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler
 
             if (!waitResult)
             {
-                throw new InvalidOperationException($"_activityIndicatorTask didn't exit in {_disposeTimeout} seconds");
+                throw new InvalidOperationException($"_activityIndicatorTask didn't exit in {_disposeTimeout}");
             }
         }
 

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -70,7 +70,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
     private static readonly TimeSpan InProgressTestsQueryTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan BestEffortDiagnosticsTimeout = TimeSpan.FromSeconds(1);
 
-    private readonly TimeSpan _disposeTimeout;
+    private TimeSpan _disposeTimeout = TimeoutHelper.DefaultHangTimeSpanTimeout;
     private int _dumpTaken;
     private Task? _waitConnectionTask;
     private Task? _activityIndicatorTask;
@@ -97,8 +97,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
         IConfiguration configuration,
         IProcessHandler processHandler,
         IClock clock,
-        IServiceProvider serviceProvider,
-        TimeSpan? disposeTimeout = null)
+        IServiceProvider serviceProvider)
     {
         _logger = loggerFactory.CreateLogger<HangDumpProcessLifetimeHandler>();
         _traceEnabled = _logger.IsEnabled(LogLevel.Trace);
@@ -112,7 +111,6 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
         _processHandler = processHandler;
         _clock = clock;
         _serviceProvider = serviceProvider;
-        _disposeTimeout = disposeTimeout ?? TimeoutHelper.DefaultHangTimeSpanTimeout;
     }
 
     public string Uid => nameof(HangDumpProcessLifetimeHandler);

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -70,6 +70,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
     private static readonly TimeSpan InProgressTestsQueryTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan BestEffortDiagnosticsTimeout = TimeSpan.FromSeconds(1);
 
+    private readonly TimeSpan _disposeTimeout;
     private int _dumpTaken;
     private Task? _waitConnectionTask;
     private Task? _activityIndicatorTask;
@@ -96,7 +97,8 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
         IConfiguration configuration,
         IProcessHandler processHandler,
         IClock clock,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        TimeSpan? disposeTimeout = null)
     {
         _logger = loggerFactory.CreateLogger<HangDumpProcessLifetimeHandler>();
         _traceEnabled = _logger.IsEnabled(LogLevel.Trace);
@@ -110,6 +112,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
         _processHandler = processHandler;
         _clock = clock;
         _serviceProvider = serviceProvider;
+        _disposeTimeout = disposeTimeout ?? TimeoutHelper.DefaultHangTimeSpanTimeout;
     }
 
     public string Uid => nameof(HangDumpProcessLifetimeHandler);

--- a/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HangDump/HangDumpProcessLifetimeHandler.cs
@@ -70,7 +70,7 @@ internal sealed partial class HangDumpProcessLifetimeHandler : ITestHostProcessL
     private static readonly TimeSpan InProgressTestsQueryTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan BestEffortDiagnosticsTimeout = TimeSpan.FromSeconds(1);
 
-    private TimeSpan _disposeTimeout = TimeoutHelper.DefaultHangTimeSpanTimeout;
+    private readonly TimeSpan _disposeTimeout = TimeoutHelper.DefaultHangTimeSpanTimeout;
     private int _dumpTaken;
     private Task? _waitConnectionTask;
     private Task? _activityIndicatorTask;

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
@@ -622,7 +622,7 @@ public sealed class HangDumpTests
 
         InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(handler.Dispose);
 
-        Assert.Contains("_activityIndicatorTask didn't exit in 00:00:00 seconds", exception.Message);
+        Assert.Contains("_activityIndicatorTask didn't exit in 00:00:00", exception.Message);
         dumpCompletion.SetResult(true);
         handler.Dispose();
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
@@ -4,14 +4,13 @@
 using Microsoft.Testing.Extensions.Diagnostics;
 using Microsoft.Testing.Extensions.Diagnostics.Helpers;
 using Microsoft.Testing.Extensions.Diagnostics.Resources;
+using Microsoft.Testing.Extensions.HangDump.Serializers;
 using Microsoft.Testing.Extensions.UnitTests.Helpers;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Helpers;
-using Microsoft.Testing.Platform.IPC;
-using Microsoft.Testing.Platform.IPC.Models;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.OutputDevice;
@@ -557,20 +556,13 @@ public sealed class HangDumpTests
     {
         using var deadlineTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         using var activityTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-        var namedPipeClient = new NamedPipeClient($"hang_{Guid.NewGuid():N}");
-        var namedPipeServer = new NamedPipeServer(
-            $"hang_{Guid.NewGuid():N}",
-            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
-            Mock.Of<IEnvironment>(),
-            Mock.Of<ILogger>(),
-            Mock.Of<ITask>(),
-            CancellationToken.None);
         HangDumpProcessLifetimeHandler handler = CreateHandler();
+        await InitializePipeResourcesAsync(handler);
+        object namedPipeClient = GetHandlerField<object>(handler, "_namedPipeClient");
+        object namedPipeServer = GetHandlerField<object>(handler, "_singleConnectionNamedPipeServer");
         SetHandlerField(handler, "_deadlineTimer", deadlineTimer);
         SetHandlerField(handler, "_activityTimer", activityTimer);
         SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
-        SetHandlerField(handler, "_namedPipeClient", namedPipeClient);
-        SetHandlerField(handler, "_singleConnectionNamedPipeServer", namedPipeServer);
 
         handler.Dispose();
 
@@ -579,10 +571,8 @@ public sealed class HangDumpTests
         AssertTimerDisposed(activityTimer);
         Assert.ThrowsExactly<ObjectDisposedException>(
             () => _ = GetHandlerField<ManualResetEventSlim>(handler, "_waitConsumerPipeName").WaitHandle);
-        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
-            () => namedPipeClient.ConnectAsync(TestContext.CancellationToken));
-        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
-            () => namedPipeServer.WaitConnectionAsync(TestContext.CancellationToken));
+        await AssertPipeDisposedAsync(namedPipeClient, "ConnectAsync", TestContext.CancellationToken);
+        await AssertPipeDisposedAsync(namedPipeServer, "WaitConnectionAsync", TestContext.CancellationToken);
     }
 
     [TestMethod]
@@ -638,6 +628,23 @@ public sealed class HangDumpTests
     }
 
 #if NETCOREAPP
+    [TestMethod]
+    public async Task DisposeAsync_CompletedDump_DisposesResources()
+    {
+        HangDumpProcessLifetimeHandler handler = CreateHandler();
+        await InitializePipeResourcesAsync(handler);
+        object namedPipeClient = GetHandlerField<object>(handler, "_namedPipeClient");
+        object namedPipeServer = GetHandlerField<object>(handler, "_singleConnectionNamedPipeServer");
+        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+
+        await handler.DisposeAsync();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(
+            () => _ = GetHandlerField<ManualResetEventSlim>(handler, "_waitConsumerPipeName").WaitHandle);
+        await AssertPipeDisposedAsync(namedPipeClient, "ConnectAsync", TestContext.CancellationToken);
+        await AssertPipeDisposedAsync(namedPipeServer, "WaitConnectionAsync", TestContext.CancellationToken);
+    }
+
     [TestMethod]
     public async Task DisposeAsync_FaultedDump_ReportsAndRethrowsOriginalException()
     {
@@ -799,6 +806,23 @@ public sealed class HangDumpTests
                 (_, data, _) => errors.Add((ErrorMessageOutputDeviceData)data))
             .Returns(Task.CompletedTask);
         return outputDevice;
+    }
+
+    private static async Task InitializePipeResourcesAsync(HangDumpProcessLifetimeHandler handler)
+    {
+        await handler.BeforeTestHostProcessStartAsync(CancellationToken.None);
+        MethodInfo callback = typeof(HangDumpProcessLifetimeHandler)
+            .GetMethod("CallbackAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        await (Task)callback.Invoke(
+            handler,
+            [new ConsumerPipeNameRequest($"hang_{Guid.NewGuid():N}")])!;
+    }
+
+    private static async Task AssertPipeDisposedAsync(object pipe, string operationName, CancellationToken cancellationToken)
+    {
+        MethodInfo operation = pipe.GetType().GetMethod(operationName)!;
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
+            () => (Task)operation.Invoke(pipe, [cancellationToken])!);
     }
 
     private static void SetHandlerField<T>(HangDumpProcessLifetimeHandler handler, string fieldName, T value)

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Testing.Extensions.UnitTests.Helpers;
 using Microsoft.Testing.Platform.Configurations;
 using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Helpers;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
@@ -550,6 +551,144 @@ public sealed class HangDumpTests
     }
 
     [TestMethod]
+    public void Dispose_CompletedDump_StopsTimersClaimsGateAndDisposesWaitSignal()
+    {
+        using var deadlineTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        using var activityTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        HangDumpProcessLifetimeHandler handler = CreateHandler();
+        SetHandlerField(handler, "_deadlineTimer", deadlineTimer);
+        SetHandlerField(handler, "_activityTimer", activityTimer);
+        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+
+        handler.Dispose();
+
+        Assert.AreEqual(1, GetHandlerField<int>(handler, "_dumpTaken"));
+        AssertTimerDisposed(deadlineTimer);
+        AssertTimerDisposed(activityTimer);
+        Assert.ThrowsExactly<ObjectDisposedException>(
+            () => _ = GetHandlerField<ManualResetEventSlim>(handler, "_waitConsumerPipeName").WaitHandle);
+    }
+
+    [TestMethod]
+    public async Task Dispose_DumpInFlight_WaitsForCompletion()
+    {
+        TaskCompletionSource<bool> dumpCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        HangDumpProcessLifetimeHandler handler = CreateHandler(disposeTimeout: TimeSpan.FromSeconds(30));
+        SetHandlerField(handler, "_activityIndicatorTask", dumpCompletion.Task);
+
+        var disposeTask = Task.Run(handler.Dispose, TestContext.CancellationToken);
+        Assert.IsTrue(
+            SpinWait.SpinUntil(() => GetHandlerField<int>(handler, "_dumpTaken") == 1, TimeSpan.FromSeconds(30)),
+            "Dispose did not reach the dump gate.");
+        Assert.IsFalse(disposeTask.IsCompleted, "Dispose returned before the in-flight dump completed.");
+
+        dumpCompletion.SetResult(true);
+        Task completed = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(30), TestContext.CancellationToken));
+
+        Assert.AreSame(disposeTask, completed);
+        await disposeTask;
+    }
+
+    [TestMethod]
+    public void Dispose_FaultedDump_ReportsAndRethrowsAggregateException()
+    {
+        var failure = new InvalidOperationException("dump failed");
+        List<ErrorMessageOutputDeviceData> errors = [];
+        Mock<IOutputDevice> outputDevice = CreateCapturingOutputDevice(errors);
+        HangDumpProcessLifetimeHandler handler = CreateHandler(outputDevice.Object);
+        SetHandlerField(handler, "_activityIndicatorTask", Task.FromException(failure));
+
+        AggregateException exception = Assert.ThrowsExactly<AggregateException>(handler.Dispose);
+
+        Assert.AreSame(failure, exception.InnerException);
+        Assert.HasCount(1, errors);
+        Assert.Contains(failure.Message, errors[0].Message);
+        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+        handler.Dispose();
+    }
+
+    [TestMethod]
+    public void Dispose_InFlightDumpExceedsTimeout_ThrowsWithoutProductionDelay()
+    {
+        TaskCompletionSource<bool> dumpCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        HangDumpProcessLifetimeHandler handler = CreateHandler(disposeTimeout: TimeSpan.Zero);
+        SetHandlerField(handler, "_activityIndicatorTask", dumpCompletion.Task);
+
+        InvalidOperationException exception = Assert.ThrowsExactly<InvalidOperationException>(handler.Dispose);
+
+        Assert.Contains("_activityIndicatorTask didn't exit in 00:00:00 seconds", exception.Message);
+        dumpCompletion.SetResult(true);
+        handler.Dispose();
+    }
+
+#if NETCOREAPP
+    [TestMethod]
+    public async Task DisposeAsync_FaultedDump_ReportsAndRethrowsOriginalException()
+    {
+        var failure = new InvalidOperationException("async dump failed");
+        List<ErrorMessageOutputDeviceData> errors = [];
+        Mock<IOutputDevice> outputDevice = CreateCapturingOutputDevice(errors);
+        HangDumpProcessLifetimeHandler handler = CreateHandler(outputDevice.Object);
+        SetHandlerField(handler, "_activityIndicatorTask", Task.FromException(failure));
+
+        InvalidOperationException exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            async () => await handler.DisposeAsync());
+
+        Assert.AreSame(failure, exception);
+        Assert.HasCount(1, errors);
+        Assert.Contains(failure.Message, errors[0].Message);
+        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+        await handler.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_InFlightDumpExceedsTimeout_ReportsAndThrowsWithoutProductionDelay()
+    {
+        TaskCompletionSource<bool> dumpCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        List<ErrorMessageOutputDeviceData> errors = [];
+        Mock<IOutputDevice> outputDevice = CreateCapturingOutputDevice(errors);
+        HangDumpProcessLifetimeHandler handler = CreateHandler(outputDevice.Object, TimeSpan.Zero);
+        SetHandlerField(handler, "_activityIndicatorTask", dumpCompletion.Task);
+
+        TimeoutException exception = await Assert.ThrowsExactlyAsync<TimeoutException>(
+            async () => await handler.DisposeAsync());
+
+        Assert.HasCount(1, errors);
+        Assert.Contains(typeof(TimeoutException).FullName!, errors[0].Message);
+        Assert.Contains(exception.Message, errors[0].Message);
+        dumpCompletion.SetResult(true);
+        await handler.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Dispose_RepeatedAndMixedSyncAsyncCalls_AreIdempotent()
+    {
+        HangDumpProcessLifetimeHandler handler = CreateHandler();
+        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+
+        handler.Dispose();
+        await handler.DisposeAsync();
+        handler.Dispose();
+
+        Assert.AreEqual(1, GetHandlerField<int>(handler, "_dumpTaken"));
+    }
+#endif
+
+    [TestMethod]
+    public void Dispose_TimerCallbackArrivingAfterGateClaim_DoesNotStartDump()
+    {
+        HangDumpProcessLifetimeHandler handler = CreateHandler();
+        handler.Dispose();
+
+        typeof(HangDumpProcessLifetimeHandler)
+            .GetMethod("TriggerDumpOnce", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(handler, [CancellationToken.None, false]);
+
+        Assert.AreEqual(1, GetHandlerField<int>(handler, "_dumpTaken"));
+        Assert.IsNull(GetHandlerField<Task?>(handler, "_activityIndicatorTask"));
+    }
+
+    [TestMethod]
     public async Task HangDumpType_And_HangDumpTypeIfSupported_AreMutuallyExclusive()
     {
         HangDumpCommandLineProvider hangDumpCommandLineProvider = GetProvider();
@@ -600,6 +739,68 @@ public sealed class HangDumpTests
             .GetField("_testsCurrentExecutionState", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(indicator)!;
         return (int)state.GetType().GetProperty("Count")!.GetValue(state)!;
+    }
+
+    private static HangDumpProcessLifetimeHandler CreateHandler(
+        IOutputDevice? outputDevice = null,
+        TimeSpan? disposeTimeout = null)
+    {
+        Mock<ILoggerFactory> loggerFactory = new();
+        loggerFactory.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>());
+        Mock<IClock> clock = new();
+        clock.SetupGet(x => x.UtcNow).Returns(DateTimeOffset.UtcNow);
+
+        var handler = new HangDumpProcessLifetimeHandler(
+            new NamedPipeServerEndpoint($"hang_{Guid.NewGuid():N}"),
+            Mock.Of<IMessageBus>(),
+            outputDevice ?? Mock.Of<IOutputDevice>(),
+            new TestCommandLineOptions([]),
+            Mock.Of<ITask>(),
+            Mock.Of<IEnvironment>(),
+            loggerFactory.Object,
+            Mock.Of<IConfiguration>(),
+            Mock.Of<IProcessHandler>(),
+            clock.Object,
+            new ServiceProvider(),
+            disposeTimeout);
+
+        return handler;
+    }
+
+    private static Mock<IOutputDevice> CreateCapturingOutputDevice(List<ErrorMessageOutputDeviceData> errors)
+    {
+        Mock<IOutputDevice> outputDevice = new();
+        outputDevice
+            .Setup(x => x.DisplayAsync(
+                It.IsAny<IOutputDeviceDataProducer>(),
+                It.IsAny<IOutputDeviceData>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<IOutputDeviceDataProducer, IOutputDeviceData, CancellationToken>(
+                (_, data, _) => errors.Add((ErrorMessageOutputDeviceData)data))
+            .Returns(Task.CompletedTask);
+        return outputDevice;
+    }
+
+    private static void SetHandlerField<T>(HangDumpProcessLifetimeHandler handler, string fieldName, T value)
+        => typeof(HangDumpProcessLifetimeHandler)
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(handler, value);
+
+    private static T GetHandlerField<T>(HangDumpProcessLifetimeHandler handler, string fieldName)
+        => (T)typeof(HangDumpProcessLifetimeHandler)
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(handler)!;
+
+    private static void AssertTimerDisposed(Timer timer)
+    {
+        try
+        {
+            Assert.IsFalse(timer.Change(TimeSpan.Zero, Timeout.InfiniteTimeSpan));
+        }
+        catch (ObjectDisposedException)
+        {
+            // .NET Framework throws while current .NET returns false for the same disposed state.
+        }
     }
 
     [TestMethod]

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
@@ -10,6 +10,8 @@ using Microsoft.Testing.Platform.Extensions.CommandLine;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.OutputDevice;
 using Microsoft.Testing.Platform.Helpers;
+using Microsoft.Testing.Platform.IPC;
+using Microsoft.Testing.Platform.IPC.Models;
 using Microsoft.Testing.Platform.Logging;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.OutputDevice;
@@ -551,14 +553,24 @@ public sealed class HangDumpTests
     }
 
     [TestMethod]
-    public void Dispose_CompletedDump_StopsTimersClaimsGateAndDisposesWaitSignal()
+    public async Task Dispose_CompletedDump_StopsTimersClaimsGateAndDisposesResources()
     {
         using var deadlineTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
         using var activityTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        var namedPipeClient = new NamedPipeClient($"hang_{Guid.NewGuid():N}");
+        var namedPipeServer = new NamedPipeServer(
+            $"hang_{Guid.NewGuid():N}",
+            _ => Task.FromResult<IResponse>(VoidResponse.CachedInstance),
+            Mock.Of<IEnvironment>(),
+            Mock.Of<ILogger>(),
+            Mock.Of<ITask>(),
+            CancellationToken.None);
         HangDumpProcessLifetimeHandler handler = CreateHandler();
         SetHandlerField(handler, "_deadlineTimer", deadlineTimer);
         SetHandlerField(handler, "_activityTimer", activityTimer);
         SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+        SetHandlerField(handler, "_namedPipeClient", namedPipeClient);
+        SetHandlerField(handler, "_singleConnectionNamedPipeServer", namedPipeServer);
 
         handler.Dispose();
 
@@ -567,6 +579,10 @@ public sealed class HangDumpTests
         AssertTimerDisposed(activityTimer);
         Assert.ThrowsExactly<ObjectDisposedException>(
             () => _ = GetHandlerField<ManualResetEventSlim>(handler, "_waitConsumerPipeName").WaitHandle);
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
+            () => namedPipeClient.ConnectAsync(TestContext.CancellationToken));
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(
+            () => namedPipeServer.WaitConnectionAsync(TestContext.CancellationToken));
     }
 
     [TestMethod]
@@ -761,8 +777,12 @@ public sealed class HangDumpTests
             Mock.Of<IConfiguration>(),
             Mock.Of<IProcessHandler>(),
             clock.Object,
-            new ServiceProvider(),
-            disposeTimeout);
+            new ServiceProvider());
+
+        if (disposeTimeout is not null)
+        {
+            SetHandlerField(handler, "_disposeTimeout", disposeTimeout.Value);
+        }
 
         return handler;
     }

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/HangDumpTests.cs
@@ -686,14 +686,22 @@ public sealed class HangDumpTests
     [TestMethod]
     public async Task Dispose_RepeatedAndMixedSyncAsyncCalls_AreIdempotent()
     {
+        using var deadlineTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        using var activityTimer = new Timer(_ => { }, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        Task completedDump = Task.CompletedTask;
         HangDumpProcessLifetimeHandler handler = CreateHandler();
-        SetHandlerField(handler, "_activityIndicatorTask", Task.CompletedTask);
+        await InitializePipeResourcesAsync(handler);
+        SetHandlerField(handler, "_deadlineTimer", deadlineTimer);
+        SetHandlerField(handler, "_activityTimer", activityTimer);
+        SetHandlerField(handler, "_activityIndicatorTask", completedDump);
 
         handler.Dispose();
         await handler.DisposeAsync();
         handler.Dispose();
 
         Assert.AreEqual(1, GetHandlerField<int>(handler, "_dumpTaken"));
+        Assert.AreSame(completedDump, GetHandlerField<Task>(handler, "_activityIndicatorTask"));
+        Assert.IsTrue(completedDump.IsCompletedSuccessfully);
     }
 #endif
 


### PR DESCRIPTION
`HangDumpProcessLifetimeHandler` teardown owns timers, dump coordination, and named-pipe resources, but its synchronous and asynchronous disposal paths had no direct unit coverage.

This adds deterministic coverage for cleanup and gate claiming, waiting for in-flight dumps, timeout and fault propagation/reporting, repeated mixed disposal, and late timer callbacks. A constructor-injected internal timeout keeps timeout tests immediate while retaining the existing production default.

Fixes #11024