### PR TITLE
Add analyzer for OS platform conditions

### DIFF
--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -298,4 +298,8 @@
     <value>Remove redundant 'DisplayName'</value>
     <comment>{Locked="DisplayName"}</comment>
   </data>
+  <data name="MakeOSConditionConsistentFix" xml:space="preserve">
+    <value>Make '[OSCondition]' consistent with platform compatibility attributes</value>
+    <comment>{Locked="[OSCondition]"}</comment>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/CodeFixResources.resx
@@ -300,6 +300,6 @@
   </data>
   <data name="MakeOSConditionConsistentFix" xml:space="preserve">
     <value>Make '[OSCondition]' consistent with platform compatibility attributes</value>
-    <comment>{Locked="[OSCondition]"}</comment>
+    <comment>{Locked="'[OSCondition]'"}</comment>
   </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/OSPlatformAttributesShouldBeConsistentFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/OSPlatformAttributesShouldBeConsistentFixer.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+
+using Analyzer.Utilities;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// Code fixer for <see cref="OSPlatformAttributesShouldBeConsistentAnalyzer"/>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OSPlatformAttributesShouldBeConsistentFixer))]
+[Shared]
+public sealed class OSPlatformAttributesShouldBeConsistentFixer : CodeFixProvider
+{
+    private const string MSTestNamespace = "Microsoft.VisualStudio.TestTools.UnitTesting";
+
+    /// <inheritdoc />
+    public override ImmutableArray<string> FixableDiagnosticIds { get; }
+        = ImmutableArray.Create(DiagnosticIds.OSPlatformAttributesShouldBeConsistentRuleId);
+
+    /// <inheritdoc />
+    public override FixAllProvider GetFixAllProvider()
+        => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        Diagnostic diagnostic = context.Diagnostics[0];
+        if (!diagnostic.Properties.TryGetValue(OSPlatformAttributesShouldBeConsistentAnalyzer.ConditionModeKey, out string? conditionMode)
+            || !diagnostic.Properties.TryGetValue(OSPlatformAttributesShouldBeConsistentAnalyzer.OperatingSystemsKey, out string? operatingSystems)
+            || conditionMode is null
+            || operatingSystems is null)
+        {
+            return;
+        }
+
+        SyntaxNode root = await context.Document.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        SyntaxNode diagnosticNode = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        MemberDeclarationSyntax? declaration = diagnosticNode.FirstAncestorOrSelf<MemberDeclarationSyntax>();
+        if (declaration is not MethodDeclarationSyntax and not TypeDeclarationSyntax)
+        {
+            return;
+        }
+
+        SemanticModel semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        ISymbol? declaredSymbol = semanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+        AttributeData? existingOSCondition = declaredSymbol?.GetAttributes().FirstOrDefault(
+            attribute => attribute.AttributeClass?.ToDisplayString() == WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingOSConditionAttribute);
+        Document targetDocument = context.Document;
+        MemberDeclarationSyntax targetDeclaration = declaration;
+        TextSpan? existingAttributeSpan = null;
+        if (existingOSCondition?.ApplicationSyntaxReference is { } existingSyntaxReference)
+        {
+            if (context.Document.Project.Solution.GetDocument(existingSyntaxReference.SyntaxTree) is not { } existingDocument)
+            {
+                return;
+            }
+
+            targetDocument = existingDocument;
+            SyntaxNode targetRoot = await targetDocument.GetRequiredSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (targetRoot.FindNode(existingSyntaxReference.Span).FirstAncestorOrSelf<MemberDeclarationSyntax>() is not { } existingDeclaration)
+            {
+                return;
+            }
+
+            targetDeclaration = existingDeclaration;
+            existingAttributeSpan = existingSyntaxReference.Span;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                CodeFixResources.MakeOSConditionConsistentFix,
+                createChangedSolution: ct => MakeOSConditionConsistentAsync(targetDocument, targetDeclaration, existingAttributeSpan, conditionMode, operatingSystems, ct),
+                nameof(OSPlatformAttributesShouldBeConsistentFixer)),
+            diagnostic);
+    }
+
+    private static async Task<Solution> MakeOSConditionConsistentAsync(
+        Document document,
+        MemberDeclarationSyntax declaration,
+        TextSpan? existingAttributeSpan,
+        string conditionMode,
+        string operatingSystems,
+        CancellationToken cancellationToken)
+    {
+        DocumentEditor editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        AttributeSyntax? existingAttribute = existingAttributeSpan is { } span
+            ? editor.OriginalRoot.FindNode(span, getInnermostNodeForTie: true).FirstAncestorOrSelf<AttributeSyntax>()
+            : null;
+        AttributeArgumentListSyntax argumentList = CreateArgumentList(conditionMode, operatingSystems);
+        if (existingAttribute is not null)
+        {
+            if (existingAttribute.ArgumentList is { } existingArgumentList)
+            {
+                argumentList = argumentList.WithArguments(
+                    argumentList.Arguments.AddRange(existingArgumentList.Arguments.Where(argument => argument.NameEquals is not null)));
+            }
+
+            editor.ReplaceNode(
+                existingAttribute,
+                existingAttribute.WithArgumentList(argumentList).WithAdditionalAnnotations(Formatter.Annotation));
+        }
+        else
+        {
+            AttributeSyntax attribute = SyntaxFactory.Attribute(
+                SyntaxFactory.ParseName($"{MSTestNamespace}.OSConditionAttribute")
+                    .WithAdditionalAnnotations(Simplifier.Annotation),
+                argumentList);
+            AttributeListSyntax attributeList = SyntaxFactory.AttributeList(
+                    SyntaxFactory.SingletonSeparatedList(attribute))
+                .WithAdditionalAnnotations(Formatter.Annotation);
+
+            MemberDeclarationSyntax updatedDeclaration = declaration switch
+            {
+                MethodDeclarationSyntax method => method.AddAttributeLists(attributeList),
+                TypeDeclarationSyntax type => type.AddAttributeLists(attributeList),
+                _ => declaration,
+            };
+            editor.ReplaceNode(declaration, updatedDeclaration);
+        }
+
+        return editor.GetChangedDocument().Project.Solution;
+    }
+
+    private static AttributeArgumentListSyntax CreateArgumentList(string conditionMode, string operatingSystems)
+    {
+        ExpressionSyntax[] operatingSystemExpressions = operatingSystems
+            .Split('|')
+            .Select(name => SyntaxFactory.ParseExpression($"{MSTestNamespace}.OperatingSystems.{name}")
+                .WithAdditionalAnnotations(Simplifier.Annotation, Simplifier.AddImportsAnnotation))
+            .ToArray();
+        ExpressionSyntax operatingSystemsExpression = operatingSystemExpressions.Aggregate(
+            (left, right) => SyntaxFactory.BinaryExpression(SyntaxKind.BitwiseOrExpression, left, right));
+
+        IEnumerable<AttributeArgumentSyntax> arguments = conditionMode == "Include"
+            ? [SyntaxFactory.AttributeArgument(operatingSystemsExpression)]
+            :
+            [
+                SyntaxFactory.AttributeArgument(
+                    SyntaxFactory.ParseExpression($"{MSTestNamespace}.ConditionMode.Exclude")
+                        .WithAdditionalAnnotations(Simplifier.Annotation, Simplifier.AddImportsAnnotation)),
+                SyntaxFactory.AttributeArgument(operatingSystemsExpression),
+            ];
+
+        return SyntaxFactory.AttributeArgumentList(SyntaxFactory.SeparatedList(arguments));
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/OSPlatformAttributesShouldBeConsistentFixer.cs
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/OSPlatformAttributesShouldBeConsistentFixer.cs
@@ -59,6 +59,13 @@ public sealed class OSPlatformAttributesShouldBeConsistentFixer : CodeFixProvide
 
         SemanticModel semanticModel = await context.Document.GetRequiredSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
         ISymbol? declaredSymbol = semanticModel.GetDeclaredSymbol(declaration, context.CancellationToken);
+        if (declaredSymbol is IMethodSymbol methodSymbol
+            && methodSymbol.ContainingType.GetAttributes().Any(
+                attribute => attribute.AttributeClass?.ToDisplayString() == WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingOSConditionAttribute))
+        {
+            return;
+        }
+
         AttributeData? existingOSCondition = declaredSymbol?.GetAttributes().FirstOrDefault(
             attribute => attribute.AttributeClass?.ToDisplayString() == WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingOSConditionAttribute);
         Document targetDocument = context.Document;

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Opravit podpis</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Předat argument TestContext.CancellationToken volání metody</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.cs.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Signatur korrigieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Argument „TestContext.CancellationToken“ an den Methodenaufruf übergeben</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.de.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Corregir firma</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Pasar el argumento 'TestContext.CancellationToken' a la llamada al método</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.es.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Corriger la signature numérique</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Transmettre l'argument « TestContext.CancellationToken » à l'appel de méthode</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.fr.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Correggi firma</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Passare l'argomento 'TestContext.CancellationToken' alla chiamata al metodo</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.it.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">署名の修正</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">'TestContext.CancellationToken' 引数をメソッド呼び出しに渡す</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ja.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">서명 수정</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">메서드 호출에 'TestContext.CancellationToken' 인수 전달</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ko.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Popraw podpis</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Przekaż argument „TestContext.CancellationToken” do wywołania metody</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pl.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Corrigir assinatura</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Passar o argumento 'TestContext.CancellationToken' para a chamada de método</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.pt-BR.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Исправить подпись</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">Передайте аргумент "TestContext.CancellationToken" в вызов метода</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.ru.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">İmzayı düzelt</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">'TestContext.CancellationToken' bağımsız değişkenini metot çağrısına aktarın</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.tr.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">修复签名</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">将 'TestContext.CancellationToken' 参数传递给方法调用</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hans.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">修正簽章</target>
         <note />
       </trans-unit>
+      <trans-unit id="MakeOSConditionConsistentFix">
+        <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
+        <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>
         <target state="translated">將 'TestContext.CancellationToken' 引數傳遞給方法呼叫</target>

--- a/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers.CodeFixes/xlf/CodeFixResources.zh-Hant.xlf
@@ -90,7 +90,7 @@
       <trans-unit id="MakeOSConditionConsistentFix">
         <source>Make '[OSCondition]' consistent with platform compatibility attributes</source>
         <target state="new">Make '[OSCondition]' consistent with platform compatibility attributes</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PassCancellationTokenFix">
         <source>Pass 'TestContext.CancellationToken' argument to method call</source>

--- a/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/MSTest.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+MSTEST0084 | Usage | Info | OSPlatformAttributesShouldBeConsistentAnalyzer, [Documentation](https://learn.microsoft.com/dotnet/core/testing/mstest-analyzers/mstest0084)

--- a/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/DiagnosticIds.cs
@@ -88,4 +88,5 @@ internal static class DiagnosticIds
     public const string TestFilterProviderShouldBeValidRuleId = "MSTEST0081";
     public const string InheritedMemberFromDifferentMSTestVersionRuleId = "MSTEST0082";
     public const string UseExecutableConditionAttributeInsteadOfProcessCheckRuleId = "MSTEST0083";
+    public const string OSPlatformAttributesShouldBeConsistentRuleId = "MSTEST0084";
 }

--- a/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
+++ b/src/Analyzers/MSTest.Analyzers/Helpers/WellKnownTypeNames.cs
@@ -80,6 +80,8 @@ internal static class WellKnownTypeNames
     public const string SystemRuntimeCompilerServicesCallerLineNumberAttribute = "System.Runtime.CompilerServices.CallerLineNumberAttribute";
     public const string SystemRuntimeInteropServicesArchitecture = "System.Runtime.InteropServices.Architecture";
     public const string SystemRuntimeInteropServicesRuntimeInformation = "System.Runtime.InteropServices.RuntimeInformation";
+    public const string SystemRuntimeVersioningSupportedOSPlatformAttribute = "System.Runtime.Versioning.SupportedOSPlatformAttribute";
+    public const string SystemRuntimeVersioningUnsupportedOSPlatformAttribute = "System.Runtime.Versioning.UnsupportedOSPlatformAttribute";
     public const string SystemThreadingCancellationToken = "System.Threading.CancellationToken";
     public const string SystemThreadingCancellationTokenSource = "System.Threading.CancellationTokenSource";
     public const string SystemThreadingTasksTask = "System.Threading.Tasks.Task";

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+using Analyzer.Utilities.Extensions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using MSTest.Analyzers.Helpers;
+
+namespace MSTest.Analyzers;
+
+/// <summary>
+/// MSTEST0084: <inheritdoc cref="Resources.OSPlatformAttributesShouldBeConsistentTitle"/>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticAnalyzer
+{
+    internal const string ConditionModeKey = nameof(ConditionModeKey);
+    internal const string OperatingSystemsKey = nameof(OperatingSystemsKey);
+
+    private static readonly LocalizableResourceString Title = new(nameof(Resources.OSPlatformAttributesShouldBeConsistentTitle), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString MessageFormat = new(nameof(Resources.OSPlatformAttributesShouldBeConsistentMessageFormat), Resources.ResourceManager, typeof(Resources));
+    private static readonly LocalizableResourceString Description = new(nameof(Resources.OSPlatformAttributesShouldBeConsistentDescription), Resources.ResourceManager, typeof(Resources));
+
+    internal static readonly DiagnosticDescriptor Rule = DiagnosticDescriptorHelper.Create(
+        DiagnosticIds.OSPlatformAttributesShouldBeConsistentRuleId,
+        Title,
+        MessageFormat,
+        Description,
+        Category.Usage,
+        DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            if (!context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestMethodAttribute, out INamedTypeSymbol? testMethodAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingTestClassAttribute, out INamedTypeSymbol? testClassAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.MicrosoftVisualStudioTestToolsUnitTestingOSConditionAttribute, out INamedTypeSymbol? osConditionAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeVersioningSupportedOSPlatformAttribute, out INamedTypeSymbol? supportedOSPlatformAttributeSymbol)
+                || !context.Compilation.TryGetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemRuntimeVersioningUnsupportedOSPlatformAttribute, out INamedTypeSymbol? unsupportedOSPlatformAttributeSymbol))
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(
+                ctx => AnalyzeSymbol(ctx, testMethodAttributeSymbol, osConditionAttributeSymbol, supportedOSPlatformAttributeSymbol, unsupportedOSPlatformAttributeSymbol),
+                SymbolKind.Method);
+            context.RegisterSymbolAction(
+                ctx => AnalyzeSymbol(ctx, testClassAttributeSymbol, osConditionAttributeSymbol, supportedOSPlatformAttributeSymbol, unsupportedOSPlatformAttributeSymbol),
+                SymbolKind.NamedType);
+        });
+    }
+
+    private static void AnalyzeSymbol(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol testAttributeSymbol,
+        INamedTypeSymbol osConditionAttributeSymbol,
+        INamedTypeSymbol supportedOSPlatformAttributeSymbol,
+        INamedTypeSymbol unsupportedOSPlatformAttributeSymbol)
+    {
+        ImmutableArray<AttributeData> attributes = context.Symbol.GetAttributes();
+        if (!attributes.Any(attribute => attribute.AttributeClass.Inherits(testAttributeSymbol)))
+        {
+            return;
+        }
+
+        var platformAttributes = attributes
+            .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
+                || SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, unsupportedOSPlatformAttributeSymbol))
+            .ToImmutableArray();
+        if (platformAttributes.IsEmpty)
+        {
+            return;
+        }
+
+        AttributeData? osConditionAttribute = attributes.FirstOrDefault(
+            attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
+
+        bool canFix = TryGetExpectedCondition(
+            platformAttributes,
+            supportedOSPlatformAttributeSymbol,
+            out bool includeMode,
+            out int operatingSystems,
+            out string? operatingSystemsExpression);
+
+        if (canFix && IsEquivalentOSCondition(osConditionAttribute, includeMode, operatingSystems))
+        {
+            return;
+        }
+
+        ImmutableDictionary<string, string?> properties = canFix
+            ? ImmutableDictionary<string, string?>.Empty
+                .Add(ConditionModeKey, includeMode ? "Include" : "Exclude")
+                .Add(OperatingSystemsKey, operatingSystemsExpression)
+            : ImmutableDictionary<string, string?>.Empty;
+
+        AttributeData diagnosticAttribute = platformAttributes[0];
+        if (diagnosticAttribute.ApplicationSyntaxReference is { } syntaxReference)
+        {
+            context.ReportDiagnostic(syntaxReference.GetSyntax(context.CancellationToken).CreateDiagnostic(Rule, properties, context.Symbol.Name));
+        }
+        else
+        {
+            context.ReportDiagnostic(context.Symbol.CreateDiagnostic(Rule, properties, context.Symbol.Name));
+        }
+    }
+
+    private static bool TryGetExpectedCondition(
+        ImmutableArray<AttributeData> platformAttributes,
+        INamedTypeSymbol supportedOSPlatformAttributeSymbol,
+        out bool includeMode,
+        out int operatingSystems,
+        out string? operatingSystemsExpression)
+    {
+        includeMode = SymbolEqualityComparer.Default.Equals(platformAttributes[0].AttributeClass, supportedOSPlatformAttributeSymbol);
+        operatingSystems = 0;
+
+        foreach (AttributeData attribute in platformAttributes)
+        {
+            if (includeMode != SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
+                || attribute.ConstructorArguments is not [{ Value: string platformName }]
+                || !TryMapPlatform(platformName, out int operatingSystem))
+            {
+                operatingSystemsExpression = null;
+                return false;
+            }
+
+            operatingSystems |= operatingSystem;
+        }
+
+        operatingSystemsExpression = CreateOperatingSystemsExpression(operatingSystems);
+        return true;
+    }
+
+    private static bool TryMapPlatform(string platformName, out int operatingSystem)
+    {
+        operatingSystem = platformName.ToUpperInvariant() switch
+        {
+            "LINUX" => 1 << 0,
+            "OSX" or "MACOS" => 1 << 1,
+            "WINDOWS" => 1 << 2,
+            "FREEBSD" => 1 << 3,
+            _ => 0,
+        };
+
+        return operatingSystem != 0;
+    }
+
+    private static string CreateOperatingSystemsExpression(int operatingSystems)
+    {
+        var names = new List<string>();
+        AddNameIfSet(names, operatingSystems, 1 << 0, "Linux");
+        AddNameIfSet(names, operatingSystems, 1 << 1, "OSX");
+        AddNameIfSet(names, operatingSystems, 1 << 2, "Windows");
+        AddNameIfSet(names, operatingSystems, 1 << 3, "FreeBSD");
+        return string.Join("|", names);
+    }
+
+    private static void AddNameIfSet(List<string> names, int operatingSystems, int value, string name)
+    {
+        if ((operatingSystems & value) != 0)
+        {
+            names.Add(name);
+        }
+    }
+
+    private static bool IsEquivalentOSCondition(AttributeData? attribute, bool includeMode, int operatingSystems)
+    {
+        if (attribute is null)
+        {
+            return false;
+        }
+
+        ImmutableArray<TypedConstant> arguments = attribute.ConstructorArguments;
+        return arguments switch
+        {
+            [{ Value: int actualOperatingSystems }]
+                => includeMode && actualOperatingSystems == operatingSystems,
+            [{ Value: int actualMode }, { Value: int actualOperatingSystems }]
+                => (actualMode == 0) == includeMode && actualOperatingSystems == operatingSystems,
+            _ => false,
+        };
+    }
+}

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -87,6 +87,11 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
 
         AttributeData? osConditionAttribute = attributes.FirstOrDefault(
             attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
+        if (osConditionAttribute is null && context.Symbol is IMethodSymbol methodSymbol)
+        {
+            osConditionAttribute = methodSymbol.ContainingType.GetAttributes().FirstOrDefault(
+                attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
+        }
 
         bool canFix = TryGetExpectedCondition(
             platformAttributes,

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -80,10 +80,6 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
                 || SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, unsupportedOSPlatformAttributeSymbol))
             .ToImmutableArray();
-        if (platformAttributes.IsEmpty)
-        {
-            return;
-        }
 
         AttributeData? localOSConditionAttribute = attributes.FirstOrDefault(
             attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
@@ -103,6 +99,19 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
         }
 
         ImmutableArray<AttributeData> assemblyAttributes = context.Compilation.Assembly.GetAttributes();
+        bool hasInheritedPlatformAttributes = containingTypeAttributeScopes.Any(scope => HasPlatformAttributes(
+                scope,
+                supportedOSPlatformAttributeSymbol,
+                unsupportedOSPlatformAttributeSymbol))
+            || HasPlatformAttributes(
+                assemblyAttributes,
+                supportedOSPlatformAttributeSymbol,
+                unsupportedOSPlatformAttributeSymbol);
+        if (platformAttributes.IsEmpty
+            && (context.Symbol is IMethodSymbol || !hasInheritedPlatformAttributes))
+        {
+            return;
+        }
 
         bool canFix = TryGetExpectedCondition(
             platformAttributes,
@@ -129,8 +138,8 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
                 .Add(OperatingSystemsKey, operatingSystemsExpression)
             : ImmutableDictionary<string, string?>.Empty;
 
-        AttributeData diagnosticAttribute = platformAttributes[0];
-        if (diagnosticAttribute.ApplicationSyntaxReference is { } syntaxReference)
+        if (!platformAttributes.IsEmpty
+            && platformAttributes[0].ApplicationSyntaxReference is { } syntaxReference)
         {
             context.ReportDiagnostic(syntaxReference.GetSyntax(context.CancellationToken).CreateDiagnostic(Rule, properties, context.Symbol.Name));
         }
@@ -139,6 +148,14 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             context.ReportDiagnostic(context.Symbol.CreateDiagnostic(Rule, properties, context.Symbol.Name));
         }
     }
