### PR TITLE
Backport localization updates to rel/4.4

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.pl.xlf
@@ -651,17 +651,17 @@
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionDefaultMustHaveValueErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must provide a non-null scalar value or a non-empty array of scalar values.</source>
-        <target state="new">The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must provide a non-null scalar value or a non-empty array of scalar values.</target>
+        <target state="translated">Wpis „{0}” w sekcji „{1}” w pliku testconfig.json („{2}”) musi zawierać niepustą wartość skalarną inną niż null albo niepustą tablicę wartości skalarnych.</target>
         <note>{0} is the option name. {1} is the section name. {2} is the path to the testconfig.json file. {Locked="testconfig.json"}{Locked="commandLineOptionDefaults"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionDefaultsValidationErrorPrefix">
         <source>In testconfig.json under 'commandLineOptionDefaults': {0}</source>
-        <target state="new">In testconfig.json under 'commandLineOptionDefaults': {0}</target>
+        <target state="translated">W testconfig.json w obszarze „commandLineOptionDefaults”: {0}</target>
         <note>{0} is the underlying validation error message (unknown option, arity mismatch, invalid arguments...). {Locked="testconfig.json"}{Locked="commandLineOptionDefaults"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
         <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under '{1}' in testconfig.json.</source>
-        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under '{1}' in testconfig.json.</target>
+        <target state="translated">Opcja „--{0}” jest odczytywana podczas ładowania początkowego platformy (przed załadowaniem pliku testconfig.json) i dlatego musi zostać przekazana w wierszu polecenia, a nie zadeklarowana w obszarze „{1}” w testconfig.json.</target>
         <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {1} is the JSON section name. {Locked="--"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">

--- a/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
+++ b/src/Platform/Microsoft.Testing.Platform/Resources/xlf/PlatformResources.zh-Hans.xlf
@@ -651,17 +651,17 @@
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionDefaultMustHaveValueErrorMessage">
         <source>The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must provide a non-null scalar value or a non-empty array of scalar values.</source>
-        <target state="new">The entry '{0}' under section '{1}' in the testconfig.json file ('{2}') must provide a non-null scalar value or a non-empty array of scalar values.</target>
+        <target state="translated">testconfig.json 文件(“{2}”)中“{1}”节下的条目“{0}”必须提供非空标量值或非空标量值数组。</target>
         <note>{0} is the option name. {1} is the section name. {2} is the path to the testconfig.json file. {Locked="testconfig.json"}{Locked="commandLineOptionDefaults"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionDefaultsValidationErrorPrefix">
         <source>In testconfig.json under 'commandLineOptionDefaults': {0}</source>
-        <target state="new">In testconfig.json under 'commandLineOptionDefaults': {0}</target>
+        <target state="translated">在 testconfig.json 的 "commandLineOptionDefaults" 下: {0}</target>
         <note>{0} is the underlying validation error message (unknown option, arity mismatch, invalid arguments...). {Locked="testconfig.json"}{Locked="commandLineOptionDefaults"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionIsBootstrapOnlyErrorMessage">
         <source>The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under '{1}' in testconfig.json.</source>
-        <target state="new">The option '--{0}' is read during platform bootstrap (before the testconfig.json file is loaded) and must therefore be passed on the command line rather than declared under '{1}' in testconfig.json.</target>
+        <target state="translated">系统会在平台启动时(在加载 testconfig.json 文件前)读取选项“--{0}”，因此必须通过命令行传递，而不能在 testconfig.json 的“{1}”下声明。</target>
         <note>{0} is the bare bootstrap-only option name without the leading "--" (e.g. config-file, diagnostic, diagnostic-verbosity); the "--" prefix is already in the format string. {1} is the JSON section name. {Locked="--"}{Locked="testconfig.json"}</note>
       </trans-unit>
       <trans-unit id="JsonCommandLineOptionsEntryMustBeScalarOrArrayErrorMessage">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.cs.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Parametr '{0}' na '{1}' má více zprostředkovatelů kombinatorických hodnot: {2}. Použijte přesně jeden atribut, který implementuje {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} vyžaduje více jedinečných náhodných hodnot, než obsahuje rozsah mezi {1} a {2}.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} musí být kladné číslo.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} nesmí být větší než {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">Rozsah překračuje maximální hodnotu celého čísla.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">Rozsah překračuje maximální hodnotu celého čísla bez znaménka.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">Rozsah obsahuje příliš mnoho hodnot.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Nelze automaticky generovat hodnoty pro parametr typu {0}. K určení hodnot použijte atribut, který implementuje {1}.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.de.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Der Parameter '{0}' für '{1}' verfügt über mehrere kombinatorische Wertanbieter: {2}. Wenden Sie genau ein Attribut an, das {3} implementiert.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} fordert mehr eindeutige Zufallswerte an, als der Bereich zwischen {1} und {2} enthält.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} muss positiv sein.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} darf nicht größer als {1} sein.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">Der Bereich überschreitet den maximalen ganzzahligen Wert.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">Der Bereich überschreitet den maximalen ganzzahligen Wert ohne Vorzeichen.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">Der Bereich enthält zu viele Werte.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Für Parameter vom Typ {0} können keine automatischen Werte generiert werden. Wenden Sie ein Attribut an, das {1} implementiert, um die Werte anzugeben.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.es.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">El parámetro '{0}' en '{1}' tiene varios proveedores de valores combinatorios: {2}. Aplique exactamente un atributo que implemente {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} solicita más valores aleatorios únicos que los que contiene el intervalo entre {1} y {2}.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} debe ser positivo.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} no debe ser mayor que {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">El intervalo supera el valor entero máximo.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">El intervalo supera el valor entero máximo sin signo.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">El intervalo contiene demasiados valores.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">No se pueden generar automáticamente valores para el parámetro de tipo {0}. Aplique un atributo que implemente {1} para especificar los valores.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.fr.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Le paramètre '{0}' sur '{1}' a plusieurs fournisseurs de valeurs combinatoires : {2}. Appliquez exactement un attribut qui implémente {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} demande plus de valeurs aléatoires uniques que la plage comprise entre {1} et {2} contient.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} doit être positif.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} ne doit pas être supérieur à {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">La plage dépasse la valeur maximale d’un entier.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">La plage dépasse la valeur maximale d’un entier non signé.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">La plage contient trop de valeurs.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Impossible de générer automatiquement des valeurs pour le paramètre de type {0}. Appliquez un attribut qui implémente {1} pour spécifier les valeurs.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.it.xlf
@@ -355,12 +355,12 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Il parametro '{0}' in '{1}' ha più provider di valori combinatori: {2}. Applicare esattamente un attributo che implementa {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} richiede più valori casuali univoci di quelli contenuti nell'intervallo compreso tra {1} e {2}.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
@@ -390,7 +390,7 @@
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Impossibile generare automaticamente valori per il parametro di tipo {0}. Applicare un attributo che implementa {1} per specificare i valori.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ja.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">'{1}' のパラメーター '{0}' には、複数の組み合わせ値プロバイダーがあります: {2}。{3} を実装する属性を 1 つだけ適用します。</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} は、{1} から {2} までの範囲に含まれる一意の乱数の数を超える値を要求しています。</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} は正である必要があります。</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} は {1} より大きくすることはできません。</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">範囲が最大整数値を超えています。</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">範囲が符号なし整数の最大値を超えています。</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">範囲に含まれる値が多すぎます。</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">型 {0} のパラメーターの値を自動的に生成できません。値を指定するために {1} を実装する属性を適用します。</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ko.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">'{1}'의 매개 변수 '{0}'에 조합 값 공급자가 여러 개 있습니다. {2}. {3} 구현하는 특성을 하나만 적용합니다.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0}에서는 {1}과(와) {2} 사이의 범위에 포함된 것보다 많은 고유한 임의 값을 요청합니다.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0}은(는) 양수여야 합니다.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0}은(는) {1}보다 크지 않아야 합니다.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">범위가 최대 정수 값을 초과합니다.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">범위가 최대 부호 없는 정수 값을 초과합니다.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">범위에 포함된 값이 너무 많습니다.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">{0} 유형의 매개 변수에 대한 값을 자동으로 생성할 수 없습니다. 값을 지정하기 위해 {1} 구현하는 특성을 적용합니다.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pl.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Parametr „{0}” w „{1}” ma wielu dostawców wartości kombinatoracyjnych: {2}. Zastosuj dokładnie jeden atrybut, który implementuje {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} żąda więcej unikatowych losowych wartości niż zawiera zakres od {1} do {2}.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} musi być wartością dodatnią.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">Wartość {0} nie może być większa niż {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">Zakres przekracza maksymalną wartość całkowitą.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">Zakres przekracza maksymalną niepodpisaną wartość całkowitą.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">Zakres zawiera zbyt wiele wartości.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Nie można automatycznie wygenerować wartości dla parametru typu {0}. Zastosuj atrybut, który implementuje {1}, aby określić wartości.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.pt-BR.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">O parâmetro '{0}' no '{1}' tem vários provedores de valor combinatório: {2}. Aplique exatamente um atributo que implemente {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} solicita mais valores aleatórios exclusivos do que o intervalo entre {1} e {2} contém.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} deve ser positivo.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} não deve ser maior que {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">O intervalo excede o valor máximo de inteiro.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">O intervalo excede o valor máximo de inteiro sem sinal.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">O intervalo contém valores demais.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Não é possível gerar automaticamente valores para o parâmetro do tipo {0}. Aplique um atributo que implemente {1} para especificar os valores.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.ru.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">Параметр '{0}' в '{1}' имеет несколько поставщиков комбинаторных значений: {2}. Примените ровно один атрибут, реализующий {3}.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} запрашивает больше уникальных случайных значений, чем содержит диапазон между {1} и {2}.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} должно быть положительным.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} не должно быть больше, чем {1}.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">Диапазон превышает максимальное значение целого числа.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">Диапазон превышает максимальное значение целого числа без знака.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">Диапазон содержит слишком много значений.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">Не удалось автоматически создать значения для параметра типа {0}. Примените атрибут, реализующий {1} для указания значений.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.tr.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">'{1}' üzerindeki '{0}' parametresinin birden çok birleşimsel değer sağlayıcısı var: {2}. {3} uygulayan tam bir öznitelik uygulayın.</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0}, {1} ile {2} arasındaki aralığın içerdiğinden daha fazla benzersiz rastgele değer istiyor.</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} pozitif olmalıdır.</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0}, {1} değerinden büyük olmamalıdır.</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">Aralık, maksimum tamsayı değerini aşıyor.</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">Aralık, maksimum işaretsiz tamsayı değerini aşıyor.</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">Aralıkta çok fazla değer var.</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">{0} türündeki parametre için değerler otomatik olarak oluşturulamıyor. Değerleri belirtmek için {1} uygulayan bir öznitelik kullanın.</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hans.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">'{1}' 上的参数 '{0}' 具有多个组合值提供程序： {2}。只应用一个实现 {3} 的属性。</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} 请求的唯一随机值数量超过 {1} 和 {2} 之间范围包含的数量。</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} 必须为正数。</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} 不得大于 {1}。</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">该范围超过最大整数值。</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">该范围超过最大无符号整数值。</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">该范围包含的值太多。</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">无法为 {0} 类型的参数自动生成值。应用实现 {1} 的属性以指定值。</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">

