### PR TITLE
Update platform terminal vendored baseline

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -228,8 +228,8 @@
           "repo": "dotnet/msbuild",
           "ref": "main",
           "path": "src/Framework/NativeMethods.cs",
-          "baseline_ref_sha": "5d4dd79d0ffc1b827c1c6baa9dee0a0c475fe79c",
-          "baseline_blob_sha": "a62b415fd2be6de86ee2d23aa35dc591050dfe95",
+          "baseline_ref_sha": "fcb368d8894f6448382f20304c659f383d210f61",
+          "baseline_blob_sha": "57b65e7302795a75fb72756f72353521f15b1d3b",
           "scope": "QueryIsScreenAndTryEnableAnsiColorCodes and supporting console-mode P/Invokes"
         }
       ]


### PR DESCRIPTION
## Why

The vendored-source drift automation detected that `dotnet/msbuild` changed `src/Framework/NativeMethods.cs` after the baseline recorded for `platform-terminal-native-methods`.

The upstream diff was reviewed against the scope copied into TestFX. It only removes MSBuild's `GetFullPath` helper and adds a POSIX `RealPath` helper. Those helpers are not vendored here: TestFX only tracks `QueryIsScreenAndTryEnableAnsiColorCodes` and its supporting console-mode P/Invokes.

## What changed

This PR updates the `platform-terminal-native-methods` entry in `eng/vendored-files.json`:

- `baseline_ref_sha`: `5d4dd79d0ffc1b827c1c6baa9dee0a0c475fe79c` -> `fcb368d8894f6448382f20304c659f383d210f61`
- `baseline_blob_sha`: `a62b415fd2be6de86ee2d23aa35dc591050dfe95` -> `57b65e7302795a75fb72756f72353521f15b1d3b`

No change is made to `src/Platform/Microsoft.Testing.Platform/OutputDevice/Terminal/NativeMethods.cs` because the upstream console detection method and supporting P/Invokes did not change. The manifest update records that the drift was reviewed and prevents the automation from reporting the same out-of-scope upstream changes again.

Fixes: #10075