+
+    private static bool HasPlatformAttributes(
+        ImmutableArray<AttributeData> attributes,
+        INamedTypeSymbol supportedOSPlatformAttributeSymbol,
+        INamedTypeSymbol unsupportedOSPlatformAttributeSymbol)
+        => attributes.Any(attribute =>
+            SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
+            || SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, unsupportedOSPlatformAttributeSymbol));
 
     private static bool TryGetExpectedCondition(
         ImmutableArray<AttributeData> localPlatformAttributes,

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -93,13 +93,20 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             : null;
         bool hasContainingClassCondition = containingClassOSConditionAttribute is not null;
 
-        ImmutableArray<AttributeData> containingTypeAttributes = context.Symbol.ContainingType?.GetAttributes()
-            ?? ImmutableArray<AttributeData>.Empty;
+        ImmutableArray<ImmutableArray<AttributeData>>.Builder containingTypeAttributeScopes =
+            ImmutableArray.CreateBuilder<ImmutableArray<AttributeData>>();
+        for (INamedTypeSymbol? containingType = context.Symbol.ContainingType;
+            containingType is not null;
+            containingType = containingType.ContainingType)
+        {
+            containingTypeAttributeScopes.Add(containingType.GetAttributes());
+        }
+
         ImmutableArray<AttributeData> assemblyAttributes = context.Compilation.Assembly.GetAttributes();
 
         bool canFix = TryGetExpectedCondition(
             platformAttributes,
-            containingTypeAttributes,
+            containingTypeAttributeScopes.ToImmutable(),
             assemblyAttributes,
             supportedOSPlatformAttributeSymbol,
             unsupportedOSPlatformAttributeSymbol,
@@ -135,7 +142,7 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
 
     private static bool TryGetExpectedCondition(
         ImmutableArray<AttributeData> localPlatformAttributes,
-        ImmutableArray<AttributeData> containingTypeAttributes,
+        ImmutableArray<ImmutableArray<AttributeData>> containingTypeAttributeScopes,
         ImmutableArray<AttributeData> assemblyAttributes,
         INamedTypeSymbol supportedOSPlatformAttributeSymbol,
         INamedTypeSymbol unsupportedOSPlatformAttributeSymbol,
@@ -151,12 +158,6 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
                 out int localAllowedOperatingSystems,
                 out bool localAllowsUnknownOperatingSystems)
             || !TryGetAllowedOperatingSystems(
-                containingTypeAttributes,
-                supportedOSPlatformAttributeSymbol,
-                unsupportedOSPlatformAttributeSymbol,
-                out int containingTypeAllowedOperatingSystems,
-                out bool containingTypeAllowsUnknownOperatingSystems)
-            || !TryGetAllowedOperatingSystems(
                 assemblyAttributes,
                 supportedOSPlatformAttributeSymbol,
                 unsupportedOSPlatformAttributeSymbol,
@@ -169,12 +170,28 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             return false;
         }
 
-        int allowedOperatingSystems =
-            localAllowedOperatingSystems & containingTypeAllowedOperatingSystems & assemblyAllowedOperatingSystems;
+        int allowedOperatingSystems = localAllowedOperatingSystems & assemblyAllowedOperatingSystems;
         bool allowsUnknownOperatingSystems =
             localAllowsUnknownOperatingSystems
-            && containingTypeAllowsUnknownOperatingSystems
             && assemblyAllowsUnknownOperatingSystems;
+        foreach (ImmutableArray<AttributeData> containingTypeAttributes in containingTypeAttributeScopes)
+        {
+            if (!TryGetAllowedOperatingSystems(
+                    containingTypeAttributes,
+                    supportedOSPlatformAttributeSymbol,
+                    unsupportedOSPlatformAttributeSymbol,
+                    out int containingTypeAllowedOperatingSystems,
+                    out bool containingTypeAllowsUnknownOperatingSystems))
+            {
+                includeMode = false;
+                operatingSystems = 0;
+                operatingSystemsExpression = null;
+                return false;
+            }
+
+            allowedOperatingSystems &= containingTypeAllowedOperatingSystems;
+            allowsUnknownOperatingSystems &= containingTypeAllowsUnknownOperatingSystems;
+        }
 
         includeMode = !allowsUnknownOperatingSystems;
         operatingSystems = includeMode
@@ -215,8 +232,11 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
         int operatingSystems = 0;
         foreach (AttributeData attribute in platformAttributes)
         {
-            if (includeMode != SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
-                || attribute.ConstructorArguments is not [{ Value: string platformName }]
+            bool isSupportedAttribute = SymbolEqualityComparer.Default.Equals(
+                attribute.AttributeClass,
+                supportedOSPlatformAttributeSymbol);
+            if (includeMode != isSupportedAttribute
+                || !TryGetPlatformName(attribute, isSupportedAttribute, out string? platformName)
                 || !TryMapPlatform(platformName, out int operatingSystem))
             {
                 allowedOperatingSystems = 0;
@@ -232,6 +252,21 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             : allOperatingSystems & ~operatingSystems;
         allowsUnknownOperatingSystems = !includeMode;
         return true;
+    }
+
+    private static bool TryGetPlatformName(
+        AttributeData attribute,
+        bool isSupportedAttribute,
+        [NotNullWhen(true)] out string? platformName)
+    {
+        platformName = attribute.ConstructorArguments switch
+        {
+            [{ Value: string value }] => value,
+            [{ Value: string value }, _] when !isSupportedAttribute => value,
+            _ => null,
+        };
+
+        return platformName is not null;
     }
 
     private static bool TryMapPlatform(string platformName, out int operatingSystem)

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -85,13 +85,13 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             return;
         }
 
-        AttributeData? osConditionAttribute = attributes.FirstOrDefault(
+        AttributeData? localOSConditionAttribute = attributes.FirstOrDefault(
             attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
-        if (osConditionAttribute is null && context.Symbol is IMethodSymbol methodSymbol)
-        {
-            osConditionAttribute = methodSymbol.ContainingType.GetAttributes().FirstOrDefault(
-                attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol));
-        }
+        AttributeData? containingClassOSConditionAttribute = context.Symbol is IMethodSymbol methodSymbol
+            ? methodSymbol.ContainingType.GetAttributes().FirstOrDefault(
+                attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, osConditionAttributeSymbol))
+            : null;
+        bool hasContainingClassCondition = containingClassOSConditionAttribute is not null;
 
         bool canFix = TryGetExpectedCondition(
             platformAttributes,
@@ -100,12 +100,16 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             out int operatingSystems,
             out string? operatingSystemsExpression);
 
-        if (canFix && IsEquivalentOSCondition(osConditionAttribute, includeMode, operatingSystems))
+        if (canFix && IsEquivalentOSCondition(
+            localOSConditionAttribute,
+            containingClassOSConditionAttribute,
+            includeMode,
+            operatingSystems))
         {
             return;
         }
 
-        ImmutableDictionary<string, string?> properties = canFix
+        ImmutableDictionary<string, string?> properties = canFix && !hasContainingClassCondition
             ? ImmutableDictionary<string, string?>.Empty
                 .Add(ConditionModeKey, includeMode ? "Include" : "Exclude")
                 .Add(OperatingSystemsKey, operatingSystemsExpression)
@@ -182,21 +186,52 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
         }
     }
 
-    private static bool IsEquivalentOSCondition(AttributeData? attribute, bool includeMode, int operatingSystems)
+    private static bool IsEquivalentOSCondition(
+        AttributeData? localAttribute,
+        AttributeData? containingClassAttribute,
+        bool includeMode,
+        int operatingSystems)
     {
-        if (attribute is null)
+        const int allOperatingSystems = (1 << 4) - 1;
+        int expectedAllowedOperatingSystems = includeMode
+            ? operatingSystems
+            : allOperatingSystems & ~operatingSystems;
+
+        if (!TryGetAllowedOperatingSystems(localAttribute, out int localAllowedOperatingSystems)
+            || !TryGetAllowedOperatingSystems(containingClassAttribute, out int containingClassAllowedOperatingSystems))
         {
             return false;
         }
 
-        ImmutableArray<TypedConstant> arguments = attribute.ConstructorArguments;
-        return arguments switch
+        int actualAllowedOperatingSystems = localAllowedOperatingSystems & containingClassAllowedOperatingSystems;
+        return actualAllowedOperatingSystems == expectedAllowedOperatingSystems;
+    }
+
+    private static bool TryGetAllowedOperatingSystems(AttributeData? attribute, out int allowedOperatingSystems)
+    {
+        const int allOperatingSystems = (1 << 4) - 1;
+        if (attribute is null)
         {
-            [{ Value: int actualOperatingSystems }]
-                => includeMode && actualOperatingSystems == operatingSystems,
-            [{ Value: int actualMode }, { Value: int actualOperatingSystems }]
-                => (actualMode == 0) == includeMode && actualOperatingSystems == operatingSystems,
-            _ => false,
-        };
+            allowedOperatingSystems = allOperatingSystems;
+            return true;
+        }
+
+        ImmutableArray<TypedConstant> arguments = attribute.ConstructorArguments;
+        switch (arguments)
+        {
+            case [{ Value: int operatingSystems }]:
+                allowedOperatingSystems = operatingSystems;
+                return true;
+
+            case [{ Value: int mode }, { Value: int operatingSystems }]:
+                allowedOperatingSystems = mode == 0
+                    ? operatingSystems
+                    : allOperatingSystems & ~operatingSystems;
+                return true;
+
+            default:
+                allowedOperatingSystems = 0;
+                return false;
+        }
     }
 }

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -148,6 +148,7 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
     {
         operatingSystem = platformName.ToUpperInvariant() switch
         {
+            // Bit positions must match the OperatingSystems enum in Microsoft.VisualStudio.TestTools.UnitTesting.
             "LINUX" => 1 << 0,
             "OSX" or "MACOS" => 1 << 1,
             "WINDOWS" => 1 << 2,

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -93,9 +93,16 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
             : null;
         bool hasContainingClassCondition = containingClassOSConditionAttribute is not null;
 
+        ImmutableArray<AttributeData> containingTypeAttributes = context.Symbol.ContainingType?.GetAttributes()
+            ?? ImmutableArray<AttributeData>.Empty;
+        ImmutableArray<AttributeData> assemblyAttributes = context.Compilation.Assembly.GetAttributes();
+
         bool canFix = TryGetExpectedCondition(
             platformAttributes,
+            containingTypeAttributes,
+            assemblyAttributes,
             supportedOSPlatformAttributeSymbol,
+            unsupportedOSPlatformAttributeSymbol,
             out bool includeMode,
             out int operatingSystems,
             out string? operatingSystemsExpression);
@@ -127,29 +134,103 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
     }
 
     private static bool TryGetExpectedCondition(
-        ImmutableArray<AttributeData> platformAttributes,
+        ImmutableArray<AttributeData> localPlatformAttributes,
+        ImmutableArray<AttributeData> containingTypeAttributes,
+        ImmutableArray<AttributeData> assemblyAttributes,
         INamedTypeSymbol supportedOSPlatformAttributeSymbol,
+        INamedTypeSymbol unsupportedOSPlatformAttributeSymbol,
         out bool includeMode,
         out int operatingSystems,
         out string? operatingSystemsExpression)
     {
-        includeMode = SymbolEqualityComparer.Default.Equals(platformAttributes[0].AttributeClass, supportedOSPlatformAttributeSymbol);
-        operatingSystems = 0;
+        const int allOperatingSystems = (1 << 4) - 1;
+        if (!TryGetAllowedOperatingSystems(
+                localPlatformAttributes,
+                supportedOSPlatformAttributeSymbol,
+                unsupportedOSPlatformAttributeSymbol,
+                out int localAllowedOperatingSystems,
+                out bool localAllowsUnknownOperatingSystems)
+            || !TryGetAllowedOperatingSystems(
+                containingTypeAttributes,
+                supportedOSPlatformAttributeSymbol,
+                unsupportedOSPlatformAttributeSymbol,
+                out int containingTypeAllowedOperatingSystems,
+                out bool containingTypeAllowsUnknownOperatingSystems)
+            || !TryGetAllowedOperatingSystems(
+                assemblyAttributes,
+                supportedOSPlatformAttributeSymbol,
+                unsupportedOSPlatformAttributeSymbol,
+                out int assemblyAllowedOperatingSystems,
+                out bool assemblyAllowsUnknownOperatingSystems))
+        {
+            includeMode = false;
+            operatingSystems = 0;
+            operatingSystemsExpression = null;
+            return false;
+        }
 
+        int allowedOperatingSystems =
+            localAllowedOperatingSystems & containingTypeAllowedOperatingSystems & assemblyAllowedOperatingSystems;
+        bool allowsUnknownOperatingSystems =
+            localAllowsUnknownOperatingSystems
+            && containingTypeAllowsUnknownOperatingSystems
+            && assemblyAllowsUnknownOperatingSystems;
+
+        includeMode = !allowsUnknownOperatingSystems;
+        operatingSystems = includeMode
+            ? allowedOperatingSystems
+            : allOperatingSystems & ~allowedOperatingSystems;
+        if (operatingSystems == 0)
+        {
+            operatingSystemsExpression = null;
+            return false;
+        }
+
+        operatingSystemsExpression = CreateOperatingSystemsExpression(operatingSystems);
+        return true;
+    }
+
+    private static bool TryGetAllowedOperatingSystems(
+        ImmutableArray<AttributeData> attributes,
+        INamedTypeSymbol supportedOSPlatformAttributeSymbol,
+        INamedTypeSymbol unsupportedOSPlatformAttributeSymbol,
+        out int allowedOperatingSystems,
+        out bool allowsUnknownOperatingSystems)
+    {
+        const int allOperatingSystems = (1 << 4) - 1;
+        var platformAttributes = attributes
+            .Where(attribute => SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
+                || SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, unsupportedOSPlatformAttributeSymbol))
+            .ToImmutableArray();
+        if (platformAttributes.IsEmpty)
+        {
+            allowedOperatingSystems = allOperatingSystems;
+            allowsUnknownOperatingSystems = true;
+            return true;
+        }
+
+        bool includeMode = SymbolEqualityComparer.Default.Equals(
+            platformAttributes[0].AttributeClass,
+            supportedOSPlatformAttributeSymbol);
+        int operatingSystems = 0;
         foreach (AttributeData attribute in platformAttributes)
         {
             if (includeMode != SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, supportedOSPlatformAttributeSymbol)
                 || attribute.ConstructorArguments is not [{ Value: string platformName }]
                 || !TryMapPlatform(platformName, out int operatingSystem))
             {
-                operatingSystemsExpression = null;
+                allowedOperatingSystems = 0;
+                allowsUnknownOperatingSystems = false;
                 return false;
             }
 
             operatingSystems |= operatingSystem;
         }
 