--- a/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
+++ b/src/TestFramework/TestFramework/Resources/xlf/FrameworkMessages.zh-Hant.xlf
@@ -355,42 +355,42 @@
       </trans-unit>
       <trans-unit id="CombinatorialMultipleValueProviders">
         <source>Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</source>
-        <target state="new">Parameter '{0}' on '{1}' has multiple combinatorial value providers: {2}. Apply exactly one attribute that implements {3}.</target>
+        <target state="translated">參數 '{0}' 在 '{1}' 中有多個組合值提供者: {2}。請只套用一個實作 {3} 的屬性。</target>
         <note>{0} is the parameter name. {1} is the test method name. {2} is the comma-separated list of provider attribute types. {3} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountExceedsRange">
         <source>{0} requests more unique random values than the range between {1} and {2} contains.</source>
-        <target state="new">{0} requests more unique random values than the range between {1} and {2} contains.</target>
+        <target state="translated">{0} 要求的唯一隨機值數量超過 {1} 與 {2} 之間的範圍所能包含的數量。</target>
         <note>{0} is the count property name. {1} is the minimum property name. {2} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomCountMustBePositive">
         <source>{0} must be positive.</source>
-        <target state="new">{0} must be positive.</target>
+        <target state="translated">{0} 必須是正數。</target>
         <note>{0} is the random data count property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRandomMinimumExceedsMaximum">
         <source>{0} must not be greater than {1}.</source>
