### PR TITLE
Make whitespace string diff markers visible

### DIFF
--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.Rendering.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.Rendering.cs
@@ -33,7 +33,7 @@ public sealed partial class Assert
     }
 
     private static string RenderMismatchFragment(StringTokenWindow window)
-        => $"[[{RenderMismatch(window)}]]";
+        => $"[[{RenderMismatch(window, makeWhitespaceVisible: true)}]]";
 
     private static StringPreview CreatePreview(StringTokenWindow window, bool useInlineMarker)
     {
@@ -183,9 +183,7 @@ public sealed partial class Assert
 
         if (makeWhitespaceVisible && IsWhitespaceOnly(window.Value, mismatch))
         {
-            return mismatch.Length == 1
-                ? "<space>"
-                : $"<{mismatch.Length} spaces>";
+            return RenderWhitespaceMismatch(window.Value, mismatch);
         }
 
         StringBuilder builder = new(mismatch.RenderedLength);
@@ -195,15 +193,90 @@ public sealed partial class Assert
 
     private static bool IsWhitespaceOnly(string value, StringToken token)
     {
-        for (int i = token.Start; i < token.End; i++)
+        for (int i = token.Start; i < token.End;)
         {
-            if (!char.IsWhiteSpace(value[i]))
+            ScalarInfo scalar = GetScalar(value, i);
+            if (scalar.Value > char.MaxValue || !char.IsWhiteSpace((char)scalar.Value))
             {
                 return false;
             }
+
+            i += scalar.Length;
         }
 
         return true;
+    }
+
+    private static bool IsMismatchSuitableForCaret(StringTokenWindow window)
+    {
+        if (window.Mismatch is not StringToken mismatch || !IsWhitespaceOnly(window.Value, mismatch))
+        {
+            return true;
+        }
+
+        for (int i = mismatch.Start; i < mismatch.End;)
+        {
+            ScalarInfo scalar = GetScalar(window.Value, i);
+            if (scalar.Value is not ('\t' or '\n' or '\r'))
+            {
+                return false;
+            }
+
+            i += scalar.Length;
+        }
+
+        return true;
+    }
+
+    private static string RenderWhitespaceMismatch(string value, StringToken token)
+    {
+        int spaceCount = 0;
+        StringBuilder builder = new();
+        for (int i = token.Start; i < token.End;)
+        {
+            ScalarInfo scalar = GetScalar(value, i);
+            if (scalar.Value == ' ')
+            {
+                spaceCount++;
+            }
+            else
+            {
+                switch (scalar.Value)
+                {
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    default:
+                        builder.Append("\\u");
+                        builder.Append(scalar.Value.ToString("X4", CultureInfo.InvariantCulture));
+                        break;
+                }
+            }
+
+            i += scalar.Length;
+        }
+
+        if (spaceCount > 0)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Insert(0, $"{spaceCount} space(s) ");
+            }
+            else
+            {
+                return spaceCount == 1
+                    ? "<space>"
+                    : $"<{spaceCount} spaces>";
+            }
+        }
+
+        return builder.ToString();
     }
 
     private static StringTokenWindow CreateTokenWindow(string value, int mismatchIndex)