-        operatingSystemsExpression = CreateOperatingSystemsExpression(operatingSystems);
+        allowedOperatingSystems = includeMode
+            ? operatingSystems
+            : allOperatingSystems & ~operatingSystems;
+        allowsUnknownOperatingSystems = !includeMode;
         return true;
     }
 

--- a/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
+++ b/src/Analyzers/MSTest.Analyzers/OSPlatformAttributesShouldBeConsistentAnalyzer.cs
@@ -196,23 +196,37 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
         int expectedAllowedOperatingSystems = includeMode
             ? operatingSystems
             : allOperatingSystems & ~operatingSystems;
+        bool expectedAllowsUnknownOperatingSystems = !includeMode;
 
-        if (!TryGetAllowedOperatingSystems(localAttribute, out int localAllowedOperatingSystems)
-            || !TryGetAllowedOperatingSystems(containingClassAttribute, out int containingClassAllowedOperatingSystems))
+        if (!TryGetAllowedOperatingSystems(
+                localAttribute,
+                out int localAllowedOperatingSystems,
+                out bool localAllowsUnknownOperatingSystems)
+            || !TryGetAllowedOperatingSystems(
+                containingClassAttribute,
+                out int containingClassAllowedOperatingSystems,
+                out bool containingClassAllowsUnknownOperatingSystems))
         {
             return false;
         }
 
         int actualAllowedOperatingSystems = localAllowedOperatingSystems & containingClassAllowedOperatingSystems;
