### PR TITLE
Fix flaky TestHostControllerCancellationServer disposal (RST instead of graceful disconnect)

### DIFF
--- a/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
+++ b/src/Platform/Microsoft.Testing.Platform/IPC/NamedPipeServer.cs
@@ -469,10 +469,18 @@ internal sealed class NamedPipeServer : NamedPipeConnectionBase, IServer
 
         if (wasConnected)
         {
+#if !NET
+            // On .NET Framework (netstandard2.0 build), PipeStream.ReadAsync(byte[], int, int, CancellationToken)
+            // does not reliably interrupt the underlying blocking read when only the cancellation token is
+            // canceled. Force-closing the stream here unblocks that pending read. On modern .NET the read uses
+            // the Memory<byte>-based overload, which honors cancellation without requiring the stream to be
+            // disposed mid-operation; eagerly disposing it there would race with the in-flight cancellation and
+            // can surface to the connected client as an abrupt reset instead of a graceful disconnect.
             if (_cancellationToken.IsCancellationRequested)
             {
                 _namedPipeServerStream.Dispose();
             }
+#endif
 
             // To close gracefully we need to ensure that the client closed the stream in the InternalLoopAsync method (there is comment `// The client has disconnected`).
             if (loopTask is not null && !loopTask.Wait(TimeoutHelper.DefaultHangTimeSpanTimeout))
@@ -508,11 +516,11 @@ internal sealed class NamedPipeServer : NamedPipeConnectionBase, IServer
 
         if (wasConnected)
         {
-            if (_cancellationToken.IsCancellationRequested)
-            {
-                _namedPipeServerStream.Dispose();
-            }
-
+            // Unlike the netstandard2.0 build used by Dispose(), this method is only compiled for modern .NET,
+            // where PipeStream.ReadAsync(Memory<byte>, CancellationToken) honors cancellation without needing the
+            // stream to be force-disposed mid-operation. Eagerly disposing it here would race with the in-flight
+            // cancellation of the pending read and can surface to the connected client as an abrupt reset instead
+            // of a graceful disconnect.
             if (loopTask is not null)
             {
                 try


### PR DESCRIPTION
## Problem

`Microsoft.Testing.Platform.UnitTests.TestHostControllerCancellationTests.ServerDisposal_WhenClientConnectsWithoutSendingRequest_DoesNotHang` is flaky in CI, occasionally failing with `System.IO.IOException: Connection reset by peer`. This has been observed on unrelated PRs (e.g. #11106, a pure NuGet dependency bump), confirming it's a pre-existing product/test flakiness issue.

## Root cause

In the test, the client connects but never sends a request, so `TestHostControllerCancellationServer` cancels its server-lifetime token to force teardown of the pending read in `NamedPipeServer.InternalLoopAsync`.

`NamedPipeServer.Dispose()`/`DisposeAsync()` eagerly called `_namedPipeServerStream.Dispose()` as soon as they observed the cancellation token was already canceled, before waiting for the in-flight `InternalLoopAsync` read to actually finish. This eager dispose was originally added to work around `PipeStream.ReadAsync(byte[], int, int, CancellationToken)` (the overload used by the netstandard2.0 build, consumed by .NET Framework hosts) not reliably honoring cancellation of a pending read.

On modern .NET builds, `InternalLoopAsync` uses `ReadAsync(Memory<byte>, CancellationToken)` instead, which does honor cancellation properly. The eager dispose there raced with the already-in-flight cancellation of the pending read, and on some platforms (observed on Linux/net9.0 in CI) that race surfaced to the connected client as an abrupt socket reset instead of a graceful disconnect (0-byte EOF), which is what the test asserts.

## Fix

- Guard the eager "dispose to unblock" workaround in `NamedPipeServer.Dispose()` with `#if !NET`, so it only runs for the netstandard2.0 build where it is actually needed.
- Remove the eager dispose entirely from `NamedPipeServer.DisposeAsync()`, which is already `#if NET`-only and uses the cancellation-aware `ReadAsync` overload — cancellation alone reliably unblocks the pending read there, and the stream is disposed only after the loop task has completed.

This preserves the test's intent (server disposal must not hang when a client connects without sending a request) without weakening any assertions.

## Testing

- `.\build.cmd -test -projects test\UnitTests\Microsoft.Testing.Platform.UnitTests\Microsoft.Testing.Platform.UnitTests.csproj` — all TFMs (net8.0, net9.0, net462) pass.
- Looped `TestHostControllerCancellationTests` 40x on net9.0 and 15x on net462 locally with 0 failures.

Note: the RST specifically reproduces on Linux socket-backed named pipes; this environment is Windows, so the exact symptom couldn't be directly reproduced here, but the fix addresses the disposal race identified as the cause.