### PR TITLE
Fix timing-sensitive message bus test on rel/4.4

### DIFF
--- a/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Platform.UnitTests/Messages/AsynchronousMessageBusTests.cs
@@ -716,6 +716,7 @@ public sealed class AsynchronousMessageBusTests
     }
 
     [TestMethod]
+    [DoNotParallelize]
     public async Task DisableAsync_WithManyCanceledConsumersIgnoringTheToken_ShouldNotMultiplyTheBudget()
     {
         using CTRLPlusCCancellationTokenSource cancellationTokenSource = new();


### PR DESCRIPTION
The rel/4.4 pipeline can intermittently fail when `DisableAsync_WithManyCanceledConsumersIgnoringTheToken_ShouldNotMultiplyTheBudget` competes with other parallel tests and exceeds its four-second timing bound.

Backport the existing main-branch isolation fix by marking this timing-sensitive test with `[DoNotParallelize]`.