### PR TITLE
Complete Azure DevOps live-published test results

### DIFF
--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/AzureDevOpsLivePublishingModels.cs
@@ -95,6 +95,16 @@ internal sealed record AzureDevOpsTestCaseResult(
     [property: JsonPropertyName("completedDate")] DateTimeOffset? CompletedDate)
 {
     /// <summary>
+    /// Gets the terminal state of the test result.
+    /// </summary>
+    /// <remarks>
+    /// Azure DevOps does not infer this from <see cref="Outcome"/>. Omitting it leaves the result in
+    /// <c>Pending</c> even after the containing run is completed.
+    /// </remarks>
+    [JsonPropertyName("state")]
+    public string State { get; } = AzureDevOpsLivePublishingConstants.CompletedTestRunState;
+
+    /// <summary>
     /// Gets the id Azure DevOps assigned to this result, set only when updating an already published result.
     /// </summary>
     /// <remarks>

--- a/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
+++ b/src/Platform/Microsoft.Testing.Extensions.AzureDevOpsReport/InternalAPI/InternalAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestCaseResult.State.get -> string!
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsClient.AzureDevOpsTestResultsClient(Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Logging.ILoggerFactory! loggerFactory) -> void
 Microsoft.Testing.Extensions.AzureDevOpsReport.AzureDevOpsTestResultsClient.AzureDevOpsTestResultsClient(System.Net.Http.HttpClient! httpClient, Microsoft.Testing.Platform.Helpers.ITask! task, Microsoft.Testing.Platform.Helpers.IClock! clock, Microsoft.Testing.Platform.Logging.ILogger? logger) -> void

--- a/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BrowserWasmExecutionTests.cs
+++ b/test/IntegrationTests/Microsoft.Testing.Platform.Acceptance.IntegrationTests/BrowserWasmExecutionTests.cs
@@ -638,6 +638,7 @@ const summary = {
     createRunRequests: 0,
     createRunStates: [],
     publishedTestOutcomes: [],
+    publishedTestStates: [],
     attachments: [],
     patchedStates: [],
     authorizedRequests: 0,
@@ -679,6 +680,7 @@ const server = http.createServer(async (request, response) => {
             count: results.length,
             value: results.map((result, index) => {
                 summary.publishedTestOutcomes.push(result.testCaseTitle + '=' + result.outcome);
+                summary.publishedTestStates.push(result.testCaseTitle + '=' + (result.state ?? '<missing>'));
                 return { id: 5000 + index, automatedTestName: result.automatedTestName };
             }),
         });
@@ -1241,12 +1243,18 @@ internal sealed class WarningFramework : ITestFramework, IDataProducer, IOutputD
             root.GetProperty("patchedStates").EnumerateArray().Select(static element => element.GetString()).ToArray(),
             combined);
 
-        // Both tests are published with their real outcomes, and the run ends with the
-        // "at least one test failed" exit code (so the publisher did not swallow the failure).
+        // Both tests are published with their real outcomes and terminal states, and the run ends with
+        // the "at least one test failed" exit code (so the publisher did not swallow the failure).
         Assert.AreEqual((int)ExitCode.AtLeastOneTestFailed, root.GetProperty("exitCode").GetInt32(), combined);
         string[] publishedTestOutcomes = [.. root.GetProperty("publishedTestOutcomes").EnumerateArray().Select(static element => element.GetString()!)];
         Assert.ContainsSingle(publishedTestOutcomes.Where(static outcome => outcome == "PassingTest=Passed"), combined);
         Assert.ContainsSingle(publishedTestOutcomes.Where(static outcome => outcome == "FailingTestWithAttachment=Failed"), combined);
+
+        // Regression for https://github.com/microsoft/testfx/issues/11122: a terminal outcome does not
+        // transition the Azure DevOps result out of Pending unless the result-level state is also sent.
+        string[] publishedTestStates = [.. root.GetProperty("publishedTestStates").EnumerateArray().Select(static element => element.GetString()!)];
+        Assert.ContainsSingle(publishedTestStates.Where(static state => state == "PassingTest=Completed"), combined);
+        Assert.ContainsSingle(publishedTestStates.Where(static state => state == "FailingTestWithAttachment=Completed"), combined);
 
         // The file-backed attachment proves TryBuildAttachmentRequest reads from the wasm virtual
         // filesystem and base64-encodes the real bytes; the inline console attachments come from the

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -4040,6 +4040,7 @@ public sealed class AzureDevOpsLivePublishingTests
         JsonElement result = document.RootElement[0];
         Assert.AreEqual(777, result.GetProperty("id").GetInt32());
         Assert.AreEqual("rerun", result.GetProperty("resultGroupType").GetString());
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, result.GetProperty("state").GetString());
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, result.GetProperty("outcome").GetString());
         Assert.AreEqual(JsonValueKind.Null, result.GetProperty("errorMessage").ValueKind);
         Assert.AreEqual(JsonValueKind.Null, result.GetProperty("stackTrace").ValueKind);
@@ -4455,6 +4456,7 @@ public sealed class AzureDevOpsLivePublishingTests
 
         using var document = JsonDocument.Parse(capturedBody!);
         JsonElement created = document.RootElement[0];
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, created.GetProperty("state").GetString());
         Assert.IsFalse(created.TryGetProperty("id", out _));
         Assert.IsFalse(created.TryGetProperty("resultGroupType", out _));
         Assert.IsFalse(created.TryGetProperty("subResults", out _));

--- a/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
+++ b/test/UnitTests/Microsoft.Testing.Extensions.UnitTests/AzureDevOpsLivePublishingTests.cs
@@ -341,15 +341,20 @@ public sealed class AzureDevOpsLivePublishingTests
 #pragma warning restore CS0618, MTP0001 // Type or member is obsolete
 
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.PassedTestOutcome, passed?.Outcome);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, passed?.State);
         Assert.AreEqual(2000L, passed?.DurationInMs);
         Assert.AreEqual(startTime, passed?.StartedDate);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, failed?.Outcome);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, failed?.State);
         Assert.AreEqual("boom", failed?.ErrorMessage);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.NotExecutedTestOutcome, skipped?.Outcome);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, skipped?.State);
         Assert.AreEqual("skip", skipped?.ErrorMessage);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.FailedTestOutcome, timeout?.Outcome);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, timeout?.State);
         Assert.AreEqual("Timeout: too slow", timeout?.ErrorMessage);
         Assert.AreEqual(AzureDevOpsLivePublishingConstants.AbortedTestOutcome, cancelled?.Outcome);
+        Assert.AreEqual(AzureDevOpsLivePublishingConstants.CompletedTestRunState, cancelled?.State);
         Assert.AreEqual("stopped", cancelled?.ErrorMessage);
     }
 


### PR DESCRIPTION
Azure DevOps keeps live-published test results in `Pending` when the payload contains a terminal outcome but omits the result-level state. This change publishes `state: "Completed"` for every terminal result so completed runs report accurate passed, failed, and incomplete counts.

The regression coverage verifies:

- MTP-to-Azure DevOps mapping for passed, failed, skipped, timed out, and cancelled results.
- The actual initial POST payload through the browser-WASM fake Azure DevOps REST endpoint.
- The initial POST and rerun PATCH payload contracts, including the separate PATCH serializer configuration.

The adjacent-path audit confirmed retry attempts use the same parent result model. Azure DevOps `TestSubResult` has no result-state field, so no equivalent sub-result change is required.

Fixes: #11122