### PR TITLE
Optimize HTML report test identity merging

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.HtmlReport/HtmlReportMerger.cs
@@ -191,9 +191,12 @@ internal static class HtmlReportMerger
     private static (JsonArray Tests, int Passed, int Failed, int Skipped, int TimedOut, int Errored, int? Flaky) ConcatenateTests(
         MergedTest[] orderedTests)
     {
+        string[] identities = new string[orderedTests.Length];
         var countByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (string identity in orderedTests.Select(CreateTestIdentity))
+        for (int i = 0; i < orderedTests.Length; i++)
         {
+            string identity = CreateTestIdentity(orderedTests[i]);
+            identities[i] = identity;
             countByIdentity[identity] = countByIdentity.TryGetValue(identity, out int existing) ? existing + 1 : 1;
         }
 
@@ -208,7 +211,7 @@ internal static class HtmlReportMerger
         {
             MergedTest mergedTest = orderedTests[i];
             JsonObject test = mergedTest.Test;
-            string identity = CreateTestIdentity(mergedTest);
+            string identity = identities[i];
             string outcome = ReadRequiredString(test, "outcome");
             _ = ReadRequiredDouble(test, "durationMs");
 


### PR DESCRIPTION
## Summary
- Cache each test identity during `HtmlReportMerger.ConcatenateTests` counting.
- Reuse the cached identities during emission to avoid duplicate `CreateTestIdentity` and `string.Join` work.

## Validation
- `.dotnet\dotnet.exe build test\UnitTests\Microsoft.Testing.Extensions.UnitTests -c Debug /bl:artifacts\bin\HtmlReportIssue11056.build.binlog`
- `HtmlReportEngineTests`: 37 passed, 0 failed
- Three focused code review passes: no actionable findings

Fixes #11056