-        <target state="new">{0} must not be greater than {1}.</target>
+        <target state="translated">{0} 不得大於 {1}。</target>
         <note>{0} is the minimum property name. {1} is the maximum property name.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsInt32">
         <source>The range exceeds the maximum integer value.</source>
-        <target state="new">The range exceeds the maximum integer value.</target>
+        <target state="translated">範圍超過整數的最大值。</target>
         <note>Error message shown when a signed combinatorial range exceeds Int32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeExceedsUInt32">
         <source>The range exceeds the maximum unsigned integer value.</source>
-        <target state="new">The range exceeds the maximum unsigned integer value.</target>
+        <target state="translated">範圍超過無符號整數的最大值。</target>
         <note>Error message shown when an unsigned combinatorial range exceeds UInt32.MaxValue.</note>
       </trans-unit>
       <trans-unit id="CombinatorialRangeTooManyValues">
         <source>The range contains too many values.</source>
-        <target state="new">The range contains too many values.</target>
+        <target state="translated">此範圍包含過多值。</target>
         <note>Error message shown when a combinatorial range cannot be represented in an array.</note>
       </trans-unit>
       <trans-unit id="CombinatorialUnableToInferValues">
         <source>Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</source>
-        <target state="new">Unable to automatically generate values for parameter of type {0}. Apply an attribute that implements {1} to specify the values.</target>
+        <target state="translated">無法自動產生類型 {0} 之參數的值。請套用實作 {1} 的屬性來指定值。</target>
         <note>{0} is the parameter type. {1} is the provider interface name.</note>
       </trans-unit>
       <trans-unit id="ContainsAllFailedSummary">


### PR DESCRIPTION
## Summary

Backport the effective OneLocBuild localization updates from #11029 and #11041 to `rel/4.4`.

- localizes eight combinatorial test-data diagnostics across all 13 supported languages
- localizes three `testconfig.json` command-line-default diagnostics in Polish and Simplified Chinese
- excludes #11028 because it was a duplicate merge with no additional diff

## Validation

- all 105 changed trans-units match `main`
- every resource key exists in the `rel/4.4` RESX files
- XLF files parse successfully and `git diff --check` passes