### PR TITLE
Use the official Windows CodeQL identifier in the nightly pipeline

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -13,6 +13,10 @@ variables:
   # Force CodeQL enabled so it may be run on any branch
 - name: Codeql.Enabled
   value: true
+  # This must stay in sync with the identifier generated for the official Windows job.
+  # Otherwise CodeQL tracks separate cadences and the official build is traced again.
+- name: Codeql.BuildIdentifier
+  value: build_Windows
   # Do not let CodeQL 3000 Extension gate scan frequency
 - name: Codeql.Cadence
   value: 0

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -125,7 +125,16 @@ extends:
           jobs:
           - job: Windows
             enablePublishing: true
-            timeoutInMinutes: 90
+            # An ordinary run fits in 90 minutes with room to spare: Build takes 19-21 minutes and Test
+            # about 28. Every 72 hours 1ES CodeQL takes its turn (see the Codeql.Cadence note above) and
+            # traces the compiler, which inflates Build to 50-57 minutes even though it still succeeds with
+            # zero errors. The job then needs about 95 minutes and is killed mid-Test with "Job cancelled
+            # due to worker timeout.", which is what happened to
+            # https://dev.azure.com/dnceng/internal/_build/results?buildId=3068335 and
+            # https://dev.azure.com/dnceng/internal/_build/results?buildId=3065040. 120 leaves headroom for
+            # the traced run and is already used elsewhere in this pipeline (the post-build stage declares
+            # 120 for Publish Using Darc and 150 for publish-build-assets).
+            timeoutInMinutes: 120
             pool:
               name: $(DncEngInternalBuildPool)
               image: windows.vs2026preview.scout.amd64

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -125,16 +125,7 @@ extends:
           jobs:
           - job: Windows
             enablePublishing: true
-            # An ordinary run fits in 90 minutes with room to spare: Build takes 19-21 minutes and Test
-            # about 28. Every 72 hours 1ES CodeQL takes its turn (see the Codeql.Cadence note above) and
-            # traces the compiler, which inflates Build to 50-57 minutes even though it still succeeds with
-            # zero errors. The job then needs about 95 minutes and is killed mid-Test with "Job cancelled
-            # due to worker timeout.", which is what happened to
-            # https://dev.azure.com/dnceng/internal/_build/results?buildId=3068335 and
-            # https://dev.azure.com/dnceng/internal/_build/results?buildId=3065040. 120 leaves headroom for
-            # the traced run and is already used elsewhere in this pipeline (the post-build stage declares
-            # 120 for Publish Using Darc and 150 for publish-build-assets).
-            timeoutInMinutes: 120
+            timeoutInMinutes: 90
             pool:
               name: $(DncEngInternalBuildPool)
               image: windows.vs2026preview.scout.amd64


### PR DESCRIPTION
## Summary

Set `Codeql.BuildIdentifier` to `build_Windows` in the nightly CodeQL pipeline and document that this value must stay synchronized with the identifier generated for the official Windows job.

## Why

The nightly pipeline is intended to refresh the CodeQL database before daytime official builds. However, the nightly and official Windows jobs were using different identifiers, so CodeQL tracked their cadence independently. The official pipeline could therefore start another traced C# build even after the nightly pipeline had uploaded a recent database.

Nightly build 3067789 successfully finalized and uploaded its C# database. Official build 3068335 did not recognize that database under its `build_Windows` identifier and traced the build again, eventually exceeding the job timeout.

The C# initialization message in nightly build 3068255 is a duplicate-request rejection for a commit already analyzed by build 3067789; it is not the cause of the missing cadence sharing.

## Validation

The next nightly run should report `BuildIdentifier = build_Windows`. An official Windows run within the cadence window should then reuse that cadence state and skip C# tracing.