-        return actualAllowedOperatingSystems == expectedAllowedOperatingSystems;
+        bool actualAllowsUnknownOperatingSystems =
+            localAllowsUnknownOperatingSystems && containingClassAllowsUnknownOperatingSystems;
+        return actualAllowedOperatingSystems == expectedAllowedOperatingSystems
+            && actualAllowsUnknownOperatingSystems == expectedAllowsUnknownOperatingSystems;
     }
 
-    private static bool TryGetAllowedOperatingSystems(AttributeData? attribute, out int allowedOperatingSystems)
+    private static bool TryGetAllowedOperatingSystems(
+        AttributeData? attribute,
+        out int allowedOperatingSystems,
+        out bool allowsUnknownOperatingSystems)
     {
         const int allOperatingSystems = (1 << 4) - 1;
         if (attribute is null)
         {
             allowedOperatingSystems = allOperatingSystems;
+            allowsUnknownOperatingSystems = true;
             return true;
         }
 
@@ -221,16 +235,19 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzer : DiagnosticA
         {
             case [{ Value: int operatingSystems }]:
                 allowedOperatingSystems = operatingSystems;
+                allowsUnknownOperatingSystems = false;
                 return true;
 
             case [{ Value: int mode }, { Value: int operatingSystems }]:
                 allowedOperatingSystems = mode == 0
                     ? operatingSystems
                     : allOperatingSystems & ~operatingSystems;
+                allowsUnknownOperatingSystems = mode != 0;
                 return true;
 
             default:
                 allowedOperatingSystems = 0;
+                allowsUnknownOperatingSystems = false;
                 return false;
         }
     }

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -1261,4 +1261,16 @@ The type declaring these methods should also respect the following rules:
     <value>MSTest resolves the inherited lifecycle attributes '[TestInitialize]', '[TestCleanup]', '[ClassInitialize]' and '[ClassCleanup]', and the test attributes '[TestMethod]' and '[DataTestMethod]', by their exact framework type identity. The framework assembly was renamed from 'Microsoft.VisualStudio.TestPlatform.TestFramework' to 'MSTest.TestFramework', so a base class compiled against a different MSTest major exposes these attributes with a different type identity. When such a base is inherited by a test class compiled against another version, the inherited setup and cleanup do not run and inherited test methods are not discovered, with no build error and no discovery error. Recompile the base assembly and, for custom attributes, the assembly that defines the attribute against the same MSTest version as the test project.</value>
     <comment>{Locked="MSTest"}{Locked="'[TestInitialize]'"}{Locked="'[TestCleanup]'"}{Locked="'[ClassInitialize]'"}{Locked="'[ClassCleanup]'"}{Locked="'[TestMethod]'"}{Locked="'[DataTestMethod]'"}{Locked="'Microsoft.VisualStudio.TestPlatform.TestFramework'"}{Locked="'MSTest.TestFramework'"}</comment>
   </data>
