### PR TITLE
Fix flaky in-process disposal timing test

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpJsonRpcConnection.cs
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpJsonRpcConnection.cs
@@ -50,6 +50,9 @@ internal sealed class MtpJsonRpcConnection : IDisposable
         _logger = logger ?? NullMtpClientLogger.Instance;
     }
 
+    internal bool IsOnReadLoopFlow
+        => _onReadLoopFlow.Value;
+
     /// <summary>
     /// Raised for every server-to-client notification. The handler receives the method name and the raw
     /// params payload (an <c>IDictionary&lt;string, object?&gt;</c> or <see langword="null"/>); the client API
@@ -321,6 +324,9 @@ internal sealed class MtpJsonRpcConnection : IDisposable
         => (id, stringId is not null);
 
     public void Dispose()
+        => Dispose(waitForReadLoop: true);
+
+    internal void Dispose(bool waitForReadLoop)
     {
         Task? readLoop;
         lock (_startLock)
@@ -355,7 +361,7 @@ internal sealed class MtpJsonRpcConnection : IDisposable
         // surface spurious ObjectDisposedExceptions (one thrown out of the write lock's finally block).
         // Guard against waiting on ourselves in case Dispose runs from a notification / server-request
         // handler executing on the read-loop flow (see _onReadLoopFlow).
-        if (readLoop is not null && !_onReadLoopFlow.Value)
+        if (waitForReadLoop && readLoop is not null && !_onReadLoopFlow.Value)
         {
             try
             {

--- a/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpServerInProcessHost.cs
+++ b/src/Platform/Microsoft.Testing.Platform.ServerMode.Client.Sources/Client/MtpServerInProcessHost.cs
@@ -33,6 +33,7 @@ internal sealed class MtpServerInProcessHost : IMtpServerHost
     private readonly object _shutdownLock = new();
 
     private Task? _shutdown;
+    private int _skipConnectionReadLoopWait;
 
     /// <summary>
     /// The exit code captured during teardown, boxed so reads and writes are atomic on every target platform.
@@ -221,7 +222,7 @@ internal sealed class MtpServerInProcessHost : IMtpServerHost
 #pragma warning disable VSTHRD002 // Synchronously waiting on tasks - this IS the synchronous disposal path; ShutdownAsync is the awaitable one.
         try
         {
-            StartShutdownAsync().GetAwaiter().GetResult();
+            StartShutdownAsync(Connection.IsOnReadLoopFlow).GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {
@@ -245,14 +246,18 @@ internal sealed class MtpServerInProcessHost : IMtpServerHost
     /// caller receives the same task, <see cref="Dispose"/> and <see cref="ShutdownAsync"/> are idempotent
     /// with respect to each other and to themselves.
     /// <para>
-    /// <see cref="Task.Run(Func{Task})"/> captures the ambient execution context, so the connection's
-    /// read-loop <see cref="AsyncLocal{T}"/> marker still flows into the teardown. Disposing from inside a
-    /// notification handler therefore continues to skip the connection's read-loop self-wait instead of
-    /// stalling for its shutdown timeout.
+    /// When disposal starts from a notification handler, the read-loop context is captured before the
+    /// teardown is scheduled and passed explicitly to the connection. This avoids relying on execution-context
+    /// flow across the thread-pool hop to decide whether the connection may wait for its own read loop.
     /// </para>
     /// </remarks>
-    private Task StartShutdownAsync()
+    private Task StartShutdownAsync(bool skipConnectionReadLoopWait = false)
     {
+        if (skipConnectionReadLoopWait)
+        {
+            Volatile.Write(ref _skipConnectionReadLoopWait, 1);
+        }
+
         lock (_shutdownLock)
         {
             return _shutdown ??= Task.Run(ShutdownCoreAsync);
@@ -272,7 +277,7 @@ internal sealed class MtpServerInProcessHost : IMtpServerHost
             // Close the transport first. A server-mode application exits its message loop when the client's
             // connection reaches EOF, so this is the graceful stop signal even for a callback that ignores the
             // cancellation token (the common case: TestApplication.RunAsync takes none).
-            Connection.Dispose();
+            Connection.Dispose(waitForReadLoop: Volatile.Read(ref _skipConnectionReadLoopWait) == 0);
             SafeDispose(_client, _logger, "Disposing the accepted client socket");
             MtpServerConnector.SafeStop(_listener, _logger);
 

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/TestHostProcessLifetimeHandlerTests.cs
@@ -86,7 +86,10 @@ public sealed class TestHostProcessLifetimeHandlerTests : AcceptanceTestBase<Tes
                 ["BLOCK_UNTIL_TIMEOUT"] = "1",
                 ["BLOCK_DISPOSAL"] = "1",
                 ["DISPOSAL_ATTEMPTS_FILE"] = disposalAttemptsFile,
-                ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "0.5",
+                // Leave enough room for the canceled-run cleanup to enter Dispose before its bounded wait
+                // expires. The handler then blocks for 10s, so the test still verifies that cleanup abandons it
+                // within the five-second assertion budget and never retries disposal.
+                ["TESTINGPLATFORM_TESTHOSTCONTROLLER_FINALIZATION_TIMEOUT_SECONDS"] = "2",
                 ["SKIP_FIXED_LIFECYCLE_FILES"] = "1",
             },
             cancellationToken: TestContext.CancellationToken);


### PR DESCRIPTION
The in-process server-mode client could still wait on its read loop after disposal was initiated from a notification handler. The teardown is scheduled on the thread pool, so relying on AsyncLocal context flow made this path sensitive to execution-context handoff and caused recurring Windows Release timing failures.

Capture the read-loop reentrancy state before scheduling teardown and pass it explicitly to the connection, so only handler-initiated disposal skips the self-wait while normal disposal retains its bounded wait.

Validation:
- Targeted Release build passed.
- All 79 net8.0 tests in Microsoft.Testing.Platform.ServerMode.Client.Sources.UnitTests passed.
- The previously flaky disposal test passed 20 consecutive runs.