--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.Rendering.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.Rendering.cs
@@ -37,7 +37,7 @@ public sealed partial class Assert
 
     private static StringPreview CreatePreview(StringTokenWindow window, bool useInlineMarker)
     {
-        string mismatch = RenderMismatch(window);
+        string mismatch = RenderMismatch(window, makeWhitespaceVisible: useInlineMarker);
         if (useInlineMarker)
         {
             mismatch = $"[[{mismatch}]]";
@@ -169,7 +169,7 @@ public sealed partial class Assert
         return lastIncludedIndex < window.Value.Length;
     }
 
-    private static string RenderMismatch(StringTokenWindow window)
+    private static string RenderMismatch(StringTokenWindow window, bool makeWhitespaceVisible = false)
     {
         if (window.Mismatch is not StringToken mismatch)
         {
@@ -181,9 +181,29 @@ public sealed partial class Assert
             return "<text element>";
         }
 
+        if (makeWhitespaceVisible && IsWhitespaceOnly(window.Value, mismatch))
+        {
+            return mismatch.Length == 1
+                ? "<space>"
+                : $"<{mismatch.Length} spaces>";
+        }
+
         StringBuilder builder = new(mismatch.RenderedLength);
         AppendEscapedToken(builder, window.Value, mismatch);
         return builder.ToString();
+    }
+
+    private static bool IsWhitespaceOnly(string value, StringToken token)
+    {
+        for (int i = token.Start; i < token.End; i++)
+        {
+            if (!char.IsWhiteSpace(value[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static StringTokenWindow CreateTokenWindow(string value, int mismatchIndex)

--- a/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
+++ b/src/TestFramework/TestFramework/Assertions/Assert.StringDifference.cs
@@ -117,6 +117,8 @@ public sealed partial class Assert
                 && !actualWindow.MismatchRequiresPlaceholder
                 && expectedWindow.IsRetainedPrefixSafe
                 && actualWindow.IsRetainedPrefixSafe
+                && IsMismatchSuitableForCaret(expectedWindow)
+                && IsMismatchSuitableForCaret(actualWindow)
                 && expectedPrefixLength == actualPrefixLength;
 
             string differenceText = useCaret
@@ -133,6 +135,8 @@ public sealed partial class Assert
             && !actualWindow.MismatchRequiresPlaceholder
             && expectedPreview.IsPrefixSafe
             && actualPreview.IsPrefixSafe
+            && IsMismatchSuitableForCaret(expectedWindow)
+            && IsMismatchSuitableForCaret(actualWindow)
             && expectedPreview.MismatchColumn == actualPreview.MismatchColumn;
 
         if (previewUsesCaret)

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -2059,6 +2059,28 @@ public partial class AssertTests : TestContainer
         }
     }
 
+    public void AreEqualStringDifferenceWhitespaceInLongValueUsesVisibleInlineMarkers()
+    {
+        string expected = """
+                       Assertion failed. Expected strings to be equal.
+
+                       expected: "Entity should not be null.'"
+                       actual:   "Entity should not be null."
+                       """;
+        string actual = """
+                     Assertion failed. Expected strings to be equal.
+
+                     expected:    "Entity should not be null.'"
+                     actual:      "Entity should not be null."
+                     """;
+
+        AssertFailedException exception = CaptureAreEqualFailure(() => Assert.AreEqual(expected, actual));
+
+        exception.Message.Should().Contain("[[<space>]]");
+        exception.Message.Should().NotContain("[[ ]]");
+        exception.Message.Should().Contain("difference:    mismatch marked with [[...]]");
+    }
+
     public void AreEqualStringDifferenceOversizedTextElementsUsePlaceholder()
     {
         string expected = "a" + new string('\u0301', 60) + new string('z', 100);

--- a/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
+++ b/test/UnitTests/TestFramework.UnitTests/Assertions/AssertTests.AreEqualTests.cs
@@ -1668,7 +1668,7 @@ public partial class AssertTests : TestContainer
 
             expected:   "aa\ta"
             actual:     "aa a"
-            difference: ---^
+            difference: expected [[\t]]; actual [[<space>]]
 
             Assert.AreEqual("aa\ta", "aa a")
             """);
@@ -2079,6 +2079,26 @@ public partial class AssertTests : TestContainer
         exception.Message.Should().Contain("[[<space>]]");
         exception.Message.Should().NotContain("[[ ]]");
         exception.Message.Should().Contain("difference:    mismatch marked with [[...]]");
+    }
+
+    public void AreEqualStringDifferenceWhitespaceCharactersRenderUnambiguously()
+    {
+        (string Expected, string Actual, string Marker)[] cases =
+        [
+            (new string('a', 120) + " " + "z", new string('a', 120) + "  " + "z", "[[<space>]]"),
+            (new string('a', 120) + "\t" + "z", new string('a', 120) + " " + "z", "[[\\t]]"),
+            (new string('a', 120) + "\r\n" + "z", new string('a', 120) + " " + "z", "[[\\r\\n]]"),
+            (new string('a', 120) + "\u00A0" + "z", new string('a', 120) + " " + "z", "[[\\u00A0]]"),
+            (new string('a', 120) + "\u2009" + "z", new string('a', 120) + " " + "z", "[[\\u2009]]"),
+        ];
+
+        foreach ((string expected, string actual, string marker) in cases)
+        {
+            AssertFailedException exception = CaptureAreEqualFailure(() => Assert.AreEqual(expected, actual));
+
+            exception.Message.Should().Contain(marker);
+            exception.Message.Should().NotContain("[[ ]]");
+        }
     }
 
     public void AreEqualStringDifferenceOversizedTextElementsUsePlaceholder()


### PR DESCRIPTION
<!-- 
- Add a brief summary of what this Pull Request is about.
- Add a link to the issue this Pull Request relates to.
-->

Case C in #11061 produced an ambiguous `[[ ]]` marker when a bounded string comparison preview encountered a whitespace-only mismatch inside a long assertion message.

Ambiguous inline previews now render whitespace mismatches as visible `<space>` or `<N spaces>` markers. Existing caret diagnostics, short-string output, and full expected/actual evidence remain unchanged. Added a regression test for the reported case.

Fixes #11061

Validation: `net8.0` TestFramework unit tests (1,559 passed).