+  <data name="OSPlatformAttributesShouldBeConsistentTitle" xml:space="preserve">
+    <value>Platform compatibility attributes should be consistent with '[OSCondition]'</value>
+    <comment>{Locked="[OSCondition]"}</comment>
+  </data>
+  <data name="OSPlatformAttributesShouldBeConsistentMessageFormat" xml:space="preserve">
+    <value>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</value>
+    <comment>{0} is the test method or test class name. {Locked="[OSCondition]"}</comment>
+  </data>
+  <data name="OSPlatformAttributesShouldBeConsistentDescription" xml:space="preserve">
+    <value>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</value>
+    <comment>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</comment>
+  </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/Resources.resx
+++ b/src/Analyzers/MSTest.Analyzers/Resources.resx
@@ -1263,14 +1263,14 @@ The type declaring these methods should also respect the following rules:
   </data>
   <data name="OSPlatformAttributesShouldBeConsistentTitle" xml:space="preserve">
     <value>Platform compatibility attributes should be consistent with '[OSCondition]'</value>
-    <comment>{Locked="[OSCondition]"}</comment>
+    <comment>{Locked="'[OSCondition]'"}</comment>
   </data>
   <data name="OSPlatformAttributesShouldBeConsistentMessageFormat" xml:space="preserve">
     <value>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</value>
-    <comment>{0} is the test method or test class name. {Locked="[OSCondition]"}</comment>
+    <comment>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</comment>
   </data>
   <data name="OSPlatformAttributesShouldBeConsistentDescription" xml:space="preserve">
     <value>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</value>
-    <comment>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</comment>
+    <comment>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</comment>
   </data>
 </root>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -760,6 +760,21 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
         <target state="translated">Neignorovat návratovou hodnotu řetězcových metod</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' explicitně vyjadřuje záměrné selhání a umožňuje ve zprávě o selhání zdokumentovat, proč test nemůže pokračovat.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.cs.xlf
@@ -763,17 +763,17 @@ Typ deklarující tyto metody by měl také respektovat následující pravidla:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -760,6 +760,21 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
         <target state="translated">Rückgabewert von Zeichenfolgenmethoden nicht ignorieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' macht einen absichtlichen Fehler explizit und ermöglicht es, anhand der Fehlermeldung zu dokumentieren, warum der Test nicht fortgesetzt werden kann.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.de.xlf
@@ -763,17 +763,17 @@ Der Typ, der diese Methoden deklariert, sollte auch die folgenden Regeln beachte
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -760,6 +760,21 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
         <target state="translated">No ignore el valor devuelto de los métodos de cadena</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' hace explícito un error intencionado y permite que el mensaje de error documente por qué la prueba no puede continuar.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.es.xlf
@@ -763,17 +763,17 @@ El tipo que declara estos métodos también debe respetar las reglas siguientes:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -760,6 +760,21 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
         <target state="translated">Ne négligez pas la valeur de retour des méthodes de chaîne</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="new">'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.fr.xlf
@@ -763,17 +763,17 @@ Le type déclarant ces méthodes doit également respecter les règles suivantes
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -760,6 +760,21 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
         <target state="translated">Non ignorare il valore restituito dei metodi stringa</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' rende esplicito un errore intenzionale e consente al messaggio di errore di documentare il motivo per cui il test non può continuare.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.it.xlf
@@ -763,17 +763,17 @@ Anche il tipo che dichiara questi metodi deve rispettare le regole seguenti:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -760,6 +760,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">文字列メソッドの戻り値を無視しない</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' は意図的な失敗を明示し、エラー メッセージでテストを続行できない理由を文書化できるようにします。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ja.xlf
@@ -763,17 +763,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -760,6 +760,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">문자열 메서드의 반환 값을 무시하지 마세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail'은 의도적인 실패를 명시적으로 나타내고 실패 메시지가 테스트를 계속할 수 없는 이유를 문서화할 수 있도록 합니다.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ko.xlf
@@ -763,17 +763,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -760,6 +760,21 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
         <target state="translated">Nie ignoruj zwracanej wartości metod ciągu</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' jawnie oznacza celowe niepowodzenie i pozwala komunikatowi o błędzie wyjaśnić, dlaczego test nie może być kontynuowany.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pl.xlf
@@ -763,17 +763,17 @@ Typ deklarujący te metody powinien również przestrzegać następujących regu
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -760,6 +760,21 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
         <target state="translated">Não ignore o valor retornado dos métodos de cadeia de caracteres</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' torna explícita uma falha intencional e permite que a mensagem de falha documente por que o teste não pode continuar.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.pt-BR.xlf
@@ -763,17 +763,17 @@ O tipo que declara esses métodos também deve respeitar as seguintes regras:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -760,6 +760,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">Не игнорируйте возвращаемое значение строковых методов</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' явно указывает на намеренный сбой и позволяет с помощью сообщения о сбое задокументировать, почему невозможно продолжить тест.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.ru.xlf
@@ -763,17 +763,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -760,6 +760,21 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
         <target state="translated">Dize yöntemlerinin dönüş değerini yok saymayın</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail', kasıtlı bir hatayı açıkça belirtir ve hata iletisinin testin neden devam edemediğini belgelemesini sağlar.</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.tr.xlf
@@ -763,17 +763,17 @@ Bu metotları bildiren türün ayrıca aşağıdaki kurallara uyması gerekir:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -760,6 +760,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">不要忽略字符串方法的返回值</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' 可显式化处理有意失败，并允许失败消息记录测试无法继续的原因。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hans.xlf
@@ -763,17 +763,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -760,6 +760,21 @@ The type declaring these methods should also respect the following rules:
         <target state="translated">請勿忽略字串方法的傳回值</target>
         <note />
       </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
+        <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
+        <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
+        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
+        <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
+        <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
+        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+      </trans-unit>
+      <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
+        <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
+        <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
+        <note>{Locked="[OSCondition]"}</note>
+      </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>
         <target state="translated">'Assert.Fail' 可明確表示刻意失敗，並讓失敗訊息說明測試為何無法繼續。</target>

--- a/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
+++ b/src/Analyzers/MSTest.Analyzers/xlf/Resources.zh-Hant.xlf
@@ -763,17 +763,17 @@ The type declaring these methods should also respect the following rules:
       <trans-unit id="OSPlatformAttributesShouldBeConsistentDescription">
         <source>'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</source>
         <target state="new">'SupportedOSPlatformAttribute' and 'UnsupportedOSPlatformAttribute' inform platform compatibility analysis but do not control MSTest execution. Test methods and test classes that use these attributes should also declare an equivalent '[OSCondition]' so unsupported tests are skipped at run time.</target>
-        <note>{Locked="SupportedOSPlatformAttribute"}{Locked="UnsupportedOSPlatformAttribute"}{Locked="MSTest"}{Locked="[OSCondition]"}</note>
+        <note>{Locked="'SupportedOSPlatformAttribute'"}{Locked="'UnsupportedOSPlatformAttribute'"}{Locked="MSTest"}{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentMessageFormat">
         <source>Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</source>
         <target state="new">Platform compatibility attributes on test '{0}' are not represented by an equivalent '[OSCondition]' attribute</target>
-        <note>{0} is the test method or test class name. {Locked="[OSCondition]"}</note>
+        <note>{0} is the test method or test class name. {Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="OSPlatformAttributesShouldBeConsistentTitle">
         <source>Platform compatibility attributes should be consistent with '[OSCondition]'</source>
         <target state="new">Platform compatibility attributes should be consistent with '[OSCondition]'</target>
-        <note>{Locked="[OSCondition]"}</note>
+        <note>{Locked="'[OSCondition]'"}</note>
       </trans-unit>
       <trans-unit id="PreferAssertFailOverAlwaysFalseConditionsDescription">
         <source>'Assert.Fail' makes an intentional failure explicit and allows the failure message to document why the test cannot continue.</source>

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -1,0 +1,420 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+
+using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
+    MSTest.Analyzers.OSPlatformAttributesShouldBeConsistentAnalyzer,
+    MSTest.Analyzers.OSPlatformAttributesShouldBeConsistentFixer>;
+using VerifyVB = MSTest.Analyzers.Test.VisualBasicCodeFixVerifier<
+    MSTest.Analyzers.OSPlatformAttributesShouldBeConsistentAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+namespace MSTest.Analyzers.Test;
+
+[TestClass]
+public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
+{
+    [TestMethod]
+    public async Task WhenSupportedPlatformHasNoOSCondition_AddsIncludeCondition()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("linux")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("linux")]
+                [OSCondition(OperatingSystems.Linux)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenUnsupportedPlatformsHaveNoOSCondition_AddsCombinedExcludeCondition()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [{|#0:UnsupportedOSPlatform("windows")|}]
+            [UnsupportedOSPlatform("OSX")]
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [UnsupportedOSPlatform("windows")]
+            [UnsupportedOSPlatform("OSX")]
+            [TestClass]
+            [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX | OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenOSConditionIsEquivalent_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("macos")]
+            [SupportedOSPlatform("linux")]
+            [TestClass]
+            [OSCondition(OperatingSystems.Linux | OperatingSystems.OSX)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenOSConditionIsInconsistent_UpdatesCondition()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows")|}]
+                [OSCondition(OperatingSystems.Linux)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("windows")]
+                [OSCondition(OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenOSConditionIsInconsistent_PreservesNamedArguments()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows")|}]
+                [OSCondition(OperatingSystems.Linux, IgnoreMessage = "Requires Windows")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("windows")]
+                [OSCondition(OperatingSystems.Windows, IgnoreMessage = "Requires Windows")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenOSConditionIsOnAnotherPartialDeclaration_UpdatesItsDocument()
+    {
+        var test = new VerifyCS.Test
+        {
+            TestState =
+            {
+                Sources =
+                {
+                    """
+                    using System.Runtime.Versioning;
+                    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                    [{|#0:SupportedOSPlatform("windows")|}]
+                    [TestClass]
+                    public partial class MyTestClass
+                    {
+                    }
+                    """,
+                    """
+                    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                    [OSCondition(OperatingSystems.Linux)]
+                    public partial class MyTestClass
+                    {
+                    }
+                    """,
+                },
+                ExpectedDiagnostics =
+                {
+                    VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
+                },
+            },
+            FixedState =
+            {
+                Sources =
+                {
+                    """
+                    using System.Runtime.Versioning;
+                    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                    [SupportedOSPlatform("windows")]
+                    [TestClass]
+                    public partial class MyTestClass
+                    {
+                    }
+                    """,
+                    """
+                    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+                    [OSCondition(OperatingSystems.Windows)]
+                    public partial class MyTestClass
+                    {
+                    }
+                    """,
+                },
+            },
+        };
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenExistingOSConditionConstructorIsMalformed_UpdatesAttributeWithoutDuplicatingIt()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows")|}]
+                [OSCondition]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("windows")]
+                [OSCondition(OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            TestCode = code,
+            FixedCode = fixedCode,
+            CompilerDiagnostics = CompilerDiagnostics.None,
+        };
+        test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task WhenDiagnosticHasNoSafeFix_DoesNotRegisterCodeFix()
+    {
+        using var workspace = new AdhocWorkspace();
+        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        Document document = workspace.AddDocument(project.Id, "Test.cs", SourceText.From("class TestClass { }"));
+        SyntaxTree syntaxTree = (await document.GetSyntaxTreeAsync())!;
+        var diagnostic = Diagnostic.Create(
+            new OSPlatformAttributesShouldBeConsistentAnalyzer().SupportedDiagnostics[0],
+            Location.Create(syntaxTree!, new TextSpan(0, 0)),
+            "TestClass");
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await new OSPlatformAttributesShouldBeConsistentFixer().RegisterCodeFixesAsync(context);
+
+        Assert.HasCount(0, actions);
+    }
+
+    [TestMethod]
+    public async Task WhenPlatformsUseMixedModes_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("linux")|}]
+                [UnsupportedOSPlatform("windows")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenPlatformHasVersion_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows10.0")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+    }
+
+    [TestMethod]
+    public async Task WhenPlatformAttributeIsOnNonTest_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+
+            [SupportedOSPlatform("linux")]
+            public class MyClass
+            {
+                [UnsupportedOSPlatform("windows")]
+                public void Method()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenSupportedPlatformHasNoOSConditionInVisualBasic_Diagnostic()
+    {
+        string code = """
+            Imports System.Runtime.Versioning
+            Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+            <TestClass>
+            Public Class MyTestClass
+                <TestMethod>
+                <[|SupportedOSPlatform("linux")|]>
+                Public Sub TestMethod()
+                End Sub
+            End Class
+            """;
+
+        await VerifyVB.VerifyAnalyzerAsync(code);
+    }
+}

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -49,8 +49,6 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             }
             """;
 
-        // The outer Windows-only scope and Linux-only method have an empty effective platform set, so the
-        // analyzer reports the inconsistency without registering an OSCondition code fix.
         await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
@@ -331,7 +329,38 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenAssemblyCompatibilityConstrainsMethod_FixUsesEffectivePlatforms()
+    public async Task WhenOuterTypeCompatibilityConflictsWithNestedMethod_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            public class OuterClass
+            {
+                [TestClass]
+                [OSCondition(OperatingSystems.Windows)]
+                public class MyTestClass
+                {
+                    [TestMethod]
+                    [{|#0:SupportedOSPlatform("linux")|}]
+                    public void TestMethod()
+                    {
+                    }
+                }
+            }
+            """;
+
+        // The outer Windows-only scope and Linux-only method have an empty effective platform set, so the
+        // analyzer reports the inconsistency without registering an OSCondition code fix.
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssemblyOnlyRestrictsTestClass_AddsEffectiveCondition()
     {
         string code = """
             using System.Runtime.Versioning;
@@ -340,10 +369,9 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             [assembly: SupportedOSPlatform("windows")]
 
             [TestClass]
-            public class MyTestClass
+            public class {|#0:MyTestClass|}
             {
                 [TestMethod]
-                [{|#0:UnsupportedOSPlatform("linux")|}]
                 public void TestMethod()
                 {
                 }
@@ -357,11 +385,10 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             [assembly: SupportedOSPlatform("windows")]
 
             [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
             public class MyTestClass
             {
                 [TestMethod]
-                [UnsupportedOSPlatform("linux")]
-                [OSCondition(OperatingSystems.Windows)]
                 public void TestMethod()
                 {
                 }
@@ -370,12 +397,12 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
             fixedCode);
     }
 
     [TestMethod]
-    public async Task WhenOuterTypeCompatibilityConflictsWithNestedMethod_DiagnosticWithoutFix()
+    public async Task WhenOuterTypeOnlyRestrictsNestedTestClass_AddsEffectiveCondition()
     {
         string code = """
             using System.Runtime.Versioning;
@@ -385,10 +412,28 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             public class OuterClass
             {
                 [TestClass]
+                public class {|#0:MyTestClass|}
+                {
+                    [TestMethod]
+                    public void TestMethod()
+                    {
+                    }
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            public class OuterClass
+            {
+                [TestClass]
+                [OSCondition(OperatingSystems.Windows)]
                 public class MyTestClass
                 {
                     [TestMethod]
-                    [{|#0:SupportedOSPlatform("linux")|}]
                     public void TestMethod()
                     {
                     }
@@ -398,8 +443,8 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
 
         await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
-            code);
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
+            fixedCode);
     }
 
     [TestMethod]

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -136,6 +136,46 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenExplicitIncludeOSConditionIsEquivalent_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            [TestClass]
+            [OSCondition(ConditionMode.Include, OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenContainingClassOSConditionIsEquivalentToMethodPlatform_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("windows")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
     public async Task WhenOSConditionIsInconsistent_UpdatesCondition()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -117,6 +117,25 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenExcludeOSConditionIsEquivalent_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [UnsupportedOSPlatform("windows")]
+            [UnsupportedOSPlatform("linux")]
+            [TestClass]
+            [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux | OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
     public async Task WhenOSConditionIsInconsistent_UpdatesCondition()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -194,6 +194,72 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenUnsupportedPlatformUsesComplementaryIncludeCondition_UpdatesToExcludeMode()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [{|#0:UnsupportedOSPlatform("windows")|}]
+            [TestClass]
+            [OSCondition(OperatingSystems.Linux | OperatingSystems.OSX | OperatingSystems.FreeBSD)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [UnsupportedOSPlatform("windows")]
+            [TestClass]
+            [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
+            fixedCode);
+    }
+
+    [TestMethod]
+    public async Task WhenSupportedPlatformUsesComplementaryExcludeCondition_UpdatesToIncludeMode()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [{|#0:SupportedOSPlatform("windows")|}]
+            [TestClass]
+            [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux | OperatingSystems.OSX | OperatingSystems.FreeBSD)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("MyTestClass"),
+            fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenContainingClassOSConditionIsEquivalentToMethodPlatform_NoDiagnostic()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -821,4 +821,26 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             code,
             VerifyVB.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
     }
+
+    [TestMethod]
+    public async Task WhenOSConditionIsInconsistentInVisualBasic_Diagnostic()
+    {
+        string code = """
+            Imports System.Runtime.Versioning
+            Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+            <TestClass>
+            Public Class MyTestClass
+                <TestMethod>
+                <{|#0:SupportedOSPlatform("windows")|}>
+                <OSCondition(OperatingSystems.Linux)>
+                Public Sub TestMethod()
+                End Sub
+            End Class
+            """;
+
+        await VerifyVB.VerifyAnalyzerAsync(
+            code,
+            VerifyVB.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+    }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -49,6 +49,8 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             }
             """;
 
+        // The outer Windows-only scope and Linux-only method have an empty effective platform set, so the
+        // analyzer reports the inconsistency without registering an OSCondition code fix.
         await VerifyCS.VerifyCodeFixAsync(
             code,
             VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -176,6 +176,80 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenContainingClassOSConditionConflictsWithMethodPlatform_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [OSCondition(OperatingSystems.Linux)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodAndClassOSConditionsConflict_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [OSCondition(OperatingSystems.Linux)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("windows")|}]
+                [OSCondition(OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenMethodAndClassOSConditionsComposeToExpectedPlatform_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("windows")]
+                [OSCondition(OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
     public async Task WhenOSConditionIsInconsistent_UpdatesCondition()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -282,6 +282,97 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenContainingClassCompatibilityAndConditionConstrainMethod_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [UnsupportedOSPlatform("linux")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssemblyCompatibilityAndClassConditionConstrainMethod_NoDiagnostic()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: SupportedOSPlatform("windows")]
+
+            [TestClass]
+            [OSCondition(OperatingSystems.Windows)]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [UnsupportedOSPlatform("linux")]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(code, code);
+    }
+
+    [TestMethod]
+    public async Task WhenAssemblyCompatibilityConstrainsMethod_FixUsesEffectivePlatforms()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: SupportedOSPlatform("windows")]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:UnsupportedOSPlatform("linux")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [assembly: SupportedOSPlatform("windows")]
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [UnsupportedOSPlatform("linux")]
+                [OSCondition(OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenContainingClassOSConditionConflictsWithMethodPlatform_DiagnosticWithoutFix()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -56,6 +56,46 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenFreeBSDSupportedPlatformHasNoOSCondition_AddsIncludeCondition()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("freebsd")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [SupportedOSPlatform("freebsd")]
+                [OSCondition(OperatingSystems.FreeBSD)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            fixedCode);
+    }
+
+    [TestMethod]
     public async Task WhenUnsupportedPlatformsHaveNoOSCondition_AddsCombinedExcludeCondition()
     {
         string code = """

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 
 using VerifyCS = MSTest.Analyzers.Test.CSharpCodeFixVerifier<
     MSTest.Analyzers.OSPlatformAttributesShouldBeConsistentAnalyzer,
@@ -311,29 +307,6 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
-    public async Task WhenDiagnosticHasNoSafeFix_DoesNotRegisterCodeFix()
-    {
-        using var workspace = new AdhocWorkspace();
-        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp);
-        Document document = workspace.AddDocument(project.Id, "Test.cs", SourceText.From("class TestClass { }"));
-        SyntaxTree syntaxTree = (await document.GetSyntaxTreeAsync())!;
-        var diagnostic = Diagnostic.Create(
-            new OSPlatformAttributesShouldBeConsistentAnalyzer().SupportedDiagnostics[0],
-            Location.Create(syntaxTree!, new TextSpan(0, 0)),
-            "TestClass");
-        var actions = new List<CodeAction>();
-        var context = new CodeFixContext(
-            document,
-            diagnostic,
-            (action, _) => actions.Add(action),
-            CancellationToken.None);
-
-        await new OSPlatformAttributesShouldBeConsistentFixer().RegisterCodeFixesAsync(context);
-
-        Assert.HasCount(0, actions);
-    }
-
-    [TestMethod]
     public async Task WhenPlatformsUseMixedModes_DiagnosticWithoutFix()
     {
         string code = """
@@ -352,9 +325,10 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
     }
 
     [TestMethod]
@@ -375,9 +349,34 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             }
             """;
 
-        await VerifyCS.VerifyAnalyzerAsync(
+        await VerifyCS.VerifyCodeFixAsync(
             code,
-            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenPlatformIsNotSupportedByOSCondition_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:SupportedOSPlatform("android")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
     }
 
     [TestMethod]
@@ -409,12 +408,14 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
             <TestClass>
             Public Class MyTestClass
                 <TestMethod>
-                <[|SupportedOSPlatform("linux")|]>
+                <{|#0:SupportedOSPlatform("linux")|}>
                 Public Sub TestMethod()
                 End Sub
             End Class
             """;
 
-        await VerifyVB.VerifyAnalyzerAsync(code);
+        await VerifyVB.VerifyAnalyzerAsync(
+            code,
+            VerifyVB.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
     }
 }

--- a/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
+++ b/test/UnitTests/MSTest.Analyzers.UnitTests/OSPlatformAttributesShouldBeConsistentAnalyzerTests.cs
@@ -373,6 +373,79 @@ public sealed class OSPlatformAttributesShouldBeConsistentAnalyzerTests
     }
 
     [TestMethod]
+    public async Task WhenOuterTypeCompatibilityConflictsWithNestedMethod_DiagnosticWithoutFix()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [SupportedOSPlatform("windows")]
+            public class OuterClass
+            {
+                [TestClass]
+                public class MyTestClass
+                {
+                    [TestMethod]
+                    [{|#0:SupportedOSPlatform("linux")|}]
+                    public void TestMethod()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            code,
+            VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"),
+            code);
+    }
+
+    [TestMethod]
+    public async Task WhenUnsupportedPlatformHasMessage_AddsExcludeCondition()
+    {
+        string code = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [{|#0:UnsupportedOSPlatform("windows", "Not supported on Windows")|}]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        string fixedCode = """
+            using System.Runtime.Versioning;
+            using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+            [TestClass]
+            public class MyTestClass
+            {
+                [TestMethod]
+                [UnsupportedOSPlatform("windows", "Not supported on Windows")]
+                [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
+                public void TestMethod()
+                {
+                }
+            }
+            """;
+
+        var test = new VerifyCS.Test
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net100,
+            TestCode = code,
+            FixedCode = fixedCode,
+        };
+        test.ExpectedDiagnostics.Add(VerifyCS.Diagnostic().WithLocation(0).WithArguments("TestMethod"));
+
+        await test.RunAsync();
+    }
+
+    [TestMethod]
     public async Task WhenContainingClassOSConditionConflictsWithMethodPlatform_DiagnosticWithoutFix()
     {
         string code = """


### PR DESCRIPTION
## Summary

- add MSTEST0084 to detect missing or inconsistent `OSCondition` attributes on tests using `SupportedOSPlatformAttribute` or `UnsupportedOSPlatformAttribute`
- add a safe C# code fix that combines same-mode platforms, preserves named arguments, and updates conditions across partial declarations
- avoid code fixes when mixed modes, platform versions, or unsupported platform names cannot be represented exactly
- add C# and Visual Basic analyzer coverage and regenerate localized resources

## Testing

- analyzer unit test project builds with 0 warnings
- 12 focused MSTEST0084 tests pass on `net8.0` and `net472`
- all 1,820 analyzer unit tests pass on `net8.0`

Fixes #11018